### PR TITLE
Require Qt >= 5.5

### DIFF
--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -4,6 +4,10 @@
 #
 #-------------------------------------------------
 
+# Check Qt versions
+lessThan(QT_MAJOR_VERSION, 5): error(Qt 4 is not supported!)
+lessThan(QT_MINOR_VERSION, 5): error(Qt 5.5 or higher is required!)
+
 include(quazip/quazip/quazip.pri)
 
 QT       += core gui network script xml sql widgets multimedia multimediawidgets concurrent qml quick quickwidgets opengl

--- a/main.cpp
+++ b/main.cpp
@@ -87,9 +87,7 @@ int main(int argc, char *argv[])
     QCoreApplication::setOrganizationName("kvibes");
     QCoreApplication::setApplicationName("MediaElch");
     QCoreApplication::setApplicationVersion("2.4.3-dev");
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 1, 0))
     QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps, true);
-#endif
 
     Settings::instance(qApp)->loadSettings();
     if (Settings::instance()->advanced()->debugLog() && !Settings::instance()->advanced()->logFile().isEmpty()) {

--- a/xbmc/XbmcSync.cpp
+++ b/xbmc/XbmcSync.cpp
@@ -173,11 +173,7 @@ void XbmcSync::startSync()
         QNetworkRequest request(xbmcUrl());
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("Accept", "application/json");
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 1, 0))
         QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
-#else
-        QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson());
-#endif
         connect(reply, SIGNAL(finished()), this, SLOT(onMovieListFinished()));
     }
 
@@ -188,11 +184,7 @@ void XbmcSync::startSync()
         QNetworkRequest request(xbmcUrl());
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("Accept", "application/json");
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 1, 0))
         QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
-#else
-        QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson());
-#endif
         connect(reply, SIGNAL(finished()), this, SLOT(onConcertListFinished()));
     }
 
@@ -203,11 +195,7 @@ void XbmcSync::startSync()
         QNetworkRequest request(xbmcUrl());
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("Accept", "application/json");
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 1, 0))
         QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
-#else
-        QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson());
-#endif
         connect(reply, SIGNAL(finished()), this, SLOT(onTvShowListFinished()));
     }
 
@@ -218,11 +206,7 @@ void XbmcSync::startSync()
         QNetworkRequest request(xbmcUrl());
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("Accept", "application/json");
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 1, 0))
         QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
-#else
-        QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson());
-#endif
         connect(reply, SIGNAL(finished()), this, SLOT(onEpisodeListFinished()));
     }
 
@@ -426,11 +410,7 @@ void XbmcSync::removeItems()
         QNetworkRequest request(xbmcUrl());
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("Accept", "application/json");
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 1, 0))
         QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
-#else
-        QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson());
-#endif
         connect(reply, SIGNAL(finished()), this, SLOT(onRemoveFinished()));
         return;
     }
@@ -445,11 +425,7 @@ void XbmcSync::removeItems()
         QNetworkRequest request(xbmcUrl());
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("Accept", "application/json");
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 1, 0))
         QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
-#else
-        QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson());
-#endif
         connect(reply, SIGNAL(finished()), this, SLOT(onRemoveFinished()));
         return;
     }
@@ -464,11 +440,7 @@ void XbmcSync::removeItems()
         QNetworkRequest request(xbmcUrl());
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("Accept", "application/json");
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 1, 0))
         QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
-#else
-        QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson());
-#endif
         connect(reply, SIGNAL(finished()), this, SLOT(onRemoveFinished()));
         return;
     }
@@ -484,11 +456,7 @@ void XbmcSync::removeItems()
         QNetworkRequest request(xbmcUrl());
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("Accept", "application/json");
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 1, 0))
         QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
-#else
-        QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson());
-#endif
         connect(reply, SIGNAL(finished()), this, SLOT(onRemoveFinished()));
         return;
     }
@@ -526,11 +494,7 @@ void XbmcSync::triggerReload()
     QNetworkRequest request(xbmcUrl());
     request.setRawHeader("Content-Type", "application/json");
     request.setRawHeader("Accept", "application/json");
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 1, 0))
     QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
-#else
-    QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson());
-#endif
     connect(reply, SIGNAL(finished()), this, SLOT(onScanFinished()));
 }
 
@@ -550,11 +514,7 @@ void XbmcSync::triggerClean()
     QNetworkRequest request(xbmcUrl());
     request.setRawHeader("Content-Type", "application/json");
     request.setRawHeader("Accept", "application/json");
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 1, 0))
     QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
-#else
-    QNetworkReply *reply = m_qnam.post(request, QJsonDocument(o).toJson());
-#endif
     connect(reply, SIGNAL(finished()), this, SLOT(onCleanFinished()));
 }
 


### PR DESCRIPTION
This PR makes this project require Qt version 5.5 and above in the `.pro` file.
It also removes some checks (Qt >= 5.1.0). Not all checks are removed to avoid merge conflicts with other pull requests.
