### PR TITLE
Add "locale" to advanced settings

### DIFF
--- a/doc/advancedsettings.xml
+++ b/doc/advancedsettings.xml
@@ -5,6 +5,15 @@
 -->
 <advancedsettings>
     <!--
+        Set the interface language. If it is set to "system", your system's
+        language will be used. Use the format "lang-COUNTRY" to specify your
+        language. Examples: "de-DE", "en-US", "pt-PT", "pt-BR"
+        If <locale> is not valid, your system's locale will be used.
+        If <locale> exists, but is not supported by MediaElch, English will be used.
+    -->
+    <locale>system</locale>
+
+    <!--
         When <portableMode> is set to true MediaElch will store its settings,
         temporary files and caches in the application directory and not in
         standard locations based on your OS.

--- a/main.cpp
+++ b/main.cpp
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
 
     // Qt localization
     QTranslator qtTranslator;
-    qtTranslator.load(":/i18n/qt_" + QLocale::system().name());
+    qtTranslator.load(":/i18n/qt_" + Settings::instance()->advanced()->locale().name());
     app.installTranslator(&qtTranslator);
 
     // MediaElch localization
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
     if (fi.isFile()) {
         editTranslator.load(localFileName);
     } else {
-        editTranslator.load(QLocale::system(), "MediaElch", "_", ":/i18n/", ".qm");
+        editTranslator.load(Settings::instance()->advanced()->locale(), "MediaElch", "_", ":/i18n/", ".qm");
     }
     app.installTranslator(&editTranslator);
 

--- a/settings/AdvancedSettings.cpp
+++ b/settings/AdvancedSettings.cpp
@@ -17,6 +17,7 @@ AdvancedSettings::AdvancedSettings(QObject *parent) : QObject(parent)
 void AdvancedSettings::reset()
 {
     m_debugLog = false;
+    m_locale = QLocale::system();
     m_forceCache = false;
     m_bookletCut = 2;
     m_logFile = "";
@@ -107,6 +108,9 @@ void AdvancedSettings::loadSettings()
         if (xml.name() == "log") {
             loadLog(xml);
 
+        } else if (xml.name() == "locale") {
+            setLocale(xml.readElementText());
+
         } else if (xml.name() == "portableMode") {
             m_portableMode = (xml.readElementText() == "true");
 
@@ -153,6 +157,7 @@ void AdvancedSettings::loadSettings()
     }
 
     qDebug() << "Advanced settings";
+    qDebug() << "    locale                " << m_locale;
     qDebug() << "    debugLog              " << m_debugLog;
     qDebug() << "    logFile               " << m_logFile;
     qDebug() << "    forceCache            " << m_forceCache;
@@ -170,6 +175,23 @@ void AdvancedSettings::loadSettings()
     qDebug() << "    writeThumbUrlsToNfo   " << m_writeThumbUrlsToNfo;
     qDebug() << "    bookletCut            " << m_bookletCut;
     qDebug() << "    useFirstStudioOnly    " << m_useFirstStudioOnly;
+}
+
+void AdvancedSettings::setLocale(QString locale)
+{
+    locale = locale.trimmed();
+    if (locale.toLower() == "system") {
+        m_locale = QLocale::system();
+
+    } else {
+        m_locale = QLocale(locale);
+        // If "locale" is not a valid locale, Qt uses the C locale.
+        // Because `.name()` also returns "C" instead of the systems locale,
+        // we have to check for it.
+        if (m_locale.name() == "C") {
+            m_locale = QLocale::system();
+        }
+    }
 }
 
 void AdvancedSettings::loadLog(QXmlStreamReader &xml)
@@ -273,6 +295,11 @@ bool AdvancedSettings::debugLog() const
 QString AdvancedSettings::logFile() const
 {
     return m_logFile;
+}
+
+QLocale AdvancedSettings::locale() const
+{
+    return m_locale;
 }
 
 QStringList AdvancedSettings::sortTokens() const

--- a/settings/AdvancedSettings.h
+++ b/settings/AdvancedSettings.h
@@ -18,6 +18,7 @@ public:
 
     bool debugLog() const;
     QString logFile() const;
+    QLocale locale() const;
     QStringList sortTokens() const;
     QHash<QString, QString> genreMappings() const;
     QStringList movieFilters() const;
@@ -38,6 +39,7 @@ public:
 private:
     bool m_debugLog;
     QString m_logFile;
+    QLocale m_locale;
     QStringList m_sortTokens;
     QHash<QString, QString> m_genreMappings;
     QStringList m_movieFilters;
@@ -58,6 +60,7 @@ private:
     QByteArray getAdvancedSettingsXml() const;
     void loadSettings();
     void reset();
+    void setLocale(QString locale);
     void loadLog(QXmlStreamReader &xml);
     void loadGui(QXmlStreamReader &xml);
     void loadSortTokens(QXmlStreamReader &xml);


### PR DESCRIPTION
Allows specifying an interface language unequal to your system's.