### PR TITLE
Add travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: generic
+matrix:
+  include:
+  - env: QT=qtMac CXX=clang
+    os: osx
+  - env: QT=qt510 QT_PPA=qt-5.10.1 CXX=g++
+    os: linux
+    dist: trusty
+    sudo: required
+  - env: QT=qt510 QT_PPA=qt-5.10.1 CXX=clang++
+    os: linux
+    dist: trusty
+    sudo: required
+  - env: QT=qt56  QT_PPA=qt563 CXX=g++
+    os: linux
+    dist: trusty
+    sudo: required
+
+branches:
+  only:
+  - master
+  - release
+
+before_install:
+- "${TRAVIS_BUILD_DIR}/travisCI/install_dependencies.sh"
+install:
+- ${CXX} -v
+
+# Set some environment variables, then run qmake
+before_script:
+- if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+    QTDIR="/opt/${QT}";
+    PATH="${QTDIR}/bin:$PATH";
+    source ${QTDIR}/bin/${QT}-env.sh;
+    qmake MediaElch.pro CONFIG+=debug CONFIG+=qml_debug;
+  fi
+- if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+    PATH="/usr/local/opt/qt/bin:$PATH";
+    qmake MediaElch.pro CONFIG+=debug CONFIG+=qml_debug;
+  fi
+
+script:
+- make -j 2

--- a/travis-ci/install_dependencies.sh
+++ b/travis-ci/install_dependencies.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env sh
+
+###########################################################
+#
+# Travis CI - Install MediaElch dependencies
+#
+# This script installs all dependencies for MediaElch on
+# linux (GCC or clang) and macOS (clang).
+#
+# Linux builds can use different Qt versions. Set $QT_PPA
+# to select a Qt version. For available versions see
+# https://launchpad.net/~beineri/
+# macOS builds use the latest Qt version available with
+# Homebrew (https://brew.sh).
+#
+###########################################################
+
+# Exit on errors
+set -e
+
+if [ -z ${QT+x} ]; then print_error "\$QT is unset"; return 1; fi
+
+# Load utils (color output, folding, etc.)
+. "${TRAVIS_BUILD_DIR}/travisCI/utils.sh"
+cd "${TRAVIS_BUILD_DIR}"
+
+print_important "Getting dependencies for building for ${QT} on ${TRAVIS_OS_NAME}"
+
+if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+
+	if [ -z ${QT_PPA+x} ]; then
+		print_error "\$QT_PPA is unset";
+		print_error "For valid PPAs see https://launchpad.net/~beineri/"
+		return 1;
+	fi
+
+	#######################################################
+	# Repositories
+
+	print_info "Add repositories + update"
+	fold_start "update"
+	sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+	sudo add-apt-repository -y ppa:beineri/opt-${QT_PPA}-trusty
+	if [ "${CXX}" = "clang++" ]; then
+		wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+		sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
+	fi
+	sudo apt-get -qq update
+	fold_end "update"
+
+	#######################################################
+	# Compilers
+
+	print_info "Updating compiler \"${CXX}\"..."
+	fold_start "update_compiler"
+	if [ "${CXX}" = "g++" ]; then
+		sudo apt-get install -y g++-7 gcc-7
+		# Overwrite defaults
+		sudo ln -sf ${BIN_DIR}/g++-7 ${BIN_DIR}/g++
+		sudo ln -sf ${BIN_DIR}/gcc-7 ${BIN_DIR}/gcc
+
+	elif [ "${CXX}" = "clang++" ]; then
+		sudo apt-get install -y clang++-6.0 clang-6.0
+		# Overwrite defaults
+		sudo ln -s ${BIN_DIR}/clang++-6.0 ${BIN_DIR}/clang++
+		sudo ln -s ${BIN_DIR}/clang-6.0 ${BIN_DIR}/clang
+
+	else
+		print_error "Unknown compiler."
+		exit 1;
+	fi
+	fold_end "update_compiler"
+
+	#######################################################
+	# Dependencies
+
+	print_info "Installing Qt packages"
+	fold_start "qt_install"
+	sudo apt-get install -y ${QT}base ${QT}script ${QT}multimedia ${QT}declarative
+	fold_end "qt_install"
+
+	print_info "Installing other dependencies"
+	fold_start "other_install"
+	sudo apt-get install -y libcurl4-openssl-dev libmediainfo-dev libpulse-dev zlib1g-dev libzen-dev
+	fold_end "other_install"
+
+elif [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+
+	print_info "Dowload MediaInfoLib sources"
+	svn checkout https://github.com/MediaArea/MediaInfoLib/trunk/Source/MediaInfoDLL
+
+	print_info "Dowload ZenLib sources"
+	svn checkout https://github.com/MediaArea/ZenLib/trunk/Source/ZenLib
+
+	print_info "Updating homebrew"
+	brew update > brew_update.log || {
+		print_error "Updating homebrew failed. Error log:";
+		cat brew_update.log;
+		exit 1;
+	}
+	print_info "Brewing packages: qt5 media-info"
+	brew install qt5 media-info
+
+else
+	print_error "Unknown operating system."
+	exit 1;
+fi
+
+print_important "Successfully installed dependencies"
+cd "${TRAVIS_BUILD_DIR}"

--- a/travis-ci/utils.sh
+++ b/travis-ci/utils.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+
+# Binary dir for compilers, etc
+BIN_DIR=$(dirname $(which g++))
+
+###########################################################
+# Print colors
+
+RED='\033[0;31m'
+ORANGE='\033[0;33m'
+BLUE='\033[0;34m'
+LIGHT_BLUE='\033[1;34m'
+NC='\033[0m' # No Color
+
+print_important()
+{
+	printf '%b' "${BLUE}${1}${NC}\n"
+}
+
+print_info() {
+	printf '%b' "${LIGHT_BLUE}${1}${NC}\n"
+}
+
+print_warning() {
+	printf '%b' "${ORANGE}${1}${NC}\n"
+}
+
+print_error() {
+	printf '%b' "${RED}${1}${NC}\n"
+}
+
+###########################################################
+# Travis CI folding
+
+fold_start() {
+	echo -e "travis_fold:start:$1"
+}
+
+fold_end() {
+	echo -e "travis_fold:end:$1"
+}


### PR DESCRIPTION
Add a `.travis.yml` with 4 jobs.  
It builds on linux and macOS. On macOS it uses the latest Qt version available with Homebrew. On Linux it uses Qt 5.6 LTS and Qt 5.10. MediaElch is compiled using clang on macOS and gcc on linux (plus clang for Qt 5.10).

I'd really like this project to use travis-ci. I found a bug using it (#383) and it really helps avoiding further ones.

### Build times
 - macOS with clang: ~8min
 - linux:
   - Qt 5.10 with clang: ~10min
   - Qt 5.10 with gcc: ~16min
   - Qt 5.6 with gcc: ~19min

The overall build needs ~20min on travis-ci.org


### Setup
@Komet This requires some action on your side. You need to sign up on https://travis-ci.org and add MediaElch to your projects.

### Next steps
We could package MediaElch using travis-ci and upload the results on e.g. [Bintray](https://bintray.com/). This would work for macOS and linux. It's also possible to build for Windows [using mingw32](https://stackoverflow.com/questions/2033997/how-to-compile-for-windows-on-linux-with-gcc-g).