### PR TITLE
fix release to match tarball from PPA

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-mediaelch (2.0.1-1) raring; urgency=low
+mediaelch (2.0.6-1) raring; urgency=low
 
   * Show all banners for seasons
   * Improve tabs ui


### PR DESCRIPTION
It seems the changelog from the git repo doesn't match the one from:

https://launchpad.net/~kvibes/+archive/mediaelch/+packages
