### PR TITLE
Possible fix for skipt or malformed search results returned by the IMDB scraper.

### DIFF
--- a/movies/MovieSearchWidget.cpp
+++ b/movies/MovieSearchWidget.cpp
@@ -6,11 +6,11 @@
 #include "scrapers/CustomMovieScraper.h"
 
 
-QDebug operator<<( QDebug lhs, const ScraperSearchResult& rhs )
+QDebug operator<<(QDebug lhs, const ScraperSearchResult &rhs)
 {
-    lhs << QString( "(\"%1\", \"%2\", %3)" ).arg( rhs.id )
-                                            .arg( rhs.name )
-                                            .arg( rhs.released.toString( "yyyy" ) );
+    lhs << QString("(\"%1\", \"%2\", %3)").arg(rhs.id)
+                                          .arg(rhs.name)
+                                          .arg(rhs.released.toString("yyyy"));
     return lhs;
 }
 

--- a/scrapers/IMDB.cpp
+++ b/scrapers/IMDB.cpp
@@ -109,49 +109,37 @@ void IMDB::onSearchFinished()
 
 void IMDB::onSearchIdFinished()
 {
-    QNetworkReply *reply = static_cast<QNetworkReply*>( QObject::sender() );
+    QNetworkReply* reply = static_cast<QNetworkReply *>(QObject::sender());
     QList<ScraperSearchResult> results;
-    if( reply->error() == QNetworkReply::NoError )
-    {
-        QString msg = QString::fromUtf8( reply->readAll() );
+    if (reply->error() == QNetworkReply::NoError) {
+        QString msg = QString::fromUtf8(reply->readAll());
         ScraperSearchResult result;
 
         QRegExp rx;
         rx.setMinimal(true);
-        rx.setPattern( "<h1 class=\"header\"> <span class=\"itemprop\" itemprop=\"name\">(.*)</span>" );
-        if( rx.indexIn( msg ) != -1 )
-        {
-            result.name = rx.cap( 1 );
-        }
-        rx.setPattern( "<h1 class=\"header\"> <span class=\"itemprop\" itemprop=\"name\">.*<span class=\"nobr\">\\(<a href=\"[^\"]*\" >([0-9]*)</a>\\)</span>" );
-        if( rx.indexIn( msg ) != -1 )
-        {
-            result.released = QDate::fromString( rx.cap( 1 ), "yyyy" );
-        }
-        else
-        {
-            rx.setPattern( "<h1 class=\"header\"> <span class=\"itemprop\" itemprop=\"name\">.*</span>.*<span class=\"nobr\">\\(([0-9]*)\\)</span>" );
-            if( rx.indexIn( msg ) != -1 )
-            {
-                result.released = QDate::fromString( rx.cap( 1 ), "yyyy" );
-            }
+        rx.setPattern("<h1 class=\"header\"> <span class=\"itemprop\" itemprop=\"name\">(.*)</span>");
+        if (rx.indexIn(msg) != -1)
+            result.name = rx.cap(1);
+
+        rx.setPattern("<h1 class=\"header\"> <span class=\"itemprop\" itemprop=\"name\">.*<span class=\"nobr\">\\(<a href=\"[^\"]*\" >([0-9]*)</a>\\)</span>");
+        if (rx.indexIn(msg) != -1) {
+            result.released = QDate::fromString(rx.cap( 1 ), "yyyy");
+        } else {
+            rx.setPattern("<h1 class=\"header\"> <span class=\"itemprop\" itemprop=\"name\">.*</span>.*<span class=\"nobr\">\\(([0-9]*)\\)</span>");
+            if (rx.indexIn(msg) != -1)
+                result.released = QDate::fromString(rx.cap(1), "yyyy");
         }
 
-        rx.setPattern( "<link rel=\"canonical\" href=\"http://www.imdb.com/title/(.*)/\" />" );
-        if( rx.indexIn( msg ) != -1 )
-        {
-            result.id = rx.cap( 1 );
-        }
+        rx.setPattern("<link rel=\"canonical\" href=\"http://www.imdb.com/title/(.*)/\" />");
+        if (rx.indexIn(msg) != -1)
+            result.id = rx.cap(1);
 
-        if( ( ! result.id.isEmpty() ) && ( ! result.name.isEmpty() ) )
-        {
-            results.append( result );
-        }
-    }
-    else
-    {
+        if ((!result.id.isEmpty()) && (!result.name.isEmpty()))
+            results.append(result);
+    } else {
         qWarning() << "Network Error" << reply->errorString();
     }
+
     reply->deleteLater();
     emit searchDone(results);
 }
@@ -160,16 +148,15 @@ QList<ScraperSearchResult> IMDB::parseSearch(QString html)
 {
     QList<ScraperSearchResult> results;
 
-    QRegExp rx( "<td class=\"result_text\"> <a href=\"/title/([t]*[\\d]+)/[^\"]*\" >([^<]*)</a>(?: \\(I+\\) | )\\(([0-9]*)\\) (?:</td>|<br/>)" );
-    rx.setMinimal( true );
+    QRegExp rx("<td class=\"result_text\"> <a href=\"/title/([t]*[\\d]+)/[^\"]*\" >([^<]*)</a>(?: \\(I+\\) | )\\(([0-9]*)\\) (?:</td>|<br/>)");
+    rx.setMinimal(true);
     int pos = 0;
-    while( ( pos = rx.indexIn( html, pos ) ) != -1 )
-    {
+    while ((pos = rx.indexIn(html, pos)) != -1) {
         ScraperSearchResult result;
-        result.name = rx.cap( 2 );
-        result.id = rx.cap( 1 );
-        result.released = QDate::fromString( rx.cap( 3 ), "yyyy" );
-        results.append( result );
+        result.name = rx.cap(2);
+        result.id = rx.cap(1);
+        result.released = QDate::fromString(rx.cap(3), "yyyy");
+        results.append(result);
         pos += rx.matchedLength();
     }
     return results;


### PR DESCRIPTION
1. IMDB title search results of the IMDB scraper differ from search results on http://www.imdb.com/. In some cases the selected search result will not lead to an update of the movie information.
2. IMDB id search returns malformed movie title.

Tested with 
- http://www.imdb.com/find?s=tt&ttype=ft&ref_=fn_ft&q=Oblivion
- http://www.imdb.com/find?s=tt&ttype=ft&ref_=fn_ft&q=Redemption
- Latest MediaElch (https://github.com/Komet/MediaElch/tree/master)

Results with "(I)", "(II)" ... in the name are skipt in title search.
Results with "(I)", "(II)" ... in the name lead to a wrongly parsed movie title in id search.
Results with "aka" are skipt in title search.

Reason: Greedy match for id or movie title, multi match regular expression and no match for above cases in regualar expression.

This leads to a wrongly match IMDB id, which contains HTML tags, which in consequence can not be used to update the movie.
This leads to a wrongly match movie title, which contains HTML tags and line breaks.
