### PR TITLE
Add changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,40 @@
+# Changelog
+
+2.4.3 (*tbd*)
+
+ - Feature: Detect duplicate movies
+ - Feature: Use HTTPS for scraping
+ - Feature: Set UI language in `advancedsettings.xml`
+ - Renamer: Create subdirectories
+ - Scraper: Remove deprecated Coverlib
+ - Scraper: Remove deprecated MovieMaze
+ - Scraper: Remove deprecated Cinefacts
+ - Scraper: Add Kino.de
+ - Bugfix: HD-Trailers scraper broken
+ - Bugfix: Fanart.tv music scraper broken
+ - Bugfix: Adult scrapers broken
+ - Bugfix: OFDB movie scraper crashes
+ - Bugfix: Fix poster IMDB scraping
+ - Bugfix: Fix studio name export
+ - Bugfix: Fix TvShow status in `.nfo` file
+ - Bugfix: Escape HTML entities in export
+ - Bugfix: Multi scraping episode thumbnails
+ - UI: Fix line break in tree views
+
+2.4.2 (2016-07-01)
+
+ - Bugfix: UniversalMusicScraper broken
+
+2.4.1 (2016-03-20)
+
+ - Renamer: Show results in table view
+ - Export: Add IMDB ID to template
+ - IMDB: Adjusted scraper to new layout
+ - StreamDetails: Stereomode not detected
+ - IMDB: Rating and votes sometimes not scraped
+ - TheTVDB: Get votes for episodes and shows
+ - Image capture: Prevent possible crash
+ - StreamDetails: Language of subtitle not detected
+ - TvShows: Possible crash when scanning for new episodes of a single show
+ - TvShowEpisodes: epbookmark not saved
+ - AdvancedSettings: Use first studio only not working


### PR DESCRIPTION
I'd like to have a changelog in the root directory (also some sort of beta changelog was requested on http://community.kvibes.de).

The changelog in [MediaElch/debian](https://github.com/Komet/MediaElch/blob/master/debian/changelog) is also not up to date.
Please let me know if this is acceptable or if I should update `MediaElch/debian/changelog`. :smiley: 

This changelog does not contain the full version history. I think for older versions `MediaElch/debian/changelog` is a better place to look.