### PR TITLE
Fix undefined behavior

### DIFF
--- a/data/MovieProxyModel.cpp
+++ b/data/MovieProxyModel.cpp
@@ -9,7 +9,10 @@
  * @brief MovieProxyModel::MovieProxyModel
  * @param parent
  */
-MovieProxyModel::MovieProxyModel(QObject *parent) : QSortFilterProxyModel(parent), m_sortBy{SortByNew}
+MovieProxyModel::MovieProxyModel(QObject *parent) :
+    QSortFilterProxyModel(parent),
+    m_sortBy{SortByNew},
+    m_filterDuplicates{false}
 {
     sort(0, Qt::AscendingOrder);
 }


### PR DESCRIPTION
 - fix undefined behavior reading a uninitialized bool
 - this bug was responsible for never showing movies on mac
   and randomly on linux

The bug came with 2bd3a741f6fcabcb44aff57da00f7427cd046de4 (Merge master). The branch my changes regarding member-initialization was based on didn't include the duplicate finder and therefore didn't initialize `m_filterDuplicates{false}`. This must have been forgotten while merging.

This led  to undefined behavior. The result was that:

 - on linux every ~6 time I started MediaElch, no movies appeared
 - on Mac no movies appeared at all (most of the time, like ~98%)

First I thought that my `apply clang-format` PR was the issue. It took me a while that the issue was the merge. But everything should work now :smile: 