### PR TITLE
Fix clang build

### DIFF
--- a/data/Storage.cpp
+++ b/data/Storage.cpp
@@ -49,7 +49,7 @@ Storage::Storage(QObject *parent, PluginInterface *plugin) : QObject(parent), m_
 {
 }
 
-Storage::Storage(QObject *parent, PluginManager::Plugin plugin) : QObject(parent), m_plugin{plugin}
+Storage::Storage(QObject *parent, PluginManager::Plugin plugin) : QObject(parent), m_plugin(plugin)
 {
 }
 


### PR DESCRIPTION
 - using braced initialization for a struct fails

An error occurred with clang-6. It didn't occur with the clang version installed on my Mac.