### PR TITLE
[Travis] Fix macOS streamdetails

### DIFF
--- a/travis-ci/package.sh
+++ b/travis-ci/package.sh
@@ -176,8 +176,7 @@ create_macos_dmg() {
 
 	fold_start "mediainfo"
 	print_info "Copying mediainfo into MediaElch.dmg"
-	mkdir -p MediaElch.app/Contents/Frameworks/
-	cp ../libmediainfo.0.dylib MediaElch.app/Contents/Frameworks/
+	cp ../libmediainfo.0.dylib MediaElch.app/Contents/MacOS/
 	fold_end
 
 	#######################################################


### PR DESCRIPTION
 - `libmediainfo.0.dylib` was not found
 - setting `LD_LIBRARY_PATH` to `MediaElch.app/Contents/Frameworks` helped
 - implemented solution: I moved `libmediainfo.0.dylib` to `MacOS`

@Komet I'll merge this because it works. 
But I wonder: How would I solve this in a better way? I can't find where MediaInfo is linked and wonder how (or why) it is loaded. It seems I still have a lot to learn about linking.

*Update:* Nevermind, found it: https://github.com/MediaArea/MediaInfoLib/blob/master/Source/MediaInfoDLL/MediaInfoDLL.h#L135