### PR TITLE
Fix some cppcheck errors; use nullptr

### DIFF
--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -8,6 +8,8 @@ include(quazip/quazip/quazip.pri)
 
 QT       += core gui network script xml sql widgets multimedia multimediawidgets concurrent qml quick quickwidgets opengl
 
+CONFIG += c++14
+
 LIBS += -lz
 
 contains(DEFINES, PLUGINS){

--- a/concerts/ConcertController.h
+++ b/concerts/ConcertController.h
@@ -17,7 +17,7 @@ class ConcertController : public QObject
 {
     Q_OBJECT
 public:
-    explicit ConcertController(Concert *parent = 0);
+    explicit ConcertController(Concert *parent = nullptr);
 
     bool saveData(MediaCenterInterface *mediaCenterInterface);
     bool loadData(MediaCenterInterface *mediaCenterInterface, bool force = false, bool reloadFromNfo = true);

--- a/concerts/ConcertFilesWidget.h
+++ b/concerts/ConcertFilesWidget.h
@@ -24,7 +24,7 @@ class ConcertFilesWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit ConcertFilesWidget(QWidget *parent = 0);
+    explicit ConcertFilesWidget(QWidget *parent = nullptr);
     ~ConcertFilesWidget();
     static ConcertFilesWidget *instance();
     QList<Concert*> selectedConcerts();

--- a/concerts/ConcertSearch.h
+++ b/concerts/ConcertSearch.h
@@ -16,13 +16,13 @@ class ConcertSearch : public QDialog
 {
     Q_OBJECT
 public:
-    explicit ConcertSearch(QWidget *parent = 0);
+    explicit ConcertSearch(QWidget *parent = nullptr);
     ~ConcertSearch();
 
 public slots:
     int exec();
     int exec(QString searchString);
-    static ConcertSearch *instance(QWidget *parent = 0);
+    static ConcertSearch *instance(QWidget *parent = nullptr);
     int scraperNo();
     QString scraperId();
     QList<int> infosToLoad();

--- a/concerts/ConcertSearchWidget.h
+++ b/concerts/ConcertSearchWidget.h
@@ -15,7 +15,7 @@ class ConcertSearchWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit ConcertSearchWidget(QWidget *parent = 0);
+    explicit ConcertSearchWidget(QWidget *parent = nullptr);
     ~ConcertSearchWidget();
 
 public slots:

--- a/concerts/ConcertWidget.h
+++ b/concerts/ConcertWidget.h
@@ -24,7 +24,7 @@ class ConcertWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit ConcertWidget(QWidget *parent = 0);
+    explicit ConcertWidget(QWidget *parent = nullptr);
     ~ConcertWidget();
 
 public slots:
@@ -33,7 +33,7 @@ public slots:
     void onStartScraperSearch();
     void onSaveInformation();
     void onSaveAll();
-    void setEnabledTrue(Concert *concert = 0);
+    void setEnabledTrue(Concert *concert = nullptr);
     void setDisabledTrue();
     void setBigWindow(bool bigWindow);
     void updateConcertInfo();

--- a/data/Concert.h
+++ b/data/Concert.h
@@ -47,7 +47,7 @@ class Concert : public QObject
     Q_PROPERTY(QString tmdbId READ tmdbId WRITE setTmdbId)
 
 public:
-    explicit Concert(QStringList files, QObject *parent = 0);
+    explicit Concert(QStringList files, QObject *parent = nullptr);
     ~Concert();
 
     ConcertController *controller();

--- a/data/ConcertFileSearcher.cpp
+++ b/data/ConcertFileSearcher.cpp
@@ -13,7 +13,8 @@
  */
 ConcertFileSearcher::ConcertFileSearcher(QObject *parent) :
     QObject(parent),
-    m_progressMessageId{Constants::ConcertFileSearcherProgressMessageId}
+    m_progressMessageId{Constants::ConcertFileSearcherProgressMessageId},
+    m_aborted{false}
 {
 }
 

--- a/data/ConcertFileSearcher.h
+++ b/data/ConcertFileSearcher.h
@@ -14,7 +14,7 @@ class ConcertFileSearcher : public QObject
 {
     Q_OBJECT
 public:
-    explicit ConcertFileSearcher(QObject *parent = 0);
+    explicit ConcertFileSearcher(QObject *parent = nullptr);
     void setConcertDirectories(QList<SettingsDir> directories);
 
 public slots:

--- a/data/ConcertModel.h
+++ b/data/ConcertModel.h
@@ -16,7 +16,7 @@ public:
          NameRole = Qt::UserRole + 1,
          FileNameRole
     };
-    explicit ConcertModel(QObject *parent = 0);
+    explicit ConcertModel(QObject *parent = nullptr);
     void addConcert(Concert *concert);
     void clear();
     QList<Concert*> concerts();

--- a/data/ConcertProxyModel.h
+++ b/data/ConcertProxyModel.h
@@ -11,7 +11,7 @@ class ConcertProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
 public:
-    explicit ConcertProxyModel(QObject *parent = 0);
+    explicit ConcertProxyModel(QObject *parent = nullptr);
     void setFilter(QList<Filter*> filters, QString text);
 
 protected:

--- a/data/Database.h
+++ b/data/Database.h
@@ -14,7 +14,7 @@ class Database : public QObject
 {
     Q_OBJECT
 public:
-    explicit Database(QObject *parent = 0);
+    explicit Database(QObject *parent = nullptr);
     ~Database();
     QSqlDatabase db();
     void transaction();

--- a/data/ImageCache.h
+++ b/data/ImageCache.h
@@ -9,8 +9,8 @@ class ImageCache : public QObject
 {
     Q_OBJECT
 public:
-    explicit ImageCache(QObject *parent = 0);
-    static ImageCache *instance(QObject *parent = 0);
+    explicit ImageCache(QObject *parent = nullptr);
+    static ImageCache *instance(QObject *parent = nullptr);
     QImage image(QString path, int width, int height, int &origWidth, int &origHeight);
     QSize imageSize(QString path);
     void invalidateImages(QString path);

--- a/data/MovieFileSearcher.cpp
+++ b/data/MovieFileSearcher.cpp
@@ -19,7 +19,8 @@
  */
 MovieFileSearcher::MovieFileSearcher(QObject *parent) :
     QObject(parent),
-    m_progressMessageId{Constants::MovieFileSearcherProgressMessageId}
+    m_progressMessageId{Constants::MovieFileSearcherProgressMessageId},
+    m_aborted{false}
 {
 }
 

--- a/data/MovieFileSearcher.h
+++ b/data/MovieFileSearcher.h
@@ -15,7 +15,7 @@ class MovieFileSearcher : public QObject
 {
     Q_OBJECT
 public:
-    explicit MovieFileSearcher(QObject *parent = 0);
+    explicit MovieFileSearcher(QObject *parent = nullptr);
     ~MovieFileSearcher();
 
     void setMovieDirectories(QList<SettingsDir> directories);

--- a/data/MovieFilesOrganizer.h
+++ b/data/MovieFilesOrganizer.h
@@ -14,7 +14,7 @@ class MovieFilesOrganizer : public QThread
 {
     Q_OBJECT
 public:
-    explicit MovieFilesOrganizer(QObject *parent = 0);
+    explicit MovieFilesOrganizer(QObject *parent = nullptr);
     ~MovieFilesOrganizer();
     void canceled(QString msg);
     void moveToDirs(QString dir);

--- a/data/MovieModel.h
+++ b/data/MovieModel.h
@@ -16,7 +16,7 @@ public:
          NameRole = Qt::UserRole + 1,
          FileNameRole
     };
-    explicit MovieModel(QObject *parent = 0);
+    explicit MovieModel(QObject *parent = nullptr);
     void addMovie(Movie *movie);
     void clear();
     virtual QList<Movie*> movies();

--- a/data/MovieProxyModel.h
+++ b/data/MovieProxyModel.h
@@ -11,7 +11,7 @@ class MovieProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
 public:
-    explicit MovieProxyModel(QObject *parent = 0);
+    explicit MovieProxyModel(QObject *parent = nullptr);
     void setFilter(QList<Filter*> filters, QString text);
     void setSortBy(SortBy sortBy);
 protected:

--- a/data/StreamDetails.cpp
+++ b/data/StreamDetails.cpp
@@ -110,9 +110,6 @@ void StreamDetails::loadWithLibrary()
     MI.Open(QString2MI(fileName));
 
     int duration = 0;
-    double aspectRatio;
-    int width = 0;
-    int height = 0;
     QString scanType;
     QString videoCodec;
 
@@ -137,9 +134,9 @@ void StreamDetails::loadWithLibrary()
     setVideoDetail("durationinseconds", QString("%1").arg(duration));
 
     if (videoCount > 0) {
-        aspectRatio = MI2QString(MI.Get(Stream_Video, 0, QString2MI("DisplayAspectRatio"))).toDouble();
-        width = MI2QString(MI.Get(Stream_Video, 0, QString2MI("Width"))).toInt();
-        height = MI2QString(MI.Get(Stream_Video, 0, QString2MI("Height"))).toInt();
+        double aspectRatio = MI2QString(MI.Get(Stream_Video, 0, QString2MI("DisplayAspectRatio"))).toDouble();
+        int width = MI2QString(MI.Get(Stream_Video, 0, QString2MI("Width"))).toInt();
+        int height = MI2QString(MI.Get(Stream_Video, 0, QString2MI("Height"))).toInt();
         scanType = MI2QString(MI.Get(Stream_Video, 0, QString2MI("ScanType")));
 
         QString codec = MI2QString(MI.Get(Stream_Video, 0, QString2MI("CodecID/Hint")));

--- a/data/Subtitle.h
+++ b/data/Subtitle.h
@@ -8,7 +8,7 @@ class Subtitle : public QObject
 {
     Q_OBJECT
 public:
-    explicit Subtitle(QObject *parent = 0);
+    explicit Subtitle(QObject *parent = nullptr);
 
     QString language() const;
     void setLanguage(const QString &language);

--- a/data/TvShow.h
+++ b/data/TvShow.h
@@ -24,7 +24,7 @@ class TvShow : public QObject
     Q_OBJECT
 
 public:
-    explicit TvShow(QString dir = QString(), QObject *parent = 0);
+    explicit TvShow(QString dir = QString(), QObject *parent = nullptr);
     void clear();
     void clear(QList<int> infos);
     void addEpisode(TvShowEpisode *episode);

--- a/data/TvShowEpisode.h
+++ b/data/TvShowEpisode.h
@@ -38,7 +38,7 @@ class TvShowEpisode : public QObject
     Q_PROPERTY(QString network READ network WRITE setNetwork)
 
 public:
-    explicit TvShowEpisode(QStringList files = QStringList(), TvShow *parent = 0);
+    explicit TvShowEpisode(QStringList files = QStringList(), TvShow *parent = nullptr);
     void clear();
     void clear(QList<int> infos);
 

--- a/data/TvShowFileSearcher.cpp
+++ b/data/TvShowFileSearcher.cpp
@@ -18,7 +18,8 @@
  */
 TvShowFileSearcher::TvShowFileSearcher(QObject *parent) :
     QObject(parent),
-    m_progressMessageId{Constants::TvShowSearcherProgressMessageId}
+    m_progressMessageId{Constants::TvShowSearcherProgressMessageId},
+    m_aborted{false}
 {
 }
 

--- a/data/TvShowFileSearcher.h
+++ b/data/TvShowFileSearcher.h
@@ -13,7 +13,7 @@ class TvShowFileSearcher : public QObject
 {
     Q_OBJECT
 public:
-    explicit TvShowFileSearcher(QObject *parent = 0);
+    explicit TvShowFileSearcher(QObject *parent = nullptr);
     void setMovieDirectories(QList<SettingsDir> directories);
     static int getSeasonNumber(QStringList files);
     static QList<int> getEpisodeNumbers(QStringList files);

--- a/data/TvShowModel.cpp
+++ b/data/TvShowModel.cpp
@@ -273,10 +273,9 @@ QModelIndex TvShowModel::parent(const QModelIndex &index) const
 bool TvShowModel::removeRows(int position, int rows, const QModelIndex &parent)
 {
     TvShowModelItem *parentItem = getItem(parent);
-    bool success = true;
 
     beginRemoveRows(parent, position, position + rows - 1);
-    success = parentItem->removeChildren(position, rows);
+    bool success = parentItem->removeChildren(position, rows);
     endRemoveRows();
 
     return success;

--- a/data/TvShowModel.h
+++ b/data/TvShowModel.h
@@ -18,7 +18,7 @@ class TvShowModel : public QAbstractItemModel
     Q_OBJECT
 
 public:
-    TvShowModel(QObject *parent = 0);
+    explicit TvShowModel(QObject *parent = nullptr);
     ~TvShowModel();
 
     QVariant data(const QModelIndex &index, int role) const;

--- a/data/TvShowModelItem.cpp
+++ b/data/TvShowModelItem.cpp
@@ -13,7 +13,8 @@ TvShowModelItem::TvShowModelItem(TvShowModelItem *parent) :
     QObject(0),
     m_parentItem{parent},
     m_tvShow{0},
-    m_tvShowEpisode{0}
+    m_tvShowEpisode{0},
+    m_seasonNumber{0}
 {
 }
 

--- a/data/TvShowModelItem.h
+++ b/data/TvShowModelItem.h
@@ -18,7 +18,7 @@ class TvShowModelItem : public QObject
 {
     Q_OBJECT
 public:
-    explicit TvShowModelItem(TvShowModelItem *parent = 0);
+    explicit TvShowModelItem(TvShowModelItem *parent = nullptr);
     ~TvShowModelItem();
 
     TvShowModelItem *child(int number);

--- a/data/TvShowProxyModel.h
+++ b/data/TvShowProxyModel.h
@@ -11,7 +11,7 @@ class TvShowProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
 public:
-    explicit TvShowProxyModel(QObject *parent = 0);
+    explicit TvShowProxyModel(QObject *parent = nullptr);
     void setFilter(QList<Filter*> filters, QString text);
 
 protected:

--- a/downloads/DownloadsWidget.h
+++ b/downloads/DownloadsWidget.h
@@ -31,7 +31,7 @@ class DownloadsWidget : public QWidget
     };
 
 public:
-    explicit DownloadsWidget(QWidget *parent = 0);
+    explicit DownloadsWidget(QWidget *parent = nullptr);
     ~DownloadsWidget();
     void updatePackagesList(QMap<QString, Package> packages);
     void updateImportsList(QMap<QString, Import> imports);
@@ -50,8 +50,8 @@ private slots:
     void onExtractorError(QString baseName, QString msg);
     void onExtractorFinished(QString baseName, bool success);
     void onExtractorProgress(QString baseName, int progress);
-    void onChangeImportType(int currentIndex, QComboBox *sender = 0);
-    void onChangeImportDetail(int currentIndex, QComboBox *sender = 0);
+    void onChangeImportType(int currentIndex, QComboBox *sender = nullptr);
+    void onChangeImportDetail(int currentIndex, QComboBox *sender = nullptr);
     void onImportWithMakeMkv();
 
 private:

--- a/downloads/Extractor.h
+++ b/downloads/Extractor.h
@@ -10,7 +10,7 @@ class Extractor : public QObject
 {
     Q_OBJECT
 public:
-    explicit Extractor(QObject *parent = 0);
+    explicit Extractor(QObject *parent = nullptr);
     ~Extractor();
 
 public slots:

--- a/downloads/FileWorker.h
+++ b/downloads/FileWorker.h
@@ -9,7 +9,7 @@ class FileWorker : public QObject
 {
     Q_OBJECT
 public:
-    explicit FileWorker(QObject *parent = 0);
+    explicit FileWorker(QObject *parent = nullptr);
     void setFiles(QMap<QString, QString> files);
     QMap<QString, QString> files();
 

--- a/downloads/ImportActions.h
+++ b/downloads/ImportActions.h
@@ -15,7 +15,7 @@ class ImportActions : public QWidget
     Q_OBJECT
 
 public:
-    explicit ImportActions(QWidget *parent = 0);
+    explicit ImportActions(QWidget *parent = nullptr);
     ~ImportActions();
     void setButtonEnabled(bool enabled);
     void setBaseName(QString baseName);

--- a/downloads/ImportDialog.h
+++ b/downloads/ImportDialog.h
@@ -24,7 +24,7 @@ class ImportDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit ImportDialog(QWidget *parent = 0);
+    explicit ImportDialog(QWidget *parent = nullptr);
     ~ImportDialog();
     void setFiles(QStringList files);
     QStringList files();

--- a/downloads/MakeMkvCon.h
+++ b/downloads/MakeMkvCon.h
@@ -9,7 +9,7 @@ class MakeMkvCon : public QObject
 {
     Q_OBJECT
 public:
-    explicit MakeMkvCon(QObject *parent = 0);
+    explicit MakeMkvCon(QObject *parent = nullptr);
     ~MakeMkvCon();
 
     struct Track {

--- a/downloads/MakeMkvDialog.h
+++ b/downloads/MakeMkvDialog.h
@@ -15,7 +15,7 @@ class MakeMkvDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit MakeMkvDialog(QWidget *parent = 0);
+    explicit MakeMkvDialog(QWidget *parent = nullptr);
     ~MakeMkvDialog();
 
 public slots:

--- a/downloads/MyFile.h
+++ b/downloads/MyFile.h
@@ -7,7 +7,7 @@ class MyFile : public QFile
 {
     Q_OBJECT
 public:
-    MyFile(const QString &name);
+    explicit MyFile(const QString &name);
     bool copy(const QString &newName);
 };
 

--- a/downloads/UnpackButtons.h
+++ b/downloads/UnpackButtons.h
@@ -12,7 +12,7 @@ class UnpackButtons : public QWidget
     Q_OBJECT
 
 public:
-    explicit UnpackButtons(QWidget *parent = 0);
+    explicit UnpackButtons(QWidget *parent = nullptr);
     ~UnpackButtons();
     void setBaseName(QString baseName);
     QString baseName() const;

--- a/export/ExportDialog.h
+++ b/export/ExportDialog.h
@@ -18,7 +18,7 @@ class ExportDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit ExportDialog(QWidget *parent = 0);
+    explicit ExportDialog(QWidget *parent = nullptr);
     ~ExportDialog();
 
 public slots:
@@ -37,7 +37,7 @@ private:
     void parseAndSaveConcerts(QDir dir, ExportTemplate *exportTemplate, QList<Concert*> concerts);
     void parseAndSaveTvShows(QDir dir, ExportTemplate *exportTemplate, QList<TvShow*> shows);
     void saveImage(QSize size, QString imageFile, QString destinationFile, const char *format, int quality);
-    void replaceImages(QString &m, const QDir &dir, const bool &subDir, Movie *movie = 0, Concert *concert = 0, TvShow *tvShow = 0, TvShowEpisode *episode = 0);
+    void replaceImages(QString &m, const QDir &dir, const bool &subDir, Movie *movie = 0, Concert *concert = 0, TvShow *tvShow = 0, TvShowEpisode *episode = nullptr);
     bool saveImageForType(const QString &type, const QSize &size, const QDir &dir, QString &destFile, Movie *movie);
     bool saveImageForType(const QString &type, const QSize &size, const QDir &dir, QString &destFile, Concert *concert);
     bool saveImageForType(const QString &type, const QSize &size, const QDir &dir, QString &destFile, TvShow *tvShow);

--- a/export/ExportTemplate.h
+++ b/export/ExportTemplate.h
@@ -16,7 +16,7 @@ public:
         SectionConcert, SectionTvShow, SectionEpisode
     };
 
-    explicit ExportTemplate(QObject *parent = 0);
+    explicit ExportTemplate(QObject *parent = nullptr);
     bool isRemote() const;
     bool isInstalled() const;
     bool updateAvailable() const;

--- a/export/ExportTemplateLoader.h
+++ b/export/ExportTemplateLoader.h
@@ -13,8 +13,8 @@ class ExportTemplateLoader : public QObject
 {
     Q_OBJECT
 public:
-    explicit ExportTemplateLoader(QObject *parent = 0);
-    static ExportTemplateLoader *instance(QObject *parent = 0);
+    explicit ExportTemplateLoader(QObject *parent = nullptr);
+    static ExportTemplateLoader *instance(QObject *parent = nullptr);
     QList<ExportTemplate*> installedTemplates();
     ExportTemplate *getTemplateByIdentifier(QString identifier);
 

--- a/globals/DownloadManager.h
+++ b/globals/DownloadManager.h
@@ -22,7 +22,7 @@ class DownloadManager : public QObject
 {
     Q_OBJECT
 public:
-    explicit DownloadManager(QObject *parent = 0);
+    explicit DownloadManager(QObject *parent = nullptr);
     void addDownload(DownloadManagerElement elem);
     void setDownloads(QList<DownloadManagerElement> elements);
     void abortDownloads();

--- a/globals/DownloadManagerElement.cpp
+++ b/globals/DownloadManagerElement.cpp
@@ -1,10 +1,5 @@
 #include "DownloadManagerElement.h"
 
-DownloadManagerElement::DownloadManagerElement():
-    episode{0},
-    movie{0},
-    show{0},
-    concert{0},
-    directDownload{false}
+DownloadManagerElement::DownloadManagerElement()
 {
 }

--- a/globals/DownloadManagerElement.h
+++ b/globals/DownloadManagerElement.h
@@ -17,20 +17,20 @@ class DownloadManagerElement
 {
 public:
     DownloadManagerElement();
-    int imageType;
+    int imageType{0};
     QUrl url;
     QByteArray data;
-    qint64 bytesReceived;
-    qint64 bytesTotal;
-    Actor *actor;
-    TvShowEpisode *episode;
-    Movie *movie;
-    TvShow *show;
-    Concert *concert;
-    Album *album;
-    Artist *artist;
-    int season;
-    bool directDownload;
+    qint64 bytesReceived{0};
+    qint64 bytesTotal{0};
+    Actor *actor{nullptr};
+    TvShowEpisode *episode{nullptr};
+    Movie *movie{nullptr};
+    TvShow *show{nullptr};
+    Concert *concert{nullptr};
+    Album *album{nullptr};
+    Artist *artist{nullptr};
+    int season{0};
+    bool directDownload{false};
 };
 
 #endif // DOWNLOADMANAGERELEMENT_H

--- a/globals/Globals.h
+++ b/globals/Globals.h
@@ -93,7 +93,7 @@ struct Actor {
     QString role;
     QString thumb;
     QByteArray image;
-    bool imageHasChanged;
+    bool imageHasChanged{false};
     QString id;
 };
 Q_DECLARE_METATYPE(Actor*)
@@ -135,7 +135,7 @@ struct Poster {
     QSize originalSize;
     QString language;
     QString hint;
-    int season;
+    int season{0};
 };
 
 enum TvShowType {

--- a/globals/Helper.cpp
+++ b/globals/Helper.cpp
@@ -332,7 +332,7 @@ void Helper::removeFocusRect(QWidget *widget)
         dateTimeEdit->setAttribute(Qt::WA_MacShowFocusRect, false);
 }
 
-void Helper::applyStyle(QWidget *widget, bool removeFocusRect, bool isTable)
+void Helper::applyStyle(QWidget *widget, bool removeFocusRect, bool /*isTable*/)
 {
     if (removeFocusRect)
         Helper::instance()->removeFocusRect(widget);

--- a/globals/Helper.h
+++ b/globals/Helper.h
@@ -18,8 +18,8 @@ public:
         ButtonPrimary, ButtonInfo, ButtonDanger, ButtonSuccess, ButtonWarning
     };
 
-    Helper(QObject *parent = 0);
-    static Helper *instance(QObject *parent = 0);
+    explicit Helper(QObject *parent = nullptr);
+    static Helper *instance(QObject *parent = nullptr);
     virtual QString toLatin1PercentEncoding(QString str);
     virtual QString urlDecode(QString str);
     virtual QString urlEncode(QString str);

--- a/globals/ImageDialog.cpp
+++ b/globals/ImageDialog.cpp
@@ -112,9 +112,10 @@ int ImageDialog::exec(int type)
     QSize savedSize = Settings::instance()->settings()->value("ImageDialog/Size").toSize();
     QPoint savedPos = Settings::instance()->settings()->value("ImageDialog/Pos").toPoint();
 
-    bool isMac = false;
 #ifdef Q_OS_MAC
-    isMac = true;
+    bool isMac = true;
+#else
+    bool isMac = false;
 #endif
 
     if (savedSize.isValid() && !savedSize.isNull() && !isMac) {

--- a/globals/ImageDialog.h
+++ b/globals/ImageDialog.h
@@ -33,9 +33,9 @@ class ImageDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit ImageDialog(QWidget *parent = 0);
+    explicit ImageDialog(QWidget *parent = nullptr);
     ~ImageDialog();
-    static ImageDialog *instance(QWidget *parent = 0);
+    static ImageDialog *instance(QWidget *parent = nullptr);
     void setDownloads(QList<Poster> downloads, bool initial = true);
     QUrl imageUrl();
     QList<QUrl> imageUrls();

--- a/globals/ImagePreviewDialog.h
+++ b/globals/ImagePreviewDialog.h
@@ -15,9 +15,9 @@ class ImagePreviewDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit ImagePreviewDialog(QWidget *parent = 0);
+    explicit ImagePreviewDialog(QWidget *parent = nullptr);
     ~ImagePreviewDialog();
-    static ImagePreviewDialog *instance(QWidget *parent = 0);
+    static ImagePreviewDialog *instance(QWidget *parent = nullptr);
     void setImage(QPixmap img);
 
 public slots:

--- a/globals/Manager.h
+++ b/globals/Manager.h
@@ -35,7 +35,7 @@ class Manager : public QObject
 {
     Q_OBJECT
 public:
-    explicit Manager(QObject *parent = 0);
+    explicit Manager(QObject *parent = nullptr);
     ~Manager();
 
     static Manager *instance();

--- a/globals/NameFormatter.cpp
+++ b/globals/NameFormatter.cpp
@@ -33,13 +33,11 @@ NameFormatter *NameFormatter::instance(QObject *parent)
  */
 QString NameFormatter::excludeWords(QString name)
 {
-    int pos;
     QRegExp rx;
     rx.setCaseSensitivity(Qt::CaseInsensitive);
     foreach (const QString &word, m_exWords) {
-        pos = 0;
         rx.setPattern("(^|[\\(\\s\\-\\.\\[]+)" + word + "([\\s\\-\\.\\)\\],]+|$)");
-        pos = rx.indexIn(name);
+        int pos = rx.indexIn(name);
         while (pos >= 0) {
             name = name.remove(pos, rx.cap(0).length());
             name = name.insert(pos, ' ');

--- a/globals/NameFormatter.h
+++ b/globals/NameFormatter.h
@@ -11,8 +11,8 @@ class NameFormatter : public QObject
 {
     Q_OBJECT
 public:
-    explicit NameFormatter(QObject *parent = 0);
-    static NameFormatter *instance(QObject *parent = 0);
+    explicit NameFormatter(QObject *parent = nullptr);
+    static NameFormatter *instance(QObject *parent = nullptr);
 
     QString excludeWords(QString name);
     QString formatName(QString name, bool replaceDots = true, bool replaceUnderscores = true);

--- a/globals/NetworkReplyWatcher.h
+++ b/globals/NetworkReplyWatcher.h
@@ -9,7 +9,7 @@ class NetworkReplyWatcher : public QObject
 {
     Q_OBJECT
 public:
-    explicit NetworkReplyWatcher(QObject *parent = 0, QNetworkReply *reply = 0);
+    explicit NetworkReplyWatcher(QObject *parent = 0, QNetworkReply *reply = nullptr);
     ~NetworkReplyWatcher();
     void setReply(QNetworkReply *reply);
 

--- a/globals/TrailerDialog.h
+++ b/globals/TrailerDialog.h
@@ -20,9 +20,9 @@ class TrailerDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit TrailerDialog(QWidget *parent = 0);
+    explicit TrailerDialog(QWidget *parent = nullptr);
     ~TrailerDialog();
-    static TrailerDialog *instance(QWidget *parent = 0);
+    static TrailerDialog *instance(QWidget *parent = nullptr);
 
 public slots:
     int exec();

--- a/image/Image.h
+++ b/image/Image.h
@@ -12,7 +12,7 @@ class Image : public QObject
     Q_PROPERTY(int imageId READ imageId CONSTANT)
 
 public:
-    explicit Image(QObject *parent = 0);
+    explicit Image(QObject *parent = nullptr);
 
     QString fileName() const;
     void setFileName(const QString &fileName);

--- a/image/ImageCapture.cpp
+++ b/image/ImageCapture.cpp
@@ -21,11 +21,12 @@ bool ImageCapture::captureImage(QString file, StreamDetails *streamDetails, QIma
         return false;
     }
 
-    QString ffmpegbin = "ffmpeg";
 #ifdef Q_OS_OSX
-    ffmpegbin = QCoreApplication::applicationDirPath() + "/ffmpeg";
+    QString ffmpegbin = QCoreApplication::applicationDirPath() + "/ffmpeg";
 #elif defined(Q_OS_WIN)
-    ffmpegbin = QCoreApplication::applicationDirPath() + "/vendor/ffmpeg.exe";
+    QString ffmpegbin = QCoreApplication::applicationDirPath() + "/vendor/ffmpeg.exe";
+#else
+    QString ffmpegbin = "ffmpeg";
 #endif
 
     QProcess ffmpeg;

--- a/image/ImageCapture.h
+++ b/image/ImageCapture.h
@@ -8,7 +8,7 @@ class ImageCapture : public QObject
 {
     Q_OBJECT
 public:
-    explicit ImageCapture(QObject *parent = 0);
+    explicit ImageCapture(QObject *parent = nullptr);
     static bool captureImage(QString file, StreamDetails *streamDetails, QImage &img);
 };
 

--- a/image/ImageModel.cpp
+++ b/image/ImageModel.cpp
@@ -61,7 +61,6 @@ QVariant ImageModel::data(const QModelIndex &index, int role) const
     {
         img->load();
         return img->rawData();
-        break;
     }
     case Qt::UserRole+5:
         return m_images.indexOf(img);

--- a/image/ImageModel.h
+++ b/image/ImageModel.h
@@ -11,7 +11,7 @@ class ImageModel : public QAbstractListModel
     Q_OBJECT
 
 public:
-    explicit ImageModel(QObject *parent = 0);
+    explicit ImageModel(QObject *parent = nullptr);
     ~ImageModel();
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
     QVariant data(const QModelIndex &index, int role) const;

--- a/image/ImageProxyModel.h
+++ b/image/ImageProxyModel.h
@@ -8,7 +8,7 @@ class ImageProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
 public:
-    explicit ImageProxyModel(QObject *parent = 0);
+    explicit ImageProxyModel(QObject *parent = nullptr);
     bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
 };
 

--- a/image/ImageWidget.h
+++ b/image/ImageWidget.h
@@ -15,7 +15,7 @@ class ImageWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit ImageWidget(QWidget *parent = 0);
+    explicit ImageWidget(QWidget *parent = nullptr);
     ~ImageWidget();
     void setAlbum(Album *album);
 

--- a/imageProviders/FanartTv.h
+++ b/imageProviders/FanartTv.h
@@ -17,7 +17,7 @@ class FanartTv : public ImageProviderInterface
 {
     Q_OBJECT
 public:
-    explicit FanartTv(QObject *parent = 0);
+    explicit FanartTv(QObject *parent = nullptr);
     QString name();
     QUrl siteUrl();
     QString identifier();

--- a/imageProviders/FanartTvMusic.h
+++ b/imageProviders/FanartTvMusic.h
@@ -13,7 +13,7 @@ class FanartTvMusic : public ImageProviderInterface
 {
     Q_OBJECT
 public:
-    explicit FanartTvMusic(QObject *parent = 0);
+    explicit FanartTvMusic(QObject *parent = nullptr);
     QString name();
     QUrl siteUrl();
     QString identifier();

--- a/imageProviders/FanartTvMusicArtists.h
+++ b/imageProviders/FanartTvMusicArtists.h
@@ -16,7 +16,7 @@ class FanartTvMusicArtists : public ImageProviderInterface
 {
     Q_OBJECT
 public:
-    explicit FanartTvMusicArtists(QObject *parent = 0);
+    explicit FanartTvMusicArtists(QObject *parent = nullptr);
     QString name();
     QUrl siteUrl();
     QString identifier();

--- a/imageProviders/MediaPassionImages.h
+++ b/imageProviders/MediaPassionImages.h
@@ -9,7 +9,7 @@ class MediaPassionImages : public ImageProviderInterface
 {
     Q_OBJECT
 public:
-    explicit MediaPassionImages(QObject *parent = 0);
+    explicit MediaPassionImages(QObject *parent = nullptr);
     QString name();
     QUrl siteUrl();
     QString identifier();

--- a/imageProviders/TMDbImages.h
+++ b/imageProviders/TMDbImages.h
@@ -12,7 +12,7 @@ class TMDbImages : public ImageProviderInterface
 {
     Q_OBJECT
 public:
-    explicit TMDbImages(QObject *parent = 0);
+    explicit TMDbImages(QObject *parent = nullptr);
     QString name();
     QUrl siteUrl();
     QString identifier();

--- a/imageProviders/TheTvDbImages.h
+++ b/imageProviders/TheTvDbImages.h
@@ -15,7 +15,7 @@ class TheTvDbImages : public ImageProviderInterface
 {
     Q_OBJECT
 public:
-    explicit TheTvDbImages(QObject *parent = 0);
+    explicit TheTvDbImages(QObject *parent = nullptr);
     QString name();
     QUrl siteUrl();
     QString identifier();

--- a/main.cpp
+++ b/main.cpp
@@ -21,14 +21,17 @@ void messageOutput(QtMsgType type, const QMessageLogContext &context, const QStr
     QTextStream out;
     if (toFile)
         out.setDevice(&data);
+
+#ifdef Q_OS_WIN32
+    QString newLine = "\r\n";
+#else
     QString newLine = "\n";
-    #ifdef Q_OS_WIN32
-        newLine = "\r\n";
-    #endif
+#endif
 
     QString f = QString("%1").arg(context.function, -70, QChar(' '));
 
     switch (type) {
+    case QtInfoMsg:
     case QtDebugMsg:
         if (toFile)
             out << "[" << f << "] " << localMsg << newLine;

--- a/main/AboutDialog.h
+++ b/main/AboutDialog.h
@@ -15,7 +15,7 @@ class AboutDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit AboutDialog(QWidget *parent = 0);
+    explicit AboutDialog(QWidget *parent = nullptr);
     ~AboutDialog();
 
 public slots:

--- a/main/FileScannerDialog.h
+++ b/main/FileScannerDialog.h
@@ -19,7 +19,7 @@ public:
         TypeAll, TypeMovies, TypeTvShows, TypeConcerts, TypeEpisodes, TypeMusic
     };
 
-    explicit FileScannerDialog(QWidget *parent = 0);
+    explicit FileScannerDialog(QWidget *parent = nullptr);
     ~FileScannerDialog();
     void setForceReload(bool force);
     void setReloadType(ReloadType type);

--- a/main/MainWindow.h
+++ b/main/MainWindow.h
@@ -30,7 +30,7 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
 public:
-    explicit MainWindow(QWidget *parent = 0);
+    explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
     static MainWindow* instance();
@@ -45,7 +45,7 @@ private slots:
     void progressProgress(int current, int max, int id);
     void progressFinished(int id);
     void progressStarted(QString msg, int id);
-    void onMenu(QToolButton *button = 0);
+    void onMenu(QToolButton *button = nullptr);
     void onActionSearch();
     void onActionSave();
     void onActionSaveAll();

--- a/main/Message.h
+++ b/main/Message.h
@@ -18,7 +18,7 @@ class Message : public QWidget
     Q_PROPERTY(int id READ id WRITE setId)
 
 public:
-    explicit Message(QWidget *parent = 0);
+    explicit Message(QWidget *parent = nullptr);
     ~Message();
     void setType(int type);
     void setMessage(QString message, int timeout = 3000);

--- a/main/MyIconFont.h
+++ b/main/MyIconFont.h
@@ -69,7 +69,7 @@ Q_OBJECT
 
 public:
 
-    MyIconFont(QObject *parent = 0);
+    explicit MyIconFont(QObject *parent = nullptr);
     virtual ~MyIconFont();
 
     void init( const QString& fontname );

--- a/main/Navbar.cpp
+++ b/main/Navbar.cpp
@@ -54,7 +54,6 @@ Navbar::Navbar(QWidget *parent) :
 
     QStringList menuIcons = QStringList() << "scrape" << "save" << "saveall" << "rename" << "sync" << "export" << "reload" << "settings" << "about";
 
-    int i=0;
     foreach (QToolButton *btn, ui->widget->findChildren<QToolButton*>()) {
         if (!btn->property("iconName").isValid())
             continue;

--- a/main/Navbar.h
+++ b/main/Navbar.h
@@ -14,7 +14,7 @@ class Navbar : public QWidget
     Q_OBJECT
 
 public:
-    explicit Navbar(QWidget *parent = 0);
+    explicit Navbar(QWidget *parent = nullptr);
     ~Navbar();
     void setActionSearchEnabled(bool enabled);
     void setActionSaveEnabled(bool enabled);

--- a/main/Update.h
+++ b/main/Update.h
@@ -8,8 +8,8 @@ class Update : public QObject
 {
     Q_OBJECT
 public:
-    explicit Update(QObject *parent = 0);
-    static Update *instance(QObject *parent = 0);
+    explicit Update(QObject *parent = nullptr);
+    static Update *instance(QObject *parent = nullptr);
 
 public slots:
     void checkForUpdate();

--- a/mediaCenterPlugins/XbmcXml.h
+++ b/mediaCenterPlugins/XbmcXml.h
@@ -20,7 +20,7 @@ class XbmcXml : public MediaCenterInterface
 {
     Q_OBJECT
 public:
-    explicit XbmcXml(QObject *parent = 0);
+    explicit XbmcXml(QObject *parent = nullptr);
     ~XbmcXml();
 
     bool saveMovie(Movie *movie);

--- a/movies/CertificationWidget.h
+++ b/movies/CertificationWidget.h
@@ -20,7 +20,7 @@ class CertificationWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit CertificationWidget(QWidget *parent = 0);
+    explicit CertificationWidget(QWidget *parent = nullptr);
     ~CertificationWidget();
 
 signals:

--- a/movies/FilesWidget.h
+++ b/movies/FilesWidget.h
@@ -29,7 +29,7 @@ class FilesWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit FilesWidget(QWidget *parent = 0);
+    explicit FilesWidget(QWidget *parent = nullptr);
     ~FilesWidget();
     static FilesWidget *instance();
     QList<Movie*> selectedMovies();

--- a/movies/GenreWidget.h
+++ b/movies/GenreWidget.h
@@ -20,7 +20,7 @@ class GenreWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit GenreWidget(QWidget *parent = 0);
+    explicit GenreWidget(QWidget *parent = nullptr);
     ~GenreWidget();
 
 signals:

--- a/movies/Movie.h
+++ b/movies/Movie.h
@@ -29,7 +29,7 @@ class Movie : public QObject
     Q_OBJECT
 
 public:
-    explicit Movie(QStringList files, QObject *parent = 0);
+    explicit Movie(QStringList files, QObject *parent = nullptr);
     ~Movie();
 
     MovieController *controller();

--- a/movies/MovieController.cpp
+++ b/movies/MovieController.cpp
@@ -19,8 +19,8 @@ MovieController::MovieController(Movie *parent) :
     m_downloadManager{new DownloadManager(this)},
     m_downloadsInProgress{false},
     m_downloadsSize{0},
-    m_forceFanartPoster{false},
     m_forceFanartBackdrop{false},
+    m_forceFanartPoster{false},
     m_forceFanartClearArt{false},
     m_forceFanartCdArt{false},
     m_forceFanartLogo{false}

--- a/movies/MovieController.h
+++ b/movies/MovieController.h
@@ -19,7 +19,7 @@ class MovieController : public QObject
 {
     Q_OBJECT
 public:
-    explicit MovieController(Movie *parent = 0);
+    explicit MovieController(Movie *parent = nullptr);
 
     bool saveData(MediaCenterInterface *mediaCenterInterface);
     bool loadData(MediaCenterInterface *mediaCenterInterface, bool force = false, bool reloadFromNfo = true);

--- a/movies/MovieMultiScrapeDialog.h
+++ b/movies/MovieMultiScrapeDialog.h
@@ -15,9 +15,9 @@ class MovieMultiScrapeDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit MovieMultiScrapeDialog(QWidget *parent = 0);
+    explicit MovieMultiScrapeDialog(QWidget *parent = nullptr);
     ~MovieMultiScrapeDialog();
-    static MovieMultiScrapeDialog *instance(QWidget *parent = 0);
+    static MovieMultiScrapeDialog *instance(QWidget *parent = nullptr);
     void setMovies(QList<Movie*> movies);
 
 public slots:

--- a/movies/MovieSearch.h
+++ b/movies/MovieSearch.h
@@ -17,13 +17,13 @@ class MovieSearch : public QDialog
 {
     Q_OBJECT
 public:
-    explicit MovieSearch(QWidget *parent = 0);
+    explicit MovieSearch(QWidget *parent = nullptr);
     ~MovieSearch();
 
 public slots:
     int exec();
     int exec(QString searchString, QString id, QString tmdbId);
-    static MovieSearch *instance(QWidget *parent = 0);
+    static MovieSearch *instance(QWidget *parent = nullptr);
     QString scraperId();
     QString scraperMovieId();
     QList<int> infosToLoad();

--- a/movies/MovieSearchWidget.h
+++ b/movies/MovieSearchWidget.h
@@ -15,7 +15,7 @@ class MovieSearchWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit MovieSearchWidget(QWidget *parent = 0);
+    explicit MovieSearchWidget(QWidget *parent = nullptr);
     ~MovieSearchWidget();
 
 public slots:

--- a/movies/MovieWidget.h
+++ b/movies/MovieWidget.h
@@ -26,7 +26,7 @@ class MovieWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit MovieWidget(QWidget *parent = 0);
+    explicit MovieWidget(QWidget *parent = nullptr);
     ~MovieWidget();
 
 public slots:
@@ -35,7 +35,7 @@ public slots:
     void startScraperSearch();
     void saveInformation();
     void saveAll();
-    void setEnabledTrue(Movie *movie = 0);
+    void setEnabledTrue(Movie *movie = nullptr);
     void setDisabledTrue();
     void setBigWindow(bool bigWindow);
     void updateMovieInfo();

--- a/music/Album.cpp
+++ b/music/Album.cpp
@@ -2,15 +2,15 @@
 
 Album::Album(QString path, QObject *parent) :
     QObject(parent),
+    m_path{path},
     m_hasChanged{false},
     m_rating{0},
     m_year{0},
     m_modelItem{0},
     m_databaseId{-1},
-    m_artistObj{0},
-    m_path{path},
-    m_bookletModel{new ImageModel(this)},
+    m_artistObj{nullptr},
     m_controller{new AlbumController(this)},
+    m_bookletModel{new ImageModel(this)},
     m_bookletProxyModel{new ImageProxyModel(this)}
 {
     m_bookletProxyModel->setSourceModel(m_bookletModel);

--- a/music/Album.h
+++ b/music/Album.h
@@ -22,7 +22,7 @@ class Album : public QObject
     Q_PROPERTY(MusicModelItem* modelItem READ modelItem NOTIFY modelItemChanged)
 
 public:
-    explicit Album(QString path, QObject *parent = 0);
+    explicit Album(QString path, QObject *parent = nullptr);
     ~Album();
 
     QString path() const;

--- a/music/AlbumController.h
+++ b/music/AlbumController.h
@@ -15,7 +15,7 @@ class AlbumController : public QObject
 {
     Q_OBJECT
 public:
-    explicit AlbumController(Album *parent = 0);
+    explicit AlbumController(Album *parent = nullptr);
     ~AlbumController();
 
     bool saveData(MediaCenterInterface *mediaCenterInterface);

--- a/music/Artist.h
+++ b/music/Artist.h
@@ -14,7 +14,7 @@ class Artist : public QObject
     Q_OBJECT
     Q_PROPERTY(MusicModelItem* modelItem READ modelItem NOTIFY modelItemChanged)
 public:
-    explicit Artist(QString path, QObject *parent = 0);
+    explicit Artist(QString path, QObject *parent = nullptr);
     ~Artist();
 
     QString path() const;

--- a/music/ArtistController.h
+++ b/music/ArtistController.h
@@ -17,7 +17,7 @@ class ArtistController : public QObject
 {
     Q_OBJECT
 public:
-    explicit ArtistController(Artist *parent = 0);
+    explicit ArtistController(Artist *parent = nullptr);
     ~ArtistController();
 
     bool saveData(MediaCenterInterface *mediaCenterInterface);

--- a/music/MusicFileSearcher.h
+++ b/music/MusicFileSearcher.h
@@ -10,7 +10,7 @@ class MusicFileSearcher : public QObject
 {
     Q_OBJECT
 public:
-    explicit MusicFileSearcher(QObject *parent = 0);
+    explicit MusicFileSearcher(QObject *parent = nullptr);
     ~MusicFileSearcher();
 
     void setMusicDirectories(QList<SettingsDir> directories);

--- a/music/MusicFilesWidget.h
+++ b/music/MusicFilesWidget.h
@@ -19,7 +19,7 @@ class MusicFilesWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit MusicFilesWidget(QWidget *parent = 0);
+    explicit MusicFilesWidget(QWidget *parent = nullptr);
     ~MusicFilesWidget();
     static MusicFilesWidget *instance();
     QList<Artist*> selectedArtists();

--- a/music/MusicModel.cpp
+++ b/music/MusicModel.cpp
@@ -125,10 +125,9 @@ QModelIndex MusicModel::parent(const QModelIndex &index) const
 bool MusicModel::removeRows(int position, int rows, const QModelIndex &parent)
 {
     MusicModelItem *parentItem = getItem(parent);
-    bool success = true;
 
     beginRemoveRows(parent, position, position + rows - 1);
-    success = parentItem->removeChildren(position, rows);
+    bool success = parentItem->removeChildren(position, rows);
     endRemoveRows();
 
     return success;

--- a/music/MusicModel.h
+++ b/music/MusicModel.h
@@ -9,7 +9,7 @@
 class MusicModel : public QAbstractItemModel
 {
 public:
-    MusicModel(QObject *parent = 0);
+    explicit MusicModel(QObject *parent = nullptr);
     ~MusicModel();
 
     QVariant data(const QModelIndex &index, int role) const;

--- a/music/MusicModelItem.h
+++ b/music/MusicModelItem.h
@@ -12,7 +12,7 @@ class MusicModelItem : public QObject
 {
     Q_OBJECT
 public:
-    explicit MusicModelItem(MusicModelItem *parent = 0);
+    explicit MusicModelItem(MusicModelItem *parent = nullptr);
     ~MusicModelItem();
 
     MusicModelItem *child(int number);

--- a/music/MusicMultiScrapeDialog.h
+++ b/music/MusicMultiScrapeDialog.h
@@ -14,9 +14,9 @@ class MusicMultiScrapeDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit MusicMultiScrapeDialog(QWidget *parent = 0);
+    explicit MusicMultiScrapeDialog(QWidget *parent = nullptr);
     ~MusicMultiScrapeDialog();
-    static MusicMultiScrapeDialog *instance(QWidget *parent = 0);
+    static MusicMultiScrapeDialog *instance(QWidget *parent = nullptr);
     void setItems(QList<Artist*> artists, QList<Album*> albums);
 
 public slots:

--- a/music/MusicProxyModel.h
+++ b/music/MusicProxyModel.h
@@ -9,7 +9,7 @@ class MusicProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
 public:
-    MusicProxyModel(QObject *parent = 0);
+    explicit MusicProxyModel(QObject *parent = nullptr);
     ~MusicProxyModel();
 
     void setFilter(QList<Filter*> filters, QString text);

--- a/music/MusicSearch.h
+++ b/music/MusicSearch.h
@@ -14,13 +14,13 @@ class MusicSearch : public QDialog
     Q_OBJECT
 
 public:
-    explicit MusicSearch(QWidget *parent = 0);
+    explicit MusicSearch(QWidget *parent = nullptr);
     ~MusicSearch();
 
 public slots:
     int exec();
     int exec(QString type, QString searchString, QString artistName = QString());
-    static MusicSearch *instance(QWidget *parent = 0);
+    static MusicSearch *instance(QWidget *parent = nullptr);
     int scraperNo();
     QString scraperId();
     QString scraperId2();

--- a/music/MusicSearchWidget.h
+++ b/music/MusicSearchWidget.h
@@ -16,7 +16,7 @@ class MusicSearchWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit MusicSearchWidget(QWidget *parent = 0);
+    explicit MusicSearchWidget(QWidget *parent = nullptr);
     ~MusicSearchWidget();
 
 public slots:

--- a/music/MusicWidget.h
+++ b/music/MusicWidget.h
@@ -14,7 +14,7 @@ class MusicWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit MusicWidget(QWidget *parent = 0);
+    explicit MusicWidget(QWidget *parent = nullptr);
     ~MusicWidget();
 
 public slots:

--- a/music/MusicWidgetAlbum.h
+++ b/music/MusicWidgetAlbum.h
@@ -17,7 +17,7 @@ class MusicWidgetAlbum : public QWidget
     Q_OBJECT
 
 public:
-    explicit MusicWidgetAlbum(QWidget *parent = 0);
+    explicit MusicWidgetAlbum(QWidget *parent = nullptr);
     ~MusicWidgetAlbum();
     void setAlbum(Album *album);
 

--- a/music/MusicWidgetArtist.h
+++ b/music/MusicWidgetArtist.h
@@ -17,7 +17,7 @@ class MusicWidgetArtist : public QWidget
     Q_OBJECT
 
 public:
-    explicit MusicWidgetArtist(QWidget *parent = 0);
+    explicit MusicWidgetArtist(QWidget *parent = nullptr);
     ~MusicWidgetArtist();
     void setArtist(Artist *artist);
     void updateArtistInfo();

--- a/notifications/NotificationBox.h
+++ b/notifications/NotificationBox.h
@@ -19,9 +19,9 @@ public:
         NotificationInfo, NotificationWarning, NotificationSuccess, NotificationError
     };
 
-    explicit NotificationBox(QWidget *parent = 0);
+    explicit NotificationBox(QWidget *parent = nullptr);
     ~NotificationBox();
-    static NotificationBox *instance(QWidget *parent = 0);
+    static NotificationBox *instance(QWidget *parent = nullptr);
     void reposition(QSize size);
     virtual int showMessage(QString message, NotificationBox::NotificationType type = NotificationInfo, int timeout = 5000);
     void showProgressBar(QString message, int id, bool unique = false);

--- a/notifications/Notificator.h
+++ b/notifications/Notificator.h
@@ -9,8 +9,8 @@ class Notificator : public QObject
 {
     Q_OBJECT
 public:
-    explicit Notificator(QSystemTrayIcon *trayIcon = 0, QWidget *parent = 0);
-    static Notificator *instance(QSystemTrayIcon *trayIcon = 0, QWidget *parent = 0);
+    explicit Notificator(QSystemTrayIcon *trayIcon = 0, QWidget *parent = nullptr);
+    static Notificator *instance(QSystemTrayIcon *trayIcon = 0, QWidget *parent = nullptr);
 
     enum Class {
         Information,

--- a/plugins/PluginManager.h
+++ b/plugins/PluginManager.h
@@ -29,8 +29,8 @@ public:
         QString localFileName;
     };
 
-    explicit PluginManager(QObject *parent = 0);
-    static PluginManager *instance(QObject *parent = 0);
+    explicit PluginManager(QObject *parent = nullptr);
+    static PluginManager *instance(QObject *parent = nullptr);
     QList<PluginManager::Plugin> plugins();
 
 public slots:

--- a/plugins/PluginManagerDialog.h
+++ b/plugins/PluginManagerDialog.h
@@ -13,7 +13,7 @@ class PluginManagerDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit PluginManagerDialog(QWidget *parent = 0);
+    explicit PluginManagerDialog(QWidget *parent = nullptr);
     ~PluginManagerDialog();
 
     void installPlugin(PluginManager::Plugin plugin);

--- a/plugins/PluginsWidget.h
+++ b/plugins/PluginsWidget.h
@@ -13,7 +13,7 @@ class PluginsWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit PluginsWidget(QWidget *parent = 0);
+    explicit PluginsWidget(QWidget *parent = nullptr);
     ~PluginsWidget();
 
     void setPlugin(PluginManager::Plugin plugin);

--- a/renamer/Renamer.h
+++ b/renamer/Renamer.h
@@ -28,7 +28,7 @@ public:
         OperationCreateDir, OperationMove, OperationRename
     };
 
-    explicit Renamer(QWidget *parent = 0);
+    explicit Renamer(QWidget *parent = nullptr);
     ~Renamer();
     void setMovies(QList<Movie*> movies);
     void setConcerts(QList<Concert*> concerts);

--- a/renamer/RenamerPlaceholders.h
+++ b/renamer/RenamerPlaceholders.h
@@ -12,7 +12,7 @@ class RenamerPlaceholders : public QWidget
     Q_OBJECT
 
 public:
-    explicit RenamerPlaceholders(QWidget *parent = 0);
+    explicit RenamerPlaceholders(QWidget *parent = nullptr);
     ~RenamerPlaceholders();
     void setType(int renameType);
 

--- a/scrapers/AEBN.h
+++ b/scrapers/AEBN.h
@@ -11,7 +11,7 @@ class AEBN : public ScraperInterface
 {
     Q_OBJECT
 public:
-    explicit AEBN(QObject *parent = 0);
+    explicit AEBN(QObject *parent = nullptr);
     QString name();
     QString identifier();
     void search(QString searchStr);

--- a/scrapers/AdultDvdEmpire.h
+++ b/scrapers/AdultDvdEmpire.h
@@ -10,7 +10,7 @@ class AdultDvdEmpire : public ScraperInterface
 {
     Q_OBJECT
 public:
-    explicit AdultDvdEmpire(QObject *parent = 0);
+    explicit AdultDvdEmpire(QObject *parent = nullptr);
     QString name();
     QString identifier();
     void search(QString searchStr);

--- a/scrapers/Cinefacts.h
+++ b/scrapers/Cinefacts.h
@@ -15,7 +15,7 @@ class Cinefacts : public ScraperInterface
 {
     Q_OBJECT
 public:
-    explicit Cinefacts(QObject *parent = 0);
+    explicit Cinefacts(QObject *parent = nullptr);
     QString name();
     QString identifier();
     void search(QString searchStr);

--- a/scrapers/CustomMovieScraper.h
+++ b/scrapers/CustomMovieScraper.h
@@ -10,8 +10,8 @@ class CustomMovieScraper : public ScraperInterface
 {
     Q_OBJECT
 public:
-    explicit CustomMovieScraper(QObject *parent = 0);
-    static CustomMovieScraper *instance(QObject *parent = 0);
+    explicit CustomMovieScraper(QObject *parent = nullptr);
+    static CustomMovieScraper *instance(QObject *parent = nullptr);
 
     QString name();
     QString identifier();

--- a/scrapers/HotMovies.h
+++ b/scrapers/HotMovies.h
@@ -11,7 +11,7 @@ class HotMovies : public ScraperInterface
 {
     Q_OBJECT
 public:
-    explicit HotMovies(QObject *parent = 0);
+    explicit HotMovies(QObject *parent = nullptr);
     QString name();
     QString identifier();
     void search(QString searchStr);

--- a/scrapers/IMDB.h
+++ b/scrapers/IMDB.h
@@ -9,7 +9,7 @@ class IMDB : public ScraperInterface
 {
     Q_OBJECT
 public:
-    explicit IMDB(QObject *parent = 0);
+    explicit IMDB(QObject *parent = nullptr);
     QString name();
     QString identifier();
     void search(QString searchStr);

--- a/scrapers/MediaPassion.h
+++ b/scrapers/MediaPassion.h
@@ -15,7 +15,7 @@ class MediaPassion : public ScraperInterface
 {
     Q_OBJECT
 public:
-    explicit MediaPassion(QObject *parent = 0);
+    explicit MediaPassion(QObject *parent = nullptr);
     QString name();
     QString identifier();
     void search(QString searchStr);

--- a/scrapers/OFDb.h
+++ b/scrapers/OFDb.h
@@ -14,7 +14,7 @@ class OFDb : public ScraperInterface
 {
     Q_OBJECT
 public:
-    explicit OFDb(QObject *parent = 0);
+    explicit OFDb(QObject *parent = nullptr);
     QString name();
     QString identifier();
     void search(QString searchStr);

--- a/scrapers/TMDb.h
+++ b/scrapers/TMDb.h
@@ -16,7 +16,7 @@ class TMDb : public ScraperInterface
 {
     Q_OBJECT
 public:
-    explicit TMDb(QObject *parent = 0);
+    explicit TMDb(QObject *parent = nullptr);
     ~TMDb();
     QString name();
     QString identifier();

--- a/scrapers/TMDbConcerts.h
+++ b/scrapers/TMDbConcerts.h
@@ -16,7 +16,7 @@ class TMDbConcerts : public ConcertScraperInterface
 {
     Q_OBJECT
 public:
-    explicit TMDbConcerts(QObject *parent = 0);
+    explicit TMDbConcerts(QObject *parent = nullptr);
     ~TMDbConcerts();
     QString name();
     void search(QString searchStr);

--- a/scrapers/TheTvDb.h
+++ b/scrapers/TheTvDb.h
@@ -17,7 +17,7 @@ class TheTvDb : public TvScraperInterface
 {
     Q_OBJECT
 public:
-    explicit TheTvDb(QObject *parent = 0);
+    explicit TheTvDb(QObject *parent = nullptr);
     QString name();
     QString identifier();
     void search(QString searchStr);

--- a/scrapers/TvTunes.h
+++ b/scrapers/TvTunes.h
@@ -10,7 +10,7 @@ class TvTunes : public QObject
 {
     Q_OBJECT
 public:
-    explicit TvTunes(QObject *parent = 0);
+    explicit TvTunes(QObject *parent = nullptr);
     void search(QString searchStr);
 
 signals:

--- a/scrapers/UniversalMusicScraper.h
+++ b/scrapers/UniversalMusicScraper.h
@@ -12,7 +12,7 @@ class UniversalMusicScraper : public MusicScraperInterface
 {
     Q_OBJECT
 public:
-    explicit UniversalMusicScraper(QObject *parent = 0);
+    explicit UniversalMusicScraper(QObject *parent = nullptr);
 
     QString name();
     QString identifier();

--- a/scrapers/VideoBuster.h
+++ b/scrapers/VideoBuster.h
@@ -15,7 +15,7 @@ class VideoBuster : public ScraperInterface
 {
     Q_OBJECT
 public:
-    explicit VideoBuster(QObject *parent = 0);
+    explicit VideoBuster(QObject *parent = nullptr);
     QString name();
     QString identifier();
     void search(QString searchStr);

--- a/sets/MovieListDialog.h
+++ b/sets/MovieListDialog.h
@@ -18,10 +18,10 @@ class MovieListDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit MovieListDialog(QWidget *parent = 0);
+    explicit MovieListDialog(QWidget *parent = nullptr);
     ~MovieListDialog();
     QList<Movie*> selectedMovies();
-    static MovieListDialog *instance(QWidget *parent = 0);
+    static MovieListDialog *instance(QWidget *parent = nullptr);
 
 public slots:
     int exec();

--- a/sets/SetsWidget.h
+++ b/sets/SetsWidget.h
@@ -19,7 +19,7 @@ class SetsWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit SetsWidget(QWidget *parent = 0);
+    explicit SetsWidget(QWidget *parent = nullptr);
     ~SetsWidget();
 
 public slots:

--- a/settings/AdvancedSettings.h
+++ b/settings/AdvancedSettings.h
@@ -11,7 +11,7 @@ class AdvancedSettings : public QObject
 {
     Q_OBJECT
 public:
-    explicit AdvancedSettings(QObject *parent = 0);
+    explicit AdvancedSettings(QObject *parent = nullptr);
     ~AdvancedSettings();
 
     bool debugLog() const;

--- a/settings/DataFile.cpp
+++ b/settings/DataFile.cpp
@@ -13,9 +13,9 @@
  * @param pos Position
  */
 DataFile::DataFile(int type, QString fileName, int pos) :
-    m_type{type},
     m_fileName{fileName},
-    m_pos{pos}
+    m_pos{pos},
+    m_type{type}
 {
 }
 

--- a/settings/ExportTemplateWidget.h
+++ b/settings/ExportTemplateWidget.h
@@ -13,7 +13,7 @@ class ExportTemplateWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit ExportTemplateWidget(QWidget *parent = 0);
+    explicit ExportTemplateWidget(QWidget *parent = nullptr);
     ~ExportTemplateWidget();
     void setExportTemplate(ExportTemplate *exportTemplate);
 

--- a/settings/Settings.h
+++ b/settings/Settings.h
@@ -18,9 +18,9 @@ class Settings : public QObject
 {
     Q_OBJECT
 public:
-    explicit Settings(QObject *parent = 0);
+    explicit Settings(QObject *parent = nullptr);
 
-    static Settings *instance(QObject *parent = 0);
+    static Settings *instance(QObject *parent = nullptr);
     AdvancedSettings* advanced();
     void loadSettings();
     QSettings *settings();

--- a/settings/SettingsWindow.cpp
+++ b/settings/SettingsWindow.cpp
@@ -19,8 +19,8 @@ SettingsWindow::SettingsWindow(QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::SettingsWindow),
     m_pluginDialog{new PluginManagerDialog(this)},
-    m_buttonActiveColor{QColor(70, 155, 198)},
-    m_buttonColor{QColor(128, 129, 132)}
+    m_buttonColor{QColor(128, 129, 132)},
+    m_buttonActiveColor{QColor(70, 155, 198)}
 {
     ui->setupUi(this);
 

--- a/settings/SettingsWindow.h
+++ b/settings/SettingsWindow.h
@@ -25,7 +25,7 @@ class SettingsWindow : public QMainWindow
     Q_OBJECT
 
 public:
-    explicit SettingsWindow(QWidget *parent = 0);
+    explicit SettingsWindow(QWidget *parent = nullptr);
     ~SettingsWindow();
 
 public slots:
@@ -54,7 +54,7 @@ private slots:
     void onTemplateUninstalled(ExportTemplate *exportTemplate, bool success);
     void onChooseUnrar();
     void onChooseMakeMkvCon();
-    void onDirTypeChanged(QComboBox *comboBox = 0);
+    void onDirTypeChanged(QComboBox *comboBox = nullptr);
     void onShowAdultScrapers();
     void onPluginListUpdated(QList<PluginManager::Plugin> plugins);
     void onPluginActivated(QListWidgetItem *item);

--- a/smallWidgets/AlphabeticalList.h
+++ b/smallWidgets/AlphabeticalList.h
@@ -14,7 +14,7 @@ class AlphabeticalList : public QWidget
 {
     Q_OBJECT
 public:
-    explicit AlphabeticalList(QWidget *parent = 0, MyTableView *parentTableView = 0);
+    explicit AlphabeticalList(QWidget *parent = 0, MyTableView *parentTableView = nullptr);
     void setTopSpace(const int space);
     void setBottomSpace(const int space);
     void setRightSpace(const int space);

--- a/smallWidgets/Badge.h
+++ b/smallWidgets/Badge.h
@@ -14,8 +14,8 @@ public:
         BadgeSuccess, BadgeDefault, BadgeWarning, BadgeImportant, BadgeInfo, BadgeInverse
     };
 
-    explicit Badge(QWidget *parent = 0);
-    explicit Badge(const QString &text, QWidget *parent = 0);
+    explicit Badge(QWidget *parent = nullptr);
+    explicit Badge(const QString &text, QWidget *parent = nullptr);
     void setBadgeType(Badge::BadgeType type);
     void setClosable(const bool &closable);
     void setActive(const bool &active);

--- a/smallWidgets/ClosableImage.h
+++ b/smallWidgets/ClosableImage.h
@@ -17,7 +17,7 @@ class ClosableImage : public QLabel
     Q_PROPERTY(QString title READ title WRITE setTitle DESIGNABLE true)
 
 public:
-    explicit ClosableImage(QWidget *parent = 0);
+    explicit ClosableImage(QWidget *parent = nullptr);
     void setMyData(const QVariant &data);
     QVariant myData() const;
     void setImage(const QByteArray &image);

--- a/smallWidgets/FilterWidget.h
+++ b/smallWidgets/FilterWidget.h
@@ -20,7 +20,7 @@ class FilterWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit FilterWidget(QWidget *parent = 0);
+    explicit FilterWidget(QWidget *parent = nullptr);
     ~FilterWidget();
     void setActiveWidget(MainWidgets widget);
 signals:

--- a/smallWidgets/ImageGallery.h
+++ b/smallWidgets/ImageGallery.h
@@ -12,7 +12,7 @@ class ImageGallery : public QWidget
 {
     Q_OBJECT
 public:
-    explicit ImageGallery(QWidget *parent = 0);
+    explicit ImageGallery(QWidget *parent = nullptr);
     void clear();
     void setImages(QList<ExtraFanart> images);
     void addImage(const QByteArray &img, const QString &url = QString());

--- a/smallWidgets/ImageLabel.h
+++ b/smallWidgets/ImageLabel.h
@@ -16,7 +16,7 @@ class ImageLabel : public QWidget
     Q_OBJECT
 
 public:
-    explicit ImageLabel(QWidget *parent = 0);
+    explicit ImageLabel(QWidget *parent = nullptr);
     ~ImageLabel();
     void setImage(QPixmap img);
     void setHint(QSize resolution, QString hint = "");

--- a/smallWidgets/LoadingStreamDetails.h
+++ b/smallWidgets/LoadingStreamDetails.h
@@ -15,7 +15,7 @@ class LoadingStreamDetails : public QDialog
     Q_OBJECT
 
 public:
-    explicit LoadingStreamDetails(QWidget *parent = 0);
+    explicit LoadingStreamDetails(QWidget *parent = nullptr);
     ~LoadingStreamDetails();
     void loadMovies(QList<Movie*> movies);
     void loadConcerts(QList<Concert*> concerts);

--- a/smallWidgets/MediaFlags.h
+++ b/smallWidgets/MediaFlags.h
@@ -17,7 +17,7 @@ class MediaFlags : public QWidget
     Q_OBJECT
 
 public:
-    explicit MediaFlags(QWidget *parent = 0);
+    explicit MediaFlags(QWidget *parent = nullptr);
     ~MediaFlags();
     void setStreamDetails(StreamDetails *streamDetails);
     void clear();

--- a/smallWidgets/MusicTreeView.h
+++ b/smallWidgets/MusicTreeView.h
@@ -9,7 +9,7 @@ class MusicTreeView : public QTreeView
 {
     Q_OBJECT
 public:
-    MusicTreeView(QWidget *parent = 0);
+    explicit MusicTreeView(QWidget *parent = nullptr);
     ~MusicTreeView();
 
 protected:

--- a/smallWidgets/MyCheckBox.h
+++ b/smallWidgets/MyCheckBox.h
@@ -8,7 +8,7 @@ class MyCheckBox : public QCheckBox
 {
     Q_OBJECT
 public:
-    explicit MyCheckBox(QWidget *parent = 0);
+    explicit MyCheckBox(QWidget *parent = nullptr);
     void setMyData(const QVariant &data);
     QVariant myData() const;
 

--- a/smallWidgets/MyLabel.h
+++ b/smallWidgets/MyLabel.h
@@ -11,7 +11,7 @@ class MyLabel : public QLabel
 {
     Q_OBJECT
 public:
-    explicit MyLabel(QWidget *parent = 0);
+    explicit MyLabel(QWidget *parent = nullptr);
     void setSeason(int season);
     void setImageSet(bool set);
     bool imageSet();

--- a/smallWidgets/MyLineEdit.h
+++ b/smallWidgets/MyLineEdit.h
@@ -24,7 +24,7 @@ public:
         TypeClear
     };
 
-    explicit MyLineEdit(QWidget *parent = 0);
+    explicit MyLineEdit(QWidget *parent = nullptr);
     void setLoading(bool loading);
     void setType(LineEditType type);
     void addAdditionalStyleSheet(QString style);

--- a/smallWidgets/MySpinBox.h
+++ b/smallWidgets/MySpinBox.h
@@ -7,7 +7,7 @@ class MySpinBox : public QSpinBox
 {
     Q_OBJECT
 public:
-    explicit MySpinBox(QWidget *parent = 0);
+    explicit MySpinBox(QWidget *parent = nullptr);
 protected:
     QString textFromValue(int val) const;
 };

--- a/smallWidgets/MySplitter.h
+++ b/smallWidgets/MySplitter.h
@@ -7,7 +7,7 @@ class MySplitter : public QSplitter
 {
     Q_OBJECT
 public:
-    explicit MySplitter(QWidget *parent = 0);
+    explicit MySplitter(QWidget *parent = nullptr);
 
 protected:
      QSplitterHandle *createHandle();

--- a/smallWidgets/MySplitterHandle.h
+++ b/smallWidgets/MySplitterHandle.h
@@ -9,7 +9,7 @@ class MySplitterHandle : public QSplitterHandle
 {
     Q_OBJECT
 public:
-    explicit MySplitterHandle(Qt::Orientation orientation, QSplitter *parent = 0);
+    explicit MySplitterHandle(Qt::Orientation orientation, QSplitter *parent = nullptr);
 
 protected:
     void paintEvent(QPaintEvent *event);

--- a/smallWidgets/MyTableView.h
+++ b/smallWidgets/MyTableView.h
@@ -16,7 +16,7 @@ class MyTableView : public QTableView
     Q_PROPERTY(bool useSearchOverlay READ useSearchOverlay WRITE setUseSearchOverlay DESIGNABLE true)
 
 public:
-    explicit MyTableView(QWidget *parent = 0);
+    explicit MyTableView(QWidget *parent = nullptr);
     int lastColumnWidth() const;
     void setLastColumnWidth(int &width);
     int firstColumnWidth() const;

--- a/smallWidgets/MyTableWidget.h
+++ b/smallWidgets/MyTableWidget.h
@@ -14,7 +14,7 @@ class MyTableWidget : public QTableWidget
 {
     Q_OBJECT
 public:
-    explicit MyTableWidget(QWidget *parent = 0);
+    explicit MyTableWidget(QWidget *parent = nullptr);
 protected:
     void dragEnterEvent(QDragEnterEvent *event);
     void dropEvent(QDropEvent *event);

--- a/smallWidgets/MyTableWidgetItem.h
+++ b/smallWidgets/MyTableWidgetItem.h
@@ -6,7 +6,7 @@
 class MyTableWidgetItem : public QTableWidgetItem
 {
 public:
-    MyTableWidgetItem(QString text);
+    explicit MyTableWidgetItem(QString text);
     MyTableWidgetItem(QString text, qreal number);
     MyTableWidgetItem(qreal number, bool isSize = false);
     QVariant data(int role) const;

--- a/smallWidgets/MyTreeView.h
+++ b/smallWidgets/MyTreeView.h
@@ -13,7 +13,7 @@ class MyTreeView : public QTreeView
 {
     Q_OBJECT
 public:
-    explicit MyTreeView(QWidget *parent = 0);
+    explicit MyTreeView(QWidget *parent = nullptr);
 protected:
     void drawBranches(QPainter *painter, const QRect &rect, const QModelIndex &index) const;
 };

--- a/smallWidgets/MyWidget.h
+++ b/smallWidgets/MyWidget.h
@@ -8,7 +8,7 @@ class MyWidget : public QWidget
 {
     Q_OBJECT
 public:
-    explicit MyWidget(QWidget *parent = 0);
+    explicit MyWidget(QWidget *parent = nullptr);
 
 signals:
     void resized();

--- a/smallWidgets/SearchOverlay.h
+++ b/smallWidgets/SearchOverlay.h
@@ -9,7 +9,7 @@ class SearchOverlay : public QWidget
 {
     Q_OBJECT
 public:
-    explicit SearchOverlay(QWidget *parent = 0);
+    explicit SearchOverlay(QWidget *parent = nullptr);
     void setText(QString text);
     void fadeIn();
     void fadeOut();

--- a/smallWidgets/SlidingStackedWidget.cpp
+++ b/smallWidgets/SlidingStackedWidget.cpp
@@ -4,9 +4,9 @@
 
 SlidingStackedWidget::SlidingStackedWidget(QWidget *parent) :
     QStackedWidget(parent),
-    m_vertical{false},
     m_speed{500},
     m_animationType{QEasingCurve::OutBack},
+    m_vertical{false},
     m_now{0},
     m_next{0},
     m_wrap{false},

--- a/smallWidgets/TagCloud.h
+++ b/smallWidgets/TagCloud.h
@@ -20,7 +20,7 @@ public:
         TypeSimpleLabel, TypeBadge
     };
 
-    explicit TagCloud(QWidget *parent = 0);
+    explicit TagCloud(QWidget *parent = nullptr);
     ~TagCloud();
     void setTags(const QStringList &tags, const QStringList &activeTags);
     QStringList activeTags() const;

--- a/smallWidgets/TvShowTreeView.h
+++ b/smallWidgets/TvShowTreeView.h
@@ -9,7 +9,7 @@ class TvShowTreeView : public QTreeView
 {
     Q_OBJECT
 public:
-    TvShowTreeView(QWidget *parent = 0);
+    explicit TvShowTreeView(QWidget *parent = nullptr);
     ~TvShowTreeView();
 
 protected:

--- a/support/SupportDialog.h
+++ b/support/SupportDialog.h
@@ -15,7 +15,7 @@ class SupportDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit SupportDialog(QWidget *parent = 0);
+    explicit SupportDialog(QWidget *parent = nullptr);
     ~SupportDialog();
 
 private slots:

--- a/trailerProviders/HdTrailers.cpp
+++ b/trailerProviders/HdTrailers.cpp
@@ -4,7 +4,9 @@
 #include "globals/Helper.h"
 
 HdTrailers::HdTrailers(QObject *parent) :
-    m_qnam{new QNetworkAccessManager(this)}
+    m_qnam{new QNetworkAccessManager(this)},
+    m_searchReply{nullptr},
+    m_loadReply{nullptr}
 {
     setParent(parent);
     m_libraryPages.enqueue("0");

--- a/trailerProviders/HdTrailers.h
+++ b/trailerProviders/HdTrailers.h
@@ -12,7 +12,7 @@ class HdTrailers : public TrailerProvider
 {
     Q_OBJECT
 public:
-    explicit HdTrailers(QObject *parent = 0);
+    explicit HdTrailers(QObject *parent = nullptr);
     QString name();
 
 public slots:

--- a/trailerProviders/MovieMaze.cpp
+++ b/trailerProviders/MovieMaze.cpp
@@ -5,7 +5,8 @@
 MovieMaze::MovieMaze(QObject *parent) :
     m_qnam{new QNetworkAccessManager(this)},
     m_searchReply{nullptr},
-    m_previewLoadReply{nullptr}
+    m_previewLoadReply{nullptr},
+    m_currentPreviewLoad{0}
 {
     setParent(parent);
 }

--- a/trailerProviders/MovieMaze.cpp
+++ b/trailerProviders/MovieMaze.cpp
@@ -3,7 +3,9 @@
 #include <QRegExp>
 
 MovieMaze::MovieMaze(QObject *parent) :
-    m_qnam{new QNetworkAccessManager(this)}
+    m_qnam{new QNetworkAccessManager(this)},
+    m_searchReply{nullptr},
+    m_previewLoadReply{nullptr}
 {
     setParent(parent);
 }

--- a/trailerProviders/MovieMaze.h
+++ b/trailerProviders/MovieMaze.h
@@ -12,7 +12,7 @@ class MovieMaze : public TrailerProvider
 {
     Q_OBJECT
 public:
-    explicit MovieMaze(QObject *parent = 0);
+    explicit MovieMaze(QObject *parent = nullptr);
     QString name();
 
 public slots:

--- a/tvShows/TvShowFilesWidget.h
+++ b/tvShows/TvShowFilesWidget.h
@@ -23,7 +23,7 @@ class TvShowFilesWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit TvShowFilesWidget(QWidget *parent = 0);
+    explicit TvShowFilesWidget(QWidget *parent = nullptr);
     ~TvShowFilesWidget();
     void setFilter(QList<Filter*> filters, QString text);
     static TvShowFilesWidget *instance();

--- a/tvShows/TvShowMultiScrapeDialog.h
+++ b/tvShows/TvShowMultiScrapeDialog.h
@@ -18,10 +18,10 @@ class TvShowMultiScrapeDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit TvShowMultiScrapeDialog(QWidget *parent = 0);
+    explicit TvShowMultiScrapeDialog(QWidget *parent = nullptr);
     ~TvShowMultiScrapeDialog();
 
-    static TvShowMultiScrapeDialog *instance(QWidget *parent = 0);
+    static TvShowMultiScrapeDialog *instance(QWidget *parent = nullptr);
 
     QList<TvShow *> shows() const;
     void setShows(const QList<TvShow *> &shows);

--- a/tvShows/TvShowSearch.h
+++ b/tvShows/TvShowSearch.h
@@ -17,7 +17,7 @@ class TvShowSearch : public QDialog
     Q_OBJECT
 
 public:
-    explicit TvShowSearch(QWidget *parent = 0);
+    explicit TvShowSearch(QWidget *parent = nullptr);
     ~TvShowSearch();
     QString scraperId();
     QList<int> infosToLoad();
@@ -27,7 +27,7 @@ public:
 public slots:
     int exec();
     int exec(QString searchString, QString id);
-    static TvShowSearch *instance(QWidget *parent = 0);
+    static TvShowSearch *instance(QWidget *parent = nullptr);
 
 private slots:
     void onSearch();

--- a/tvShows/TvShowSearchEpisode.h
+++ b/tvShows/TvShowSearchEpisode.h
@@ -14,7 +14,7 @@ class TvShowSearchEpisode : public QWidget
     Q_OBJECT
 
 public:
-    explicit TvShowSearchEpisode(QWidget *parent = 0);
+    explicit TvShowSearchEpisode(QWidget *parent = nullptr);
     ~TvShowSearchEpisode();
     QString scraperId();
     QList<int> infosToLoad();

--- a/tvShows/TvShowUpdater.h
+++ b/tvShows/TvShowUpdater.h
@@ -10,8 +10,8 @@ class TvShowUpdater : public QObject
 {
     Q_OBJECT
 public:
-    explicit TvShowUpdater(QObject *parent = 0);
-    static TvShowUpdater *instance(QObject *parent = 0);
+    explicit TvShowUpdater(QObject *parent = nullptr);
+    static TvShowUpdater *instance(QObject *parent = nullptr);
     void updateShow(TvShow *show, bool force = false);
 
 private slots:

--- a/tvShows/TvShowWidget.h
+++ b/tvShows/TvShowWidget.h
@@ -17,7 +17,7 @@ class TvShowWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit TvShowWidget(QWidget *parent = 0);
+    explicit TvShowWidget(QWidget *parent = nullptr);
     ~TvShowWidget();
     void updateInfo();
 

--- a/tvShows/TvShowWidgetEpisode.h
+++ b/tvShows/TvShowWidgetEpisode.h
@@ -20,7 +20,7 @@ class TvShowWidgetEpisode : public QWidget
     Q_OBJECT
 
 public:
-    explicit TvShowWidgetEpisode(QWidget *parent = 0);
+    explicit TvShowWidgetEpisode(QWidget *parent = nullptr);
     ~TvShowWidgetEpisode();
     void setEpisode(TvShowEpisode *episode);
     void updateEpisodeInfo();

--- a/tvShows/TvShowWidgetSeason.h
+++ b/tvShows/TvShowWidgetSeason.h
@@ -18,7 +18,7 @@ class TvShowWidgetSeason : public QWidget
     Q_OBJECT
 
 public:
-    explicit TvShowWidgetSeason(QWidget *parent = 0);
+    explicit TvShowWidgetSeason(QWidget *parent = nullptr);
     ~TvShowWidgetSeason();
     void setSeason(TvShow *show, int season);
     void updateSeasonInfo();

--- a/tvShows/TvShowWidgetTvShow.h
+++ b/tvShows/TvShowWidgetTvShow.h
@@ -21,7 +21,7 @@ class TvShowWidgetTvShow : public QWidget
     Q_OBJECT
 
 public:
-    explicit TvShowWidgetTvShow(QWidget *parent = 0);
+    explicit TvShowWidgetTvShow(QWidget *parent = nullptr);
     ~TvShowWidgetTvShow();
     void setTvShow(TvShow *show);
     void updateTvShowInfo();

--- a/tvShows/TvTunesDialog.h
+++ b/tvShows/TvTunesDialog.h
@@ -19,9 +19,9 @@ class TvTunesDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit TvTunesDialog(QWidget *parent = 0);
+    explicit TvTunesDialog(QWidget *parent = nullptr);
     ~TvTunesDialog();
-    static TvTunesDialog* instance(QWidget *parent = 0);
+    static TvTunesDialog* instance(QWidget *parent = nullptr);
     void setTvShow(TvShow *show);
 
 public slots:

--- a/xbmc/XbmcSync.cpp
+++ b/xbmc/XbmcSync.cpp
@@ -15,8 +15,8 @@
 XbmcSync::XbmcSync(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::XbmcSync),
-    m_renameArtworkInProgress{false},
     m_cancelRenameArtwork{false},
+    m_renameArtworkInProgress{false},
     m_artworkWasRenamed{false},
     m_reloadTimeOut{2000},
     m_requestId{0}

--- a/xbmc/XbmcSync.h
+++ b/xbmc/XbmcSync.h
@@ -20,7 +20,7 @@ class XbmcSync : public QDialog
     Q_OBJECT
 
 public:
-    explicit XbmcSync(QWidget *parent = 0);
+    explicit XbmcSync(QWidget *parent = nullptr);
     ~XbmcSync();
     enum Elements {
         ElementMovies, ElementConcerts, ElementTvShows, ElementEpisodes


### PR DESCRIPTION
This PR:

 - uses `nullptr` instead of `0` in many places
 - fixes various cppcheck warnings

_Note_: There are still cppcheck warnings that need to be fixed. Many of them are "unused variable" warnings.