### PR TITLE
Remove deprecated TheTvDB mirrors API

### DIFF
--- a/scrapers/TheTvDb.h
+++ b/scrapers/TheTvDb.h
@@ -37,7 +37,6 @@ signals:
     void sigLoadProgress(TvShow *, int, int);
 
 private slots:
-    void onMirrorsReady();
     void onSearchFinished();
     void onLoadFinished();
     void onEpisodeLoadFinished();
@@ -59,9 +58,7 @@ private:
     QString m_apiKey;
     QString m_language;
     QNetworkAccessManager m_qnam;
-    QStringList m_xmlMirrors;
-    QStringList m_bannerMirrors;
-    QStringList m_zipMirrors;
+    QString m_mirror;
     QComboBox *m_box;
     QWidget *m_widget;
     QMap<QUrl, CacheElement> m_cache;
@@ -70,7 +67,6 @@ private:
     QList<int> m_movieInfos;
 
     QNetworkAccessManager *qnam();
-    void setMirrors();
     QList<ScraperSearchResult> parseSearch(QString xml);
     void parseAndAssignInfos(QString xml,
         TvShow *show,


### PR DESCRIPTION
 - TheTvDb mirrors.xml is deprecated: remove it
 - https://www.thetvdb.com/wiki/index.php/API:mirrors.xml

This PR is similar to 362 but uses `QStringLiteral` for member initializers.

Tested on:
 - Linux Mint 18.3 with Qt 5.9.0 and GCC