### PR TITLE
remove minus sign in TMDB searches

### DIFF
--- a/scrapers/TMDb.cpp
+++ b/scrapers/TMDb.cpp
@@ -193,7 +193,7 @@ void TMDb::search(QString searchStr)
 {
     qDebug() << "Entered, searchStr=" << searchStr;
     m_results.clear();
-    m_searchString = searchStr.replace("-", "");
+    m_searchString = searchStr.replace("-", " ");
     QString encodedSearch = QUrl::toPercentEncoding(searchStr);
     QUrl url(QString("http://api.themoviedb.org/3/search/movie?api_key=%1&language=%2&query=%3").arg(m_apiKey).arg(m_language).arg(encodedSearch));
     QNetworkRequest request(url);


### PR DESCRIPTION
mir ist aufgefallen, dass suchen bei tmdb keine ergebnisse liefern, wenn ein minus im namen ist, warscheinlich bedeutet es dort: das nächste wort ausschließen

bei den anderen movie scrapern ist das kein problem, vielleicht aber bei TMDB-Concerts
