### PR TITLE
[Tree View] Fix too long titles

### DIFF
--- a/smallWidgets/MusicTreeView.cpp
+++ b/smallWidgets/MusicTreeView.cpp
@@ -121,9 +121,12 @@ void MusicTreeView::drawRow(QPainter *painter, const QStyleOptionViewItem &optio
             option.rect.y(),
             option.rect.width() - albumIndent - itemIndent,
             option.rect.height() - 1);
-        painter->setFont(index.data(Qt::FontRole).value<QFont>());
+        const QFont font = index.data(Qt::FontRole).value<QFont>();
+        painter->setFont(font);
         painter->setPen(index.data(isSelected ? MusicRoles::SelectionForeground : Qt::ForegroundRole).value<QColor>());
-        painter->drawText(albumRect, index.data().toString(), QTextOption(Qt::AlignVCenter));
+        const QFontMetrics metrics(font);
+        const QString itemStr = metrics.elidedText(index.data().toString(), Qt::ElideRight, albumRect.width());
+        painter->drawText(albumRect, itemStr, QTextOption(Qt::AlignVCenter));
     }
 
     painter->restore();

--- a/smallWidgets/TvShowTreeView.cpp
+++ b/smallWidgets/TvShowTreeView.cpp
@@ -201,11 +201,12 @@ void TvShowTreeView::drawRow(QPainter *painter, const QStyleOptionViewItem &opti
 
         QRect itemRect(
             option.rect.x() + itemIndent, option.rect.y(), option.rect.width() - itemIndent, option.rect.height() - 1);
-        QFont font = index.data(Qt::FontRole).value<QFont>();
+        const QFont font = index.data(Qt::FontRole).value<QFont>();
         painter->setFont(font);
         painter->setPen(index.data(isSelected ? TvShowRoles::SelectionForeground : Qt::ForegroundRole).value<QColor>());
-        painter->drawText(itemRect, index.data().toString(), QTextOption(Qt::AlignVCenter));
+        const QFontMetrics metrics(font);
+        const QString itemStr = metrics.elidedText(index.data().toString(), Qt::ElideRight, itemRect.width());
+        painter->drawText(itemRect, itemStr, QTextOption(Qt::AlignVCenter));
     }
-
     painter->restore();
 }


### PR DESCRIPTION
 - too long titles were broken into multiple lines
 - instead uses an ellipsis ("...")

### Before
![screenshot_20180417_203149](https://user-images.githubusercontent.com/1667306/38889357-cd2d7f12-427e-11e8-9863-06bc511c010a.png)

### After
![screenshot_20180417_204834](https://user-images.githubusercontent.com/1667306/38890128-cc85d8f0-4280-11e8-8e5e-34cf752590ad.png)