### PR TITLE
Update languages supported by TMDb; better language handling

### DIFF
--- a/scrapers/TMDb.cpp
+++ b/scrapers/TMDb.cpp
@@ -21,23 +21,28 @@
  * @brief TMDb::TMDb
  * @param parent
  */
-TMDb::TMDb(QObject *parent)
+TMDb::TMDb(QObject *parent) : m_language{"en"}, m_baseUrl{"http://cf2.imgobject.com/t/p/"}
 {
     setParent(parent);
-    m_language = "en";
 
     m_widget = new QWidget(MainWindow::instance());
     m_box = new QComboBox(m_widget);
+
+    // For officially supported languages, see:
+    // https://developers.themoviedb.org/3/configuration/get-primary-translations
+    m_box->addItem(tr("Arabic"), "ar");
     m_box->addItem(tr("Bulgarian"), "bg");
-    m_box->addItem(tr("Chinese"), "zh");
+    m_box->addItem(tr("Chinese (T)"), "zh-TW");
+    m_box->addItem(tr("Chinese (S)"), "zh-CN");
     m_box->addItem(tr("Croatian"), "hr");
     m_box->addItem(tr("Czech"), "cs");
     m_box->addItem(tr("Danish"), "da");
     m_box->addItem(tr("Dutch"), "nl");
     m_box->addItem(tr("English"), "en");
-    m_box->addItem(tr("English (US)"), "en_US");
+    m_box->addItem(tr("English (US)"), "en-US");
     m_box->addItem(tr("Finnish"), "fi");
     m_box->addItem(tr("French"), "fr");
+    m_box->addItem(tr("French (Canada)"), "fr-CA");
     m_box->addItem(tr("German"), "de");
     m_box->addItem(tr("Greek"), "el");
     m_box->addItem(tr("Hebrew"), "he");
@@ -47,12 +52,15 @@ TMDb::TMDb(QObject *parent)
     m_box->addItem(tr("Korean"), "ko");
     m_box->addItem(tr("Norwegian"), "no");
     m_box->addItem(tr("Polish"), "pl");
-    m_box->addItem(tr("Portuguese"), "pt");
+    m_box->addItem(tr("Portuguese (Brazil)"), "pt-BR");
+    m_box->addItem(tr("Portuguese (Portugal)"), "pt-PT");
     m_box->addItem(tr("Russian"), "ru");
     m_box->addItem(tr("Slovene"), "sl");
     m_box->addItem(tr("Spanish"), "es");
+    m_box->addItem(tr("Spanish (Mexico)"), "es-MX");
     m_box->addItem(tr("Swedish"), "sv");
     m_box->addItem(tr("Turkish"), "tr");
+
     auto layout = new QGridLayout(m_widget);
     layout->addWidget(new QLabel(tr("Language")), 0, 0);
     layout->addWidget(m_box, 0, 1);
@@ -100,8 +108,6 @@ TMDb::TMDb(QObject *parent)
                               << MovieScraperInfos::Director      //
                               << MovieScraperInfos::Writer        //
                               << MovieScraperInfos::Set;
-
-    m_baseUrl = "http://cf2.imgobject.com/t/p/";
     setup();
 }
 

--- a/scrapers/TMDb.h
+++ b/scrapers/TMDb.h
@@ -2,6 +2,7 @@
 #define TMDB_H
 
 #include <QComboBox>
+#include <QLocale>
 #include <QMap>
 #include <QObject>
 #include <QPointer>
@@ -47,8 +48,7 @@ private slots:
 
 private:
     QNetworkAccessManager m_qnam;
-    QString m_language;
-    QString m_language2;
+    QLocale m_locale;
     QString m_baseUrl;
     QMutex m_mutex;
     QList<int> m_scraperSupports;
@@ -66,7 +66,6 @@ private:
     };
     enum class ApiUrlParameter
     {
-        LANGUAGE,
         YEAR,
         PAGE,
         INCLUDE_ADULT
@@ -74,6 +73,9 @@ private:
     using UrlParameterMap = QMap<ApiUrlParameter, QString>;
 
     void setup();
+    QString localeForTMDb() const;
+    QString language() const;
+    QString country() const;
     QString apiUrlParameterString(ApiUrlParameter parameter) const;
     QUrl getMovieSearchUrl(const QString &searchStr, const UrlParameterMap &parameters) const;
     QUrl getMovieUrl(const QString &title,

--- a/scrapers/TMDbConcerts.cpp
+++ b/scrapers/TMDbConcerts.cpp
@@ -18,24 +18,31 @@
  * @brief TMDbConcerts::TMDbConcerts
  * @param parent
  */
-TMDbConcerts::TMDbConcerts(QObject *parent)
+TMDbConcerts::TMDbConcerts(QObject *parent) :
+    m_apiKey{"5d832bdf69dcb884922381ab01548d5b"},
+    m_language{"en"},
+    m_baseUrl{"http://cf2.imgobject.com/t/p/"}
 {
     setParent(parent);
-    m_apiKey = "5d832bdf69dcb884922381ab01548d5b";
-    m_language = "en";
 
     m_widget = new QWidget(MainWindow::instance());
     m_box = new QComboBox(m_widget);
+
+    // For officially supported languages, see:
+    // https://developers.themoviedb.org/3/configuration/get-primary-translations
+    m_box->addItem(tr("Arabic"), "ar");
     m_box->addItem(tr("Bulgarian"), "bg");
-    m_box->addItem(tr("Chinese"), "zh");
+    m_box->addItem(tr("Chinese (T)"), "zh-TW");
+    m_box->addItem(tr("Chinese (S)"), "zh-CN");
     m_box->addItem(tr("Croatian"), "hr");
     m_box->addItem(tr("Czech"), "cs");
     m_box->addItem(tr("Danish"), "da");
     m_box->addItem(tr("Dutch"), "nl");
     m_box->addItem(tr("English"), "en");
-    m_box->addItem(tr("English (US)"), "en_US");
+    m_box->addItem(tr("English (US)"), "en-US");
     m_box->addItem(tr("Finnish"), "fi");
     m_box->addItem(tr("French"), "fr");
+    m_box->addItem(tr("French (Canada)"), "fr-CA");
     m_box->addItem(tr("German"), "de");
     m_box->addItem(tr("Greek"), "el");
     m_box->addItem(tr("Hebrew"), "he");
@@ -45,12 +52,15 @@ TMDbConcerts::TMDbConcerts(QObject *parent)
     m_box->addItem(tr("Korean"), "ko");
     m_box->addItem(tr("Norwegian"), "no");
     m_box->addItem(tr("Polish"), "pl");
-    m_box->addItem(tr("Portuguese"), "pt");
+    m_box->addItem(tr("Portuguese (Brazil)"), "pt-BR");
+    m_box->addItem(tr("Portuguese (Portugal)"), "pt-PT");
     m_box->addItem(tr("Russian"), "ru");
     m_box->addItem(tr("Slovene"), "sl");
     m_box->addItem(tr("Spanish"), "es");
+    m_box->addItem(tr("Spanish (Mexico)"), "es-MX");
     m_box->addItem(tr("Swedish"), "sv");
     m_box->addItem(tr("Turkish"), "tr");
+
     auto layout = new QGridLayout(m_widget);
     layout->addWidget(new QLabel(tr("Language")), 0, 0);
     layout->addWidget(m_box, 0, 1);
@@ -71,18 +81,16 @@ TMDbConcerts::TMDbConcerts(QObject *parent)
                       << ConcertScraperInfos::Genres        //
                       << ConcertScraperInfos::ExtraArts;
 
-    m_baseUrl = "http://cf2.imgobject.com/t/p/";
     setup();
 }
 
-TMDbConcerts::~TMDbConcerts() = default;
 /**
  * @brief Returns the name of the scraper
  * @return Name of the Scraper
  */
 QString TMDbConcerts::name()
 {
-    return QString("The Movie DB (Concerts)");
+    return QStringLiteral("The Movie DB (Concerts)");
 }
 
 /**

--- a/scrapers/TMDbConcerts.cpp
+++ b/scrapers/TMDbConcerts.cpp
@@ -20,7 +20,7 @@
  */
 TMDbConcerts::TMDbConcerts(QObject *parent) :
     m_apiKey{"5d832bdf69dcb884922381ab01548d5b"},
-    m_language{"en"},
+    m_locale{"en"},
     m_baseUrl{"http://cf2.imgobject.com/t/p/"}
 {
     setParent(parent);
@@ -112,23 +112,18 @@ QWidget *TMDbConcerts::settingsWidget()
  */
 void TMDbConcerts::loadSettings(QSettings &settings)
 {
-    QString lang = settings.value("Scrapers/TMDbConcerts/Language", "en").toString();
-    m_language = lang;
-    m_language2 = "";
-    if (m_language.split("_").count() > 1) {
-        m_language = lang.split("_").at(0);
-        m_language2 = lang.split("_").at(1);
+    m_locale = QLocale(settings.value("Scrapers/TMDbConcerts/Language", "en").toString());
+    if (m_locale.name() == "C") {
+        m_locale = QLocale("en");
     }
 
-    bool found = false;
+    const QString locale = localeForTMDb();
+    const QString lang = language();
+
     for (int i = 0, n = m_box->count(); i < n; ++i) {
-        if (m_box->itemData(i).toString() == m_language + "_" + m_language2) {
+        if (m_box->itemData(i).toString() == lang || m_box->itemData(i).toString() == locale) {
             m_box->setCurrentIndex(i);
-            found = true;
-        }
-        if (m_box->itemData(i).toString() == m_language && !found) {
-            m_box->setCurrentIndex(i);
-            found = true;
+            break;
         }
     }
 }
@@ -138,12 +133,7 @@ void TMDbConcerts::loadSettings(QSettings &settings)
  */
 void TMDbConcerts::saveSettings(QSettings &settings)
 {
-    QString language;
-    language = m_box->itemData(m_box->currentIndex()).toString();
-    if (language.split("_").count() > 1) {
-        m_language = language.split("_").at(0);
-        m_language2 = language.split("_").at(1);
-    }
+    const QString language = m_box->itemData(m_box->currentIndex()).toString();
     settings.setValue("Scrapers/TMDbConcerts/Language", language);
     loadSettings(settings);
 }
@@ -178,6 +168,27 @@ void TMDbConcerts::setup()
     QNetworkReply *reply = qnam()->get(request);
     new NetworkReplyWatcher(this, reply);
     connect(reply, &QNetworkReply::finished, this, &TMDbConcerts::setupFinished);
+}
+
+QString TMDbConcerts::localeForTMDb() const
+{
+    return m_locale.name().replace('_', '-');
+}
+
+/**
+ * @return Two letter language code (lowercase)
+ */
+QString TMDbConcerts::language() const
+{
+    return m_locale.name().split('_').first();
+}
+
+/**
+ * @return Two or three letter country code (uppercase)
+ */
+QString TMDbConcerts::country() const
+{
+    return m_locale.name().split('_').last();
 }
 
 /**
@@ -216,16 +227,16 @@ void TMDbConcerts::search(QString searchStr)
         url.setUrl(QString("https://api.themoviedb.org/3/movie/%1?api_key=%2&language=%3")
                        .arg(searchStr)
                        .arg(m_apiKey)
-                       .arg(m_language));
+                       .arg(localeForTMDb()));
     else if (rxTmdbId.exactMatch(searchStr))
         url.setUrl(QString("http://api.themoviedb.org/3/movie/%1?api_key=%2&language=%3")
                        .arg(searchStr.mid(2))
                        .arg(m_apiKey)
-                       .arg(m_language));
+                       .arg(localeForTMDb()));
     else
         url.setUrl(QString("https://api.themoviedb.org/3/search/movie?api_key=%1&language=%2&query=%3")
                        .arg(m_apiKey)
-                       .arg(m_language)
+                       .arg(localeForTMDb())
                        .arg(searchStr));
     QNetworkRequest request(url);
     request.setRawHeader("Accept", "application/json");
@@ -264,7 +275,7 @@ void TMDbConcerts::searchFinished()
     } else {
         QUrl url(QString("https://api.themoviedb.org/3/search/movie?api_key=%1&language=%2&page=%3&query=%4")
                      .arg(m_apiKey)
-                     .arg(m_language)
+                     .arg(localeForTMDb())
                      .arg(nextPage)
                      .arg(searchString));
         QNetworkRequest request(url);
@@ -348,8 +359,10 @@ void TMDbConcerts::loadData(QString id, Concert *concert, QList<int> infos)
 
     // Infos
     loadsLeft.append(DataInfos);
-    url.setUrl(
-        QString("https://api.themoviedb.org/3/movie/%1?api_key=%2&language=%3").arg(id).arg(m_apiKey).arg(m_language));
+    url.setUrl(QString("https://api.themoviedb.org/3/movie/%1?api_key=%2&language=%3")
+                   .arg(id)
+                   .arg(m_apiKey)
+                   .arg(localeForTMDb()));
     request.setUrl(url);
     QNetworkReply *reply = qnam()->get(request);
     new NetworkReplyWatcher(this, reply);
@@ -581,23 +594,33 @@ void TMDbConcerts::parseAndAssignInfos(QString json, Concert *concert, QList<int
         while (itB.hasNext()) {
             itB.next();
             QScriptValue vB = itB.value();
-            if (vB.property("iso_3166_1").toString() == "US")
-                us = vB.property("certification").toString();
-            if (vB.property("iso_3166_1").toString() == "GB")
-                gb = vB.property("certification").toString();
-            if (vB.property("iso_3166_1").toString().toLower() == m_language)
-                locale = vB.property("certification").toString();
+            const QString iso3166 = vB.property("iso_3166_1").toString();
+            const QString certification = vB.property("certification").toString();
+            if (iso3166 == "US") {
+                us = certification;
+            }
+            if (iso3166 == "GB") {
+                gb = certification;
+            }
+            if (iso3166.toUpper() == country()) {
+                locale = certification;
+            }
         }
 
-        if (m_language2 == "US" && !us.isEmpty())
+        if (m_locale.country() == QLocale::UnitedStates && !us.isEmpty()) {
             concert->setCertification(Helper::instance()->mapCertification(us));
-        else if (m_language == "en" && m_language2 == "" && !gb.isEmpty())
+
+        } else if (m_locale.language() == QLocale::English && !gb.isEmpty()) {
             concert->setCertification(Helper::instance()->mapCertification(gb));
-        else if (!locale.isEmpty())
+
+        } else if (!locale.isEmpty()) {
             concert->setCertification(Helper::instance()->mapCertification(locale));
-        else if (!us.isEmpty())
+
+        } else if (!us.isEmpty()) {
             concert->setCertification(Helper::instance()->mapCertification(us));
-        else if (!gb.isEmpty())
+
+        } else if (!gb.isEmpty()) {
             concert->setCertification(Helper::instance()->mapCertification(gb));
+        }
     }
 }

--- a/scrapers/TMDbConcerts.h
+++ b/scrapers/TMDbConcerts.h
@@ -17,7 +17,7 @@ class TMDbConcerts : public ConcertScraperInterface
     Q_OBJECT
 public:
     explicit TMDbConcerts(QObject *parent = nullptr);
-    ~TMDbConcerts() override;
+    ~TMDbConcerts() override = default;
     QString name() override;
     void search(QString searchStr) override;
     void loadData(QString id, Concert *concert, QList<int> infos) override;

--- a/scrapers/TMDbConcerts.h
+++ b/scrapers/TMDbConcerts.h
@@ -2,6 +2,7 @@
 #define TMDBCONCERTS_H
 
 #include <QComboBox>
+#include <QLocale>
 #include <QObject>
 #include <QWidget>
 #include <QtNetwork/QNetworkAccessManager>
@@ -41,7 +42,7 @@ private slots:
 private:
     QString m_apiKey;
     QNetworkAccessManager m_qnam;
-    QString m_language;
+    QLocale m_locale;
     QString m_language2;
     QString m_baseUrl;
     QList<int> m_scraperSupports;
@@ -49,6 +50,9 @@ private:
     QComboBox *m_box;
 
     void setup();
+    QString localeForTMDb() const;
+    QString language() const;
+    QString country() const;
     QNetworkAccessManager *qnam();
     QList<ScraperSearchResult> parseSearch(QString json, int *nextPage);
     void parseAndAssignInfos(QString json, Concert *concert, QList<int> infos);


### PR DESCRIPTION
This PR will update the list of supported languages by TMDb.

Languages that are supported by TMDb but have not yet been added to this PR: `be-BY`, `bn-BD`, `ca-ES`, `ch-GU`, `eo-EO`, `eu-ES`, `fa-IR`, `hi-IN`, `id-ID`, `ka-GE`, `kn-IN`, `lt-LT`, `ml-IN`, `nb-NO`, `ro-RO`, `sk-SK`, `sr-RS`, `ta-IN`, `te-IN`, `th-TH`, `uk-UA`, `vi-VN`

*Links:*
 - MediaElch Community Thread: http://community.kvibes.de/topic/show/the-movie-db-modified-pt-language
 - Supported languages by TMDb: https://gist.github.com/bugwelle/3a9c10ae702440cda043f2568cf4ee46 (copied from: https://developers.themoviedb.org/3/configuration/get-primary-translations)

**What was changed?**
- [x] add TMDb concert languages
- [x] add further languages (uncomment `hr`)
- [x] add member variable and `m_locale`. _Reason_: If we add languages like `pt-BR`, we will never get a "certification" because MediaElch compares `pt-BR` to the country code in the TMDb response.
- [x] better language handling in general
- [x] load posters in selected language and english as a fallback