### PR TITLE
Needless call of MovieSearchWidget::showResults.

### DIFF
--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -161,7 +161,8 @@ SOURCES += main.cpp\
     main/Navbar.cpp \
     smallWidgets/FilterWidget.cpp \
     downloads/MakeMkvDialog.cpp \
-    downloads/MakeMkvCon.cpp
+    downloads/MakeMkvCon.cpp \
+    globals/Globals.cpp
 
 macx {
     OBJECTIVE_SOURCES += notifications/MacNotificationHandler.mm

--- a/globals/Globals.cpp
+++ b/globals/Globals.cpp
@@ -1,0 +1,28 @@
+/*
+    Copyright 2012-2014 Daniel Kabel.
+    Copyright 2014 Udo Schläpfer.
+
+    This file is part of MediaElch.
+
+    MediaElch is free software: you can redistribute it and/or modify it under the terms of
+    the GNU Lesser General Public License as published by the Free Software Foundation, either
+    version 3 of the License, or (at your option) any later version.
+
+    MediaElch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+    without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+    the GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License along with MediaElch.
+    If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "globals/Globals.h"
+#include <QDebug>
+
+QDebug operator<<(QDebug lhs, const ScraperSearchResult& rhs)
+{
+    lhs.nospace() << "(id: "      << rhs.id                        << ", "
+                  << "name: "     << rhs.name                      << ", "
+                  << "released: " << rhs.released.toString("yyyy") << ")";
+    return lhs;
+}

--- a/globals/Globals.h
+++ b/globals/Globals.h
@@ -94,6 +94,8 @@ struct ScraperSearchResult {
     QDate released;
 };
 
+QDebug operator<<(QDebug lhs, const ScraperSearchResult& rhs);
+
 struct TrailerResult {
     QUrl preview;
     QString name;

--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -21,7 +21,6 @@
 #include "notifications/NotificationBox.h"
 #include "main/Update.h"
 #include "movies/MovieMultiScrapeDialog.h"
-#include "movies/MovieSearch.h"
 #include "notifications/Notificator.h"
 #include "sets/MovieListDialog.h"
 #include "settings/Settings.h"
@@ -152,7 +151,6 @@ MainWindow::MainWindow(QWidget *parent) :
 
     connect(Update::instance(this), SIGNAL(sigNewVersion(QString)), this, SLOT(onNewVersion(QString)));
 
-    MovieSearch::instance(this);
     TvShowSearch::instance(this);
     ImageDialog::instance(this);
     MovieListDialog::instance(this);

--- a/movies/MovieSearch.cpp
+++ b/movies/MovieSearch.cpp
@@ -1,6 +1,6 @@
 #include "MovieSearch.h"
 #include "ui_MovieSearch.h"
-
+#include "settings/Settings.h"
 #include <QDebug>
 
 /**
@@ -27,21 +27,9 @@ MovieSearch::MovieSearch(QWidget *parent) :
  */
 MovieSearch::~MovieSearch()
 {
-    delete ui;
-}
+    qDebug() << "Trace.";
 
-/**
- * @brief Returns an instance of the class
- * @param parent Parent widget
- * @return Instance of MovieSearch
- */
-MovieSearch* MovieSearch::instance(QWidget *parent)
-{
-    static MovieSearch *m_instance = 0;
-    if (m_instance == 0) {
-        m_instance = new MovieSearch(parent);
-    }
-    return m_instance;
+    delete ui;
 }
 
 /**
@@ -65,6 +53,22 @@ int MovieSearch::exec(QString searchString, QString id, QString tmdbId)
 int MovieSearch::exec()
 {
     return 0;
+}
+
+void MovieSearch::accept()
+{
+    qDebug() << "Trace.";
+
+    Settings::instance()->saveSettings();
+    QDialog::accept();
+}
+
+void MovieSearch::reject()
+{
+    qDebug() << "Trace.";
+
+    Settings::instance()->saveSettings();
+    QDialog::reject();
 }
 
 /*** GETTER ***/

--- a/movies/MovieSearch.h
+++ b/movies/MovieSearch.h
@@ -23,7 +23,13 @@ public:
 public slots:
     int exec();
     int exec(QString searchString, QString id, QString tmdbId);
-    static MovieSearch *instance(QWidget *parent = 0);
+
+    //! \brief Reimplemented from QDialog. Saves persitent user changes.
+    void accept();
+
+    //! \brief Reimplemented from QDialog. Saves persitent user changes.
+    void reject();
+
     QString scraperId();
     QString scraperMovieId();
     QList<int> infosToLoad();

--- a/movies/MovieSearchWidget.cpp
+++ b/movies/MovieSearchWidget.cpp
@@ -5,16 +5,6 @@
 #include "globals/Manager.h"
 #include "scrapers/CustomMovieScraper.h"
 
-
-QDebug operator<<(QDebug lhs, const ScraperSearchResult &rhs)
-{
-    lhs << QString("(\"%1\", \"%2\", %3)").arg(rhs.id)
-                                          .arg(rhs.name)
-                                          .arg(rhs.released.toString("yyyy"));
-    return lhs;
-}
-
-
 MovieSearchWidget::MovieSearchWidget(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::MovieSearchWidget)
@@ -151,7 +141,7 @@ void MovieSearchWidget::search()
 
 void MovieSearchWidget::showResults(QList<ScraperSearchResult> results)
 {
-    qDebug() << "results.count(): " << results.count() << ", results:" << results;
+    qDebug() << this << "results:" << results;
 
     ui->comboScraper->setEnabled(m_customScraperIds.isEmpty());
     ui->searchString->setLoading(false);

--- a/movies/MovieSearchWidget.cpp
+++ b/movies/MovieSearchWidget.cpp
@@ -1,20 +1,29 @@
 #include "MovieSearchWidget.h"
 #include "ui_MovieSearchWidget.h"
 
-#include <QDebug>
-#include "globals/Manager.h"
+#include "settings/Settings.h"
+#include "scrapers/AdultDvdEmpire.h"
+#include "scrapers/AEBN.h"
+#include "scrapers/Cinefacts.h"
 #include "scrapers/CustomMovieScraper.h"
+#include "scrapers/HotMovies.h"
+#include "scrapers/IMDB.h"
+#include "scrapers/MediaPassion.h"
+#include "scrapers/OFDb.h"
+#include "scrapers/TheTvDb.h"
+#include "scrapers/TMDb.h"
+#include "scrapers/VideoBuster.h"
+#include <QDebug>
 
 MovieSearchWidget::MovieSearchWidget(QWidget *parent) :
     QWidget(parent),
-    ui(new Ui::MovieSearchWidget)
+    ui(new Ui::MovieSearchWidget),
+    m_scrapers()
 {
     ui->setupUi(this);
     ui->results->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
     ui->searchString->setType(MyLineEdit::TypeLoading);
 
-    foreach (ScraperInterface *scraper, Manager::instance()->scrapers())
-        connect(scraper, SIGNAL(searchDone(QList<ScraperSearchResult>)), this, SLOT(showResults(QList<ScraperSearchResult>)));
     setupScrapers();
 
     connect(ui->comboScraper, SIGNAL(currentIndexChanged(int)), this, SLOT(onUpdateSearchString()), Qt::QueuedConnection);
@@ -68,9 +77,61 @@ void MovieSearchWidget::clear()
 
 void MovieSearchWidget::setupScrapers()
 {
+    qDebug() << "Trace.";
+
+    // Create our own scrapers, do not share signals with other widgets (as was the case with
+    // Manager, MovieSearchWidget and MakeMkv).
+    if (this->m_scrapers.isEmpty()) {
+        ScraperInterface *scraper = new TMDb(this);
+        Q_CHECK_PTR(scraper);
+        this->m_scrapers.insert(scraper->identifier(), scraper);
+
+        scraper = new IMDB(this);
+        Q_CHECK_PTR(scraper);
+        this->m_scrapers.insert(scraper->identifier(), scraper);
+
+        scraper = new MediaPassion(this);
+        Q_CHECK_PTR(scraper);
+        this->m_scrapers.insert(scraper->identifier(), scraper);
+
+        scraper = new Cinefacts(this);
+        Q_CHECK_PTR(scraper);
+        this->m_scrapers.insert(scraper->identifier(), scraper);
+
+        scraper = new OFDb(this);
+        Q_CHECK_PTR(scraper);
+        this->m_scrapers.insert(scraper->identifier(), scraper);
+
+        scraper = new VideoBuster(this);
+        Q_CHECK_PTR(scraper);
+        this->m_scrapers.insert(scraper->identifier(), scraper);
+
+        scraper = new AEBN(this);
+        Q_CHECK_PTR(scraper);
+        this->m_scrapers.insert(scraper->identifier(), scraper);
+
+        scraper = new HotMovies(this);
+        Q_CHECK_PTR(scraper);
+        this->m_scrapers.insert(scraper->identifier(), scraper);
+
+        scraper = new AdultDvdEmpire(this);
+        Q_CHECK_PTR(scraper);
+        this->m_scrapers.insert(scraper->identifier(), scraper);
+
+        scraper = new CustomMovieScraper(this);
+        Q_CHECK_PTR(scraper);
+        this->m_scrapers.insert(scraper->identifier(), scraper);
+
+        foreach (scraper, this->m_scrapers) {
+            // Connect scrapers to the default slot.
+            connect(scraper, SIGNAL(searchDone(QList<ScraperSearchResult>)),
+                    this, SLOT(showResults(QList<ScraperSearchResult>)));
+        }
+    }
+
     ui->comboScraper->blockSignals(true);
     ui->comboScraper->clear();
-    foreach (ScraperInterface *scraper, Manager::instance()->scrapers()) {
+    foreach (ScraperInterface *scraper, this->m_scrapers) {
         if (!Settings::instance()->showAdultScrapers() && scraper->isAdult())
             continue;
         if (scraper->isAdult())
@@ -93,12 +154,8 @@ void MovieSearchWidget::search(QString searchString, QString id, QString tmdbId)
     m_currentCustomScraper = 0;
     m_customScraperIds.clear();
 
-    int index = ui->comboScraper->currentIndex();
-    if (index < 0 || index >= Manager::instance()->scrapers().size()) {
-        return;
-    }
-    m_scraperId = ui->comboScraper->itemData(index, Qt::UserRole).toString();
-    ScraperInterface *scraper = Manager::instance()->scraper(m_scraperId);
+    m_scraperId = ui->comboScraper->currentData().toString();
+    ScraperInterface *scraper = this->m_scrapers.value(m_scraperId, 0);
     if (!scraper)
         return;
 
@@ -119,19 +176,16 @@ void MovieSearchWidget::search(QString searchString, QString id, QString tmdbId)
 void MovieSearchWidget::search()
 {
     qDebug() << "Entered";
-    int index = ui->comboScraper->currentIndex();
-    if (index < 0 || index >= Manager::instance()->scrapers().size()) {
-        return;
-    }
-    m_scraperId = ui->comboScraper->itemData(index, Qt::UserRole).toString();
-    ScraperInterface *scraper = Manager::instance()->scraper(m_scraperId);
+
+    m_scraperId = ui->comboScraper->currentData().toString();
+    ScraperInterface *scraper = this->m_scrapers.value(m_scraperId, 0);
     if (!scraper)
         return;
 
     if (m_scraperId == "custom-movie")
         m_currentCustomScraper = CustomMovieScraper::instance()->titleScraper();
 
-    setChkBoxesEnabled(Manager::instance()->scraper(m_scraperId)->scraperSupports());
+    setChkBoxesEnabled(scraper->scraperSupports());
     clear();
     ui->comboScraper->setEnabled(false);
     ui->searchString->setLoading(true);
@@ -203,7 +257,7 @@ void MovieSearchWidget::chkToggled()
     }
     ui->chkUnCheckAll->setChecked(allToggled);
 
-    QString scraperId = ui->comboScraper->itemData(ui->comboScraper->currentIndex(), Qt::UserRole).toString();
+    QString scraperId = ui->comboScraper->currentData().toString();
     Settings::instance()->setScraperInfos(WidgetMovies, scraperId, m_infosToLoad);
 }
 
@@ -233,7 +287,7 @@ QList<int> MovieSearchWidget::infosToLoad()
 
 void MovieSearchWidget::setChkBoxesEnabled(QList<int> scraperSupports)
 {
-    QString scraperId = ui->comboScraper->itemData(ui->comboScraper->currentIndex(), Qt::UserRole).toString();
+    QString scraperId = ui->comboScraper->currentData().toString();
     QList<int> infos = Settings::instance()->scraperInfos(WidgetMovies, scraperId);
 
     foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox*>()) {
@@ -250,12 +304,8 @@ QMap<ScraperInterface*, QString> MovieSearchWidget::customScraperIds()
 
 void MovieSearchWidget::onUpdateSearchString()
 {
-    int index = ui->comboScraper->currentIndex();
-    if (index < 0 || index >= Manager::instance()->scrapers().size()) {
-        return;
-    }
-    m_scraperId = ui->comboScraper->itemData(index, Qt::UserRole).toString();
-    ScraperInterface *scraper = Manager::instance()->scraper(m_scraperId);
+    m_scraperId = ui->comboScraper->currentData().toString();
+    ScraperInterface *scraper = this->m_scrapers.value(m_scraperId, 0);
     if (!scraper)
         return;
 

--- a/movies/MovieSearchWidget.h
+++ b/movies/MovieSearchWidget.h
@@ -39,6 +39,10 @@ private slots:
 
 private:
     Ui::MovieSearchWidget *ui;
+
+    //! \brief The movie scrapers.
+    QMap<QString, ScraperInterface *> m_scrapers;
+
     QString m_scraperId;
     QString m_scraperMovieId;
     QList<int> m_infosToLoad;

--- a/movies/MovieWidget.cpp
+++ b/movies/MovieWidget.cpp
@@ -419,24 +419,29 @@ void MovieWidget::startScraperSearch()
     }
     emit setActionSearchEnabled(false, WidgetMovies);
     emit setActionSaveEnabled(false, WidgetMovies);
-    MovieSearch::instance()->exec(m_movie->name(), m_movie->id(), m_movie->tmdbId());
-    if (MovieSearch::instance()->result() == QDialog::Accepted) {
+
+    MovieSearch *searchDlg = new MovieSearch(this);
+    Q_CHECK_PTR(searchDlg);
+    searchDlg->exec(m_movie->name(), m_movie->id(), m_movie->tmdbId());
+    if (searchDlg->result() == QDialog::Accepted) {
         setDisabledTrue();
         QMap<ScraperInterface*, QString> ids;
         QList<int> infosToLoad;
-        if (MovieSearch::instance()->scraperId() == "custom-movie") {
-            ids = MovieSearch::instance()->customScraperIds();
+        if (searchDlg->scraperId() == "custom-movie") {
+            ids = searchDlg->customScraperIds();
             infosToLoad = Settings::instance()->scraperInfos(WidgetMovies, "custom-movie");
         } else {
-            ids.insert(0, MovieSearch::instance()->scraperMovieId());
-            infosToLoad = MovieSearch::instance()->infosToLoad();
+            ids.insert(0, searchDlg->scraperMovieId());
+            infosToLoad = searchDlg->infosToLoad();
         }
-        m_movie->controller()->loadData(ids, Manager::instance()->scraper(MovieSearch::instance()->scraperId()),
+        m_movie->controller()->loadData(ids, Manager::instance()->scraper(searchDlg->scraperId()),
                                         infosToLoad);
     } else {
         emit setActionSearchEnabled(true, WidgetMovies);
         emit setActionSaveEnabled(true, WidgetMovies);
     }
+
+    searchDlg->deleteLater();
 }
 
 void MovieWidget::onInfoLoadDone(Movie *movie)

--- a/scrapers/TMDb.cpp
+++ b/scrapers/TMDb.cpp
@@ -330,6 +330,7 @@ void TMDb::searchFinished()
     reply->deleteLater();
 
     if (nextPage == -1) {
+        qDebug() << "receiver count:" << this->receivers(SIGNAL(searchDone(QList<ScraperSearchResult>)));
         emit searchDone(results);
     } else {
         QUrl url(QString("http://api.themoviedb.org/3/search/movie?api_key=%1&language=%2&page=%3&query=%4").arg(TMDb::apiKey()).arg(m_language).arg(nextPage).arg(searchString));


### PR DESCRIPTION
*Problem*
Scrapers are Singeltons. MovieSearch and MakeMkvDialog are also Singeltons. MovieSearchWidget has two instances (MovieSearch and MakeMkvDialog) that are both connected to the same scraper signal (searchDone).

*Effect*
MovieSearchWidget::showResults is called for each instance of MovieSearchWidget. See debug output of commit bc8f6472e8c3cc46ab2b5e3c49b3e6ffd8b414a for a demonstration with MovieSearch and TMDB scraper.

*Possible fix*
MovieSearchWidget creates its own scraper instances. See commit f62667d6131666c682bd4dfc9bbca8bad6a0e5dd.

*Problem with Fix I*
Stray scraper settings widget combobox.

*Reason*
MovieSearch is a Singleton. MainWindow instance is not yet initialized at MovieSearch instanciation time.

*Possible fix*
No MovieSearch Singelton. See commit e08feb4fc7135cbbbde190699daf2927df9372e5.

*Not resolved*
Scraper settings are not loaded. Should be easy to add.