### PR TITLE
Fix format script on MacOS

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -8,4 +8,4 @@ if [ ! -f MediaElch.pro ]; then
 fi
 
 # Format all files using clang-format
-find . ! -path "*/quazip/*" -regex '.*\.\(cpp\|hpp\|h\|cc\|cxx\)' -exec clang-format -i -style=file {} \;
+find . ! -path "*/quazip/*" -type f \( -name "*.cpp" -o -name "*.h" \) -exec clang-format -i -style=file {} \;


### PR DESCRIPTION
Fixes the clang-format script for macOS.
macOS' `find` does not support `\|` in the RegEx pattern.