### PR TITLE
Remove QScript from TMDb; restructure request urls

### DIFF
--- a/scrapers/TMDb.h
+++ b/scrapers/TMDb.h
@@ -2,6 +2,7 @@
 #define TMDB_H
 
 #include <QComboBox>
+#include <QMap>
 #include <QObject>
 #include <QPointer>
 #include <QtNetwork/QNetworkAccessManager>
@@ -17,7 +18,7 @@ class TMDb : public ScraperInterface
     Q_OBJECT
 public:
     explicit TMDb(QObject *parent = nullptr);
-    ~TMDb() override;
+    ~TMDb() override = default;
     QString name() override;
     QString identifier() override;
     void search(QString searchStr) override;
@@ -55,8 +56,29 @@ private:
     QWidget *m_widget;
     QComboBox *m_box;
 
-    QNetworkAccessManager *qnam();
+    enum class ApiMovieDetails
+    {
+        INFOS,
+        IMAGES,
+        CASTS,
+        TRAILERS,
+        RELEASES
+    };
+    enum class ApiUrlParameter
+    {
+        LANGUAGE,
+        YEAR,
+        PAGE,
+        INCLUDE_ADULT
+    };
+    using UrlParameterMap = QMap<ApiUrlParameter, QString>;
+
     void setup();
+    QString apiUrlParameterString(ApiUrlParameter parameter) const;
+    QUrl getMovieSearchUrl(const QString &searchStr, const UrlParameterMap &parameters) const;
+    QUrl getMovieUrl(const QString &title,
+        ApiMovieDetails type,
+        const UrlParameterMap &parameters = UrlParameterMap{}) const;
     void parseAndAssignInfos(QString json, Movie *movie, QList<int> infos);
 };
 


### PR DESCRIPTION
 - removes the dependency "QScript" from TMDb.cpp
 - restructures TMDb.cpp (simplify request urls)

### Removal of QScript
With this PR, the only files that still use QScript are `CustomMovieScraper.cpp` and `TMDbConcerts.cpp`. 

### Restructuring `TMDb.cpp`
There was way to much copy&paste regarding the search/movie URL of TheMovieDb which makes changes to the URL difficult.  I created two methods that handle creating the search and movie URL. All parameter values are percent encoded. I also switched to enums for parameters to avoid typos.

### Bug fix
There was also one bug that is now fixed:

```cpp
movie->setOverview(sc.property("overview").toString());
if (Settings::instance()->usePlotForOutline())
    movie->setOutline(sc.property("overview").toString());
```

The outline was never set to the plot's value.

### Everything works :smile: 
This PR should not break anything. Images are loaded, information is assigned, etc.
Please let me know if I should rename the enums, etc.


Regards,
Andre