### PR TITLE
Escape HTML entities in exported strings

### DIFF
--- a/export/ExportDialog.cpp
+++ b/export/ExportDialog.cpp
@@ -200,20 +200,20 @@ void ExportDialog::replaceVars(QString &m, Movie *movie, QDir dir, bool subDir)
     m.replace("{{ MOVIE.LINK }}", QString("movies/%1.html").arg(movie->movieId()));
     m.replace("{{ MOVIE.IMDB_ID }}", movie->id());
     m.replace("{{ MOVIE.TMDB_ID }}", movie->tmdbId());
-    m.replace("{{ MOVIE.TITLE }}", movie->name());
+    m.replace("{{ MOVIE.TITLE }}", movie->name().toHtmlEscaped());
     m.replace("{{ MOVIE.YEAR }}", movie->released().isValid() ? movie->released().toString("yyyy") : "");
-    m.replace("{{ MOVIE.ORIGINAL_TITLE }}", movie->originalName());
-    m.replace("{{ MOVIE.PLOT }}", movie->overview().replace("\n", "<br />"));
-    m.replace("{{ MOVIE.PLOT_SIMPLE }}", movie->outline().replace("\n", "<br />"));
-    m.replace("{{ MOVIE.SET }}", movie->set());
-    m.replace("{{ MOVIE.TAGLINE }}", movie->tagline());
-    m.replace("{{ MOVIE.GENRES }}", movie->genres().join(", "));
-    m.replace("{{ MOVIE.COUNTRIES }}", movie->countries().join(", "));
-    m.replace("{{ MOVIE.STUDIOS }}", movie->studios().join(", "));
-    m.replace("{{ MOVIE.TAGS }}", movie->tags().join(", "));
-    m.replace("{{ MOVIE.WRITER }}", movie->writer());
-    m.replace("{{ MOVIE.DIRECTOR }}", movie->director());
-    m.replace("{{ MOVIE.CERTIFICATION }}", movie->certification());
+    m.replace("{{ MOVIE.ORIGINAL_TITLE }}", movie->originalName().toHtmlEscaped());
+    m.replace("{{ MOVIE.PLOT }}", movie->overview().toHtmlEscaped().replace("\n", "<br />"));
+    m.replace("{{ MOVIE.PLOT_SIMPLE }}", movie->outline().toHtmlEscaped().replace("\n", "<br />"));
+    m.replace("{{ MOVIE.SET }}", movie->set().toHtmlEscaped());
+    m.replace("{{ MOVIE.TAGLINE }}", movie->tagline().toHtmlEscaped());
+    m.replace("{{ MOVIE.GENRES }}", movie->genres().join(", ")).toHtmlEscaped();
+    m.replace("{{ MOVIE.COUNTRIES }}", movie->countries().join(", ").toHtmlEscaped());
+    m.replace("{{ MOVIE.STUDIOS }}", movie->studios().join(", ").toHtmlEscaped());
+    m.replace("{{ MOVIE.TAGS }}", movie->tags().join(", ").toHtmlEscaped());
+    m.replace("{{ MOVIE.WRITER }}", movie->writer().toHtmlEscaped());
+    m.replace("{{ MOVIE.DIRECTOR }}", movie->director().toHtmlEscaped());
+    m.replace("{{ MOVIE.CERTIFICATION }}", movie->certification().toHtmlEscaped());
     m.replace("{{ MOVIE.TRAILER }}", movie->trailer().toString());
     m.replace("{{ MOVIE.RATING }}", QString::number(movie->rating(), 'f', 1));
     m.replace("{{ MOVIE.VOTES }}", QString::number(movie->votes(), 'f', 0));
@@ -309,21 +309,21 @@ void ExportDialog::replaceVars(QString &m, Concert *concert, QDir dir, bool subD
 {
     m.replace("{{ CONCERT.ID }}", QString::number(concert->concertId(), 'f', 0));
     m.replace("{{ CONCERT.LINK }}", QString("concerts/%1.html").arg(concert->concertId()));
-    m.replace("{{ CONCERT.TITLE }}", concert->name());
-    m.replace("{{ CONCERT.ARTIST }}", concert->artist());
-    m.replace("{{ CONCERT.ALBUM }}", concert->album());
-    m.replace("{{ CONCERT.TAGLINE }}", concert->tagline());
+    m.replace("{{ CONCERT.TITLE }}", concert->name().toHtmlEscaped());
+    m.replace("{{ CONCERT.ARTIST }}", concert->artist().toHtmlEscaped());
+    m.replace("{{ CONCERT.ALBUM }}", concert->album().toHtmlEscaped());
+    m.replace("{{ CONCERT.TAGLINE }}", concert->tagline().toHtmlEscaped());
     m.replace("{{ CONCERT.RATING }}", QString::number(concert->rating(), 'f', 1));
     m.replace("{{ CONCERT.YEAR }}", concert->released().isValid() ? concert->released().toString("yyyy") : "");
     m.replace("{{ CONCERT.RUNTIME }}", QString::number(concert->runtime(), 'f', 0));
-    m.replace("{{ CONCERT.CERTIFICATION }}", concert->certification());
+    m.replace("{{ CONCERT.CERTIFICATION }}", concert->certification().toHtmlEscaped());
     m.replace("{{ CONCERT.TRAILER }}", concert->trailer().toString());
     m.replace("{{ CONCERT.PLAY_COUNT }}", QString::number(concert->playcount(), 'f', 0));
     m.replace("{{ CONCERT.LAST_PLAYED }}",
         concert->lastPlayed().isValid() ? concert->lastPlayed().toString("yyyy-MM-dd hh:mm") : "");
-    m.replace("{{ CONCERT.PLOT }}", concert->overview().replace("\n", "<br />"));
-    m.replace("{{ CONCERT.TAGS }}", concert->tags().join(", "));
-    m.replace("{{ CONCERT.GENRES }}", concert->genres().join(", "));
+    m.replace("{{ CONCERT.PLOT }}", concert->overview().toHtmlEscaped().replace("\n", "<br />"));
+    m.replace("{{ CONCERT.TAGS }}", concert->tags().join(", ").toHtmlEscaped());
+    m.replace("{{ CONCERT.GENRES }}", concert->genres().join(", ").toHtmlEscaped());
 
     replaceStreamDetailsVars(m, concert->streamDetails());
     replaceSingleBlock(m, "TAGS", "TAG.NAME", concert->tags());
@@ -404,15 +404,15 @@ void ExportDialog::replaceVars(QString &m, TvShow *show, QDir dir, bool subDir)
     m.replace("{{ TVSHOW.ID }}", QString::number(show->showId(), 'f', 0));
     m.replace("{{ TVSHOW.LINK }}", QString("tvshows/%1.html").arg(show->showId()));
     m.replace("{{ TVSHOW.IMDB_ID }}", show->imdbId());
-    m.replace("{{ TVSHOW.TITLE }}", show->name());
+    m.replace("{{ TVSHOW.TITLE }}", show->name().toHtmlEscaped());
     m.replace("{{ TVSHOW.RATING }}", QString::number(show->rating(), 'f', 1));
-    m.replace("{{ TVSHOW.CERTIFICATION }}", show->certification());
+    m.replace("{{ TVSHOW.CERTIFICATION }}", show->certification().toHtmlEscaped());
     m.replace(
         "{{ TVSHOW.FIRST_AIRED }}", show->firstAired().isValid() ? show->firstAired().toString("yyyy-MM-dd") : "");
-    m.replace("{{ TVSHOW.STUDIO }}", show->network());
-    m.replace("{{ TVSHOW.PLOT }}", show->overview().replace("\n", "<br />"));
-    m.replace("{{ TVSHOW.TAGS }}", show->tags().join(", "));
-    m.replace("{{ TVSHOW.GENRES }}", show->genres().join(", "));
+    m.replace("{{ TVSHOW.STUDIO }}", show->network().toHtmlEscaped());
+    m.replace("{{ TVSHOW.PLOT }}", show->overview().toHtmlEscaped().replace("\n", "<br />"));
+    m.replace("{{ TVSHOW.TAGS }}", show->tags().join(", ").toHtmlEscaped());
+    m.replace("{{ TVSHOW.GENRES }}", show->genres().join(", ").toHtmlEscaped());
 
     QStringList actorNames;
     QStringList actorRoles;
@@ -482,22 +482,22 @@ void ExportDialog::replaceVars(QString &m, TvShow *show, QDir dir, bool subDir)
 
 void ExportDialog::replaceVars(QString &m, TvShowEpisode *episode, QDir dir, bool subDir)
 {
-    m.replace("{{ SHOW.TITLE }}", episode->tvShow()->name());
+    m.replace("{{ SHOW.TITLE }}", episode->tvShow()->name().toHtmlEscaped());
     m.replace("{{ SHOW.LINK }}", QString("../tvshows/%1.html").arg(episode->tvShow()->showId()));
     m.replace("{{ EPISODE.LINK }}", QString("../episodes/%1.html").arg(episode->episodeId()));
-    m.replace("{{ EPISODE.TITLE }}", episode->name());
-    m.replace("{{ EPISODE.SEASON }}", episode->seasonString());
-    m.replace("{{ EPISODE.EPISODE }}", episode->episodeString());
+    m.replace("{{ EPISODE.TITLE }}", episode->name().toHtmlEscaped());
+    m.replace("{{ EPISODE.SEASON }}", episode->seasonString().toHtmlEscaped());
+    m.replace("{{ EPISODE.EPISODE }}", episode->episodeString().toHtmlEscaped());
     m.replace("{{ EPISODE.RATING }}", QString::number(episode->rating(), 'f', 1));
-    m.replace("{{ EPISODE.CERTIFICATION }}", episode->certification());
+    m.replace("{{ EPISODE.CERTIFICATION }}", episode->certification().toHtmlEscaped());
     m.replace("{{ EPISODE.FIRST_AIRED }}",
         episode->firstAired().isValid() ? episode->firstAired().toString("yyyy-MM-dd") : "");
     m.replace("{{ EPISODE.LAST_PLAYED }}",
         episode->lastPlayed().isValid() ? episode->lastPlayed().toString("yyyy-MM-dd hh:mm") : "");
-    m.replace("{{ EPISODE.STUDIO }}", episode->network());
-    m.replace("{{ EPISODE.PLOT }}", episode->overview().replace("\n", "<br />"));
-    m.replace("{{ EPISODE.WRITERS }}", episode->writers().join(", "));
-    m.replace("{{ EPISODE.DIRECTORS }}", episode->directors().join(", "));
+    m.replace("{{ EPISODE.STUDIO }}", episode->network().toHtmlEscaped());
+    m.replace("{{ EPISODE.PLOT }}", episode->overview().toHtmlEscaped().replace("\n", "<br />"));
+    m.replace("{{ EPISODE.WRITERS }}", episode->writers().join(", ").toHtmlEscaped());
+    m.replace("{{ EPISODE.DIRECTORS }}", episode->directors().join(", ").toHtmlEscaped());
 
     replaceStreamDetailsVars(m, episode->streamDetails());
     replaceSingleBlock(m, "WRITERS", "WRITER.NAME", episode->writers());
@@ -543,7 +543,7 @@ void ExportDialog::replaceMultiBlock(QString &m, QString blockName, QStringList 
         for (int i = 0, n = replaces.at(0).count(); i < n; ++i) {
             QString subItem = item;
             for (int x = 0, y = itemNames.count(); x < y; ++x) {
-                subItem.replace("{{ " + itemNames.at(x) + " }}", replaces.at(x).at(i));
+                subItem.replace("{{ " + itemNames.at(x) + " }}", replaces.at(x).at(i).toHtmlEscaped());
             }
             list << subItem;
         }


### PR DESCRIPTION
Since the data is exported in a HTML file, all the strings that may contain HTML entities (`"`, `<`, `>`, `&`) should be escaped so that they don't break the syntax of the HTML file.