### PR TITLE
Fix various cppcheck errors

### DIFF
--- a/data/Storage.h
+++ b/data/Storage.h
@@ -74,8 +74,8 @@ private:
     QList<int> m_infosToLoad;
     QPointer<ExportTemplate> m_exportTemplate;
     QMap<ScraperInterface *, QString> m_ids;
-    QTableWidgetItem *m_tableWidgetItem;
-    PluginInterface *m_pluginInterface;
+    QTableWidgetItem *m_tableWidgetItem = nullptr;
+    PluginInterface *m_pluginInterface = nullptr;
     PluginManager::Plugin m_plugin;
     QList<TvShowEpisode *> m_episodes;
 };

--- a/globals/ImageDialog.cpp
+++ b/globals/ImageDialog.cpp
@@ -826,8 +826,6 @@ void ImageDialog::loadImagesFromProvider(QString id)
             m_currentProvider->moviePosters(id);
         else if (m_type == ImageType::MovieBackdrop)
             m_currentProvider->movieBackdrops(id);
-        else if (m_type == ImageType::MoviePoster)
-            m_currentProvider->moviePosters(id);
         else if (m_type == ImageType::MovieLogo)
             m_currentProvider->movieLogos(id);
         else if (m_type == ImageType::MovieBanner)

--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -307,17 +307,11 @@ MainWindow *MainWindow::instance()
  */
 void MainWindow::resizeEvent(QResizeEvent *event)
 {
-    if (event->size().width() >= 1500) {
-        ui->movieWidget->setBigWindow(true);
-        ui->tvShowWidget->setBigWindow(true);
-        ui->concertWidget->setBigWindow(true);
-        ui->musicWidget->setBigWindow(true);
-    } else if (event->size().width() < 1500) {
-        ui->movieWidget->setBigWindow(false);
-        ui->tvShowWidget->setBigWindow(false);
-        ui->concertWidget->setBigWindow(false);
-        ui->musicWidget->setBigWindow(false);
-    }
+    bool isBigWindow = event->size().width() >= 1500;
+    ui->movieWidget->setBigWindow(isBigWindow);
+    ui->tvShowWidget->setBigWindow(isBigWindow);
+    ui->concertWidget->setBigWindow(isBigWindow);
+    ui->musicWidget->setBigWindow(isBigWindow);
 
     NotificationBox::instance()->reposition(event->size());
     QWidget::resizeEvent(event);

--- a/music/Album.cpp
+++ b/music/Album.cpp
@@ -16,8 +16,6 @@ Album::Album(QString path, QObject *parent) :
     m_bookletProxyModel->setSourceModel(m_bookletModel);
 }
 
-Album::~Album() = default;
-
 QString Album::path() const
 {
     return m_path;

--- a/music/Album.h
+++ b/music/Album.h
@@ -24,7 +24,7 @@ class Album : public QObject
 
 public:
     explicit Album(QString path, QObject *parent = nullptr);
-    ~Album() override;
+    ~Album() override = default;
 
     QString path() const;
     void setPath(const QString &path);

--- a/music/Artist.cpp
+++ b/music/Artist.cpp
@@ -10,8 +10,6 @@ Artist::Artist(QString path, QObject *parent) :
 {
 }
 
-Artist::~Artist() = default;
-
 QString Artist::path() const
 {
     return m_path;

--- a/music/Artist.h
+++ b/music/Artist.h
@@ -16,7 +16,7 @@ class Artist : public QObject
     Q_PROPERTY(MusicModelItem *modelItem READ modelItem NOTIFY modelItemChanged)
 public:
     explicit Artist(QString path, QObject *parent = nullptr);
-    ~Artist() override;
+    ~Artist() override = default;
 
     QString path() const;
     void setPath(const QString &path);

--- a/music/MusicFileSearcher.cpp
+++ b/music/MusicFileSearcher.cpp
@@ -9,11 +9,10 @@
 
 MusicFileSearcher::MusicFileSearcher(QObject *parent) :
     QObject(parent),
-    m_progressMessageId{Constants::MusicFileSearcherProgressMessageId}
+    m_progressMessageId{Constants::MusicFileSearcherProgressMessageId},
+    m_aborted{false}
 {
 }
-
-MusicFileSearcher::~MusicFileSearcher() = default;
 
 void MusicFileSearcher::setMusicDirectories(QList<SettingsDir> directories)
 {

--- a/music/MusicFileSearcher.h
+++ b/music/MusicFileSearcher.h
@@ -12,7 +12,7 @@ class MusicFileSearcher : public QObject
     Q_OBJECT
 public:
     explicit MusicFileSearcher(QObject *parent = nullptr);
-    ~MusicFileSearcher() override;
+    ~MusicFileSearcher() override = default;
 
     void setMusicDirectories(QList<SettingsDir> directories);
     static Artist *loadArtistData(Artist *artist);

--- a/music/MusicModel.cpp
+++ b/music/MusicModel.cpp
@@ -53,7 +53,7 @@ QVariant MusicModel::data(const QModelIndex &index, int role) const
         return font;
     } else if (role == Qt::SizeHintRole) {
 #ifdef Q_OS_WIN
-        return QSize(0, (item->data(MusicRoles::Type) == TypeArtist) ? 22 : 22);
+        return QSize(0, 22);
 #else
         return QSize(0, (item->data(MusicRoles::Type) == TypeArtist) ? 44 : 22);
 #endif

--- a/smallWidgets/SlidingStackedWidget.cpp
+++ b/smallWidgets/SlidingStackedWidget.cpp
@@ -14,14 +14,12 @@ SlidingStackedWidget::SlidingStackedWidget(QWidget *parent) :
     m_active{false},
     m_expanded{false}
 {
-    if (parent != nullptr)
+    if (parent != nullptr) {
         m_mainWindow = parent;
-    else
+    } else {
         m_mainWindow = this;
+    }
 }
-
-
-SlidingStackedWidget::~SlidingStackedWidget() = default;
 
 void SlidingStackedWidget::setVerticalMode(bool vertical)
 {

--- a/smallWidgets/SlidingStackedWidget.h
+++ b/smallWidgets/SlidingStackedWidget.h
@@ -28,8 +28,8 @@ public:
         AUTOMATIC
     };
 
-    SlidingStackedWidget(QWidget *parent);
-    ~SlidingStackedWidget() override;
+    explicit SlidingStackedWidget(QWidget *parent);
+    ~SlidingStackedWidget() override = default;
     bool isExpanded() const;
 
 public slots:


### PR DESCRIPTION
 - remove doubled if condition
 - remove doubled condition body
 - add "explicit" keyword
 - move "default" keyword to header in some places
 - Storage.cpp: initialize pointers to nullptr in constructors

*using:* `cppcheck --enable=all -iquazip -j4 . 2> cppcheck.txt`