### PR TITLE
Refactor AdvancedSettings; add example XML

### DIFF
--- a/doc/advancedsettings.xml
+++ b/doc/advancedsettings.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    This XML contains advanced settings for MediaElch (http://mediaelch.de/).
+    All tags contain MediaElch's default values unless stated otherwise.
+-->
+<advancedsettings>
+    <!--
+        When <portableMode> is set to true MediaElch will store its settings,
+        temporary files and caches in the application directory and not in
+        standard locations based on your OS.
+        This settings is only available on Windows.
+    -->
+    <portableMode>false</portableMode>
+
+    <!--
+        If you want to enable the debug mode, change false to true and set a
+        path to a log file. The path should either be absolute or relative
+        to the MediaElch application directory.
+    -->
+    <log>
+        <debug>false</debug>
+        <file>./MediaElch.log</file>
+    </log>
+
+    <!--
+        Interface related settings.
+    -->
+    <gui>
+        <forceCache>false</forceCache>
+    </gui>
+
+    <!--
+        When set to false no thumbnail or poster URLs will be
+        written to the nfo file.
+    -->
+    <writeThumbUrlsToNfo>true</writeThumbUrlsToNfo>
+
+    <!--
+        When cutting a music album booklet in two pieces this percentage
+        will be removed in the middle of the image.
+    -->
+    <bookletCut>2</bookletCut>
+
+    <!--
+        When »MediaElch -> Settings -> "Ignore articles when sorting"« is
+        checked these words are ignored and appended to the movie name
+        ("The Movie" -> "Movie, The").
+    -->
+    <sorttokens>
+        <token>Der</token>
+        <token>Die</token>
+        <token>Das</token>
+        <token>The</token>
+        <token>Le</token>
+        <token>La</token>
+        <token>Les</token>
+        <token>Un</token>
+        <token>Une</token>
+        <token>Des</token>
+    </sorttokens>
+
+    <!--
+        certifications defines a mapping which is applied when data is loaded
+        from a scraper. If uncommented, the example below will replace
+        the certification  "PG-13" with "FSK 12" and "R" with "FSK 18".
+    -->
+    <certifications>
+        <!-- <map from="PG-13" to="FSK 12" />
+        <map from="R" to="FSK 18" />-->
+    </certifications>
+
+    <!--
+        <genres> defines a mapping which is applied when data is loaded from
+        a scraper. If uncommented, the example below will replace the genre
+        "SciFi" with "Science Fiction".
+    -->
+    <genres>
+        <!--<map from="SciFi" to="Science Fiction" />-->
+    </genres>
+
+    <!--
+        <countries> defines a mapping which is applied when data is
+        loaded from a scraper. If uncommented, the example below will
+        replace the country "US" with "United states".
+    -->
+    <countries>
+        <!--<map from="US" to="United States" />-->
+    </countries>
+
+    <!--
+        <studios> defines a mapping which is applied when data is loaded
+        from a scraper. If uncommented, the example below will replace the
+        studio "Studio 1" with "Studio 2". If the attribute "useFirstStudioOnly"
+        is set to "true", MediaElch will only save the first studio found.
+    -->
+    <studios useFirstStudioOnly="false">
+        <!--<map from="Studio 1" to="Studio 2" />-->
+    </studios>
+
+    <!--
+        <audioCodecs> defines a mapping which is applied when
+        streamdetails are loaded. The example below will replace
+        the audio codec "MPA1L3" with "MP3".
+    -->
+    <audioCodecs>
+        <map from="MPA1L2" to="MP2" />
+        <map from="MPA1L3" to="MP3" />
+    </audioCodecs>
+
+    <!--
+        <videoCodecs> defines a mapping which is applied when
+        streamdetails are loaded. The example below will replace
+        the video codec "v_mpeg4/iso/avc" with "h264".
+    -->
+    <videoCodecs>
+        <map from="v_mpeg4/iso/avc" to="h264" />
+    </videoCodecs>
+
+    <!--
+        <fileFilters> defines the extensions of files MediaElch will
+        scan. Multiple extensions can be added comma separated.
+        A special case is <subtitle> these files will also be
+        renamed when renaming a movie.
+    -->
+    <fileFilters>
+        <movies>
+            *.mkv,*.mk3d,*.avi,*.mpg,*.mpeg,*.mp4,*.m2ts,*.disc,
+            *.m4v,*.strm,*.dat,*.flv,*.vob,*.ts,*.iso,*.ogg,*.ogm,
+            *.rmvb,*.img,*.wmv,*.mov,*.divx,VIDEO_TS.IFO,
+            index.bdmv,*.wtv"
+        </movies>
+        <tvShows>
+            *.mkv,*.mk3d,*.avi,*.mpg,*.mpeg,*.mp4,*.m2ts,*.disc,
+            *.m4v,*.strm,*.dat,*.flv,*.vob,*.ts,*.iso,*.ogg,*.ogm,
+            *.rmvb,*.img,*.wmv,*.mov,*.divx,VIDEO_TS.IFO,
+            index.bdmv,*.wtv"
+        </tvShows>
+        <concerts>
+            *.mkv,*.mk3d,*.avi,*.mpg,*.mpeg,*.mp4,*.m2ts,*.disc,
+            *.m4v,*.strm,*.dat,*.flv,*.vob,*.ts,*.iso,*.ogg,*.ogm,
+            *.rmvb,*.img,*.wmv,*.mov,*.divx,VIDEO_TS.IFO,
+            index.bdmv,*.wtv"
+        </concerts>
+        <subtitle>
+            *.idx,*.sub,*.srr,*.srt
+        </subtitle>
+    </fileFilters>
+</advancedsettings>

--- a/settings/AdvancedSettings.h
+++ b/settings/AdvancedSettings.h
@@ -1,6 +1,7 @@
 #ifndef ADVANCEDSETTINGS_H
 #define ADVANCEDSETTINGS_H
 
+#include <QByteArray>
 #include <QHash>
 #include <QObject>
 #include <QStringList>
@@ -13,7 +14,7 @@ class AdvancedSettings : public QObject
     Q_OBJECT
 public:
     explicit AdvancedSettings(QObject *parent = nullptr);
-    ~AdvancedSettings() override;
+    ~AdvancedSettings() override = default;
 
     bool debugLog() const;
     QString logFile() const;
@@ -54,18 +55,14 @@ private:
     bool m_writeThumbUrlsToNfo;
     bool m_useFirstStudioOnly;
 
+    QByteArray getAdvancedSettingsXml() const;
     void loadSettings();
     void reset();
     void loadLog(QXmlStreamReader &xml);
     void loadGui(QXmlStreamReader &xml);
     void loadSortTokens(QXmlStreamReader &xml);
-    void loadGenreMappings(QXmlStreamReader &xml);
     void loadFilters(QXmlStreamReader &xml);
-    void loadAudioCodecMappings(QXmlStreamReader &xml);
-    void loadVideoCodecMappings(QXmlStreamReader &xml);
-    void loadCertificationMappings(QXmlStreamReader &xml);
-    void loadStudioMappings(QXmlStreamReader &xml);
-    void loadCountryMappings(QXmlStreamReader &xml);
+    void loadMappings(QXmlStreamReader &xml, QHash<QString, QString> &map);
 };
 
 #endif // ADVANCEDSETTINGS_H


### PR DESCRIPTION
*commit message:* 
- refactor "loadMappings" functions
 - trim values of XML elements/attributes
 - clear mappings if the corresponding XML element exists
 - add an example advancedsettings.xml with all default values

### AdvancedSettings
This pull request refactors `AdvancedSettings.cpp`. It removes redundant code and simplifies code regarding mappings. Also, tags are now trimmed and `*.mk3d` is added as a video format.

### Example `advancedsettings.xml`
This PR also adds an example xml file that is based on your version posted [here](http://community.kvibes.de/topic/show/advanced-settings). I added missing tags and changed the values to MediaElch's defaults.

I'm not exactly sure what `<forceCache>` does. Could you explain that tag to me? :smile: 

### Changes
This PR has one change regarding the XML. `useFirstStudioOnly` is no longer an XML tag but instead an attribute of `<studios>`. This makes handling mappings easier as we only need one method for it. I also didn't find any documentation explaining that tag. The only website that mentions it is a post on [https://www.kodinerds.net/](https://www.kodinerds.net/index.php/Thread/14560-MediaElch-MediaManager-for-Mac-Linux-Win/?postID=113024#post113024).
So I guess (?) this won't affect many users.



