### PR TITLE
Update quazip for newer versions of zlib

### DIFF
--- a/quazip/quazip/ioapi.h
+++ b/quazip/quazip/ioapi.h
@@ -11,6 +11,10 @@
 #ifndef _ZLIBIOAPI_H
 #define _ZLIBIOAPI_H
 
+#ifdef _Z_OF
+#undef OF
+#define OF _Z_OF
+#endif
 
 #define ZLIB_FILEFUNC_SEEK_CUR (1)
 #define ZLIB_FILEFUNC_SEEK_END (2)


### PR DESCRIPTION
This change is required for building against newer versions of zlib (not sure exactly what version this starts from)
