### PR TITLE
Proposed changes to movie scraper dialog.

### DIFF
--- a/i18n/MediaElch_de.ts
+++ b/i18n/MediaElch_de.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="de" version="2.0">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
 <context>
     <name>AEBN</name>
     <message>
@@ -319,7 +321,10 @@
         <location filename="../concerts/ConcertFilesWidget.cpp" line="26"/>
         <location filename="../concerts/ConcertFilesWidget.cpp" line="325"/>
         <source>%n concerts</source>
-        <translation><numerusform>Ein Konzert</numerusform><numerusform>%n Konzerte</numerusform></translation>
+        <translation>
+            <numerusform>Ein Konzert</numerusform>
+            <numerusform>%n Konzerte</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../concerts/ConcertFilesWidget.cpp" line="45"/>
@@ -354,7 +359,10 @@
     <message numerus="yes">
         <location filename="../concerts/ConcertFilesWidget.cpp" line="327"/>
         <source>%1 of %n concerts</source>
-        <translation><numerusform>%1 von einem Konzert</numerusform><numerusform>%1 von %n Konzerten</numerusform></translation>
+        <translation>
+            <numerusform>%1 von einem Konzert</numerusform>
+            <numerusform>%1 von %n Konzerten</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -790,7 +798,10 @@
         <location filename="../downloads/DownloadsWidget.cpp" line="202"/>
         <location filename="../downloads/DownloadsWidget.cpp" line="330"/>
         <source>%n file(s)</source>
-        <translation><numerusform>%n Datei</numerusform><numerusform>%n Dateien</numerusform></translation>
+        <translation>
+            <numerusform>%n Datei</numerusform>
+            <numerusform>%n Dateien</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../downloads/DownloadsWidget.cpp" line="272"/>
@@ -1197,7 +1208,10 @@
         <location filename="../movies/FilesWidget.cpp" line="29"/>
         <location filename="../movies/FilesWidget.cpp" line="505"/>
         <source>%n movies</source>
-        <translation><numerusform>Ein Film</numerusform><numerusform>%n Filme</numerusform></translation>
+        <translation>
+            <numerusform>Ein Film</numerusform>
+            <numerusform>%n Filme</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../movies/FilesWidget.cpp" line="61"/>
@@ -1247,7 +1261,10 @@
     <message numerus="yes">
         <location filename="../movies/FilesWidget.cpp" line="507"/>
         <source>%1 of %n movies</source>
-        <translation><numerusform>%1 von einem Film</numerusform><numerusform>%1 von %n Filmen</numerusform></translation>
+        <translation>
+            <numerusform>%1 von einem Film</numerusform>
+            <numerusform>%1 von %n Filmen</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -2452,7 +2469,10 @@
     <message numerus="yes">
         <location filename="../downloads/ImportDialog.cpp" line="641"/>
         <source>Import of %n file(s) has finished</source>
-        <translation><numerusform>%n Datei wurde erfolgreich importiert</numerusform><numerusform>%n Dateien wurden erfolgreich importiert</numerusform></translation>
+        <translation>
+            <numerusform>%n Datei wurde erfolgreich importiert</numerusform>
+            <numerusform>%n Dateien wurden erfolgreich importiert</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../downloads/ImportDialog.cpp" line="644"/>
@@ -2495,7 +2515,10 @@
     <message numerus="yes">
         <location filename="../tvShows/ItemWidgetShow.cpp" line="50"/>
         <source>%n Episodes</source>
-        <translation><numerusform>%n Episode</numerusform><numerusform>%n Episoden</numerusform></translation>
+        <translation>
+            <numerusform>%n Episode</numerusform>
+            <numerusform>%n Episoden</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3330,7 +3353,10 @@ Operation abgebrochen.</translation>
     <message numerus="yes">
         <location filename="../movies/MovieMultiScrapeDialog.cpp" line="175"/>
         <source>Scraping of %n movies has finished.</source>
-        <translation><numerusform>Informationen für %n Film wurde geladen.</numerusform><numerusform>Informationen für %n Filme wurden geladen.</numerusform></translation>
+        <translation>
+            <numerusform>Informationen für %n Film wurde geladen.</numerusform>
+            <numerusform>Informationen für %n Filme wurden geladen.</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3354,144 +3380,179 @@ Operation abgebrochen.</translation>
         <translation>Form</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="25"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="22"/>
         <source>Scraper</source>
         <translation>Scraper</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="50"/>
         <source>When using IMDB you can also use the IMDB id as search query.
 If you want to search by an TMDB or OFDb id please prefix it with &quot;id&quot;.</source>
-        <translation>Wenn du IMDB benutzt, kannst du auch eine IMDB ID eingeben.
+        <translation type="vanished">Wenn du IMDB benutzt, kannst du auch eine IMDB ID eingeben.
 Wenn du bei TMDB oder OFDb nach einer ID suchen möchtest, stelle bitte &quot;id&quot; voran.</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="91"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="55"/>
+        <source>Activate to search by movie title.</source>
+        <translation>Aktivieren, um nach einem Film Titel zu suchen.</translation>
+    </message>
+    <message>
+        <location filename="../movies/MovieSearchWidget.ui" line="61"/>
+        <source>Title:</source>
+        <translation>Titel:</translation>
+    </message>
+    <message>
+        <location filename="../movies/MovieSearchWidget.ui" line="77"/>
+        <source>Enter the movie title you wish to search for.
+Press the Enter key to start the search.</source>
+        <translation>Geb den Film Titel ein, nach dem du suchen möchtest.
+Betätige die Enter Taste, um die Suche zu starten.</translation>
+    </message>
+    <message>
+        <location filename="../movies/MovieSearchWidget.ui" line="94"/>
+        <source>Activate to search by remote database id.</source>
+        <translation>Aktivieren, um nach einer Datenbank Id zu suchen.</translation>
+    </message>
+    <message>
+        <location filename="../movies/MovieSearchWidget.ui" line="100"/>
+        <source>Id:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../movies/MovieSearchWidget.ui" line="116"/>
+        <source>When using IMDB you can also use the IMDB id as search query.
+If you want to search by an TMDB or OFDb id please prefix it with &quot;id&quot;.
+Press the Enter key to start the search.</source>
+        <translation type="unfinished">Wenn du IMDB benutzt, kannst du auch eine IMDB ID eingeben.
+Wenn du bei TMDB oder OFDb nach einer ID suchen möchtest, stelle bitte &quot;id&quot; voran.
+Betätige die Enter Taste, um die Suche zu starten.</translation>
+    </message>
+    <message>
+        <location filename="../movies/MovieSearchWidget.ui" line="160"/>
         <source>Result</source>
         <translation>Ergebnis</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="118"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="187"/>
         <source>Infos to load</source>
         <translation>Lade Infos</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="141"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="210"/>
         <source>Title</source>
         <translation>Titel</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="148"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="217"/>
         <source>Set</source>
         <translation>Zusammenstellung</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="155"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="224"/>
         <source>Tagline</source>
         <translation>Tagline</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="162"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="231"/>
         <source>Rating</source>
         <translation>Bewertung</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="169"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="238"/>
         <source>Released</source>
         <translation>Erschienen</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="176"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="245"/>
         <source>Runtime</source>
         <translation>Laufzeit</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="183"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="252"/>
         <source>Director</source>
         <translation>Regisseur</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="190"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="259"/>
         <source>Writer</source>
         <translation>Drehbuch</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="197"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="266"/>
         <source>Certification</source>
         <translation>Freigabe</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="204"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="273"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="211"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="280"/>
         <source>Overview</source>
         <translation>Inhalt</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="218"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="287"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="225"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="294"/>
         <source>Backdrop</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="232"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="301"/>
         <source>Actors</source>
         <translation>Schauspieler</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="239"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="308"/>
         <source>Genres</source>
         <translation>Genres</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="246"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="315"/>
         <source>Studios</source>
         <translation>Studios</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="253"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="322"/>
         <source>Countries</source>
         <translation>Länder</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="260"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="329"/>
         <source>Tags</source>
         <translation>Tags</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="267"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="336"/>
         <source>Logo</source>
         <translation>Logo</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="274"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="343"/>
         <source>Clear Art</source>
         <translation>Clear Art</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="281"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="350"/>
         <source>CD Art</source>
         <translation>CD Art</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="288"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="357"/>
         <source>Banner</source>
         <translation>Banner</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="295"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="364"/>
         <source>Thumb</source>
         <translation>Thumb</translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="309"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="378"/>
         <source>(Un)Check all</source>
         <translation>Alle aus/abwählen</translation>
     </message>
@@ -4242,7 +4303,7 @@ Wenn du bei TMDB oder OFDb nach einer ID suchen möchtest, stelle bitte &quot;id
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.Lucida Grande UI'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;.Lucida Grande UI&apos;; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Lucida Grande&apos;;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt; &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt; p, li { white-space: pre-wrap; } &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;.Lucida Grande UI&apos;; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt; &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Lucida Grande&apos;;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -4264,22 +4325,34 @@ p, li { white-space: pre-wrap; }
     <message numerus="yes">
         <location filename="../renamer/Renamer.cpp" line="39"/>
         <source>%n Movie(s) will be renamed</source>
-        <translation><numerusform>%n Film wird umbenannt</numerusform><numerusform>%n Filme werden umbenannt</numerusform></translation>
+        <translation>
+            <numerusform>%n Film wird umbenannt</numerusform>
+            <numerusform>%n Filme werden umbenannt</numerusform>
+        </translation>
     </message>
     <message numerus="yes">
         <location filename="../renamer/Renamer.cpp" line="42"/>
         <source>%n Concert(s) will be renamed</source>
-        <translation><numerusform>%n Konzert wird umbenannt</numerusform><numerusform>%n Konzerte werden umbenannt</numerusform></translation>
+        <translation>
+            <numerusform>%n Konzert wird umbenannt</numerusform>
+            <numerusform>%n Konzerte werden umbenannt</numerusform>
+        </translation>
     </message>
     <message numerus="yes">
         <location filename="../renamer/Renamer.cpp" line="45"/>
         <source>%n TV Show(s) and %1</source>
-        <translation><numerusform>%n Serie und %1</numerusform><numerusform>%n Serien und %1</numerusform></translation>
+        <translation>
+            <numerusform>%n Serie und %1</numerusform>
+            <numerusform>%n Serien und %1</numerusform>
+        </translation>
     </message>
     <message numerus="yes">
         <location filename="../renamer/Renamer.cpp" line="45"/>
         <source>%n Episode(s) will be renamed</source>
-        <translation><numerusform>%n Episode werden umbenannt</numerusform><numerusform>%n Episoden werden umbenannt</numerusform></translation>
+        <translation>
+            <numerusform>%n Episode werden umbenannt</numerusform>
+            <numerusform>%n Episoden werden umbenannt</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../renamer/Renamer.cpp" line="174"/>
@@ -5152,7 +5225,7 @@ Bei Serien müssen Episoden in Unterverzeichnissen mit dem Namen der Serie sein.
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Helvetica'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Helvetica&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;amp;hosted_button_id=6EU9GPSQ8PSUA&quot;&gt;&lt;img src=&quot;:/img/btn_donate_LG.gif&quot; /&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -5730,13 +5803,19 @@ p, li { white-space: pre-wrap; }
         <location filename="../tvShows/TvShowFilesWidget.cpp" line="26"/>
         <location filename="../tvShows/TvShowFilesWidget.cpp" line="518"/>
         <source>%n tv shows</source>
-        <translation><numerusform>Eine Serie</numerusform><numerusform>%n Serien</numerusform></translation>
+        <translation>
+            <numerusform>Eine Serie</numerusform>
+            <numerusform>%n Serien</numerusform>
+        </translation>
     </message>
     <message numerus="yes">
         <location filename="../tvShows/TvShowFilesWidget.cpp" line="26"/>
         <location filename="../tvShows/TvShowFilesWidget.cpp" line="518"/>
         <source>%n episodes</source>
-        <translation><numerusform>Eine Episode</numerusform><numerusform>%n Episoden</numerusform></translation>
+        <translation>
+            <numerusform>Eine Episode</numerusform>
+            <numerusform>%n Episoden</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../tvShows/TvShowFilesWidget.cpp" line="50"/>
@@ -5798,7 +5877,10 @@ Danach wird MediaElch bei jedem Start automatisch nach neuen Episoden suchen.</t
     <message numerus="yes">
         <location filename="../tvShows/TvShowFilesWidget.cpp" line="520"/>
         <source>%1 of %n tv shows</source>
-        <translation><numerusform>%1 von einer Serie</numerusform><numerusform>%1 von %n Serien</numerusform></translation>
+        <translation>
+            <numerusform>%1 von einer Serie</numerusform>
+            <numerusform>%1 von %n Serien</numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/i18n/MediaElch_en.ts
+++ b/i18n/MediaElch_en.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="en_US">
+<TS version="2.1" language="en_US">
 <context>
     <name>AEBN</name>
     <message>
@@ -3379,143 +3379,170 @@ Main menu entry (tooltip)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="25"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="22"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="50"/>
-        <source>When using IMDB you can also use the IMDB id as search query.
-If you want to search by an TMDB or OFDb id please prefix it with &quot;id&quot;.</source>
+        <location filename="../movies/MovieSearchWidget.ui" line="55"/>
+        <source>Activate to search by movie title.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="91"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="61"/>
+        <source>Title:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../movies/MovieSearchWidget.ui" line="77"/>
+        <source>Enter the movie title you wish to search for.
+Press the Enter key to start the search.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../movies/MovieSearchWidget.ui" line="94"/>
+        <source>Activate to search by remote database id.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../movies/MovieSearchWidget.ui" line="100"/>
+        <source>Id:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../movies/MovieSearchWidget.ui" line="116"/>
+        <source>When using IMDB you can also use the IMDB id as search query.
+If you want to search by an TMDB or OFDb id please prefix it with &quot;id&quot;.
+Press the Enter key to start the search.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../movies/MovieSearchWidget.ui" line="160"/>
         <source>Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="118"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="187"/>
         <source>Infos to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="141"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="210"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="148"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="217"/>
         <source>Set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="155"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="224"/>
         <source>Tagline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="162"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="231"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="169"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="238"/>
         <source>Released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="176"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="245"/>
         <source>Runtime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="183"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="252"/>
         <source>Director</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="190"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="259"/>
         <source>Writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="197"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="266"/>
         <source>Certification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="204"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="273"/>
         <source>Trailer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="211"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="280"/>
         <source>Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="218"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="287"/>
         <source>Poster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="225"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="294"/>
         <source>Backdrop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="232"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="301"/>
         <source>Actors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="239"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="308"/>
         <source>Genres</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="246"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="315"/>
         <source>Studios</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="253"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="322"/>
         <source>Countries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="260"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="329"/>
         <source>Tags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="267"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="336"/>
         <source>Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="274"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="343"/>
         <source>Clear Art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="281"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="350"/>
         <source>CD Art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="288"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="357"/>
         <source>Banner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="295"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="364"/>
         <source>Thumb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../movies/MovieSearchWidget.ui" line="309"/>
+        <location filename="../movies/MovieSearchWidget.ui" line="378"/>
         <source>(Un)Check all</source>
         <translation type="unfinished"></translation>
     </message>

--- a/movies/MovieSearchWidget.h
+++ b/movies/MovieSearchWidget.h
@@ -34,8 +34,12 @@ private slots:
     void resultClicked(QTableWidgetItem *item);
     void chkToggled();
     void chkAllToggled(bool toggled);
-    void onUpdateSearchString();
-    void onStoreSearchString(QString searchString);
+
+    //! \brief Update remote database id after switch of scraper.
+    void onUpdateSearchStringId();
+
+    //! \brief Handle switch of search identifier.
+    void onSearchIdentifierSwitched();
 
 private:
     Ui::MovieSearchWidget *ui;
@@ -46,11 +50,13 @@ private:
     ScraperInterface *m_currentCustomScraper;
     QString m_id;
     QString m_tmdbId;
-    QString m_searchString;
 
     void clear();
     void setChkBoxesEnabled(QList<int> scraperSupports);
     void setupScrapers();
+
+    //! \brief Switch between seach by id (\a flag == true) and search by movie title (\a flag == false).
+    void searchById( bool flag );
 };
 
 #endif // MOVIESEARCHWIDGET_H

--- a/movies/MovieSearchWidget.ui
+++ b/movies/MovieSearchWidget.ui
@@ -7,18 +7,15 @@
     <x>0</x>
     <y>0</y>
     <width>810</width>
-    <height>692</height>
+    <height>771</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="margin">
-    <number>0</number>
-   </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,0">
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
@@ -45,12 +42,84 @@
     </layout>
    </item>
    <item>
-    <widget class="MyLineEdit" name="searchString">
-     <property name="toolTip">
-      <string>When using IMDB you can also use the IMDB id as search query.
-If you want to search by an TMDB or OFDb id please prefix it with &quot;id&quot;.</string>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QRadioButton" name="rBtnSearchTitle">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Activate to search by movie title.</string>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::RightToLeft</enum>
+       </property>
+       <property name="text">
+        <string>Title:</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="MyLineEdit" name="searchStringTitle">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Enter the movie title you wish to search for.
+Press the Enter key to start the search.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="rBtnSearchId">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Activate to search by remote database id.</string>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::RightToLeft</enum>
+       </property>
+       <property name="text">
+        <string>Id:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="MyLineEdit" name="searchStringId">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>When using IMDB you can also use the IMDB id as search query.
+If you want to search by an TMDB or OFDb id please prefix it with &quot;id&quot;.
+Press the Enter key to start the search.</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0">


### PR DESCRIPTION
Changes
- Divided search between search by remote database id and search by movie title. Defaults to remote database id, if known.
- Replace "_" with " " in movie titles search string (in addition to ".").
- Updated german translation affected by changes.

Purpose
- Stop MediaElch from forcing me to enter the movie title manually after selecting the wrong movie.
- I use "_" instead of spaces in file names.

![bildschirmfoto vom 2014-03-29 11 22 49](https://cloud.githubusercontent.com/assets/7099464/2558031/881bb8da-b72c-11e3-98d7-d36e7e7c5590.png)
