### PR TITLE
Fix linux .desktop file

### DIFF
--- a/desktop/MediaElch.desktop
+++ b/desktop/MediaElch.desktop
@@ -1,9 +1,8 @@
 [Desktop Entry]
-Encoding=UTF-8
-Version=2.4.2
 Type=Application
-Terminal=false
-Exec=/usr/bin/MediaElch
 Name=MediaElch
 Icon=MediaElch
-Categories=Video;
+Terminal=false
+Exec=/usr/bin/MediaElch
+Categories=AudioVideo;Video;
+GenericName=Media Manager


### PR DESCRIPTION
 - "Encoding" is deprecated
 - "Version" refers to the file format's version
 - "Video" in "Categories" requires "AudioVideo" to be present