### PR TITLE
Fix hd-trailers.net scraping

### DIFF
--- a/trailerProviders/HdTrailers.cpp
+++ b/trailerProviders/HdTrailers.cpp
@@ -106,7 +106,7 @@ QList<TrailerResult> HdTrailers::parseTrailers(QString html)
     QList<TrailerResult> results;
 
     int pos = 0;
-    QRegExp rx("<tr style=\"\" itemprop=\"trailer\" itemscope itemtype=\"http://schema.org/VideoObject\">.*<td class=\"bottomTableName\" rowspan=\"2\"><span class=\"standardTrailerName\" itemprop=\"name\">(.*)</span>.*</td>(.*)</tr>");
+    QRegExp rx("<tr itemprop=\"trailer\" itemscope itemtype=\"http://schema.org/VideoObject\">.*<td class=\"bottomTableName\" rowspan=\"2\"><span class=\"standardTrailerName\" itemprop=\"name\">(.*)</span>.*</td>(.*)</tr>");
     rx.setMinimal(true);
     while ((pos = rx.indexIn(html, pos)) != -1) {
         QRegExp rx2("<td class=\"bottomTableResolution\"><a href=\"([^\"]*)\".*>([^<]*)</a></td>");


### PR DESCRIPTION
Hd-trailers.net changed their markup a tiny little bit, breaking trailer downloads. This fixes it.
