### PR TITLE
Remove usage of QtScript in ImageProviders and some scrapers

### DIFF
--- a/imageProviders/FanartTvMusic.cpp
+++ b/imageProviders/FanartTvMusic.cpp
@@ -2,10 +2,11 @@
 
 #include <QApplication>
 #include <QDebug>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
 #include <QSettings>
-#include <QtScript/QScriptEngine>
-#include <QtScript/QScriptValue>
-#include <QtScript/QScriptValueIterator>
 
 #include "data/Storage.h"
 #include "imageProviders/FanartTv.h"
@@ -128,7 +129,7 @@ void FanartTvMusic::albumThumbs(QString mbId)
     request.setRawHeader("Accept", "application/json");
     url.setUrl(QString("https://webservice.fanart.tv/v3/music/albums/%1?%2").arg(mbId).arg(keyParameter()));
     request.setUrl(url);
-    QNetworkReply *reply = qnam()->get(QNetworkRequest(request));
+    QNetworkReply *reply = qnam()->get(request);
     reply->setProperty("infoToLoad", ImageType::AlbumThumb);
     connect(reply, SIGNAL(finished()), this, SLOT(onLoadAlbumFinished()));
 }
@@ -252,46 +253,66 @@ void FanartTvMusic::onLoadAlbumFinished()
 QList<Poster> FanartTvMusic::parseData(QString json, int type)
 {
     QMap<int, QStringList> map;
-    map.insert(ImageType::ArtistFanart, QStringList() << "artistbackground");
-    map.insert(ImageType::ArtistExtraFanart, QStringList() << "artistbackground");
-    map.insert(ImageType::ArtistLogo,
-        QStringList() << "hdmusiclogo"
-                      << "musiclogo");
-    map.insert(ImageType::ArtistThumb, QStringList() << "artistthumb");
-    map.insert(ImageType::AlbumCdArt, QStringList() << "cdart");
-    map.insert(ImageType::AlbumThumb, QStringList() << "albumcover");
-    QList<Poster> posters;
-    QScriptValue sc;
-    QScriptEngine engine;
-    sc = engine.evaluate("(" + QString(json) + ")");
 
-    if (type == ImageType::AlbumCdArt || type == ImageType::AlbumThumb) {
-        QScriptValueIterator it(sc.property("albums"));
-        while (it.hasNext()) {
-            it.next();
-            sc = it.value();
-            break;
-        }
+    // clang-format off
+    map.insert(ImageType::ArtistFanart,      QStringList() << "artistbackground");
+    map.insert(ImageType::ArtistExtraFanart, QStringList() << "artistbackground");
+    map.insert(ImageType::ArtistLogo,        QStringList() << "hdmusiclogo" << "musiclogo");
+    map.insert(ImageType::ArtistThumb,       QStringList() << "artistthumb");
+    map.insert(ImageType::AlbumCdArt,        QStringList() << "cdart");
+    map.insert(ImageType::AlbumThumb,        QStringList() << "albumcover");
+    // clang-format on
+
+    QList<Poster> posters;
+
+    QJsonParseError parseError;
+    const auto parsedJson = QJsonDocument::fromJson(json.toUtf8(), &parseError);
+
+    if (parseError.error != QJsonParseError::NoError) {
+        qWarning() << "Error parsing fanart music json: " << parseError.errorString();
+        return posters;
     }
 
+    // The JSON contains one object with all URLs to fanart images
+    const auto jsonObject = [&parsedJson, &type] {
+        const auto jsonObj = parsedJson.object();
+
+        // The JSON for CD Art and Thumbs has a different structure. This is a "hack"
+        // to get a uniform one. We grab the last album (sorted lexicographical by key).
+        if (type == ImageType::AlbumCdArt || type == ImageType::AlbumThumb) {
+            const auto albums = jsonObj.value("albums").toObject();
+            const auto key = albums.keys().back();
+            return albums.value(key).toObject();
+        }
+
+        return jsonObj;
+    }();
+
     foreach (const QString &section, map.value(type)) {
-        if (sc.property(section).isArray()) {
-            QScriptValueIterator itB(sc.property(section));
-            while (itB.hasNext()) {
-                itB.next();
-                QScriptValue vB = itB.value();
-                if (vB.property("url").toString().isEmpty())
-                    continue;
-                Poster b;
-                b.thumbUrl = vB.property("url").toString().replace("/fanart/", "/preview/");
-                b.originalUrl = vB.property("url").toString();
-                if (section == "hdmusiclogo")
-                    b.hint = "HD";
-                else if (section == "musiclogo")
-                    b.hint = "SD";
-                b.language = vB.property("lang").toString();
-                FanartTv::insertPoster(posters, b, m_language, "");
+        const auto jsonValue = jsonObject.value(section);
+        if (!jsonValue.isArray()) {
+            continue;
+        }
+
+        for (const auto &it : jsonValue.toArray()) {
+            const auto val = it.toObject();
+            if (val.value("url").toString().isEmpty()) {
+                continue;
             }
+            Poster b;
+            b.thumbUrl = val.value("url").toString().replace("/fanart/", "/preview/");
+            b.originalUrl = val.value("url").toString();
+            b.hint = [&section] {
+                if (section == "hdmusiclogo") {
+                    return QStringLiteral("HD");
+                } else if (section == "musiclogo") {
+                    return QStringLiteral("SD");
+                } else {
+                    return QStringLiteral("");
+                }
+            }();
+            b.language = val.value("lang").toString();
+            FanartTv::insertPoster(posters, b, m_language, "");
         }
     }
 
@@ -497,7 +518,7 @@ void FanartTvMusic::artistImages(Artist *artist, QString mbId, QList<int> types)
     request.setRawHeader("Accept", "application/json");
     url.setUrl(QString("https://webservice.fanart.tv/v3/music/%1?%2").arg(mbId).arg(keyParameter()));
     request.setUrl(url);
-    QNetworkReply *reply = qnam()->get(QNetworkRequest(request));
+    QNetworkReply *reply = qnam()->get(request);
     reply->setProperty("storage", Storage::toVariant(reply, artist));
     reply->setProperty("infosToLoad", Storage::toVariant(reply, types));
     connect(reply, SIGNAL(finished()), this, SLOT(onLoadAllArtistDataFinished()));
@@ -510,7 +531,7 @@ void FanartTvMusic::albumImages(Album *album, QString mbId, QList<int> types)
     request.setRawHeader("Accept", "application/json");
     url.setUrl(QString("https://webservice.fanart.tv/v3/music/albums/%1?%2").arg(mbId).arg(keyParameter()));
     request.setUrl(url);
-    QNetworkReply *reply = qnam()->get(QNetworkRequest(request));
+    QNetworkReply *reply = qnam()->get(request);
     reply->setProperty("storage", Storage::toVariant(reply, album));
     reply->setProperty("infosToLoad", Storage::toVariant(reply, types));
     connect(reply, SIGNAL(finished()), this, SLOT(onLoadAllAlbumDataFinished()));

--- a/imageProviders/FanartTvMusicArtists.cpp
+++ b/imageProviders/FanartTvMusicArtists.cpp
@@ -1,10 +1,11 @@
 #include "FanartTvMusicArtists.h"
 
 #include <QDebug>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
 #include <QSettings>
-#include <QtScript/QScriptEngine>
-#include <QtScript/QScriptValue>
-#include <QtScript/QScriptValueIterator>
 
 #include "data/Storage.h"
 #include "imageProviders/FanartTv.h"
@@ -150,35 +151,50 @@ QList<Poster> FanartTvMusicArtists::parseData(QString json, int type)
     map.insert(ImageType::ConcertLogo,
         QStringList() << "hdmusiclogo"
                       << "musiclogo");
+
     QList<Poster> posters;
-    QScriptValue sc;
-    QScriptEngine engine;
-    sc = engine.evaluate("(" + QString(json) + ")");
+
+    QJsonParseError parseError;
+    // The JSON contains one object with all URLs to fanart images
+    const auto parsedJson = QJsonDocument::fromJson(json.toUtf8(), &parseError).object();
+
+    if (parseError.error != QJsonParseError::NoError) {
+        qWarning() << "Error parsing fanart music json: " << parseError.errorString();
+        return posters;
+    }
 
     foreach (const QString &section, map.value(type)) {
-        if (sc.property(section).isArray()) {
-            QScriptValueIterator itB(sc.property(section));
-            while (itB.hasNext()) {
-                itB.next();
-                QScriptValue vB = itB.value();
-                if (vB.property("url").toString().isEmpty())
-                    continue;
-                Poster b;
-                b.thumbUrl = vB.property("url").toString().replace("/fanart/", "/preview/");
-                b.originalUrl = vB.property("url").toString();
-                if (section == "hdmusiclogo")
-                    b.hint = "HD";
-                else if (section == "musiclogo")
-                    b.hint = "SD";
-                else if (vB.property("disc_type").toString() == "bluray")
-                    b.hint = "BluRay";
-                else if (vB.property("disc_type").toString() == "dvd")
-                    b.hint = "DVD";
-                else if (vB.property("disc_type").toString() == "3d")
-                    b.hint = "3D";
-                b.language = vB.property("lang").toString();
-                FanartTv::insertPoster(posters, b, m_language, m_preferredDiscType);
+        const auto jsonPosters = parsedJson.value(section).toArray();
+
+        for (const auto &it : jsonPosters) {
+            const auto poster = it.toObject();
+            if (poster.value("url").toString().isEmpty()) {
+                continue;
             }
+
+            Poster b;
+            b.thumbUrl = poster.value("url").toString().replace("/fanart/", "/preview/");
+            b.originalUrl = poster.value("url").toString();
+
+            const auto discType = poster.value("disc_type").toString();
+            b.hint = [&section, &discType] {
+                if (section == "hdmusiclogo") {
+                    return QStringLiteral("HD");
+                } else if (section == "musiclogo") {
+                    return QStringLiteral("SD");
+                } else if (discType == "bluray") {
+                    return QStringLiteral("BluRay");
+                } else if (discType == "dvd") {
+                    return QStringLiteral("DVD");
+                } else if (discType == "3d") {
+                    return QStringLiteral("3D");
+                } else {
+                    return QStringLiteral("");
+                }
+            }();
+
+            b.language = poster.value("lang").toString();
+            FanartTv::insertPoster(posters, b, m_language, m_preferredDiscType);
         }
     }
 

--- a/imageProviders/MediaPassionImages.cpp
+++ b/imageProviders/MediaPassionImages.cpp
@@ -1,9 +1,6 @@
 #include "MediaPassionImages.h"
 
 #include <QSettings>
-#include <QtScript/QScriptEngine>
-#include <QtScript/QScriptValue>
-#include <QtScript/QScriptValueIterator>
 
 #include "scrapers/TMDb.h"
 #include "settings/Settings.h"

--- a/imageProviders/TMDbImages.cpp
+++ b/imageProviders/TMDbImages.cpp
@@ -1,9 +1,5 @@
 #include "TMDbImages.h"
 
-#include <QtScript/QScriptEngine>
-#include <QtScript/QScriptValue>
-#include <QtScript/QScriptValueIterator>
-
 #include "scrapers/TMDb.h"
 #include "settings/Settings.h"
 

--- a/scrapers/IMDB.cpp
+++ b/scrapers/IMDB.cpp
@@ -1,7 +1,5 @@
 #include "IMDB.h"
 
-#include <QScriptEngine>
-#include <QScriptValueIterator>
 #include <QWidget>
 
 #include "data/Storage.h"

--- a/scrapers/UniversalMusicScraper.h
+++ b/scrapers/UniversalMusicScraper.h
@@ -69,9 +69,9 @@ private:
     void appendDownloadElement(Artist *artist, QString source, QString type, QUrl url);
     void appendDownloadElement(Album *album, QString source, QString type, QUrl url);
     void parseAndAssignMusicbrainzInfos(QString xml, Album *album, QList<int> infos);
-    void parseAndAssignTadbInfos(QString json, Artist *artist, QList<int> infos);
-    void parseAndAssignTadbInfos(QString json, Album *album, QList<int> infos);
-    void parseAndAssignTadbDiscography(QString json, Artist *artist, QList<int> infos);
+    void parseAndAssignTadbInfos(QJsonObject document, Artist *artist, QList<int> infos);
+    void parseAndAssignTadbInfos(QJsonObject document, Album *album, QList<int> infos);
+    void parseAndAssignTadbDiscography(QJsonObject document, Artist *artist, QList<int> infos);
     void parseAndAssignAmInfos(QString html, Artist *artist, QList<int> infos);
     void parseAndAssignAmInfos(QString html, Album *album, QList<int> infos);
     void parseAndAssignAmBiography(QString html, Artist *artist, QList<int> infos);

--- a/xbmc/XbmcSync.cpp
+++ b/xbmc/XbmcSync.cpp
@@ -5,9 +5,6 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMessageBox>
-#include <QScriptEngine>
-#include <QScriptValue>
-#include <QScriptValueIterator>
 
 #include "globals/Manager.h"
 #include "notifications/NotificationBox.h"

--- a/xbmc/XbmcSync.h
+++ b/xbmc/XbmcSync.h
@@ -6,7 +6,6 @@
 #include <QMutex>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
-#include <QScriptValue>
 #include <QTcpSocket>
 #include <QTimer>
 


### PR DESCRIPTION
 - use QtJsonDocument instead of QtScript parsing
 - reason: QtScript is deprecated
 - not all occurrences of QtScript are removed, yet