### PR TITLE
Change MediaPassion URL

### DIFF
--- a/scrapers/MediaPassion.cpp
+++ b/scrapers/MediaPassion.cpp
@@ -17,7 +17,7 @@ MediaPassion::MediaPassion(QObject *parent)
 {
     setParent(parent);
 
-    m_baseUrl = "http://passion-xbmc.org/scraper/API/1";
+    m_baseUrl = "http://kodi-passion.fr/scraper/API/1";
 
     m_widget = new QWidget(MainWindow::instance());
 


### PR DESCRIPTION
Media Passion scraper has changed its API URL. There's a 301 redirect on old url, but QNetworkAccessManager doesn't follow it.

Thanks.