### PR TITLE
do not require zen and mediainfo for building on mac

### DIFF
--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -8,7 +8,7 @@ include(quazip/quazip/quazip.pri)
 
 QT       += core gui network script xml sql widgets multimedia multimediawidgets concurrent qml quick quickwidgets opengl
 
-LIBS += -lzen -lz -lmediainfo
+LIBS += -lz
 
 contains(DEFINES, PLUGINS){
     LIBS += -lqca


### PR DESCRIPTION
These are not necessary; I can build without them.