### PR TITLE
Use scoped enum instead of integers in namespaces

### DIFF
--- a/concerts/ConcertController.cpp
+++ b/concerts/ConcertController.cpp
@@ -142,20 +142,19 @@ void ConcertController::scraperLoadDone(ConcertScraperInterface *scraper)
 
     emit sigInfoLoadDone(m_concert);
     if (!m_concert->tmdbId().isEmpty() && infosToLoad().contains(ConcertScraperInfos::ExtraArts)) {
-        QList<int> images;
-        images << ImageType::ConcertCdArt << ImageType::ConcertClearArt << ImageType::ConcertLogo;
+        QList<ImageType> images{ImageType::ConcertCdArt, ImageType::ConcertClearArt, ImageType::ConcertLogo};
         connect(Manager::instance()->fanartTv(),
-            SIGNAL(sigImagesLoaded(Concert *, QMap<int, QList<Poster>>)),
+            SIGNAL(sigImagesLoaded(Concert *, QMap<ImageType, QList<Poster>>)),
             this,
-            SLOT(onFanartLoadDone(Concert *, QMap<int, QList<Poster>>)),
+            SLOT(onFanartLoadDone(Concert *, QMap<ImageType, QList<Poster>>)),
             Qt::UniqueConnection);
         Manager::instance()->fanartTv()->concertImages(m_concert, m_concert->tmdbId(), images);
     } else {
-        onFanartLoadDone(m_concert, QMap<int, QList<Poster>>());
+        onFanartLoadDone(m_concert, QMap<ImageType, QList<Poster>>());
     }
 }
 
-void ConcertController::onFanartLoadDone(Concert *concert, QMap<int, QList<Poster>> posters)
+void ConcertController::onFanartLoadDone(Concert *concert, QMap<ImageType, QList<Poster>> posters)
 {
     if (concert != m_concert) {
         return;
@@ -170,8 +169,8 @@ void ConcertController::onFanartLoadDone(Concert *concert, QMap<int, QList<Poste
 
     QList<DownloadManagerElement> downloads;
 
-    QList<int> imageTypes;
-    QMapIterator<int, QList<Poster>> it(posters);
+    QList<ImageType> imageTypes;
+    QMapIterator<ImageType, QList<Poster>> it(posters);
     while (it.hasNext()) {
         it.next();
         if (it.value().isEmpty()) {
@@ -225,24 +224,24 @@ void ConcertController::onDownloadFinished(DownloadManagerElement elem)
     emit sigImage(m_concert, elem.imageType, elem.data);
 }
 
-void ConcertController::loadImage(int type, QUrl url)
+void ConcertController::loadImage(ImageType type, QUrl url)
 {
     DownloadManagerElement d;
     d.concert = m_concert;
     d.imageType = type;
     d.url = url;
-    emit sigLoadingImages(m_concert, QList<int>() << type);
+    emit sigLoadingImages(m_concert, {type});
     m_downloadManager->addDownload(d);
 }
 
-void ConcertController::loadImages(int type, QList<QUrl> urls)
+void ConcertController::loadImages(ImageType type, QList<QUrl> urls)
 {
-    foreach (const QUrl &url, urls) {
+    for (const QUrl &url : urls) {
         DownloadManagerElement d;
         d.concert = m_concert;
         d.imageType = type;
         d.url = url;
-        emit sigLoadingImages(m_concert, QList<int>() << type);
+        emit sigLoadingImages(m_concert, {type});
         m_downloadManager->addDownload(d);
     }
 }

--- a/concerts/ConcertController.cpp
+++ b/concerts/ConcertController.cpp
@@ -112,7 +112,9 @@ bool ConcertController::loadData(MediaCenterInterface *mediaCenterInterface, boo
     return infoLoaded;
 }
 
-void ConcertController::loadData(QString id, ConcertScraperInterface *scraperInterface, QList<int> infos)
+void ConcertController::loadData(QString id,
+    ConcertScraperInterface *scraperInterface,
+    QList<ConcertScraperInfos> infos)
 {
     m_infosToLoad = infos;
     scraperInterface->loadData(id, m_concert, infos);
@@ -126,12 +128,12 @@ void ConcertController::loadStreamDetailsFromFile()
     m_concert->setChanged(true);
 }
 
-QList<int> ConcertController::infosToLoad()
+QList<ConcertScraperInfos> ConcertController::infosToLoad()
 {
     return m_infosToLoad;
 }
 
-void ConcertController::setInfosToLoad(QList<int> infos)
+void ConcertController::setInfosToLoad(QList<ConcertScraperInfos> infos)
 {
     m_infosToLoad = infos;
 }

--- a/concerts/ConcertController.h
+++ b/concerts/ConcertController.h
@@ -28,8 +28,8 @@ public:
     QList<int> infosToLoad();
     bool infoLoaded() const;
     bool downloadsInProgress() const;
-    void loadImage(int type, QUrl url);
-    void loadImages(int type, QList<QUrl> urls);
+    void loadImage(ImageType type, QUrl url);
+    void loadImages(ImageType type, QList<QUrl> urls);
     void abortDownloads();
     void setLoadsLeft(QList<ScraperData> loadsLeft);
     void removeFromLoadsLeft(ScraperData load);
@@ -40,11 +40,11 @@ signals:
     void sigLoadDone(Concert *);
     void sigLoadImagesStarted(Concert *);
     void sigDownloadProgress(Concert *, int, int);
-    void sigLoadingImages(Concert *, QList<int>);
-    void sigImage(Concert *, int, QByteArray);
+    void sigLoadingImages(Concert *, QList<ImageType>);
+    void sigImage(Concert *, ImageType, QByteArray);
 
 private slots:
-    void onFanartLoadDone(Concert *concert, QMap<int, QList<Poster>> posters);
+    void onFanartLoadDone(Concert *concert, QMap<ImageType, QList<Poster>> posters);
     void onAllDownloadsFinished();
     void onDownloadFinished(DownloadManagerElement elem);
 

--- a/concerts/ConcertController.h
+++ b/concerts/ConcertController.h
@@ -22,10 +22,10 @@ public:
 
     bool saveData(MediaCenterInterface *mediaCenterInterface);
     bool loadData(MediaCenterInterface *mediaCenterInterface, bool force = false, bool reloadFromNfo = true);
-    void loadData(QString id, ConcertScraperInterface *scraperInterface, QList<int> infos);
+    void loadData(QString id, ConcertScraperInterface *scraperInterface, QList<ConcertScraperInfos> infos);
     void loadStreamDetailsFromFile();
     void scraperLoadDone(ConcertScraperInterface *scraper);
-    QList<int> infosToLoad();
+    QList<ConcertScraperInfos> infosToLoad();
     bool infoLoaded() const;
     bool downloadsInProgress() const;
     void loadImage(ImageType type, QUrl url);
@@ -33,7 +33,7 @@ public:
     void abortDownloads();
     void setLoadsLeft(QList<ScraperData> loadsLeft);
     void removeFromLoadsLeft(ScraperData load);
-    void setInfosToLoad(QList<int> infos);
+    void setInfosToLoad(QList<ConcertScraperInfos> infos);
 
 signals:
     void sigInfoLoadDone(Concert *);
@@ -52,7 +52,7 @@ private:
     Concert *m_concert;
     bool m_infoLoaded;
     bool m_infoFromNfoLoaded;
-    QList<int> m_infosToLoad;
+    QList<ConcertScraperInfos> m_infosToLoad;
     DownloadManager *m_downloadManager;
     bool m_downloadsInProgress;
     int m_downloadsSize;

--- a/concerts/ConcertSearch.cpp
+++ b/concerts/ConcertSearch.cpp
@@ -92,7 +92,7 @@ QString ConcertSearch::scraperId()
  * @brief ConcertSearch::infosToLoad
  * @return List of infos to load from the scraper
  */
-QList<int> ConcertSearch::infosToLoad()
+QList<ConcertScraperInfos> ConcertSearch::infosToLoad()
 {
     return ui->concertSearchWidget->infosToLoad();
 }

--- a/concerts/ConcertSearch.h
+++ b/concerts/ConcertSearch.h
@@ -25,7 +25,7 @@ public slots:
     static ConcertSearch *instance(QWidget *parent = nullptr);
     int scraperNo();
     QString scraperId();
-    QList<int> infosToLoad();
+    QList<ConcertScraperInfos> infosToLoad();
 
 private:
     Ui::ConcertSearch *ui;

--- a/concerts/ConcertSearchWidget.cpp
+++ b/concerts/ConcertSearchWidget.cpp
@@ -24,18 +24,18 @@ ConcertSearchWidget::ConcertSearchWidget(QWidget *parent) : QWidget(parent), ui(
     connect(ui->searchString, SIGNAL(returnPressed()), this, SLOT(search()));
     connect(ui->results, &QTableWidget::itemClicked, this, &ConcertSearchWidget::resultClicked);
 
-    ui->chkBackdrop->setMyData(ConcertScraperInfos::Backdrop);
-    ui->chkCertification->setMyData(ConcertScraperInfos::Certification);
-    ui->chkExtraArts->setMyData(ConcertScraperInfos::ExtraArts);
-    ui->chkGenres->setMyData(ConcertScraperInfos::Genres);
-    ui->chkOverview->setMyData(ConcertScraperInfos::Overview);
-    ui->chkPoster->setMyData(ConcertScraperInfos::Poster);
-    ui->chkRating->setMyData(ConcertScraperInfos::Rating);
-    ui->chkReleased->setMyData(ConcertScraperInfos::Released);
-    ui->chkRuntime->setMyData(ConcertScraperInfos::Runtime);
-    ui->chkTagline->setMyData(ConcertScraperInfos::Tagline);
-    ui->chkTitle->setMyData(ConcertScraperInfos::Title);
-    ui->chkTrailer->setMyData(ConcertScraperInfos::Trailer);
+    ui->chkBackdrop->setMyData(static_cast<int>(ConcertScraperInfos::Backdrop));
+    ui->chkCertification->setMyData(static_cast<int>(ConcertScraperInfos::Certification));
+    ui->chkExtraArts->setMyData(static_cast<int>(ConcertScraperInfos::ExtraArts));
+    ui->chkGenres->setMyData(static_cast<int>(ConcertScraperInfos::Genres));
+    ui->chkOverview->setMyData(static_cast<int>(ConcertScraperInfos::Overview));
+    ui->chkPoster->setMyData(static_cast<int>(ConcertScraperInfos::Poster));
+    ui->chkRating->setMyData(static_cast<int>(ConcertScraperInfos::Rating));
+    ui->chkReleased->setMyData(static_cast<int>(ConcertScraperInfos::Released));
+    ui->chkRuntime->setMyData(static_cast<int>(ConcertScraperInfos::Runtime));
+    ui->chkTagline->setMyData(static_cast<int>(ConcertScraperInfos::Tagline));
+    ui->chkTitle->setMyData(static_cast<int>(ConcertScraperInfos::Title));
+    ui->chkTrailer->setMyData(static_cast<int>(ConcertScraperInfos::Trailer));
 
     foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
         if (box->myData().toInt() > 0) {
@@ -110,7 +110,7 @@ void ConcertSearchWidget::chkToggled()
     bool allToggled = true;
     foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
         if (box->isChecked() && box->myData().toInt() > 0 && box->isEnabled()) {
-            m_infosToLoad.append(box->myData().toInt());
+            m_infosToLoad.append(ConcertScraperInfos(box->myData().toInt()));
         }
         if (!box->isChecked() && box->myData().toInt() > 0 && box->isEnabled()) {
             allToggled = false;
@@ -144,20 +144,21 @@ QString ConcertSearchWidget::scraperId()
     return m_scraperId;
 }
 
-QList<int> ConcertSearchWidget::infosToLoad()
+QList<ConcertScraperInfos> ConcertSearchWidget::infosToLoad()
 {
     return m_infosToLoad;
 }
 
-void ConcertSearchWidget::setChkBoxesEnabled(QList<int> scraperSupports)
+void ConcertSearchWidget::setChkBoxesEnabled(QList<ConcertScraperInfos> scraperSupports)
 {
     int scraperNo = ui->comboScraper->itemData(ui->comboScraper->currentIndex(), Qt::UserRole).toInt();
-    QList<int> infos = Settings::instance()->scraperInfos(MainWidgets::Concerts, QString::number(scraperNo));
+    QList<ConcertScraperInfos> infos =
+        Settings::instance()->scraperInfos<ConcertScraperInfos>(QString::number(scraperNo));
 
-    foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
-        box->setEnabled(scraperSupports.contains(box->myData().toInt()));
-        box->setChecked((infos.contains(box->myData().toInt()) || infos.isEmpty())
-                        && scraperSupports.contains(box->myData().toInt()));
+    for (auto box : ui->groupBox->findChildren<MyCheckBox *>()) {
+        box->setEnabled(scraperSupports.contains(ConcertScraperInfos(box->myData().toInt())));
+        box->setChecked((infos.contains(ConcertScraperInfos(box->myData().toInt())) || infos.isEmpty())
+                        && scraperSupports.contains(ConcertScraperInfos(box->myData().toInt())));
     }
     chkToggled();
 }

--- a/concerts/ConcertSearchWidget.h
+++ b/concerts/ConcertSearchWidget.h
@@ -22,7 +22,7 @@ public slots:
     void search(QString searchString);
     int scraperNo();
     QString scraperId();
-    QList<int> infosToLoad();
+    QList<ConcertScraperInfos> infosToLoad();
 
 signals:
     void sigResultClicked();
@@ -38,10 +38,10 @@ private:
     Ui::ConcertSearchWidget *ui;
     int m_scraperNo;
     QString m_scraperId;
-    QList<int> m_infosToLoad;
+    QList<ConcertScraperInfos> m_infosToLoad;
 
     void clear();
-    void setChkBoxesEnabled(QList<int> scraperSupports);
+    void setChkBoxesEnabled(QList<ConcertScraperInfos> scraperSupports);
 };
 
 #endif // CONCERTSEARCHWIDGET_H

--- a/concerts/ConcertWidget.h
+++ b/concerts/ConcertWidget.h
@@ -49,13 +49,13 @@ private slots:
     void onInfoLoadDone(Concert *concert);
     void onLoadDone(Concert *concert);
     void onLoadImagesStarted(Concert *concert);
-    void onLoadingImages(Concert *concert, QList<int> imageTypes);
+    void onLoadingImages(Concert *concert, QList<ImageType> imageTypes);
     void onDownloadProgress(Concert *concert, int current, int maximum);
-    void onSetImage(Concert *concert, int type, QByteArray data);
+    void onSetImage(Concert *concert, ImageType type, QByteArray data);
 
     void onChooseImage();
     void onDeleteImage();
-    void onImageDropped(int imageType, QUrl imageUrl);
+    void onImageDropped(ImageType imageType, QUrl imageUrl);
 
     void concertNameChanged(QString text);
     void addGenre(QString genre);
@@ -89,7 +89,7 @@ private slots:
     void onAddExtraFanart();
     void onExtraFanartDropped(QUrl imageUrl);
 
-    void updateImage(const int &imageType, ClosableImage *image);
+    void updateImage(ImageType imageType, ClosableImage *image);
 
 private:
     Ui::ConcertWidget *ui;
@@ -99,7 +99,7 @@ private:
     QList<QWidget *> m_streamDetailsWidgets;
     QList<QList<QLineEdit *>> m_streamDetailsAudio;
     QList<QList<QLineEdit *>> m_streamDetailsSubtitles;
-    void updateImages(QList<int> images);
+    void updateImages(QList<ImageType> images);
 };
 
 #endif // CONCERTWIDGET_H

--- a/data/Concert.cpp
+++ b/data/Concert.cpp
@@ -926,12 +926,12 @@ DiscType Concert::discType()
     return DiscType::Single;
 }
 
-QList<int> Concert::imagesToRemove() const
+QList<ImageType> Concert::imagesToRemove() const
 {
     return m_imagesToRemove;
 }
 
-void Concert::removeImage(int type)
+void Concert::removeImage(ImageType type)
 {
     if (!m_images.value(type, QByteArray()).isNull()) {
         m_images.insert(type, QByteArray());
@@ -949,38 +949,38 @@ bool Concert::lessThan(Concert *a, Concert *b)
             < 0);
 }
 
-QList<int> Concert::imageTypes()
+QList<ImageType> Concert::imageTypes()
 {
-    return QList<int>() << ImageType::ConcertPoster   //
-                        << ImageType::ConcertCdArt    //
-                        << ImageType::ConcertClearArt //
-                        << ImageType::ConcertLogo     //
-                        << ImageType::ConcertBackdrop;
+    return {ImageType::ConcertPoster,
+        ImageType::ConcertCdArt,
+        ImageType::ConcertClearArt,
+        ImageType::ConcertLogo,
+        ImageType::ConcertBackdrop};
 }
 
-QByteArray Concert::image(int imageType)
+QByteArray Concert::image(ImageType imageType)
 {
     return m_images.value(imageType, QByteArray());
 }
 
-bool Concert::imageHasChanged(int imageType)
+bool Concert::imageHasChanged(ImageType imageType)
 {
     return m_hasImageChanged.value(imageType, false);
 }
 
-void Concert::setImage(int imageType, QByteArray image)
+void Concert::setImage(ImageType imageType, QByteArray image)
 {
     m_images.insert(imageType, image);
     m_hasImageChanged.insert(imageType, true);
     setChanged(true);
 }
 
-bool Concert::hasImage(int imageType)
+bool Concert::hasImage(ImageType imageType)
 {
     return m_hasImage.value(imageType, false);
 }
 
-void Concert::setHasImage(int imageType, bool has)
+void Concert::setHasImage(ImageType imageType, bool has)
 {
     m_hasImage.insert(imageType, has);
 }

--- a/data/Concert.cpp
+++ b/data/Concert.cpp
@@ -53,7 +53,7 @@ void Concert::setFiles(QStringList files)
  */
 void Concert::clear()
 {
-    QList<int> infos;
+    QList<ConcertScraperInfos> infos;
     infos.reserve(14);
     infos << ConcertScraperInfos::Title         //
           << ConcertScraperInfos::Tagline       //
@@ -77,7 +77,7 @@ void Concert::clear()
  * @brief Clears contents of the concert based on a list
  * @param infos List of infos which should be cleared
  */
-void Concert::clear(QList<int> infos)
+void Concert::clear(QList<ConcertScraperInfos> infos)
 {
     if (infos.contains(ConcertScraperInfos::Backdrop)) {
         m_backdrops.clear();

--- a/data/Concert.h
+++ b/data/Concert.h
@@ -53,7 +53,7 @@ public:
     ConcertController *controller() const;
 
     void clear();
-    void clear(QList<int> infos);
+    void clear(QList<ConcertScraperInfos> infos);
 
     virtual QString name() const;
     virtual QString artist() const;
@@ -149,7 +149,7 @@ public:
     void setHasExtraFanarts(bool has);
 
     void scraperLoadDone();
-    QList<int> infosToLoad();
+    QList<ConcertScraperInfos> infosToLoad();
     void setLoadsLeft(QList<ScraperData> loadsLeft);
     void removeFromLoadsLeft(ScraperData load);
 
@@ -191,7 +191,7 @@ private:
     int m_mediaCenterId;
     QString m_tmdbId;
     QString m_id;
-    QList<int> m_infosToLoad;
+    QList<ConcertScraperInfos> m_infosToLoad;
     bool m_streamDetailsLoaded;
     StreamDetails *m_streamDetails;
     QString m_nfoContent;

--- a/data/Concert.h
+++ b/data/Concert.h
@@ -137,14 +137,14 @@ public:
     void clearExtraFanartData();
 
     void clearImages();
-    void removeImage(int type);
-    QList<int> imagesToRemove() const;
+    void removeImage(ImageType type);
+    QList<ImageType> imagesToRemove() const;
 
-    QByteArray image(int imageType);
-    bool imageHasChanged(int imageType);
-    void setImage(int imageType, QByteArray image);
-    void setHasImage(int imageType, bool has);
-    bool hasImage(int imageType);
+    QByteArray image(ImageType imageType);
+    bool imageHasChanged(ImageType imageType);
+    void setImage(ImageType imageType, QByteArray image);
+    void setHasImage(ImageType imageType, bool has);
+    bool hasImage(ImageType imageType);
     bool hasExtraFanarts() const;
     void setHasExtraFanarts(bool has);
 
@@ -157,7 +157,7 @@ public:
     DiscType discType();
 
     static bool lessThan(Concert *a, Concert *b);
-    static QList<int> imageTypes();
+    static QList<ImageType> imageTypes();
 
 signals:
     void sigChanged(Concert *);
@@ -203,11 +203,11 @@ private:
     QStringList m_extraFanarts;
     bool m_hasExtraFanarts;
 
-    QMap<int, QByteArray> m_images;
-    QMap<int, bool> m_hasImageChanged;
+    QMap<ImageType, QByteArray> m_images;
+    QMap<ImageType, bool> m_hasImageChanged;
     QList<QByteArray> m_extraFanartImagesToAdd;
-    QList<int> m_imagesToRemove;
-    QMap<int, bool> m_hasImage;
+    QList<ImageType> m_imagesToRemove;
+    QMap<ImageType, bool> m_hasImage;
 };
 
 #endif // CONCERT_H

--- a/data/ConcertScraperInterface.h
+++ b/data/ConcertScraperInterface.h
@@ -19,11 +19,11 @@ class ConcertScraperInterface : public QObject
 public:
     virtual QString name() = 0;
     virtual void search(QString searchStr) = 0;
-    virtual void loadData(QString id, Concert *concert, QList<int> infos) = 0;
+    virtual void loadData(QString id, Concert *concert, QList<ConcertScraperInfos> infos) = 0;
     virtual bool hasSettings() = 0;
     virtual void loadSettings(QSettings &settings) = 0;
     virtual void saveSettings(QSettings &settings) = 0;
-    virtual QList<int> scraperSupports() = 0;
+    virtual QList<ConcertScraperInfos> scraperSupports() = 0;
     virtual QWidget *settingsWidget() = 0;
 signals:
     virtual void searchDone(QList<ScraperSearchResult>) = 0;

--- a/data/ImageProviderInterface.h
+++ b/data/ImageProviderInterface.h
@@ -18,7 +18,7 @@ class ImageProviderInterface : public QObject
 public:
     virtual QString name() = 0;
     virtual QString identifier() = 0;
-    virtual void movieImages(Movie *movie, QString tmdbId, QList<int> types) = 0;
+    virtual void movieImages(Movie *movie, QString tmdbId, QList<ImageType> types) = 0;
     virtual void moviePosters(QString tmdbId) = 0;
     virtual void movieBackdrops(QString tmdbId) = 0;
     virtual void movieLogos(QString tmdbId) = 0;
@@ -26,13 +26,13 @@ public:
     virtual void movieThumbs(QString tmdbId) = 0;
     virtual void movieClearArts(QString tmdbId) = 0;
     virtual void movieCdArts(QString tmdbId) = 0;
-    virtual void concertImages(Concert *concert, QString tmdbId, QList<int> types) = 0;
+    virtual void concertImages(Concert *concert, QString tmdbId, QList<ImageType> types) = 0;
     virtual void concertPosters(QString tmdbId) = 0;
     virtual void concertBackdrops(QString tmdbId) = 0;
     virtual void concertLogos(QString tmdbId) = 0;
     virtual void concertClearArts(QString tmdbId) = 0;
     virtual void concertCdArts(QString tmdbId) = 0;
-    virtual void tvShowImages(TvShow *show, QString tvdbId, QList<int> types) = 0;
+    virtual void tvShowImages(TvShow *show, QString tvdbId, QList<ImageType> types) = 0;
     virtual void tvShowPosters(QString tvdbId) = 0;
     virtual void tvShowBackdrops(QString tvdbId) = 0;
     virtual void tvShowLogos(QString tvdbId) = 0;
@@ -51,9 +51,9 @@ public:
     virtual void albumCdArts(QString mbId) = 0;
     virtual void albumThumbs(QString mbId) = 0;
     virtual void albumBooklets(QString mbId) = 0;
-    virtual void artistImages(Artist *artist, QString mbId, QList<int> types) = 0;
-    virtual void albumImages(Album *album, QString mbId, QList<int> types) = 0;
-    virtual QList<int> provides() = 0;
+    virtual void artistImages(Artist *artist, QString mbId, QList<ImageType> types) = 0;
+    virtual void albumImages(Album *album, QString mbId, QList<ImageType> types) = 0;
+    virtual QList<ImageType> provides() = 0;
     virtual bool hasSettings() = 0;
     virtual void loadSettings(QSettings &settings) = 0;
     virtual void saveSettings(QSettings &settings) = 0;
@@ -69,11 +69,11 @@ public slots:
 signals:
     virtual void sigSearchDone(QList<ScraperSearchResult>) = 0;
     virtual void sigImagesLoaded(QList<Poster>) = 0;
-    virtual void sigImagesLoaded(Movie *, QMap<int, QList<Poster>>) = 0;
-    virtual void sigImagesLoaded(Concert *, QMap<int, QList<Poster>>) = 0;
-    virtual void sigImagesLoaded(TvShow *, QMap<int, QList<Poster>>) = 0;
-    virtual void sigImagesLoaded(Artist *, QMap<int, QList<Poster>>) = 0;
-    virtual void sigImagesLoaded(Album *, QMap<int, QList<Poster>>) = 0;
+    virtual void sigImagesLoaded(Movie *, QMap<ImageType, QList<Poster>>) = 0;
+    virtual void sigImagesLoaded(Concert *, QMap<ImageType, QList<Poster>>) = 0;
+    virtual void sigImagesLoaded(TvShow *, QMap<ImageType, QList<Poster>>) = 0;
+    virtual void sigImagesLoaded(Artist *, QMap<ImageType, QList<Poster>>) = 0;
+    virtual void sigImagesLoaded(Album *, QMap<ImageType, QList<Poster>>) = 0;
 };
 
 Q_DECLARE_METATYPE(ImageProviderInterface *)

--- a/data/MediaCenterInterface.h
+++ b/data/MediaCenterInterface.h
@@ -59,12 +59,12 @@ public:
     virtual QString nfoFilePath(Album *album) = 0;
 
     // clang-format off
-    virtual QString imageFileName(Movie *movie, int type, QList<DataFile> dataFiles = QList<DataFile>(), bool constructName = false) = 0;
-    virtual QString imageFileName(Concert *concert, int type, QList<DataFile> dataFiles = QList<DataFile>(), bool constructName = false) = 0;
-    virtual QString imageFileName(TvShowEpisode *episode, int type, QList<DataFile> dataFiles = QList<DataFile>(), bool constructName = false) = 0;
-    virtual QString imageFileName(TvShow *show, int type, int season = -2, QList<DataFile> dataFiles = QList<DataFile>(), bool constructName = false) = 0;
-    virtual QString imageFileName(Artist *artist, int type, QList<DataFile> dataFiles = QList<DataFile>(), bool constructName = false) = 0;
-    virtual QString imageFileName(Album *album, int type, QList<DataFile> dataFiles = QList<DataFile>(), bool constructName = false) = 0;
+    virtual QString imageFileName(Movie *movie, ImageType type, QList<DataFile> dataFiles = QList<DataFile>(), bool constructName = false) = 0;
+    virtual QString imageFileName(Concert *concert, ImageType type, QList<DataFile> dataFiles = QList<DataFile>(), bool constructName = false) = 0;
+    virtual QString imageFileName(TvShowEpisode *episode, ImageType type, QList<DataFile> dataFiles = QList<DataFile>(), bool constructName = false) = 0;
+    virtual QString imageFileName(TvShow *show, ImageType type, int season = -2, QList<DataFile> dataFiles = QList<DataFile>(), bool constructName = false) = 0;
+    virtual QString imageFileName(Artist *artist, ImageType type, QList<DataFile> dataFiles = QList<DataFile>(), bool constructName = false) = 0;
+    virtual QString imageFileName(Album *album, ImageType type, QList<DataFile> dataFiles = QList<DataFile>(), bool constructName = false) = 0;
     // clang-format on
 
     virtual void loadBooklets(Album *album) = 0;

--- a/data/MusicScraperInterface.h
+++ b/data/MusicScraperInterface.h
@@ -16,12 +16,12 @@ public:
     virtual QString identifier() = 0;
     virtual void searchAlbum(QString artistName, QString searchStr) = 0;
     virtual void searchArtist(QString searchStr) = 0;
-    virtual void loadData(QString id, Artist *artist, QList<int> infos) = 0;
-    virtual void loadData(QString id, QString id2, Album *album, QList<int> infos) = 0;
+    virtual void loadData(QString id, Artist *artist, QList<MusicScraperInfos> infos) = 0;
+    virtual void loadData(QString id, QString id2, Album *album, QList<MusicScraperInfos> infos) = 0;
     virtual bool hasSettings() = 0;
     virtual void loadSettings(QSettings &settings) = 0;
     virtual void saveSettings(QSettings &settings) = 0;
-    virtual QList<int> scraperSupports() = 0;
+    virtual QList<MusicScraperInfos> scraperSupports() = 0;
     virtual QWidget *settingsWidget() = 0;
 signals:
     virtual void sigSearchDone(QList<ScraperSearchResult>) = 0;

--- a/data/ScraperInterface.h
+++ b/data/ScraperInterface.h
@@ -20,12 +20,12 @@ public:
     virtual QString name() = 0;
     virtual QString identifier() = 0;
     virtual void search(QString searchStr) = 0;
-    virtual void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos) = 0;
+    virtual void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos) = 0;
     virtual bool hasSettings() = 0;
     virtual void loadSettings(QSettings &settings) = 0;
     virtual void saveSettings(QSettings &settings) = 0;
-    virtual QList<int> scraperSupports() = 0;
-    virtual QList<int> scraperNativelySupports() = 0;
+    virtual QList<MovieScraperInfos> scraperSupports() = 0;
+    virtual QList<MovieScraperInfos> scraperNativelySupports() = 0;
     virtual QWidget *settingsWidget() = 0;
     virtual bool isAdult() = 0;
 signals:

--- a/data/Storage.cpp
+++ b/data/Storage.cpp
@@ -45,6 +45,12 @@ Storage::Storage(QObject *parent, QList<TvShowScraperInfos> infosToLoad) :
 {
 }
 
+Storage::Storage(QObject *parent, QList<ConcertScraperInfos> infosToLoad) :
+    QObject(parent),
+    m_concertInfosToLoad{infosToLoad}
+{
+}
+
 Storage::Storage(QObject *parent, QList<ImageType> infosToLoad) : QObject(parent), m_imageInfosToLoad{infosToLoad}
 {
 }
@@ -219,6 +225,14 @@ QVariant Storage::toVariant(QObject *parent, QList<TvShowScraperInfos> infosToLo
     return var;
 }
 
+QVariant Storage::toVariant(QObject *parent, QList<ConcertScraperInfos> infosToLoad)
+{
+    Storage *const storage = new Storage(parent, infosToLoad);
+    QVariant var;
+    var.setValue(storage);
+    return var;
+}
+
 QVariant Storage::toVariant(QObject *parent, QList<ImageType> infosToLoad)
 {
     Storage *const storage = new Storage(parent, infosToLoad);
@@ -277,6 +291,11 @@ QList<MovieScraperInfos> Storage::movieInfosToLoad() const
 QList<TvShowScraperInfos> Storage::showInfosToLoad() const
 {
     return m_showInfosToLoad;
+}
+
+QList<ConcertScraperInfos> Storage::concertInfosToLoad() const
+{
+    return m_concertInfosToLoad;
 }
 
 QList<ImageType> Storage::imageInfosToLoad() const

--- a/data/Storage.cpp
+++ b/data/Storage.cpp
@@ -29,10 +29,6 @@ Storage::Storage(QObject *parent, QList<ScraperSearchResult> results) : QObject(
 {
 }
 
-Storage::Storage(QObject *parent, QList<int> infosToLoad) : QObject(parent), m_infosToLoad{infosToLoad}
-{
-}
-
 Storage::Storage(QObject *parent, QList<MovieScraperInfos> infosToLoad) :
     QObject(parent),
     m_movieInfosToLoad{infosToLoad}
@@ -50,6 +46,13 @@ Storage::Storage(QObject *parent, QList<ConcertScraperInfos> infosToLoad) :
     m_concertInfosToLoad{infosToLoad}
 {
 }
+
+Storage::Storage(QObject *parent, QList<MusicScraperInfos> infosToLoad) :
+    QObject(parent),
+    m_musicInfosToLoad{infosToLoad}
+{
+}
+
 
 Storage::Storage(QObject *parent, QList<ImageType> infosToLoad) : QObject(parent), m_imageInfosToLoad{infosToLoad}
 {
@@ -201,14 +204,6 @@ QVariant Storage::toVariant(QObject *parent, QList<ScraperSearchResult> results)
     return var;
 }
 
-QVariant Storage::toVariant(QObject *parent, QList<int> infosToLoad)
-{
-    Storage *const storage = new Storage(parent, infosToLoad);
-    QVariant var;
-    var.setValue(storage);
-    return var;
-}
-
 QVariant Storage::toVariant(QObject *parent, QList<MovieScraperInfos> infosToLoad)
 {
     Storage *const storage = new Storage(parent, infosToLoad);
@@ -226,6 +221,14 @@ QVariant Storage::toVariant(QObject *parent, QList<TvShowScraperInfos> infosToLo
 }
 
 QVariant Storage::toVariant(QObject *parent, QList<ConcertScraperInfos> infosToLoad)
+{
+    Storage *const storage = new Storage(parent, infosToLoad);
+    QVariant var;
+    var.setValue(storage);
+    return var;
+}
+
+QVariant Storage::toVariant(QObject *parent, QList<MusicScraperInfos> infosToLoad)
 {
     Storage *const storage = new Storage(parent, infosToLoad);
     QVariant var;
@@ -278,11 +281,6 @@ QList<ScraperSearchResult> Storage::results() const
     return m_results;
 }
 
-QList<int> Storage::infosToLoad() const
-{
-    return m_infosToLoad;
-}
-
 QList<MovieScraperInfos> Storage::movieInfosToLoad() const
 {
     return m_movieInfosToLoad;
@@ -296,6 +294,11 @@ QList<TvShowScraperInfos> Storage::showInfosToLoad() const
 QList<ConcertScraperInfos> Storage::concertInfosToLoad() const
 {
     return m_concertInfosToLoad;
+}
+
+QList<MusicScraperInfos> Storage::musicInfosToLoad() const
+{
+    return m_musicInfosToLoad;
 }
 
 QList<ImageType> Storage::imageInfosToLoad() const

--- a/data/Storage.cpp
+++ b/data/Storage.cpp
@@ -33,6 +33,22 @@ Storage::Storage(QObject *parent, QList<int> infosToLoad) : QObject(parent), m_i
 {
 }
 
+Storage::Storage(QObject *parent, QList<MovieScraperInfos> infosToLoad) :
+    QObject(parent),
+    m_movieInfosToLoad{infosToLoad}
+{
+}
+
+Storage::Storage(QObject *parent, QList<TvShowScraperInfos> infosToLoad) :
+    QObject(parent),
+    m_showInfosToLoad{infosToLoad}
+{
+}
+
+Storage::Storage(QObject *parent, QList<ImageType> infosToLoad) : QObject(parent), m_imageInfosToLoad{infosToLoad}
+{
+}
+
 Storage::Storage(QObject *parent, ExportTemplate *exportTemplate) : QObject(parent), m_exportTemplate{exportTemplate}
 {
 }
@@ -187,6 +203,30 @@ QVariant Storage::toVariant(QObject *parent, QList<int> infosToLoad)
     return var;
 }
 
+QVariant Storage::toVariant(QObject *parent, QList<MovieScraperInfos> infosToLoad)
+{
+    Storage *const storage = new Storage(parent, infosToLoad);
+    QVariant var;
+    var.setValue(storage);
+    return var;
+}
+
+QVariant Storage::toVariant(QObject *parent, QList<TvShowScraperInfos> infosToLoad)
+{
+    Storage *const storage = new Storage(parent, infosToLoad);
+    QVariant var;
+    var.setValue(storage);
+    return var;
+}
+
+QVariant Storage::toVariant(QObject *parent, QList<ImageType> infosToLoad)
+{
+    Storage *const storage = new Storage(parent, infosToLoad);
+    QVariant var;
+    var.setValue(storage);
+    return var;
+}
+
 QVariant Storage::toVariant(QObject *parent, ExportTemplate *exportTemplate)
 {
     const auto storage = new Storage(parent, exportTemplate);
@@ -227,4 +267,19 @@ QList<ScraperSearchResult> Storage::results() const
 QList<int> Storage::infosToLoad() const
 {
     return m_infosToLoad;
+}
+
+QList<MovieScraperInfos> Storage::movieInfosToLoad() const
+{
+    return m_movieInfosToLoad;
+}
+
+QList<TvShowScraperInfos> Storage::showInfosToLoad() const
+{
+    return m_showInfosToLoad;
+}
+
+QList<ImageType> Storage::imageInfosToLoad() const
+{
+    return m_imageInfosToLoad;
 }

--- a/data/Storage.h
+++ b/data/Storage.h
@@ -26,6 +26,9 @@ public:
     explicit Storage(QObject *parent, Album *album);
     explicit Storage(QObject *parent, QList<ScraperSearchResult> results);
     explicit Storage(QObject *parent, QList<int> infosToLoad);
+    explicit Storage(QObject *parent, QList<MovieScraperInfos> infosToLoad);
+    explicit Storage(QObject *parent, QList<TvShowScraperInfos> infosToLoad);
+    explicit Storage(QObject *parent, QList<ImageType> infosToLoad);
     explicit Storage(QObject *parent, ExportTemplate *exportTemplate);
     explicit Storage(QObject *parent, QMap<ScraperInterface *, QString> ids);
     explicit Storage(QObject *parent, QTableWidgetItem *item);
@@ -38,6 +41,9 @@ public:
     Album *album() const;
     QList<ScraperSearchResult> results() const;
     QList<int> infosToLoad() const;
+    QList<MovieScraperInfos> movieInfosToLoad() const;
+    QList<TvShowScraperInfos> showInfosToLoad() const;
+    QList<ImageType> imageInfosToLoad() const;
     ExportTemplate *exportTemplate() const;
     QMap<ScraperInterface *, QString> ids() const;
     QTableWidgetItem *tableWidgetItem() const;
@@ -50,6 +56,9 @@ public:
     static QVariant toVariant(QObject *parent, Album *album);
     static QVariant toVariant(QObject *parent, QList<ScraperSearchResult> results);
     static QVariant toVariant(QObject *parent, QList<int> infosToLoad);
+    static QVariant toVariant(QObject *parent, QList<MovieScraperInfos> infosToLoad);
+    static QVariant toVariant(QObject *parent, QList<TvShowScraperInfos> infosToLoad);
+    static QVariant toVariant(QObject *parent, QList<ImageType> infosToLoad);
     static QVariant toVariant(QObject *parent, ExportTemplate *exportTemplate);
     static QVariant toVariant(QObject *parent, QMap<ScraperInterface *, QString> ids);
     static QVariant toVariant(QObject *parent, QTableWidgetItem *item);
@@ -64,6 +73,9 @@ private:
     QPointer<Album> m_album;
     QList<ScraperSearchResult> m_results;
     QList<int> m_infosToLoad;
+    QList<MovieScraperInfos> m_movieInfosToLoad;
+    QList<TvShowScraperInfos> m_showInfosToLoad;
+    QList<ImageType> m_imageInfosToLoad;
     QPointer<ExportTemplate> m_exportTemplate;
     QMap<ScraperInterface *, QString> m_ids;
     QTableWidgetItem *m_tableWidgetItem = nullptr;

--- a/data/Storage.h
+++ b/data/Storage.h
@@ -25,10 +25,10 @@ public:
     explicit Storage(QObject *parent, Artist *artist);
     explicit Storage(QObject *parent, Album *album);
     explicit Storage(QObject *parent, QList<ScraperSearchResult> results);
-    explicit Storage(QObject *parent, QList<int> infosToLoad);
     explicit Storage(QObject *parent, QList<MovieScraperInfos> infosToLoad);
     explicit Storage(QObject *parent, QList<TvShowScraperInfos> infosToLoad);
     explicit Storage(QObject *parent, QList<ConcertScraperInfos> infosToLoad);
+    explicit Storage(QObject *parent, QList<MusicScraperInfos> infosToLoad);
     explicit Storage(QObject *parent, QList<ImageType> infosToLoad);
     explicit Storage(QObject *parent, ExportTemplate *exportTemplate);
     explicit Storage(QObject *parent, QMap<ScraperInterface *, QString> ids);
@@ -41,10 +41,10 @@ public:
     Artist *artist() const;
     Album *album() const;
     QList<ScraperSearchResult> results() const;
-    QList<int> infosToLoad() const;
     QList<MovieScraperInfos> movieInfosToLoad() const;
     QList<TvShowScraperInfos> showInfosToLoad() const;
     QList<ConcertScraperInfos> concertInfosToLoad() const;
+    QList<MusicScraperInfos> musicInfosToLoad() const;
     QList<ImageType> imageInfosToLoad() const;
     ExportTemplate *exportTemplate() const;
     QMap<ScraperInterface *, QString> ids() const;
@@ -57,10 +57,10 @@ public:
     static QVariant toVariant(QObject *parent, Artist *artist);
     static QVariant toVariant(QObject *parent, Album *album);
     static QVariant toVariant(QObject *parent, QList<ScraperSearchResult> results);
-    static QVariant toVariant(QObject *parent, QList<int> infosToLoad);
     static QVariant toVariant(QObject *parent, QList<MovieScraperInfos> infosToLoad);
     static QVariant toVariant(QObject *parent, QList<TvShowScraperInfos> infosToLoad);
     static QVariant toVariant(QObject *parent, QList<ConcertScraperInfos> infosToLoad);
+    static QVariant toVariant(QObject *parent, QList<MusicScraperInfos> infosToLoad);
     static QVariant toVariant(QObject *parent, QList<ImageType> infosToLoad);
     static QVariant toVariant(QObject *parent, ExportTemplate *exportTemplate);
     static QVariant toVariant(QObject *parent, QMap<ScraperInterface *, QString> ids);
@@ -75,7 +75,7 @@ private:
     QPointer<Artist> m_artist;
     QPointer<Album> m_album;
     QList<ScraperSearchResult> m_results;
-    QList<int> m_infosToLoad;
+    QList<MusicScraperInfos> m_musicInfosToLoad;
     QList<MovieScraperInfos> m_movieInfosToLoad;
     QList<TvShowScraperInfos> m_showInfosToLoad;
     QList<ConcertScraperInfos> m_concertInfosToLoad;

--- a/data/Storage.h
+++ b/data/Storage.h
@@ -28,6 +28,7 @@ public:
     explicit Storage(QObject *parent, QList<int> infosToLoad);
     explicit Storage(QObject *parent, QList<MovieScraperInfos> infosToLoad);
     explicit Storage(QObject *parent, QList<TvShowScraperInfos> infosToLoad);
+    explicit Storage(QObject *parent, QList<ConcertScraperInfos> infosToLoad);
     explicit Storage(QObject *parent, QList<ImageType> infosToLoad);
     explicit Storage(QObject *parent, ExportTemplate *exportTemplate);
     explicit Storage(QObject *parent, QMap<ScraperInterface *, QString> ids);
@@ -43,6 +44,7 @@ public:
     QList<int> infosToLoad() const;
     QList<MovieScraperInfos> movieInfosToLoad() const;
     QList<TvShowScraperInfos> showInfosToLoad() const;
+    QList<ConcertScraperInfos> concertInfosToLoad() const;
     QList<ImageType> imageInfosToLoad() const;
     ExportTemplate *exportTemplate() const;
     QMap<ScraperInterface *, QString> ids() const;
@@ -58,6 +60,7 @@ public:
     static QVariant toVariant(QObject *parent, QList<int> infosToLoad);
     static QVariant toVariant(QObject *parent, QList<MovieScraperInfos> infosToLoad);
     static QVariant toVariant(QObject *parent, QList<TvShowScraperInfos> infosToLoad);
+    static QVariant toVariant(QObject *parent, QList<ConcertScraperInfos> infosToLoad);
     static QVariant toVariant(QObject *parent, QList<ImageType> infosToLoad);
     static QVariant toVariant(QObject *parent, ExportTemplate *exportTemplate);
     static QVariant toVariant(QObject *parent, QMap<ScraperInterface *, QString> ids);
@@ -75,6 +78,7 @@ private:
     QList<int> m_infosToLoad;
     QList<MovieScraperInfos> m_movieInfosToLoad;
     QList<TvShowScraperInfos> m_showInfosToLoad;
+    QList<ConcertScraperInfos> m_concertInfosToLoad;
     QList<ImageType> m_imageInfosToLoad;
     QPointer<ExportTemplate> m_exportTemplate;
     QMap<ScraperInterface *, QString> m_ids;

--- a/data/TvScraperInterface.h
+++ b/data/TvScraperInterface.h
@@ -21,8 +21,9 @@ class TvScraperInterface : public QObject
 public:
     virtual QString name() = 0;
     virtual void search(QString searchStr) = 0;
-    virtual void loadTvShowData(QString id, TvShow *show, TvShowUpdateType updateType, QList<int> infosToLoad) = 0;
-    virtual void loadTvShowEpisodeData(QString id, TvShowEpisode *episode, QList<int> infosToLoad) = 0;
+    virtual void
+    loadTvShowData(QString id, TvShow *show, TvShowUpdateType updateType, QList<TvShowScraperInfos> infosToLoad) = 0;
+    virtual void loadTvShowEpisodeData(QString id, TvShowEpisode *episode, QList<TvShowScraperInfos> infosToLoad) = 0;
     virtual bool hasSettings() = 0;
     virtual void loadSettings(QSettings &settings) = 0;
     virtual void saveSettings(QSettings &settings) = 0;

--- a/data/TvShow.h
+++ b/data/TvShow.h
@@ -27,7 +27,7 @@ class TvShow : public QObject
 public:
     explicit TvShow(QString dir = QString(), QObject *parent = nullptr);
     void clear();
-    void clear(QList<int> infos);
+    void clear(QList<TvShowScraperInfos> infos);
     void addEpisode(TvShowEpisode *episode);
     virtual int episodeCount() const;
 
@@ -73,7 +73,7 @@ public:
     virtual QString nfoContent() const;
     virtual int databaseId() const;
     virtual bool syncNeeded() const;
-    virtual QList<int> infosToLoad() const;
+    virtual QList<TvShowScraperInfos> infosToLoad() const;
     virtual bool hasTune() const;
     virtual int runtime() const;
     virtual QString sortTitle() const;
@@ -131,22 +131,25 @@ public:
     void removeTag(QString tag);
 
     bool loadData(MediaCenterInterface *mediaCenterInterface, bool reloadFromNfo = true);
-    void loadData(QString id, TvScraperInterface *tvScraperInterface, TvShowUpdateType type, QList<int> infosToLoad);
+    void loadData(QString id,
+        TvScraperInterface *tvScraperInterface,
+        TvShowUpdateType type,
+        QList<TvShowScraperInfos> infosToLoad);
     bool saveData(MediaCenterInterface *mediaCenterInterface);
     void clearImages();
     void fillMissingEpisodes();
     void clearMissingEpisodes();
 
     // Images
-    void removeImage(int type, int season = -2);
-    QMap<int, QList<int>> imagesToRemove() const;
-    QByteArray image(int imageType);
-    QByteArray seasonImage(int season, int imageType);
-    void setImage(int imageType, QByteArray image);
-    void setSeasonImage(int season, int imageType, QByteArray image);
-    bool imageHasChanged(int imageType) const;
-    bool seasonImageHasChanged(int season, int imageType) const;
-    bool hasImage(int type);
+    void removeImage(ImageType type, int season = -2);
+    QMap<ImageType, QList<int>> imagesToRemove() const;
+    QByteArray image(ImageType imageType);
+    QByteArray seasonImage(int season, ImageType imageType);
+    void setImage(ImageType imageType, QByteArray image);
+    void setSeasonImage(int season, ImageType imageType, QByteArray image);
+    bool imageHasChanged(ImageType imageType) const;
+    bool seasonImageHasChanged(int season, ImageType imageType) const;
+    bool hasImage(ImageType type);
 
     // Extra Fanarts
     QList<ExtraFanart> extraFanarts(MediaCenterInterface *mediaCenterInterface);
@@ -160,8 +163,8 @@ public:
     void scraperLoadDone();
 
     static bool lessThan(TvShow *a, TvShow *b);
-    static QList<int> imageTypes();
-    static QList<int> seasonImageTypes();
+    static QList<ImageType> imageTypes();
+    static QList<ImageType> seasonImageTypes();
 
     void setDir(const QString &dir);
 
@@ -211,22 +214,22 @@ private:
     QString m_nfoContent;
     int m_databaseId;
     bool m_syncNeeded;
-    QList<int> m_infosToLoad;
+    QList<TvShowScraperInfos> m_infosToLoad;
     QList<QByteArray> m_extraFanartImagesToAdd;
     QStringList m_extraFanartsToRemove;
     QStringList m_extraFanarts;
-    QMap<int, QList<int>> m_imagesToRemove;
-    QMap<int, bool> m_hasImage;
+    QMap<ImageType, QList<int>> m_imagesToRemove;
+    QMap<ImageType, bool> m_hasImage;
     bool m_showMissingEpisodes;
     bool m_hideSpecialsInMissingEpisodes;
     QString m_status;
 
-    QMap<int, QByteArray> m_images;
-    QMap<int, QMap<int, QByteArray>> m_seasonImages;
-    QMap<int, bool> m_hasImageChanged;
-    QMap<int, QMap<int, bool>> m_hasSeasonImageChanged;
+    QMap<ImageType, QByteArray> m_images;
+    QMap<int, QMap<ImageType, QByteArray>> m_seasonImages;
+    QMap<ImageType, bool> m_hasImageChanged;
+    QMap<int, QMap<ImageType, bool>> m_hasSeasonImageChanged;
 
-    void clearSeasonImageType(int imageType);
+    void clearSeasonImageType(ImageType imageType);
 };
 
 QDebug operator<<(QDebug dbg, const TvShow &show);

--- a/data/TvShowEpisode.cpp
+++ b/data/TvShowEpisode.cpp
@@ -63,7 +63,7 @@ void TvShowEpisode::setShow(TvShow *show)
  */
 void TvShowEpisode::clear()
 {
-    QList<int> infos;
+    QList<TvShowScraperInfos> infos;
     infos << TvShowScraperInfos::Certification //
           << TvShowScraperInfos::Rating        //
           << TvShowScraperInfos::Director      //
@@ -77,7 +77,7 @@ void TvShowEpisode::clear()
     m_nfoContent.clear();
 }
 
-void TvShowEpisode::clear(QList<int> infos)
+void TvShowEpisode::clear(QList<TvShowScraperInfos> infos)
 {
     if (infos.contains(TvShowScraperInfos::Certification)) {
         m_certification = "";
@@ -114,7 +114,7 @@ void TvShowEpisode::clear(QList<int> infos)
     m_hasChanged = false;
 }
 
-QList<int> TvShowEpisode::infosToLoad()
+QList<TvShowScraperInfos> TvShowEpisode::infosToLoad()
 {
     return m_infosToLoad;
 }
@@ -160,7 +160,7 @@ bool TvShowEpisode::loadData(MediaCenterInterface *mediaCenterInterface, bool re
  * @param id ID of the show for the scraper
  * @param tvScraperInterface ScraperInterface to use
  */
-void TvShowEpisode::loadData(QString id, TvScraperInterface *tvScraperInterface, QList<int> infosToLoad)
+void TvShowEpisode::loadData(QString id, TvScraperInterface *tvScraperInterface, QList<TvShowScraperInfos> infosToLoad)
 {
     qDebug() << "Entered, id=" << id << "scraperInterface=" << tvScraperInterface->name();
     m_infosToLoad = infosToLoad;
@@ -912,12 +912,12 @@ void TvShowEpisode::setSyncNeeded(bool syncNeeded)
     m_syncNeeded = syncNeeded;
 }
 
-QList<int> TvShowEpisode::imagesToRemove() const
+QList<ImageType> TvShowEpisode::imagesToRemove() const
 {
     return m_imagesToRemove;
 }
 
-void TvShowEpisode::removeImage(int type)
+void TvShowEpisode::removeImage(ImageType type)
 {
     if (type == ImageType::TvShowEpisodeThumb) {
         if (!m_thumbnailImage.isNull()) {

--- a/data/TvShowEpisode.h
+++ b/data/TvShowEpisode.h
@@ -42,7 +42,7 @@ class TvShowEpisode : public QObject
 public:
     explicit TvShowEpisode(QStringList files = QStringList(), TvShow *parent = nullptr);
     void clear();
-    void clear(QList<int> infos);
+    void clear(QList<TvShowScraperInfos> infos);
 
     void setFiles(QStringList files);
     virtual TvShow *tvShow();
@@ -126,14 +126,14 @@ public:
     void removeActor(Actor *actor);
 
     bool loadData(MediaCenterInterface *mediaCenterInterface, bool reloadFromNfo = true);
-    void loadData(QString id, TvScraperInterface *tvScraperInterface, QList<int> infosToLoad);
+    void loadData(QString id, TvScraperInterface *tvScraperInterface, QList<TvShowScraperInfos> infosToLoad);
     bool saveData(MediaCenterInterface *mediaCenterInterface);
     void loadStreamDetailsFromFile();
     void clearImages();
-    QList<int> infosToLoad();
+    QList<TvShowScraperInfos> infosToLoad();
 
-    QList<int> imagesToRemove() const;
-    void removeImage(int type);
+    QList<ImageType> imagesToRemove() const;
+    void removeImage(ImageType type);
 
     void scraperLoadDone();
 
@@ -181,8 +181,8 @@ private:
     QString m_nfoContent;
     int m_databaseId;
     bool m_syncNeeded;
-    QList<int> m_infosToLoad;
-    QList<int> m_imagesToRemove;
+    QList<TvShowScraperInfos> m_infosToLoad;
+    QList<ImageType> m_imagesToRemove;
     bool m_isDummy;
     QList<Actor> m_actors;
 };

--- a/downloads/ImportDialog.cpp
+++ b/downloads/ImportDialog.cpp
@@ -246,10 +246,10 @@ void ImportDialog::storeDefaults()
 void ImportDialog::onMovieChosen()
 {
     QMap<ScraperInterface *, QString> ids;
-    QList<int> infosToLoad;
+    QList<MovieScraperInfos> infosToLoad;
     if (ui->movieSearchWidget->scraperId() == "custom-movie") {
         ids = ui->movieSearchWidget->customScraperIds();
-        infosToLoad = Settings::instance()->scraperInfos(MainWidgets::Movies, "custom-movie");
+        infosToLoad = Settings::instance()->scraperInfos<MovieScraperInfos>("custom-movie");
     } else {
         ids.insert(0, ui->movieSearchWidget->scraperMovieId());
         infosToLoad = ui->movieSearchWidget->infosToLoad();

--- a/downloads/MakeMkvDialog.cpp
+++ b/downloads/MakeMkvDialog.cpp
@@ -221,10 +221,10 @@ void MakeMkvDialog::onImportComplete()
 void MakeMkvDialog::onMovieChosen()
 {
     QMap<ScraperInterface *, QString> ids;
-    QList<int> infosToLoad;
+    QList<MovieScraperInfos> infosToLoad;
     if (ui->movieSearchWidget->scraperId() == "custom-movie") {
         ids = ui->movieSearchWidget->customScraperIds();
-        infosToLoad = Settings::instance()->scraperInfos(MainWidgets::Movies, "custom-movie");
+        infosToLoad = Settings::instance()->scraperInfos<MovieScraperInfos>("custom-movie");
     } else {
         ids.insert(0, ui->movieSearchWidget->scraperMovieId());
         infosToLoad = ui->movieSearchWidget->infosToLoad();

--- a/globals/DownloadManagerElement.h
+++ b/globals/DownloadManagerElement.h
@@ -17,7 +17,7 @@ class DownloadManagerElement
 {
 public:
     DownloadManagerElement();
-    int imageType{0};
+    ImageType imageType{ImageType::None};
     QUrl url;
     QByteArray data;
     qint64 bytesReceived{0};

--- a/globals/Globals.h
+++ b/globals/Globals.h
@@ -339,32 +339,32 @@ enum class ConcertScraperInfos : int {
     ExtraFanarts  = 14
 };
 
-namespace MusicScraperInfos {
-    const int Name         = 1;
-    const int Genres       = 2;
-    const int Styles       = 3;
-    const int Moods        = 4;
-    const int YearsActive  = 5;
-    const int Formed       = 6;
-    const int Born         = 7;
-    const int Died         = 8;
-    const int Disbanded    = 9;
-    const int Biography    = 10;
-    const int Thumb        = 11;
-    const int Fanart       = 12;
-    const int Logo         = 13;
-    const int Title        = 14;
-    const int Artist       = 15;
-    const int Review       = 16;
-    const int ReleaseDate  = 17;
-    const int Label        = 18;
-    const int Rating       = 19;
-    const int Year         = 20;
-    const int CdArt        = 21;
-    const int Cover        = 22;
-    const int ExtraFanarts = 23;
-    const int Discography  = 24;
-}
+enum class MusicScraperInfos : int {
+    Name         = 1,
+    Genres       = 2,
+    Styles       = 3,
+    Moods        = 4,
+    YearsActive  = 5,
+    Formed       = 6,
+    Born         = 7,
+    Died         = 8,
+    Disbanded    = 9,
+    Biography    = 10,
+    Thumb        = 11,
+    Fanart       = 12,
+    Logo         = 13,
+    Title        = 14,
+    Artist       = 15,
+    Review       = 16,
+    ReleaseDate  = 17,
+    Label        = 18,
+    Rating       = 19,
+    Year         = 20,
+    CdArt        = 21,
+    Cover        = 22,
+    ExtraFanarts = 23,
+    Discography  = 24
+};
 
 // The filter numbers have to unique for MovieFilters, TvShowFilters and ConcertFilters
 namespace MovieFilters {

--- a/globals/Globals.h
+++ b/globals/Globals.h
@@ -225,102 +225,102 @@ enum ComboDelegateType
 };
 
 // clang-format off
-namespace ImageType {
-    const int MoviePoster          = 1;
-    const int MovieBackdrop        = 2;
-    const int TvShowPoster         = 3;
-    const int TvShowBackdrop       = 4;
-    const int TvShowEpisodeThumb   = 5;
-    const int TvShowBanner         = 7;
-    const int ConcertPoster        = 8;
-    const int ConcertBackdrop      = 9;
-    const int MovieLogo            = 10;
-    const int MovieClearArt        = 11;
-    const int MovieCdArt           = 12;
-    const int ConcertLogo          = 13;
-    const int ConcertClearArt      = 14;
-    const int ConcertCdArt         = 15;
-    const int TvShowClearArt       = 16;
-    const int TvShowLogos          = 17;
-    const int TvShowCharacterArt   = 18;
-    const int TvShowSeasonBackdrop = 19;
-    const int TvShowSeasonBanner   = 20;
-    const int MovieBanner          = 21;
-    const int MovieThumb           = 22;
-    const int TvShowThumb          = 23;
-    const int TvShowSeasonThumb    = 24;
-    const int TvShowSeasonPoster   = 25;
-    const int Actor                = 26;
-    const int MovieExtraFanart     = 27;
-    const int MovieSetPoster       = 28;
-    const int MovieSetBackdrop     = 29;
-    const int ConcertExtraFanart   = 30;
-    const int TvShowExtraFanart    = 31;
-    const int ArtistThumb          = 32;
-    const int ArtistFanart         = 33;
-    const int ArtistLogo           = 34;
-    const int AlbumThumb           = 35;
-    const int AlbumCdArt           = 36;
-    const int ArtistExtraFanart    = 37;
-    const int AlbumBooklet         = 38;
-}
+enum class ImageType : int {
+    None                 = -1,
+    MoviePoster          = 1,
+    MovieBackdrop        = 2,
+    TvShowPoster         = 3,
+    TvShowBackdrop       = 4,
+    TvShowEpisodeThumb   = 5,
+    TvShowBanner         = 7,
+    ConcertPoster        = 8,
+    ConcertBackdrop      = 9,
+    MovieLogo            = 10,
+    MovieClearArt        = 11,
+    MovieCdArt           = 12,
+    ConcertLogo          = 13,
+    ConcertClearArt      = 14,
+    ConcertCdArt         = 15,
+    TvShowClearArt       = 16,
+    TvShowLogos          = 17,
+    TvShowCharacterArt   = 18,
+    TvShowSeasonBackdrop = 19,
+    TvShowSeasonBanner   = 20,
+    MovieBanner          = 21,
+    MovieThumb           = 22,
+    TvShowThumb          = 23,
+    TvShowSeasonThumb    = 24,
+    TvShowSeasonPoster   = 25,
+    Actor                = 26,
+    MovieExtraFanart     = 27,
+    MovieSetPoster       = 28,
+    MovieSetBackdrop     = 29,
+    ConcertExtraFanart   = 30,
+    TvShowExtraFanart    = 31,
+    ArtistThumb          = 32,
+    ArtistFanart         = 33,
+    ArtistLogo           = 34,
+    AlbumThumb           = 35,
+    AlbumCdArt           = 36,
+    ArtistExtraFanart    = 37,
+    AlbumBooklet         = 38
+};
 
-namespace MovieScraperInfos {
-    const int Title         = 1;
-    const int Tagline       = 2;
-    const int Rating        = 3;
-    const int Released      = 4;
-    const int Runtime       = 5;
-    const int Certification = 6;
-    const int Trailer       = 7;
-    const int Overview      = 8;
-    const int Poster        = 9;
-    const int Backdrop      = 10;
-    const int Actors        = 11;
-    const int Genres        = 12;
-    const int Studios       = 13;
-    const int Countries     = 14;
-    const int Writer        = 15;
-    const int Director      = 16;
-    const int Tags          = 18;
-    const int ExtraFanarts  = 19;
-    const int Set           = 20;
-    const int Logo          = 21;
-    const int CdArt         = 22;
-    const int ClearArt      = 23;
-    const int Banner        = 24;
-    const int Thumb         = 25;
+enum class MovieScraperInfos : int {
+    Title         = 1,
+    Tagline       = 2,
+    Rating        = 3,
+    Released      = 4,
+    Runtime       = 5,
+    Certification = 6,
+    Trailer       = 7,
+    Overview      = 8,
+    Poster        = 9,
+    Backdrop      = 10,
+    Actors        = 11,
+    Genres        = 12,
+    Studios       = 13,
+    Countries     = 14,
+    Writer        = 15,
+    Director      = 16,
+    Tags          = 18,
+    ExtraFanarts  = 19,
+    Set           = 20,
+    Logo          = 21,
+    CdArt         = 22,
+    ClearArt      = 23,
+    Banner        = 24,
+    Thumb         = 25,
+    First         = 1,
+    Last          = 25
+};
 
-    const int First         = 1;
-    const int Last          = 25;
-}
-
-namespace TvShowScraperInfos {
-    const int Actors         = 1;
-    const int Banner         = 2;
-    const int Certification  = 3;
-    const int Director       = 4;
-    const int Fanart         = 5;
-    const int FirstAired     = 6;
-    const int Genres         = 7;
-    const int Network        = 8;
-    const int Overview       = 9;
-    const int Poster         = 10;
-    const int Rating         = 11;
-    const int SeasonPoster   = 13;
-    const int Thumbnail      = 14;
-    const int Title          = 15;
-    const int Writer         = 16;
-    const int Tags           = 17;
-    const int ExtraArts      = 18;
-    const int SeasonBackdrop = 19;
-    const int SeasonBanner   = 20;
-    const int ExtraFanarts   = 21;
-    const int Thumb          = 22;
-    const int SeasonThumb    = 23;
-    const int Runtime        = 24;
-    const int Status         = 25;
-}
+enum class TvShowScraperInfos : int {
+    Actors         = 1,
+    Banner         = 2,
+    Certification  = 3,
+    Director       = 4,
+    Fanart         = 5,
+    FirstAired     = 6,
+    Genres         = 7,
+    Network        = 8,
+    Overview       = 9,
+    Poster         = 10,
+    Rating         = 11,
+    SeasonPoster   = 13,
+    Thumbnail      = 14,
+    Title          = 15,
+    Writer         = 16,
+    Tags           = 17,
+    ExtraArts      = 18,
+    SeasonBackdrop = 19,
+    SeasonBanner   = 20,
+    ExtraFanarts   = 21,
+    Thumb          = 22,
+    SeasonThumb    = 23,
+    Runtime        = 24,
+    Status         = 25
+};
 
 namespace ConcertScraperInfos {
     const int Title         = 1;
@@ -424,45 +424,46 @@ enum SortBy
 };
 
 // clang-format off
-namespace DataFileType {
-    const int MovieNfo             = 1;
-    const int MoviePoster          = 2;
-    const int MovieBackdrop        = 3;
-    const int MovieLogo            = 4;
-    const int MovieClearArt        = 5;
-    const int MovieCdArt           = 6;
-    const int ConcertNfo           = 7;
-    const int ConcertPoster        = 8;
-    const int ConcertBackdrop      = 9;
-    const int ConcertLogo          = 10;
-    const int ConcertClearArt      = 11;
-    const int ConcertCdArt         = 12;
-    const int TvShowNfo            = 13;
-    const int TvShowPoster         = 14;
-    const int TvShowBackdrop       = 15;
-    const int TvShowBanner         = 16;
-    const int TvShowSeasonPoster   = 17;
-    const int TvShowLogo           = 18;
-    const int TvShowClearArt       = 19;
-    const int TvShowCharacterArt   = 20;
-    const int TvShowEpisodeNfo     = 21;
-    const int TvShowEpisodeThumb   = 22;
-    const int TvShowSeasonBackdrop = 23;
-    const int TvShowSeasonBanner   = 24;
-    const int MovieBanner          = 25;
-    const int MovieThumb           = 26;
-    const int TvShowSeasonThumb    = 27;
-    const int TvShowThumb          = 28;
-    const int MovieSetPoster       = 29;
-    const int MovieSetBackdrop     = 30;
-    const int ArtistNfo            = 31;
-    const int AlbumNfo             = 32;
-    const int ArtistThumb          = 33;
-    const int ArtistFanart         = 34;
-    const int ArtistLogo           = 35;
-    const int AlbumThumb           = 36;
-    const int AlbumCdArt           = 37;
-}
+enum class DataFileType : int {
+    NoType               = -1,
+    MovieNfo             = 1,
+    MoviePoster          = 2,
+    MovieBackdrop        = 3,
+    MovieLogo            = 4,
+    MovieClearArt        = 5,
+    MovieCdArt           = 6,
+    ConcertNfo           = 7,
+    ConcertPoster        = 8,
+    ConcertBackdrop      = 9,
+    ConcertLogo          = 10,
+    ConcertClearArt      = 11,
+    ConcertCdArt         = 12,
+    TvShowNfo            = 13,
+    TvShowPoster         = 14,
+    TvShowBackdrop       = 15,
+    TvShowBanner         = 16,
+    TvShowSeasonPoster   = 17,
+    TvShowLogo           = 18,
+    TvShowClearArt       = 19,
+    TvShowCharacterArt   = 20,
+    TvShowEpisodeNfo     = 21,
+    TvShowEpisodeThumb   = 22,
+    TvShowSeasonBackdrop = 23,
+    TvShowSeasonBanner   = 24,
+    MovieBanner          = 25,
+    MovieThumb           = 26,
+    TvShowSeasonThumb    = 27,
+    TvShowThumb          = 28,
+    MovieSetPoster       = 29,
+    MovieSetBackdrop     = 30,
+    ArtistNfo            = 31,
+    AlbumNfo             = 32,
+    ArtistThumb          = 33,
+    ArtistFanart         = 34,
+    ArtistLogo           = 35,
+    AlbumThumb           = 36,
+    AlbumCdArt           = 37
+};
 // clang-format on
 
 enum TvShowUpdateType

--- a/globals/Globals.h
+++ b/globals/Globals.h
@@ -322,22 +322,22 @@ enum class TvShowScraperInfos : int {
     Status         = 25
 };
 
-namespace ConcertScraperInfos {
-    const int Title         = 1;
-    const int Tagline       = 2;
-    const int Rating        = 3;
-    const int Released      = 4;
-    const int Runtime       = 5;
-    const int Certification = 6;
-    const int Trailer       = 7;
-    const int Overview      = 8;
-    const int Poster        = 9;
-    const int Backdrop      = 10;
-    const int Genres        = 11;
-    const int ExtraArts     = 12;
-    const int Tags          = 13;
-    const int ExtraFanarts  = 14;
-}
+enum class ConcertScraperInfos : int {
+    Title         = 1,
+    Tagline       = 2,
+    Rating        = 3,
+    Released      = 4,
+    Runtime       = 5,
+    Certification = 6,
+    Trailer       = 7,
+    Overview      = 8,
+    Poster        = 9,
+    Backdrop      = 10,
+    Genres        = 11,
+    ExtraArts     = 12,
+    Tags          = 13,
+    ExtraFanarts  = 14
+};
 
 namespace MusicScraperInfos {
     const int Name         = 1;

--- a/globals/ImageDialog.cpp
+++ b/globals/ImageDialog.cpp
@@ -105,14 +105,15 @@ int ImageDialog::exec()
  * @param type Type of the images (ImageDialogType)
  * @return Result of QDialog::exec
  */
-int ImageDialog::exec(int type)
+int ImageDialog::exec(ImageType type)
 {
-    qDebug() << "Entered, type=" << type;
     m_type = type;
 
     // set slider value
-    ui->previewSizeSlider->setValue(
-        Settings::instance()->settings()->value(QString("ImageDialog/PreviewSize_%1").arg(m_type), 8).toInt());
+    ui->previewSizeSlider->setValue(Settings::instance()
+                                        ->settings()
+                                        ->value(QString("ImageDialog/PreviewSize_%1").arg(static_cast<int>(m_type)), 8)
+                                        .toInt());
 
     QSize savedSize = Settings::instance()->settings()->value("ImageDialog/Size").toSize();
     QPoint savedPos = Settings::instance()->settings()->value("ImageDialog/Pos").toPoint();
@@ -478,7 +479,7 @@ void ImageDialog::imageClicked(int row, int col)
  * @brief Sets the type of images
  * @param type Type of images
  */
-void ImageDialog::setImageType(int type)
+void ImageDialog::setImageType(ImageType type)
 {
     m_imageType = type;
 }
@@ -659,7 +660,8 @@ void ImageDialog::onPreviewSizeChange(int value)
 {
     ui->buttonZoomOut->setDisabled(value == ui->previewSizeSlider->minimum());
     ui->buttonZoomIn->setDisabled(value == ui->previewSizeSlider->maximum());
-    Settings::instance()->settings()->setValue(QString("ImageDialog/PreviewSize_%1").arg(m_type), value);
+    Settings::instance()->settings()->setValue(
+        QString("ImageDialog/PreviewSize_%1").arg(static_cast<int>(m_type)), value);
     renderTable();
 }
 

--- a/globals/ImageDialog.h
+++ b/globals/ImageDialog.h
@@ -39,7 +39,7 @@ public:
     void setDownloads(QList<Poster> downloads, bool initial = true);
     QUrl imageUrl();
     QList<QUrl> imageUrls();
-    void setImageType(int type);
+    void setImageType(ImageType type);
     void setItemType(ItemType type);
     void setMultiSelection(const bool &enable);
     void setMovie(Movie *movie);
@@ -56,7 +56,7 @@ public slots:
     void accept() override;
     void reject() override;
     int exec() override;
-    int exec(int type);
+    int exec(ImageType type);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -99,11 +99,11 @@ private:
     QNetworkAccessManager m_qnam;
     int m_currentDownloadIndex;
     QNetworkReply *m_currentDownloadReply;
-    int m_imageType;
+    ImageType m_imageType;
     QList<DownloadElement> m_elements;
     QUrl m_imageUrl;
     QList<QUrl> m_imageUrls;
-    int m_type;
+    ImageType m_type;
     QList<ImageProviderInterface *> m_providers;
     Concert *m_concert;
     Movie *m_movie;

--- a/globals/Manager.cpp
+++ b/globals/Manager.cpp
@@ -241,10 +241,10 @@ TvShowProxyModel *Manager::tvShowProxyModel()
  * @param type Type of image
  * @return List of pointers of image providers
  */
-QList<ImageProviderInterface *> Manager::imageProviders(int type)
+QList<ImageProviderInterface *> Manager::imageProviders(ImageType type)
 {
     QList<ImageProviderInterface *> providers;
-    foreach (ImageProviderInterface *provider, m_imageProviders) {
+    for (auto provider : m_imageProviders) {
         if (provider->provides().contains(type)) {
             providers.append(provider);
         }

--- a/globals/Manager.h
+++ b/globals/Manager.h
@@ -47,7 +47,7 @@ public:
     QList<ConcertScraperInterface *> concertScrapers();
     QList<MusicScraperInterface *> musicScrapers();
     QList<ImageProviderInterface *> imageProviders();
-    QList<ImageProviderInterface *> imageProviders(int type);
+    QList<ImageProviderInterface *> imageProviders(ImageType type);
     QList<TrailerProvider *> trailerProviders();
     MediaCenterInterface *mediaCenterInterface();
     MediaCenterInterface *mediaCenterInterfaceTvShow();

--- a/imageProviders/FanartTv.h
+++ b/imageProviders/FanartTv.h
@@ -22,7 +22,7 @@ public:
     QString name() override;
     QUrl siteUrl() override;
     QString identifier() override;
-    void movieImages(Movie *movie, QString tmdbId, QList<int> types) override;
+    void movieImages(Movie *movie, QString tmdbId, QList<ImageType> types) override;
     void moviePosters(QString tmdbId) override;
     void movieBackdrops(QString tmdbId) override;
     void movieLogos(QString tmdbId) override;
@@ -30,13 +30,13 @@ public:
     void movieThumbs(QString tmdbId) override;
     void movieClearArts(QString tmdbId) override;
     void movieCdArts(QString tmdbId) override;
-    void concertImages(Concert *concert, QString tmdbId, QList<int> types) override;
+    void concertImages(Concert *concert, QString tmdbId, QList<ImageType> types) override;
     void concertPosters(QString tmdbId) override;
     void concertBackdrops(QString tmdbId) override;
     void concertLogos(QString tmdbId) override;
     void concertClearArts(QString tmdbId) override;
     void concertCdArts(QString tmdbId) override;
-    void tvShowImages(TvShow *show, QString tvdbId, QList<int> types) override;
+    void tvShowImages(TvShow *show, QString tvdbId, QList<ImageType> types) override;
     void tvShowPosters(QString tvdbId) override;
     void tvShowBackdrops(QString tvdbId) override;
     void tvShowLogos(QString tvdbId) override;
@@ -54,10 +54,10 @@ public:
     void artistThumbs(QString mbId) override;
     void albumCdArts(QString mbId) override;
     void albumThumbs(QString mbId) override;
-    void artistImages(Artist *artist, QString mbId, QList<int> types) override;
-    void albumImages(Album *album, QString mbId, QList<int> types) override;
+    void artistImages(Artist *artist, QString mbId, QList<ImageType> types) override;
+    void albumImages(Album *album, QString mbId, QList<ImageType> types) override;
     void albumBooklets(QString mbId) override;
-    QList<int> provides() override;
+    QList<ImageType> provides() override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
@@ -74,11 +74,11 @@ public slots:
 signals:
     void sigSearchDone(QList<ScraperSearchResult>) override;
     void sigImagesLoaded(QList<Poster>) override;
-    void sigImagesLoaded(Movie *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(Concert *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(TvShow *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(Artist *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(Album *, QMap<int, QList<Poster>>) override;
+    void sigImagesLoaded(Movie *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(Concert *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(TvShow *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(Artist *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(Album *, QMap<ImageType, QList<Poster>>) override;
 
 private slots:
     void onSearchMovieFinished(QList<ScraperSearchResult> results);
@@ -90,7 +90,7 @@ private slots:
     void onLoadAllTvShowDataFinished();
 
 private:
-    QList<int> m_provides;
+    QList<ImageType> m_provides;
     QString m_apiKey;
     QString m_personalApiKey;
     QNetworkAccessManager m_qnam;
@@ -105,13 +105,13 @@ private:
     QLineEdit *m_personalApiKeyEdit;
 
     QNetworkAccessManager *qnam();
-    QList<Poster> parseMovieData(QString json, int type);
-    void loadMovieData(QString tmdbId, int type);
-    void loadMovieData(QString tmdbId, QList<int> types, Movie *movie);
-    void loadConcertData(QString tmdbId, QList<int> types, Concert *concert);
-    QList<Poster> parseTvShowData(QString json, int type, int season = -2);
-    void loadTvShowData(QString tvdbId, int type, int season = -2);
-    void loadTvShowData(QString tvdbId, QList<int> types, TvShow *show);
+    QList<Poster> parseMovieData(QString json, ImageType type);
+    void loadMovieData(QString tmdbId, ImageType type);
+    void loadMovieData(QString tmdbId, QList<ImageType> types, Movie *movie);
+    void loadConcertData(QString tmdbId, QList<ImageType> types, Concert *concert);
+    QList<Poster> parseTvShowData(QString json, ImageType type, int season = -2);
+    void loadTvShowData(QString tvdbId, ImageType type, int season = -2);
+    void loadTvShowData(QString tvdbId, QList<ImageType> types, TvShow *show);
     QString keyParameter();
 };
 

--- a/imageProviders/FanartTvMusic.cpp
+++ b/imageProviders/FanartTvMusic.cpp
@@ -15,8 +15,12 @@
 FanartTvMusic::FanartTvMusic(QObject *parent)
 {
     setParent(parent);
-    m_provides << ImageType::AlbumCdArt << ImageType::AlbumThumb << ImageType::ArtistFanart << ImageType::ArtistLogo
-               << ImageType::ArtistThumb << ImageType::ArtistExtraFanart;
+    m_provides = {ImageType::AlbumCdArt,
+        ImageType::AlbumThumb,
+        ImageType::ArtistFanart,
+        ImageType::ArtistLogo,
+        ImageType::ArtistThumb,
+        ImageType::ArtistExtraFanart};
     m_apiKey = "842f7a5d1cc7396f142b8dd47c4ba42b";
     m_searchResultLimit = 0;
     m_language = "en";
@@ -37,7 +41,7 @@ QString FanartTvMusic::identifier()
     return QString("images.fanarttv-music_lib");
 }
 
-QList<int> FanartTvMusic::provides()
+QList<ImageType> FanartTvMusic::provides()
 {
     return m_provides;
 }
@@ -83,7 +87,7 @@ void FanartTvMusic::artistFanarts(QString mbId)
     url.setUrl(QString("https://webservice.fanart.tv/v3/music/%1?%2").arg(mbId).arg(keyParameter()));
     request.setUrl(url);
     QNetworkReply *reply = qnam()->get(request);
-    reply->setProperty("infoToLoad", ImageType::ArtistFanart);
+    reply->setProperty("infoToLoad", static_cast<int>(ImageType::ArtistFanart));
     connect(reply, &QNetworkReply::finished, this, &FanartTvMusic::onLoadArtistFinished);
 }
 
@@ -95,7 +99,7 @@ void FanartTvMusic::artistLogos(QString mbId)
     url.setUrl(QString("https://webservice.fanart.tv/v3/music/%1?%2").arg(mbId).arg(keyParameter()));
     request.setUrl(url);
     QNetworkReply *reply = qnam()->get(request);
-    reply->setProperty("infoToLoad", ImageType::ArtistLogo);
+    reply->setProperty("infoToLoad", static_cast<int>(ImageType::ArtistLogo));
     connect(reply, &QNetworkReply::finished, this, &FanartTvMusic::onLoadArtistFinished);
 }
 
@@ -107,7 +111,7 @@ void FanartTvMusic::artistThumbs(QString mbId)
     url.setUrl(QString("https://webservice.fanart.tv/v3/music/%1?%2").arg(mbId).arg(keyParameter()));
     request.setUrl(url);
     QNetworkReply *reply = qnam()->get(request);
-    reply->setProperty("infoToLoad", ImageType::ArtistThumb);
+    reply->setProperty("infoToLoad", static_cast<int>(ImageType::ArtistThumb));
     connect(reply, &QNetworkReply::finished, this, &FanartTvMusic::onLoadArtistFinished);
 }
 
@@ -119,7 +123,7 @@ void FanartTvMusic::albumCdArts(QString mbId)
     url.setUrl(QString("https://webservice.fanart.tv/v3/music/albums/%1?%2").arg(mbId).arg(keyParameter()));
     request.setUrl(url);
     QNetworkReply *reply = qnam()->get(request);
-    reply->setProperty("infoToLoad", ImageType::AlbumCdArt);
+    reply->setProperty("infoToLoad", static_cast<int>(ImageType::AlbumCdArt));
     connect(reply, &QNetworkReply::finished, this, &FanartTvMusic::onLoadAlbumFinished);
 }
 
@@ -131,7 +135,7 @@ void FanartTvMusic::albumThumbs(QString mbId)
     url.setUrl(QString("https://webservice.fanart.tv/v3/music/albums/%1?%2").arg(mbId).arg(keyParameter()));
     request.setUrl(url);
     QNetworkReply *reply = qnam()->get(request);
-    reply->setProperty("infoToLoad", ImageType::AlbumThumb);
+    reply->setProperty("infoToLoad", static_cast<int>(ImageType::AlbumThumb));
     connect(reply, &QNetworkReply::finished, this, &FanartTvMusic::onLoadAlbumFinished);
 }
 
@@ -232,7 +236,7 @@ void FanartTvMusic::onSearchAlbumFinished()
 void FanartTvMusic::onLoadArtistFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
-    int info = reply->property("infoToLoad").toInt();
+    ImageType info = ImageType(reply->property("infoToLoad").toInt());
     reply->deleteLater();
     QList<Poster> posters;
     if (reply->error() == QNetworkReply::NoError) {
@@ -245,7 +249,7 @@ void FanartTvMusic::onLoadArtistFinished()
 void FanartTvMusic::onLoadAlbumFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
-    int info = reply->property("infoToLoad").toInt();
+    ImageType info = ImageType(reply->property("infoToLoad").toInt());
     reply->deleteLater();
     QList<Poster> posters;
     if (reply->error() == QNetworkReply::NoError) {
@@ -255,9 +259,9 @@ void FanartTvMusic::onLoadAlbumFinished()
     emit sigImagesLoaded(posters);
 }
 
-QList<Poster> FanartTvMusic::parseData(QString json, int type)
+QList<Poster> FanartTvMusic::parseData(QString json, ImageType type)
 {
-    QMap<int, QStringList> map;
+    QMap<ImageType, QStringList> map;
 
     // clang-format off
     map.insert(ImageType::ArtistFanart,      QStringList() << "artistbackground");
@@ -340,7 +344,7 @@ void FanartTvMusic::searchTvShow(QString searchStr, int limit)
     Q_UNUSED(limit);
 }
 
-void FanartTvMusic::tvShowImages(TvShow *show, QString tvdbId, QList<int> types)
+void FanartTvMusic::tvShowImages(TvShow *show, QString tvdbId, QList<ImageType> types)
 {
     Q_UNUSED(tvdbId);
     Q_UNUSED(show);
@@ -413,7 +417,7 @@ void FanartTvMusic::tvShowSeasonBackdrops(QString tvdbId, int season)
     Q_UNUSED(season);
 }
 
-void FanartTvMusic::movieImages(Movie *movie, QString tmdbId, QList<int> types)
+void FanartTvMusic::movieImages(Movie *movie, QString tmdbId, QList<ImageType> types)
 {
     Q_UNUSED(movie);
     Q_UNUSED(tmdbId);
@@ -455,7 +459,7 @@ void FanartTvMusic::movieCdArts(QString tmdbId)
     Q_UNUSED(tmdbId);
 }
 
-void FanartTvMusic::concertImages(Concert *concert, QString tmdbId, QList<int> types)
+void FanartTvMusic::concertImages(Concert *concert, QString tmdbId, QList<ImageType> types)
 {
     Q_UNUSED(tmdbId);
     Q_UNUSED(concert);
@@ -516,7 +520,7 @@ void FanartTvMusic::searchConcert(QString searchStr, int limit)
     Q_UNUSED(limit);
 }
 
-void FanartTvMusic::artistImages(Artist *artist, QString mbId, QList<int> types)
+void FanartTvMusic::artistImages(Artist *artist, QString mbId, QList<ImageType> types)
 {
     QUrl url;
     QNetworkRequest request;
@@ -529,7 +533,7 @@ void FanartTvMusic::artistImages(Artist *artist, QString mbId, QList<int> types)
     connect(reply, &QNetworkReply::finished, this, &FanartTvMusic::onLoadAllArtistDataFinished);
 }
 
-void FanartTvMusic::albumImages(Album *album, QString mbId, QList<int> types)
+void FanartTvMusic::albumImages(Album *album, QString mbId, QList<ImageType> types)
 {
     QUrl url;
     QNetworkRequest request;
@@ -547,11 +551,12 @@ void FanartTvMusic::onLoadAllAlbumDataFinished()
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Album *album = reply->property("storage").value<Storage *>()->album();
     reply->deleteLater();
-    QMap<int, QList<Poster>> posters;
+    QMap<ImageType, QList<Poster>> posters;
     if (reply->error() == QNetworkReply::NoError) {
         QString msg = QString::fromUtf8(reply->readAll());
-        foreach (int type, reply->property("infosToLoad").value<Storage *>()->infosToLoad())
+        for (const auto type : reply->property("infosToLoad").value<Storage *>()->imageInfosToLoad()) {
             posters.insert(type, parseData(msg, type));
+        }
     }
     emit sigImagesLoaded(album, posters);
 }
@@ -561,11 +566,12 @@ void FanartTvMusic::onLoadAllArtistDataFinished()
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Artist *artist = reply->property("storage").value<Storage *>()->artist();
     reply->deleteLater();
-    QMap<int, QList<Poster>> posters;
+    QMap<ImageType, QList<Poster>> posters;
     if (reply->error() == QNetworkReply::NoError) {
         QString msg = QString::fromUtf8(reply->readAll());
-        foreach (int type, reply->property("infosToLoad").value<Storage *>()->infosToLoad())
+        for (const auto type : reply->property("infosToLoad").value<Storage *>()->imageInfosToLoad()) {
             posters.insert(type, parseData(msg, type));
+        }
     }
     emit sigImagesLoaded(artist, posters);
 }

--- a/imageProviders/FanartTvMusic.h
+++ b/imageProviders/FanartTvMusic.h
@@ -18,7 +18,7 @@ public:
     QString name() override;
     QUrl siteUrl() override;
     QString identifier() override;
-    void movieImages(Movie *movie, QString tmdbId, QList<int> types) override;
+    void movieImages(Movie *movie, QString tmdbId, QList<ImageType> types) override;
     void moviePosters(QString tmdbId) override;
     void movieBackdrops(QString tmdbId) override;
     void movieLogos(QString tmdbId) override;
@@ -26,13 +26,13 @@ public:
     void movieThumbs(QString tmdbId) override;
     void movieClearArts(QString tmdbId) override;
     void movieCdArts(QString tmdbId) override;
-    void concertImages(Concert *concert, QString tmdbId, QList<int> types) override;
+    void concertImages(Concert *concert, QString tmdbId, QList<ImageType> types) override;
     void concertPosters(QString tmdbId) override;
     void concertBackdrops(QString mbId) override;
     void concertLogos(QString mbId) override;
     void concertClearArts(QString tmdbId) override;
     void concertCdArts(QString tmdbId) override;
-    void tvShowImages(TvShow *show, QString tvdbId, QList<int> types) override;
+    void tvShowImages(TvShow *show, QString tvdbId, QList<ImageType> types) override;
     void tvShowPosters(QString tvdbId) override;
     void tvShowBackdrops(QString tvdbId) override;
     void tvShowLogos(QString tvdbId) override;
@@ -50,10 +50,10 @@ public:
     void artistThumbs(QString mbId) override;
     void albumCdArts(QString mbId) override;
     void albumThumbs(QString mbId) override;
-    void artistImages(Artist *artist, QString mbId, QList<int> types) override;
-    void albumImages(Album *album, QString mbId, QList<int> types) override;
+    void artistImages(Artist *artist, QString mbId, QList<ImageType> types) override;
+    void albumImages(Album *album, QString mbId, QList<ImageType> types) override;
     void albumBooklets(QString mbId) override;
-    QList<int> provides() override;
+    QList<ImageType> provides() override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
@@ -69,11 +69,11 @@ public slots:
 signals:
     void sigSearchDone(QList<ScraperSearchResult>) override;
     void sigImagesLoaded(QList<Poster>) override;
-    void sigImagesLoaded(Movie *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(Concert *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(TvShow *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(Artist *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(Album *, QMap<int, QList<Poster>>) override;
+    void sigImagesLoaded(Movie *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(Concert *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(TvShow *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(Artist *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(Album *, QMap<ImageType, QList<Poster>>) override;
 
 private slots:
     void onSearchArtistFinished();
@@ -84,7 +84,7 @@ private slots:
     void onLoadAllAlbumDataFinished();
 
 private:
-    QList<int> m_provides;
+    QList<ImageType> m_provides;
     QString m_apiKey;
     QString m_personalApiKey;
     QNetworkAccessManager m_qnam;
@@ -92,7 +92,7 @@ private:
     QString m_language;
 
     QNetworkAccessManager *qnam();
-    QList<Poster> parseData(QString json, int type);
+    QList<Poster> parseData(QString json, ImageType type);
     QString keyParameter();
 };
 

--- a/imageProviders/FanartTvMusicArtists.cpp
+++ b/imageProviders/FanartTvMusicArtists.cpp
@@ -48,7 +48,7 @@ QString FanartTvMusicArtists::identifier()
  * @brief Returns a list of supported image types
  * @return List of supported image types
  */
-QList<int> FanartTvMusicArtists::provides()
+QList<ImageType> FanartTvMusicArtists::provides()
 {
     return m_provides;
 }
@@ -117,7 +117,7 @@ void FanartTvMusicArtists::concertBackdrops(QString mbId)
     url.setUrl(QString("https://webservice.fanart.tv/v3/music/%1?%2").arg(mbId).arg(keyParameter()));
     request.setUrl(url);
     QNetworkReply *reply = qnam()->get(request);
-    reply->setProperty("infoToLoad", ImageType::ConcertBackdrop);
+    reply->setProperty("infoToLoad", static_cast<int>(ImageType::ConcertBackdrop));
     connect(reply, &QNetworkReply::finished, this, &FanartTvMusicArtists::onLoadConcertFinished);
 }
 
@@ -129,14 +129,14 @@ void FanartTvMusicArtists::concertLogos(QString mbId)
     url.setUrl(QString("https://webservice.fanart.tv/v3/music/%1?%2").arg(mbId).arg(keyParameter()));
     request.setUrl(url);
     QNetworkReply *reply = qnam()->get(request);
-    reply->setProperty("infoToLoad", ImageType::ConcertLogo);
+    reply->setProperty("infoToLoad", static_cast<int>(ImageType::ConcertLogo));
     connect(reply, &QNetworkReply::finished, this, &FanartTvMusicArtists::onLoadConcertFinished);
 }
 
 void FanartTvMusicArtists::onLoadConcertFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
-    int info = reply->property("infoToLoad").toInt();
+    ImageType info = ImageType(reply->property("infoToLoad").toInt());
     reply->deleteLater();
     QList<Poster> posters;
     if (reply->error() == QNetworkReply::NoError) {
@@ -146,13 +146,11 @@ void FanartTvMusicArtists::onLoadConcertFinished()
     emit sigImagesLoaded(posters);
 }
 
-QList<Poster> FanartTvMusicArtists::parseData(QString json, int type)
+QList<Poster> FanartTvMusicArtists::parseData(QString json, ImageType type)
 {
-    QMap<int, QStringList> map;
+    QMap<ImageType, QStringList> map;
     map.insert(ImageType::ConcertBackdrop, QStringList() << "artistbackground");
-    map.insert(ImageType::ConcertLogo,
-        QStringList() << "hdmusiclogo"
-                      << "musiclogo");
+    map.insert(ImageType::ConcertLogo, {"hdmusiclogo", "musiclogo"});
 
     QList<Poster> posters;
 
@@ -165,7 +163,7 @@ QList<Poster> FanartTvMusicArtists::parseData(QString json, int type)
         return posters;
     }
 
-    foreach (const QString &section, map.value(type)) {
+    for (const auto &section : map.value(type)) {
         const auto jsonPosters = parsedJson.value(section).toArray();
 
         for (const auto &it : jsonPosters) {
@@ -209,7 +207,7 @@ void FanartTvMusicArtists::searchTvShow(QString searchStr, int limit)
     Q_UNUSED(limit);
 }
 
-void FanartTvMusicArtists::tvShowImages(TvShow *show, QString tvdbId, QList<int> types)
+void FanartTvMusicArtists::tvShowImages(TvShow *show, QString tvdbId, QList<ImageType> types)
 {
     Q_UNUSED(tvdbId);
     Q_UNUSED(show);
@@ -282,7 +280,7 @@ void FanartTvMusicArtists::tvShowSeasonBackdrops(QString tvdbId, int season)
     Q_UNUSED(season);
 }
 
-void FanartTvMusicArtists::movieImages(Movie *movie, QString tmdbId, QList<int> types)
+void FanartTvMusicArtists::movieImages(Movie *movie, QString tmdbId, QList<ImageType> types)
 {
     Q_UNUSED(movie);
     Q_UNUSED(tmdbId);
@@ -324,7 +322,7 @@ void FanartTvMusicArtists::movieCdArts(QString tmdbId)
     Q_UNUSED(tmdbId);
 }
 
-void FanartTvMusicArtists::concertImages(Concert *concert, QString tmdbId, QList<int> types)
+void FanartTvMusicArtists::concertImages(Concert *concert, QString tmdbId, QList<ImageType> types)
 {
     Q_UNUSED(tmdbId);
     Q_UNUSED(concert);
@@ -418,14 +416,14 @@ void FanartTvMusicArtists::albumThumbs(QString mbId)
     Q_UNUSED(mbId);
 }
 
-void FanartTvMusicArtists::artistImages(Artist *artist, QString mbId, QList<int> types)
+void FanartTvMusicArtists::artistImages(Artist *artist, QString mbId, QList<ImageType> types)
 {
     Q_UNUSED(artist);
     Q_UNUSED(mbId);
     Q_UNUSED(types);
 }
 
-void FanartTvMusicArtists::albumImages(Album *album, QString mbId, QList<int> types)
+void FanartTvMusicArtists::albumImages(Album *album, QString mbId, QList<ImageType> types)
 {
     Q_UNUSED(album);
     Q_UNUSED(mbId);

--- a/imageProviders/FanartTvMusicArtists.h
+++ b/imageProviders/FanartTvMusicArtists.h
@@ -21,7 +21,7 @@ public:
     QString name() override;
     QUrl siteUrl() override;
     QString identifier() override;
-    void movieImages(Movie *movie, QString tmdbId, QList<int> types) override;
+    void movieImages(Movie *movie, QString tmdbId, QList<ImageType> types) override;
     void moviePosters(QString tmdbId) override;
     void movieBackdrops(QString tmdbId) override;
     void movieLogos(QString tmdbId) override;
@@ -29,13 +29,13 @@ public:
     void movieThumbs(QString tmdbId) override;
     void movieClearArts(QString tmdbId) override;
     void movieCdArts(QString tmdbId) override;
-    void concertImages(Concert *concert, QString tmdbId, QList<int> types) override;
+    void concertImages(Concert *concert, QString tmdbId, QList<ImageType> types) override;
     void concertPosters(QString tmdbId) override;
     void concertBackdrops(QString mbId) override;
     void concertLogos(QString mbId) override;
     void concertClearArts(QString tmdbId) override;
     void concertCdArts(QString tmdbId) override;
-    void tvShowImages(TvShow *show, QString tvdbId, QList<int> types) override;
+    void tvShowImages(TvShow *show, QString tvdbId, QList<ImageType> types) override;
     void tvShowPosters(QString tvdbId) override;
     void tvShowBackdrops(QString tvdbId) override;
     void tvShowLogos(QString tvdbId) override;
@@ -53,10 +53,10 @@ public:
     void artistThumbs(QString mbId) override;
     void albumCdArts(QString mbId) override;
     void albumThumbs(QString mbId) override;
-    void artistImages(Artist *artist, QString mbId, QList<int> types) override;
-    void albumImages(Album *album, QString mbId, QList<int> types) override;
+    void artistImages(Artist *artist, QString mbId, QList<ImageType> types) override;
+    void albumImages(Album *album, QString mbId, QList<ImageType> types) override;
     void albumBooklets(QString mbId) override;
-    QList<int> provides() override;
+    QList<ImageType> provides() override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
@@ -72,18 +72,18 @@ public slots:
 signals:
     void sigSearchDone(QList<ScraperSearchResult>) override;
     void sigImagesLoaded(QList<Poster>) override;
-    void sigImagesLoaded(Movie *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(Concert *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(TvShow *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(Artist *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(Album *, QMap<int, QList<Poster>>) override;
+    void sigImagesLoaded(Movie *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(Concert *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(TvShow *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(Artist *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(Album *, QMap<ImageType, QList<Poster>>) override;
 
 private slots:
     void onSearchArtistFinished();
     void onLoadConcertFinished();
 
 private:
-    QList<int> m_provides;
+    QList<ImageType> m_provides;
     QString m_apiKey;
     QString m_personalApiKey;
     QNetworkAccessManager m_qnam;
@@ -92,7 +92,7 @@ private:
     QString m_preferredDiscType;
 
     QNetworkAccessManager *qnam();
-    QList<Poster> parseData(QString json, int type);
+    QList<Poster> parseData(QString json, ImageType type);
     QString keyParameter();
 };
 

--- a/imageProviders/TMDbImages.cpp
+++ b/imageProviders/TMDbImages.cpp
@@ -10,8 +10,10 @@
 TMDbImages::TMDbImages(QObject *parent)
 {
     setParent(parent);
-    m_provides << ImageType::MovieBackdrop << ImageType::MoviePoster << ImageType::ConcertBackdrop
-               << ImageType::ConcertPoster;
+    m_provides = {ImageType::MovieBackdrop, //
+        ImageType::MoviePoster,             //
+        ImageType::ConcertBackdrop,         //
+        ImageType::ConcertPoster};
     m_searchResultLimit = 0;
     m_tmdb = new TMDb(this);
     m_dummyMovie = new Movie(QStringList(), this);
@@ -45,7 +47,7 @@ QString TMDbImages::identifier()
  * @brief Returns a list of supported image types
  * @return List of supported image types
  */
-QList<int> TMDbImages::provides()
+QList<ImageType> TMDbImages::provides()
 {
     return m_provides;
 }
@@ -97,7 +99,7 @@ void TMDbImages::moviePosters(QString tmdbId)
 {
     m_dummyMovie->clear();
     m_imageType = ImageType::MoviePoster;
-    QList<int> infos;
+    QList<MovieScraperInfos> infos;
     infos << MovieScraperInfos::Poster;
     QMap<ScraperInterface *, QString> ids;
     ids.insert(0, tmdbId);
@@ -112,7 +114,7 @@ void TMDbImages::movieBackdrops(QString tmdbId)
 {
     m_dummyMovie->clear();
     m_imageType = ImageType::MovieBackdrop;
-    QList<int> infos;
+    QList<MovieScraperInfos> infos;
     infos << MovieScraperInfos::Backdrop;
     QMap<ScraperInterface *, QString> ids;
     ids.insert(0, tmdbId);
@@ -158,7 +160,7 @@ void TMDbImages::onLoadImagesFinished()
  * @param tmdbId
  * @param types
  */
-void TMDbImages::movieImages(Movie *movie, QString tmdbId, QList<int> types)
+void TMDbImages::movieImages(Movie *movie, QString tmdbId, QList<ImageType> types)
 {
     Q_UNUSED(movie);
     Q_UNUSED(tmdbId);
@@ -208,7 +210,7 @@ void TMDbImages::movieCdArts(QString tmdbId)
  * @param tmdbId
  * @param types
  */
-void TMDbImages::concertImages(Concert *concert, QString tmdbId, QList<int> types)
+void TMDbImages::concertImages(Concert *concert, QString tmdbId, QList<ImageType> types)
 {
     Q_UNUSED(concert);
     Q_UNUSED(tmdbId);
@@ -259,7 +261,7 @@ void TMDbImages::searchTvShow(QString searchStr, int limit)
  * @param tvdbId
  * @param types
  */
-void TMDbImages::tvShowImages(TvShow *show, QString tvdbId, QList<int> types)
+void TMDbImages::tvShowImages(TvShow *show, QString tvdbId, QList<ImageType> types)
 {
     Q_UNUSED(show);
     Q_UNUSED(tvdbId);
@@ -425,14 +427,14 @@ void TMDbImages::albumThumbs(QString mbId)
     Q_UNUSED(mbId);
 }
 
-void TMDbImages::artistImages(Artist *artist, QString mbId, QList<int> types)
+void TMDbImages::artistImages(Artist *artist, QString mbId, QList<ImageType> types)
 {
     Q_UNUSED(artist);
     Q_UNUSED(mbId);
     Q_UNUSED(types);
 }
 
-void TMDbImages::albumImages(Album *album, QString mbId, QList<int> types)
+void TMDbImages::albumImages(Album *album, QString mbId, QList<ImageType> types)
 {
     Q_UNUSED(album);
     Q_UNUSED(mbId);

--- a/imageProviders/TMDbImages.h
+++ b/imageProviders/TMDbImages.h
@@ -16,7 +16,7 @@ public:
     QString name() override;
     QUrl siteUrl() override;
     QString identifier() override;
-    void movieImages(Movie *movie, QString tmdbId, QList<int> types) override;
+    void movieImages(Movie *movie, QString tmdbId, QList<ImageType> types) override;
     void moviePosters(QString tmdbId) override;
     void movieBackdrops(QString tmdbId) override;
     void movieLogos(QString tmdbId) override;
@@ -24,13 +24,13 @@ public:
     void movieThumbs(QString tmdbId) override;
     void movieClearArts(QString tmdbId) override;
     void movieCdArts(QString tmdbId) override;
-    void concertImages(Concert *concert, QString tmdbId, QList<int> types) override;
+    void concertImages(Concert *concert, QString tmdbId, QList<ImageType> types) override;
     void concertPosters(QString tmdbId) override;
     void concertBackdrops(QString tmdbId) override;
     void concertLogos(QString tmdbId) override;
     void concertClearArts(QString tmdbId) override;
     void concertCdArts(QString tmdbId) override;
-    void tvShowImages(TvShow *show, QString tvdbId, QList<int> types) override;
+    void tvShowImages(TvShow *show, QString tvdbId, QList<ImageType> types) override;
     void tvShowPosters(QString tvdbId) override;
     void tvShowBackdrops(QString tvdbId) override;
     void tvShowLogos(QString tvdbId) override;
@@ -48,10 +48,10 @@ public:
     void artistThumbs(QString mbId) override;
     void albumCdArts(QString mbId) override;
     void albumThumbs(QString mbId) override;
-    void artistImages(Artist *artist, QString mbId, QList<int> types) override;
-    void albumImages(Album *album, QString mbId, QList<int> types) override;
+    void artistImages(Artist *artist, QString mbId, QList<ImageType> types) override;
+    void albumImages(Album *album, QString mbId, QList<ImageType> types) override;
     void albumBooklets(QString mbId) override;
-    QList<int> provides() override;
+    QList<ImageType> provides() override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
@@ -67,22 +67,22 @@ public slots:
 signals:
     void sigSearchDone(QList<ScraperSearchResult>) override;
     void sigImagesLoaded(QList<Poster>) override;
-    void sigImagesLoaded(Movie *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(Concert *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(TvShow *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(Artist *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(Album *, QMap<int, QList<Poster>>) override;
+    void sigImagesLoaded(Movie *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(Concert *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(TvShow *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(Artist *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(Album *, QMap<ImageType, QList<Poster>>) override;
 
 private slots:
     void onSearchMovieFinished(QList<ScraperSearchResult> results);
     void onLoadImagesFinished();
 
 private:
-    QList<int> m_provides;
+    QList<ImageType> m_provides;
     int m_searchResultLimit;
     TMDb *m_tmdb;
     Movie *m_dummyMovie;
-    int m_imageType;
+    ImageType m_imageType;
 };
 
 #endif // TMDBIMAGES_H

--- a/imageProviders/TheTvDbImages.cpp
+++ b/imageProviders/TheTvDbImages.cpp
@@ -9,9 +9,13 @@
 TheTvDbImages::TheTvDbImages(QObject *parent)
 {
     setParent(parent);
-    m_provides << ImageType::TvShowPoster << ImageType::TvShowBackdrop << ImageType::TvShowBanner
-               << ImageType::TvShowSeasonPoster << ImageType::TvShowEpisodeThumb << ImageType::TvShowSeasonBanner
-               << ImageType::TvShowSeasonBackdrop;
+    m_provides = {ImageType::TvShowPoster,
+        ImageType::TvShowBackdrop,
+        ImageType::TvShowBanner,
+        ImageType::TvShowSeasonPoster,
+        ImageType::TvShowEpisodeThumb,
+        ImageType::TvShowSeasonBanner,
+        ImageType::TvShowSeasonBackdrop};
     m_dummyShow = new TvShow(QString(), this);
     m_dummyEpisode = new TvShowEpisode(QStringList(), m_dummyShow);
     m_tvdb = new TheTvDb(this);
@@ -47,7 +51,7 @@ QString TheTvDbImages::identifier()
  * @brief Returns a list of supported image types
  * @return List of supported image types
  */
-QList<int> TheTvDbImages::provides()
+QList<ImageType> TheTvDbImages::provides()
 {
     return m_provides;
 }
@@ -104,12 +108,12 @@ void TheTvDbImages::onSearchTvShowFinished(QList<ScraperSearchResult> results)
  * @param tvdbId
  * @param type
  */
-void TheTvDbImages::loadTvShowData(QString tvdbId, int type)
+void TheTvDbImages::loadTvShowData(QString tvdbId, ImageType type)
 {
     m_currentType = type;
     m_dummyShow->clear();
 
-    QList<int> infosToLoad;
+    QList<TvShowScraperInfos> infosToLoad;
     infosToLoad.append(TvShowScraperInfos::Thumbnail);
     infosToLoad.append(TvShowScraperInfos::Banner);
     infosToLoad.append(TvShowScraperInfos::Fanart);
@@ -161,7 +165,7 @@ void TheTvDbImages::onLoadTvShowDataFinished()
  * @param tvdbId
  * @param types
  */
-void TheTvDbImages::tvShowImages(TvShow *show, QString tvdbId, QList<int> types)
+void TheTvDbImages::tvShowImages(TvShow *show, QString tvdbId, QList<ImageType> types)
 {
     Q_UNUSED(show);
     Q_UNUSED(tvdbId);
@@ -234,7 +238,7 @@ void TheTvDbImages::tvShowSeasonBanners(QString tvdbId, int season)
  * @param tmdbId
  * @param types
  */
-void TheTvDbImages::movieImages(Movie *movie, QString tmdbId, QList<int> types)
+void TheTvDbImages::movieImages(Movie *movie, QString tmdbId, QList<ImageType> types)
 {
     Q_UNUSED(movie);
     Q_UNUSED(tmdbId);
@@ -308,7 +312,7 @@ void TheTvDbImages::movieCdArts(QString tmdbId)
  * @param tmdbId
  * @param types
  */
-void TheTvDbImages::concertImages(Concert *concert, QString tmdbId, QList<int> types)
+void TheTvDbImages::concertImages(Concert *concert, QString tmdbId, QList<ImageType> types)
 {
     Q_UNUSED(concert);
     Q_UNUSED(tmdbId);
@@ -456,14 +460,14 @@ void TheTvDbImages::albumThumbs(QString mbId)
     Q_UNUSED(mbId);
 }
 
-void TheTvDbImages::artistImages(Artist *artist, QString mbId, QList<int> types)
+void TheTvDbImages::artistImages(Artist *artist, QString mbId, QList<ImageType> types)
 {
     Q_UNUSED(artist);
     Q_UNUSED(mbId);
     Q_UNUSED(types);
 }
 
-void TheTvDbImages::albumImages(Album *album, QString mbId, QList<int> types)
+void TheTvDbImages::albumImages(Album *album, QString mbId, QList<ImageType> types)
 {
     Q_UNUSED(album);
     Q_UNUSED(mbId);

--- a/imageProviders/TheTvDbImages.h
+++ b/imageProviders/TheTvDbImages.h
@@ -20,7 +20,7 @@ public:
     QString name() override;
     QUrl siteUrl() override;
     QString identifier() override;
-    void movieImages(Movie *movie, QString tmdbId, QList<int> types) override;
+    void movieImages(Movie *movie, QString tmdbId, QList<ImageType> types) override;
     void moviePosters(QString tmdbId) override;
     void movieBackdrops(QString tmdbId) override;
     void movieLogos(QString tmdbId) override;
@@ -28,13 +28,13 @@ public:
     void movieThumbs(QString tmdbId) override;
     void movieClearArts(QString tmdbId) override;
     void movieCdArts(QString tmdbId) override;
-    void concertImages(Concert *concert, QString tmdbId, QList<int> types) override;
+    void concertImages(Concert *concert, QString tmdbId, QList<ImageType> types) override;
     void concertPosters(QString tmdbId) override;
     void concertBackdrops(QString tmdbId) override;
     void concertLogos(QString tmdbId) override;
     void concertClearArts(QString tmdbId) override;
     void concertCdArts(QString tmdbId) override;
-    void tvShowImages(TvShow *show, QString tvdbId, QList<int> types) override;
+    void tvShowImages(TvShow *show, QString tvdbId, QList<ImageType> types) override;
     void tvShowPosters(QString tvdbId) override;
     void tvShowBackdrops(QString tvdbId) override;
     void tvShowLogos(QString tvdbId) override;
@@ -52,10 +52,10 @@ public:
     void artistThumbs(QString mbId) override;
     void albumCdArts(QString mbId) override;
     void albumThumbs(QString mbId) override;
-    void artistImages(Artist *artist, QString mbId, QList<int> types) override;
-    void albumImages(Album *album, QString mbId, QList<int> types) override;
+    void artistImages(Artist *artist, QString mbId, QList<ImageType> types) override;
+    void albumImages(Album *album, QString mbId, QList<ImageType> types) override;
     void albumBooklets(QString mbId) override;
-    QList<int> provides() override;
+    QList<ImageType> provides() override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
@@ -71,27 +71,26 @@ public slots:
 signals:
     void sigSearchDone(QList<ScraperSearchResult>) override;
     void sigImagesLoaded(QList<Poster>) override;
-    void sigImagesLoaded(Movie *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(Concert *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(TvShow *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(Artist *, QMap<int, QList<Poster>>) override;
-    void sigImagesLoaded(Album *, QMap<int, QList<Poster>>) override;
+    void sigImagesLoaded(Movie *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(Concert *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(TvShow *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(Artist *, QMap<ImageType, QList<Poster>>) override;
+    void sigImagesLoaded(Album *, QMap<ImageType, QList<Poster>>) override;
 
 private slots:
     void onSearchTvShowFinished(QList<ScraperSearchResult> results);
     void onLoadTvShowDataFinished();
 
 private:
-    QList<int> m_provides;
-    int m_currentType;
+    QList<ImageType> m_provides;
+    ImageType m_currentType;
     int m_searchResultLimit;
     TheTvDb *m_tvdb;
     TvShow *m_dummyShow;
     TvShowEpisode *m_dummyEpisode;
     int m_season;
 
-    QList<Poster> parseTvShowData(QString json, int type);
-    void loadTvShowData(QString tvdbId, int type);
+    void loadTvShowData(QString tvdbId, ImageType type);
 };
 
 #endif // THETVDBIMAGES_H

--- a/mediaCenterPlugins/XbmcXml.cpp
+++ b/mediaCenterPlugins/XbmcXml.cpp
@@ -168,7 +168,7 @@ bool XbmcXml::saveMovie(Movie *movie)
 
     bool saved = false;
     QFileInfo fi(movie->files().at(0));
-    foreach (DataFile dataFile, Settings::instance()->dataFiles(DataFileType::MovieNfo)) {
+    for (auto dataFile : Settings::instance()->dataFiles(DataFileType::MovieNfo)) {
         QString saveFileName = dataFile.saveFileName(fi.fileName(), -1, movie->files().count() > 1);
         QString saveFilePath = fi.absolutePath() + "/" + saveFileName;
         QDir saveFileDir = QFileInfo(saveFilePath).dir();
@@ -189,8 +189,8 @@ bool XbmcXml::saveMovie(Movie *movie)
         return false;
     }
 
-    foreach (const int &imageType, Movie::imageTypes()) {
-        int dataFileType = DataFile::dataFileTypeForImageType(imageType);
+    for (const auto imageType : Movie::imageTypes()) {
+        DataFileType dataFileType = DataFile::dataFileTypeForImageType(imageType);
         if (movie->imageHasChanged(imageType) && !movie->image(imageType).isNull()) {
             foreach (DataFile dataFile, Settings::instance()->dataFiles(dataFileType)) {
                 QString saveFileName = dataFile.saveFileName(fi.fileName(), -1, movie->files().count() > 1);
@@ -561,8 +561,9 @@ bool XbmcXml::loadMovie(Movie *movie, QString initialNfoContent)
 
     // Existence of images
     if (initialNfoContent.isEmpty()) {
-        foreach (const int &imageType, Movie::imageTypes())
+        for (const auto imageType : Movie::imageTypes()) {
             movie->setHasImage(imageType, !imageFileName(movie, imageType).isEmpty());
+        }
         movie->setHasExtraFanarts(!extraFanartNames(movie).isEmpty());
     }
 
@@ -920,8 +921,8 @@ bool XbmcXml::saveConcert(Concert *concert)
         return false;
     }
 
-    foreach (const int &imageType, Concert::imageTypes()) {
-        int dataFileType = DataFile::dataFileTypeForImageType(imageType);
+    for (const auto imageType : Concert::imageTypes()) {
+        DataFileType dataFileType = DataFile::dataFileTypeForImageType(imageType);
         if (concert->imageHasChanged(imageType) && !concert->image(imageType).isNull()) {
             foreach (DataFile dataFile, Settings::instance()->dataFiles(dataFileType)) {
                 QString saveFileName = dataFile.saveFileName(fi.fileName(), -1, concert->files().count() > 1);
@@ -1078,8 +1079,9 @@ bool XbmcXml::loadConcert(Concert *concert, QString initialNfoContent)
 
     // Existence of images
     if (initialNfoContent.isEmpty()) {
-        foreach (const int &imageType, Concert::imageTypes())
+        for (const auto &imageType : Concert::imageTypes()) {
             concert->setHasImage(imageType, !imageFileName(concert, imageType).isEmpty());
+        }
         concert->setHasExtraFanarts(!extraFanartNames(concert).isEmpty());
     }
 
@@ -1469,25 +1471,25 @@ bool XbmcXml::saveTvShow(TvShow *show)
         file.close();
     }
 
-    foreach (const int &imageType, TvShow::imageTypes()) {
-        int dataFileType = DataFile::dataFileTypeForImageType(imageType);
+    for (const auto imageType : TvShow::imageTypes()) {
+        DataFileType dataFileType = DataFile::dataFileTypeForImageType(imageType);
         if (show->imageHasChanged(imageType) && !show->image(imageType).isNull()) {
-            foreach (DataFile dataFile, Settings::instance()->dataFiles(dataFileType)) {
+            for (auto dataFile : Settings::instance()->dataFiles(dataFileType)) {
                 QString saveFileName = dataFile.saveFileName("");
                 saveFile(show->dir() + "/" + saveFileName, show->image(imageType));
             }
         }
         if (show->imagesToRemove().contains(imageType)) {
-            foreach (DataFile dataFile, Settings::instance()->dataFiles(dataFileType)) {
+            for (auto dataFile : Settings::instance()->dataFiles(dataFileType)) {
                 QString saveFileName = dataFile.saveFileName("");
                 QFile(show->dir() + "/" + saveFileName).remove();
             }
         }
     }
 
-    foreach (const int &imageType, TvShow::seasonImageTypes()) {
-        int dataFileType = DataFile::dataFileTypeForImageType(imageType);
-        foreach (int season, show->seasons()) {
+    for (const auto imageType : TvShow::seasonImageTypes()) {
+        DataFileType dataFileType = DataFile::dataFileTypeForImageType(imageType);
+        for (const auto season : show->seasons()) {
             if (show->seasonImageHasChanged(season, imageType) && !show->seasonImage(season, imageType).isNull()) {
                 foreach (DataFile dataFile, Settings::instance()->dataFiles(dataFileType)) {
                     QString saveFileName = dataFile.saveFileName("", season);
@@ -2023,9 +2025,9 @@ QString XbmcXml::movieSetFileName(QString setName, DataFile *dataFile)
     return QString();
 }
 
-QString XbmcXml::imageFileName(Movie *movie, int type, QList<DataFile> dataFiles, bool constructName)
+QString XbmcXml::imageFileName(Movie *movie, ImageType type, QList<DataFile> dataFiles, bool constructName)
 {
-    int fileType;
+    DataFileType fileType;
     switch (type) {
     case ImageType::MoviePoster: fileType = DataFileType::MoviePoster; break;
     case ImageType::MovieBackdrop: fileType = DataFileType::MovieBackdrop; break;
@@ -2069,9 +2071,9 @@ QString XbmcXml::imageFileName(Movie *movie, int type, QList<DataFile> dataFiles
     return fileName;
 }
 
-QString XbmcXml::imageFileName(Concert *concert, int type, QList<DataFile> dataFiles, bool constructName)
+QString XbmcXml::imageFileName(Concert *concert, ImageType type, QList<DataFile> dataFiles, bool constructName)
 {
-    int fileType;
+    DataFileType fileType;
     switch (type) {
     case ImageType::ConcertPoster: fileType = DataFileType::ConcertPoster; break;
     case ImageType::ConcertBackdrop: fileType = DataFileType::ConcertBackdrop; break;
@@ -2113,9 +2115,9 @@ QString XbmcXml::imageFileName(Concert *concert, int type, QList<DataFile> dataF
     return fileName;
 }
 
-QString XbmcXml::imageFileName(TvShow *show, int type, int season, QList<DataFile> dataFiles, bool constructName)
+QString XbmcXml::imageFileName(TvShow *show, ImageType type, int season, QList<DataFile> dataFiles, bool constructName)
 {
-    int fileType;
+    DataFileType fileType;
     switch (type) {
     case ImageType::TvShowPoster: fileType = DataFileType::TvShowPoster; break;
     case ImageType::TvShowBackdrop: fileType = DataFileType::TvShowBackdrop; break;
@@ -2151,9 +2153,9 @@ QString XbmcXml::imageFileName(TvShow *show, int type, int season, QList<DataFil
     return fileName;
 }
 
-QString XbmcXml::imageFileName(TvShowEpisode *episode, int type, QList<DataFile> dataFiles, bool constructName)
+QString XbmcXml::imageFileName(TvShowEpisode *episode, ImageType type, QList<DataFile> dataFiles, bool constructName)
 {
-    int fileType;
+    DataFileType fileType;
     switch (type) {
     case ImageType::TvShowEpisodeThumb: fileType = DataFileType::TvShowEpisodeThumb; break;
     default: return "";
@@ -2387,9 +2389,9 @@ bool XbmcXml::loadAlbum(Album *album, QString initialNfoContent)
     return true;
 }
 
-QString XbmcXml::imageFileName(Artist *artist, int type, QList<DataFile> dataFiles, bool constructName)
+QString XbmcXml::imageFileName(Artist *artist, ImageType type, QList<DataFile> dataFiles, bool constructName)
 {
-    int fileType;
+    DataFileType fileType;
     switch (type) {
     case ImageType::ArtistThumb: fileType = DataFileType::ArtistThumb; break;
     case ImageType::ArtistFanart: fileType = DataFileType::ArtistFanart; break;
@@ -2418,9 +2420,9 @@ QString XbmcXml::imageFileName(Artist *artist, int type, QList<DataFile> dataFil
     return fileName;
 }
 
-QString XbmcXml::imageFileName(Album *album, int type, QList<DataFile> dataFiles, bool constructName)
+QString XbmcXml::imageFileName(Album *album, ImageType type, QList<DataFile> dataFiles, bool constructName)
 {
-    int fileType;
+    DataFileType fileType;
     switch (type) {
     case ImageType::AlbumThumb: fileType = DataFileType::AlbumThumb; break;
     case ImageType::AlbumCdArt: fileType = DataFileType::AlbumCdArt; break;
@@ -2494,8 +2496,8 @@ bool XbmcXml::saveArtist(Artist *artist)
     file.write(xmlContent);
     file.close();
 
-    foreach (const int &imageType, Artist::imageTypes()) {
-        int dataFileType = DataFile::dataFileTypeForImageType(imageType);
+    for (const auto imageType : Artist::imageTypes()) {
+        DataFileType dataFileType = DataFile::dataFileTypeForImageType(imageType);
 
         if (artist->imagesToRemove().contains(imageType)) {
             foreach (DataFile dataFile, Settings::instance()->dataFiles(dataFileType)) {
@@ -2559,8 +2561,8 @@ bool XbmcXml::saveAlbum(Album *album)
     file.write(xmlContent);
     file.close();
 
-    foreach (const int &imageType, Album::imageTypes()) {
-        int dataFileType = DataFile::dataFileTypeForImageType(imageType);
+    for (const auto imageType : Album::imageTypes()) {
+        DataFileType dataFileType = DataFile::dataFileTypeForImageType(imageType);
 
         if (album->imagesToRemove().contains(imageType)) {
             foreach (DataFile dataFile, Settings::instance()->dataFiles(dataFileType)) {

--- a/mediaCenterPlugins/XbmcXml.h
+++ b/mediaCenterPlugins/XbmcXml.h
@@ -52,28 +52,28 @@ public:
     QString actorImageName(TvShowEpisode *episode, Actor actor) override;
 
     QString imageFileName(Movie *movie,
-        int type,
+        ImageType type,
         QList<DataFile> dataFiles = QList<DataFile>(),
         bool constructName = false) override;
     QString imageFileName(Concert *concert,
-        int type,
+        ImageType type,
         QList<DataFile> dataFiles = QList<DataFile>(),
         bool constructName = false) override;
     QString imageFileName(TvShowEpisode *episode,
-        int type,
+        ImageType type,
         QList<DataFile> dataFiles = QList<DataFile>(),
         bool constructName = false) override;
     QString imageFileName(TvShow *show,
-        int type,
+        ImageType type,
         int season = -1,
         QList<DataFile> dataFiles = QList<DataFile>(),
         bool constructName = false) override;
     QString imageFileName(Artist *artist,
-        int type,
+        ImageType type,
         QList<DataFile> dataFiles = QList<DataFile>(),
         bool constructName = false) override;
     QString imageFileName(Album *album,
-        int type,
+        ImageType type,
         QList<DataFile> dataFiles = QList<DataFile>(),
         bool constructName = false) override;
 

--- a/movies/Movie.cpp
+++ b/movies/Movie.cpp
@@ -70,7 +70,7 @@ MovieController *Movie::controller() const
  */
 void Movie::clear()
 {
-    QList<int> infos;
+    QList<MovieScraperInfos> infos;
     infos << MovieScraperInfos::Title         //
           << MovieScraperInfos::Set           //
           << MovieScraperInfos::Tagline       //
@@ -103,7 +103,7 @@ void Movie::clear()
  * @brief Clears contents of the movie based on a list
  * @param infos List of infos which should be cleared
  */
-void Movie::clear(QList<int> infos)
+void Movie::clear(QList<MovieScraperInfos> infos)
 {
     if (infos.contains(MovieScraperInfos::Actors)) {
         m_actors.clear();
@@ -1373,12 +1373,12 @@ bool Movie::hasExtraFanarts() const
     return m_hasExtraFanarts;
 }
 
-QList<int> Movie::imagesToRemove() const
+QList<ImageType> Movie::imagesToRemove() const
 {
     return m_imagesToRemove;
 }
 
-void Movie::removeImage(int type)
+void Movie::removeImage(ImageType type)
 {
     if (!m_images.value(type, QByteArray()).isNull()) {
         m_images.remove(type);
@@ -1389,27 +1389,27 @@ void Movie::removeImage(int type)
     setChanged(true);
 }
 
-QByteArray Movie::image(int imageType) const
+QByteArray Movie::image(ImageType imageType) const
 {
     return m_images.value(imageType, QByteArray());
 }
 
-bool Movie::imageHasChanged(int imageType)
+bool Movie::imageHasChanged(ImageType imageType)
 {
     return m_hasImageChanged.value(imageType, false);
 }
 
-bool Movie::hasImage(int imageType) const
+bool Movie::hasImage(ImageType imageType) const
 {
     return m_hasImage.value(imageType, false);
 }
 
-void Movie::setHasImage(int imageType, bool has)
+void Movie::setHasImage(ImageType imageType, bool has)
 {
     m_hasImage.insert(imageType, has);
 }
 
-void Movie::setImage(int imageType, QByteArray image)
+void Movie::setImage(ImageType imageType, QByteArray image)
 {
     m_images.insert(imageType, image);
     m_hasImageChanged.insert(imageType, true);
@@ -1423,15 +1423,15 @@ bool Movie::lessThan(Movie *a, Movie *b)
             < 0);
 }
 
-QList<int> Movie::imageTypes()
+QList<ImageType> Movie::imageTypes()
 {
-    return QList<int>() << ImageType::MoviePoster   //
-                        << ImageType::MovieBanner   //
-                        << ImageType::MovieCdArt    //
-                        << ImageType::MovieClearArt //
-                        << ImageType::MovieLogo     //
-                        << ImageType::MovieThumb    //
-                        << ImageType::MovieBackdrop;
+    return {ImageType::MoviePoster,
+        ImageType::MovieBanner,
+        ImageType::MovieCdArt,
+        ImageType::MovieClearArt,
+        ImageType::MovieLogo,
+        ImageType::MovieThumb,
+        ImageType::MovieBackdrop};
 }
 
 QList<Subtitle *> Movie::subtitles() const

--- a/movies/Movie.h
+++ b/movies/Movie.h
@@ -35,7 +35,7 @@ public:
     MovieController *controller() const;
 
     void clear();
-    void clear(QList<int> infos);
+    void clear(QList<MovieScraperInfos> infos);
 
     virtual QString name() const;
     virtual QString sortTitle() const;
@@ -143,7 +143,7 @@ public:
     QList<ExtraFanart> extraFanarts(MediaCenterInterface *mediaCenterInterface);
     QStringList extraFanartsToRemove();
     QList<QByteArray> extraFanartImagesToAdd();
-    QList<int> imagesToRemove() const;
+    QList<ImageType> imagesToRemove() const;
 
     void addPoster(Poster poster, bool primaryLang = false);
     void addBackdrop(Poster backdrop);
@@ -155,7 +155,7 @@ public:
     void removeExtraFanart(QString file);
     void clearExtraFanartData();
     void clearImages();
-    void removeImage(int type);
+    void removeImage(ImageType type);
 
     void setLabel(int label);
     int label() const;
@@ -163,17 +163,17 @@ public:
     // Images
     bool hasExtraFanarts() const;
     void setHasExtraFanarts(bool has);
-    QByteArray image(int imageType) const;
-    bool imageHasChanged(int imageType);
-    void setHasImage(int imageType, bool has);
-    bool hasImage(int imageType) const;
-    void setImage(int imageType, QByteArray image);
+    QByteArray image(ImageType imageType) const;
+    bool imageHasChanged(ImageType imageType);
+    void setHasImage(ImageType imageType, bool has);
+    bool hasImage(ImageType imageType) const;
+    void setImage(ImageType imageType, QByteArray image);
 
     DiscType discType() const;
     void setDiscType(DiscType type);
 
     static bool lessThan(Movie *a, Movie *b);
-    static QList<int> imageTypes();
+    static QList<ImageType> imageTypes();
 
     QList<Subtitle *> subtitles() const;
     void setSubtitles(const QList<Subtitle *> &subtitles);
@@ -248,11 +248,11 @@ private:
     QList<Subtitle *> m_subtitles;
 
     // Images
-    QMap<int, QByteArray> m_images;
-    QMap<int, bool> m_hasImage;
-    QMap<int, bool> m_hasImageChanged;
+    QMap<ImageType, QByteArray> m_images;
+    QMap<ImageType, bool> m_hasImage;
+    QMap<ImageType, bool> m_hasImageChanged;
     QList<QByteArray> m_extraFanartImagesToAdd;
-    QList<int> m_imagesToRemove;
+    QList<ImageType> m_imagesToRemove;
 };
 
 Q_DECLARE_METATYPE(Movie *)

--- a/movies/MovieController.h
+++ b/movies/MovieController.h
@@ -24,18 +24,19 @@ public:
 
     bool saveData(MediaCenterInterface *mediaCenterInterface);
     bool loadData(MediaCenterInterface *mediaCenterInterface, bool force = false, bool reloadFromNfo = true);
-    void loadData(QMap<ScraperInterface *, QString> ids, ScraperInterface *scraperInterface, QList<int> infos);
+    void
+    loadData(QMap<ScraperInterface *, QString> ids, ScraperInterface *scraperInterface, QList<MovieScraperInfos> infos);
     void loadStreamDetailsFromFile();
     void scraperLoadDone(ScraperInterface *scraper);
-    QList<int> infosToLoad();
+    QList<MovieScraperInfos> infosToLoad();
     bool infoLoaded() const;
     bool downloadsInProgress() const;
-    void loadImage(int type, QUrl url);
-    void loadImages(int type, QList<QUrl> urls);
+    void loadImage(ImageType type, QUrl url);
+    void loadImages(ImageType type, QList<QUrl> urls);
     void abortDownloads();
     void setLoadsLeft(QList<ScraperData> loadsLeft);
     void removeFromLoadsLeft(ScraperData load);
-    void setInfosToLoad(QList<int> infos);
+    void setInfosToLoad(QList<MovieScraperInfos> infos);
     void setForceFanartBackdrop(const bool &force);
     void setForceFanartPoster(const bool &force);
     void setForceFanartCdArt(const bool &force);
@@ -47,11 +48,11 @@ signals:
     void sigLoadDone(Movie *);
     void sigLoadImagesStarted(Movie *);
     void sigDownloadProgress(Movie *, int, int);
-    void sigLoadingImages(Movie *, QList<int>);
-    void sigImage(Movie *, int, QByteArray);
+    void sigLoadingImages(Movie *, QList<ImageType>);
+    void sigImage(Movie *, ImageType, QByteArray);
 
 private slots:
-    void onFanartLoadDone(Movie *movie, QMap<int, QList<Poster>> posters);
+    void onFanartLoadDone(Movie *movie, QMap<ImageType, QList<Poster>> posters);
     void onAllDownloadsFinished();
     void onDownloadFinished(DownloadManagerElement elem);
 
@@ -59,7 +60,7 @@ private:
     Movie *m_movie;
     bool m_infoLoaded;
     bool m_infoFromNfoLoaded;
-    QList<int> m_infosToLoad;
+    QList<MovieScraperInfos> m_infosToLoad;
     DownloadManager *m_downloadManager;
     bool m_downloadsInProgress;
     int m_downloadsSize;

--- a/movies/MovieMultiScrapeDialog.cpp
+++ b/movies/MovieMultiScrapeDialog.cpp
@@ -3,6 +3,7 @@
 
 #include "globals/Manager.h"
 #include "scrapers/CustomMovieScraper.h"
+#include "settings/Settings.h"
 #include "smallWidgets/MyCheckBox.h"
 
 MovieMultiScrapeDialog::MovieMultiScrapeDialog(QWidget *parent) : QDialog(parent), ui(new Ui::MovieMultiScrapeDialog)
@@ -26,29 +27,29 @@ MovieMultiScrapeDialog::MovieMultiScrapeDialog(QWidget *parent) : QDialog(parent
     m_executed = false;
     m_currentMovie = nullptr;
 
-    ui->chkActors->setMyData(MovieScraperInfos::Actors);
-    ui->chkBackdrop->setMyData(MovieScraperInfos::Backdrop);
-    ui->chkCertification->setMyData(MovieScraperInfos::Certification);
-    ui->chkCountries->setMyData(MovieScraperInfos::Countries);
-    ui->chkDirector->setMyData(MovieScraperInfos::Director);
-    ui->chkGenres->setMyData(MovieScraperInfos::Genres);
-    ui->chkOverview->setMyData(MovieScraperInfos::Overview);
-    ui->chkPoster->setMyData(MovieScraperInfos::Poster);
-    ui->chkRating->setMyData(MovieScraperInfos::Rating);
-    ui->chkReleased->setMyData(MovieScraperInfos::Released);
-    ui->chkRuntime->setMyData(MovieScraperInfos::Runtime);
-    ui->chkSet->setMyData(MovieScraperInfos::Set);
-    ui->chkStudios->setMyData(MovieScraperInfos::Studios);
-    ui->chkTagline->setMyData(MovieScraperInfos::Tagline);
-    ui->chkTitle->setMyData(MovieScraperInfos::Title);
-    ui->chkTrailer->setMyData(MovieScraperInfos::Trailer);
-    ui->chkWriter->setMyData(MovieScraperInfos::Writer);
-    ui->chkLogo->setMyData(MovieScraperInfos::Logo);
-    ui->chkClearArt->setMyData(MovieScraperInfos::ClearArt);
-    ui->chkCdArt->setMyData(MovieScraperInfos::CdArt);
-    ui->chkBanner->setMyData(MovieScraperInfos::Banner);
-    ui->chkThumb->setMyData(MovieScraperInfos::Thumb);
-    ui->chkTags->setMyData(MovieScraperInfos::Tags);
+    ui->chkActors->setMyData(static_cast<int>(MovieScraperInfos::Actors));
+    ui->chkBackdrop->setMyData(static_cast<int>(MovieScraperInfos::Backdrop));
+    ui->chkCertification->setMyData(static_cast<int>(MovieScraperInfos::Certification));
+    ui->chkCountries->setMyData(static_cast<int>(MovieScraperInfos::Countries));
+    ui->chkDirector->setMyData(static_cast<int>(MovieScraperInfos::Director));
+    ui->chkGenres->setMyData(static_cast<int>(MovieScraperInfos::Genres));
+    ui->chkOverview->setMyData(static_cast<int>(MovieScraperInfos::Overview));
+    ui->chkPoster->setMyData(static_cast<int>(MovieScraperInfos::Poster));
+    ui->chkRating->setMyData(static_cast<int>(MovieScraperInfos::Rating));
+    ui->chkReleased->setMyData(static_cast<int>(MovieScraperInfos::Released));
+    ui->chkRuntime->setMyData(static_cast<int>(MovieScraperInfos::Runtime));
+    ui->chkSet->setMyData(static_cast<int>(MovieScraperInfos::Set));
+    ui->chkStudios->setMyData(static_cast<int>(MovieScraperInfos::Studios));
+    ui->chkTagline->setMyData(static_cast<int>(MovieScraperInfos::Tagline));
+    ui->chkTitle->setMyData(static_cast<int>(MovieScraperInfos::Title));
+    ui->chkTrailer->setMyData(static_cast<int>(MovieScraperInfos::Trailer));
+    ui->chkWriter->setMyData(static_cast<int>(MovieScraperInfos::Writer));
+    ui->chkLogo->setMyData(static_cast<int>(MovieScraperInfos::Logo));
+    ui->chkClearArt->setMyData(static_cast<int>(MovieScraperInfos::ClearArt));
+    ui->chkCdArt->setMyData(static_cast<int>(MovieScraperInfos::CdArt));
+    ui->chkBanner->setMyData(static_cast<int>(MovieScraperInfos::Banner));
+    ui->chkThumb->setMyData(static_cast<int>(MovieScraperInfos::Thumb));
+    ui->chkTags->setMyData(static_cast<int>(MovieScraperInfos::Tags));
 
     foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
         if (box->myData().toInt() > 0) {
@@ -333,7 +334,7 @@ void MovieMultiScrapeDialog::onChkToggled()
     bool allToggled = true;
     foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
         if (box->isChecked() && box->myData().toInt() > 0) {
-            m_infosToLoad.append(box->myData().toInt());
+            m_infosToLoad.append(MovieScraperInfos(box->myData().toInt()));
         }
         if (!box->isChecked() && box->myData().toInt() > 0) {
             allToggled = false;
@@ -367,13 +368,13 @@ void MovieMultiScrapeDialog::setChkBoxesEnabled()
         return;
     }
 
-    QList<int> scraperSupports = scraper->scraperSupports();
-    QList<int> infos = Settings::instance()->scraperInfos(MainWidgets::Movies, scraperId);
+    QList<MovieScraperInfos> scraperSupports = scraper->scraperSupports();
+    QList<MovieScraperInfos> infos = Settings::instance()->scraperInfos<MovieScraperInfos>(scraperId);
 
     foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
-        box->setEnabled(scraperSupports.contains(box->myData().toInt()));
-        box->setChecked((infos.contains(box->myData().toInt()) || infos.isEmpty())
-                        && scraperSupports.contains(box->myData().toInt()));
+        box->setEnabled(scraperSupports.contains(MovieScraperInfos(box->myData().toInt())));
+        box->setChecked((infos.contains(MovieScraperInfos(box->myData().toInt())) || infos.isEmpty())
+                        && scraperSupports.contains(MovieScraperInfos(box->myData().toInt())));
     }
     onChkToggled();
 }

--- a/movies/MovieMultiScrapeDialog.h
+++ b/movies/MovieMultiScrapeDialog.h
@@ -46,7 +46,7 @@ private:
     bool m_isImdb;
     bool m_isTmdb;
     bool m_executed;
-    QList<int> m_infosToLoad;
+    QList<MovieScraperInfos> m_infosToLoad;
     void loadMovieData(Movie *movie, QString id);
     bool isExecuted();
 };

--- a/movies/MovieSearch.cpp
+++ b/movies/MovieSearch.cpp
@@ -89,7 +89,7 @@ QString MovieSearch::scraperMovieId()
  * @brief MovieSearch::infosToLoad
  * @return List of infos to load from the scraper
  */
-QList<int> MovieSearch::infosToLoad()
+QList<MovieScraperInfos> MovieSearch::infosToLoad()
 {
     return ui->movieSearchWidget->infosToLoad();
 }

--- a/movies/MovieSearch.h
+++ b/movies/MovieSearch.h
@@ -27,7 +27,7 @@ public slots:
     static MovieSearch *instance(QWidget *parent = nullptr);
     QString scraperId();
     QString scraperMovieId();
-    QList<int> infosToLoad();
+    QList<MovieScraperInfos> infosToLoad();
     QMap<ScraperInterface *, QString> customScraperIds();
 
 private:

--- a/movies/MovieSearchWidget.cpp
+++ b/movies/MovieSearchWidget.cpp
@@ -5,14 +5,13 @@
 
 #include "globals/Manager.h"
 #include "scrapers/CustomMovieScraper.h"
-
+#include "settings/Settings.h"
 
 QDebug operator<<(QDebug lhs, const ScraperSearchResult &rhs)
 {
     lhs << QString(R"(("%1", "%2", %3))").arg(rhs.id).arg(rhs.name).arg(rhs.released.toString("yyyy"));
     return lhs;
 }
-
 
 MovieSearchWidget::MovieSearchWidget(QWidget *parent) : QWidget(parent), ui(new Ui::MovieSearchWidget)
 {
@@ -34,29 +33,29 @@ MovieSearchWidget::MovieSearchWidget(QWidget *parent) : QWidget(parent), ui(new 
     connect(ui->searchString, SIGNAL(returnPressed()), this, SLOT(search()));
     connect(ui->results, &QTableWidget::itemClicked, this, &MovieSearchWidget::resultClicked);
 
-    ui->chkActors->setMyData(MovieScraperInfos::Actors);
-    ui->chkBackdrop->setMyData(MovieScraperInfos::Backdrop);
-    ui->chkCertification->setMyData(MovieScraperInfos::Certification);
-    ui->chkCountries->setMyData(MovieScraperInfos::Countries);
-    ui->chkDirector->setMyData(MovieScraperInfos::Director);
-    ui->chkGenres->setMyData(MovieScraperInfos::Genres);
-    ui->chkOverview->setMyData(MovieScraperInfos::Overview);
-    ui->chkPoster->setMyData(MovieScraperInfos::Poster);
-    ui->chkRating->setMyData(MovieScraperInfos::Rating);
-    ui->chkReleased->setMyData(MovieScraperInfos::Released);
-    ui->chkRuntime->setMyData(MovieScraperInfos::Runtime);
-    ui->chkSet->setMyData(MovieScraperInfos::Set);
-    ui->chkStudios->setMyData(MovieScraperInfos::Studios);
-    ui->chkTagline->setMyData(MovieScraperInfos::Tagline);
-    ui->chkTitle->setMyData(MovieScraperInfos::Title);
-    ui->chkTrailer->setMyData(MovieScraperInfos::Trailer);
-    ui->chkWriter->setMyData(MovieScraperInfos::Writer);
-    ui->chkLogo->setMyData(MovieScraperInfos::Logo);
-    ui->chkClearArt->setMyData(MovieScraperInfos::ClearArt);
-    ui->chkCdArt->setMyData(MovieScraperInfos::CdArt);
-    ui->chkBanner->setMyData(MovieScraperInfos::Banner);
-    ui->chkThumb->setMyData(MovieScraperInfos::Thumb);
-    ui->chkTags->setMyData(MovieScraperInfos::Tags);
+    ui->chkActors->setMyData(static_cast<int>(MovieScraperInfos::Actors));
+    ui->chkBackdrop->setMyData(static_cast<int>(MovieScraperInfos::Backdrop));
+    ui->chkCertification->setMyData(static_cast<int>(MovieScraperInfos::Certification));
+    ui->chkCountries->setMyData(static_cast<int>(MovieScraperInfos::Countries));
+    ui->chkDirector->setMyData(static_cast<int>(MovieScraperInfos::Director));
+    ui->chkGenres->setMyData(static_cast<int>(MovieScraperInfos::Genres));
+    ui->chkOverview->setMyData(static_cast<int>(MovieScraperInfos::Overview));
+    ui->chkPoster->setMyData(static_cast<int>(MovieScraperInfos::Poster));
+    ui->chkRating->setMyData(static_cast<int>(MovieScraperInfos::Rating));
+    ui->chkReleased->setMyData(static_cast<int>(MovieScraperInfos::Released));
+    ui->chkRuntime->setMyData(static_cast<int>(MovieScraperInfos::Runtime));
+    ui->chkSet->setMyData(static_cast<int>(MovieScraperInfos::Set));
+    ui->chkStudios->setMyData(static_cast<int>(MovieScraperInfos::Studios));
+    ui->chkTagline->setMyData(static_cast<int>(MovieScraperInfos::Tagline));
+    ui->chkTitle->setMyData(static_cast<int>(MovieScraperInfos::Title));
+    ui->chkTrailer->setMyData(static_cast<int>(MovieScraperInfos::Trailer));
+    ui->chkWriter->setMyData(static_cast<int>(MovieScraperInfos::Writer));
+    ui->chkLogo->setMyData(static_cast<int>(MovieScraperInfos::Logo));
+    ui->chkClearArt->setMyData(static_cast<int>(MovieScraperInfos::ClearArt));
+    ui->chkCdArt->setMyData(static_cast<int>(MovieScraperInfos::CdArt));
+    ui->chkBanner->setMyData(static_cast<int>(MovieScraperInfos::Banner));
+    ui->chkThumb->setMyData(static_cast<int>(MovieScraperInfos::Thumb));
+    ui->chkTags->setMyData(static_cast<int>(MovieScraperInfos::Tags));
 
     foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
         if (box->myData().toInt() > 0) {
@@ -221,7 +220,7 @@ void MovieSearchWidget::chkToggled()
     bool allToggled = true;
     foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
         if (box->isChecked() && box->myData().toInt() > 0) {
-            m_infosToLoad.append(box->myData().toInt());
+            m_infosToLoad.append(MovieScraperInfos(box->myData().toInt()));
         }
         if (!box->isChecked() && box->myData().toInt() > 0 && box->isEnabled()) {
             allToggled = false;
@@ -253,20 +252,20 @@ QString MovieSearchWidget::scraperMovieId()
     return m_scraperMovieId;
 }
 
-QList<int> MovieSearchWidget::infosToLoad()
+QList<MovieScraperInfos> MovieSearchWidget::infosToLoad()
 {
     return m_infosToLoad;
 }
 
-void MovieSearchWidget::setChkBoxesEnabled(QList<int> scraperSupports)
+void MovieSearchWidget::setChkBoxesEnabled(QList<MovieScraperInfos> scraperSupports)
 {
     QString scraperId = ui->comboScraper->itemData(ui->comboScraper->currentIndex(), Qt::UserRole).toString();
-    QList<int> infos = Settings::instance()->scraperInfos(MainWidgets::Movies, scraperId);
+    QList<MovieScraperInfos> infos = Settings::instance()->scraperInfos<MovieScraperInfos>(scraperId);
 
-    foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
-        box->setEnabled(scraperSupports.contains(box->myData().toInt()));
-        box->setChecked((infos.contains(box->myData().toInt()) || infos.isEmpty())
-                        && scraperSupports.contains(box->myData().toInt()));
+    for (auto box : ui->groupBox->findChildren<MyCheckBox *>()) {
+        box->setEnabled(scraperSupports.contains(MovieScraperInfos(box->myData().toInt())));
+        box->setChecked((infos.contains(MovieScraperInfos(box->myData().toInt())) || infos.isEmpty())
+                        && scraperSupports.contains(MovieScraperInfos(box->myData().toInt())));
     }
     chkToggled();
 }

--- a/movies/MovieSearchWidget.h
+++ b/movies/MovieSearchWidget.h
@@ -22,7 +22,7 @@ public:
 public slots:
     QString scraperId();
     QString scraperMovieId();
-    QList<int> infosToLoad();
+    QList<MovieScraperInfos> infosToLoad();
     QMap<ScraperInterface *, QString> customScraperIds();
     void search(QString searchString, QString id, QString tmdbId);
 
@@ -42,7 +42,7 @@ private:
     Ui::MovieSearchWidget *ui;
     QString m_scraperId;
     QString m_scraperMovieId;
-    QList<int> m_infosToLoad;
+    QList<MovieScraperInfos> m_infosToLoad;
     QMap<ScraperInterface *, QString> m_customScraperIds;
     ScraperInterface *m_currentCustomScraper;
     QString m_id;
@@ -50,7 +50,7 @@ private:
     QString m_searchString;
 
     void clear();
-    void setChkBoxesEnabled(QList<int> scraperSupports);
+    void setChkBoxesEnabled(QList<MovieScraperInfos> scraperSupports);
     void setupScrapers();
 };
 

--- a/movies/MovieWidget.h
+++ b/movies/MovieWidget.h
@@ -54,10 +54,10 @@ private slots:
     void onInfoLoadDone(Movie *movie);
     void onLoadDone(Movie *movie);
     void onLoadImagesStarted(Movie *movie);
-    void onLoadingImages(Movie *movie, QList<int> imageTypes);
+    void onLoadingImages(Movie *movie, QList<ImageType> imageTypes);
     void onDownloadProgress(Movie *movie, int current, int maximum);
-    void onSetImage(Movie *movie, int type, QByteArray data);
-    void onImageDropped(int imageType, QUrl imageUrl);
+    void onSetImage(Movie *movie, ImageType type, QByteArray data);
+    void onImageDropped(ImageType imageType, QUrl imageUrl);
     void onExtraFanartDropped(QUrl imageUrl);
 
     void onChooseImage();
@@ -114,7 +114,7 @@ private slots:
     void onRemoveExtraFanart(const QByteArray &image);
     void onAddExtraFanart();
 
-    void updateImage(const int &imageType, ClosableImage *image);
+    void updateImage(ImageType imageType, ClosableImage *image);
 
 private:
     Ui::MovieWidget *ui;
@@ -125,7 +125,7 @@ private:
     QList<QList<QLineEdit *>> m_streamDetailsAudio;
     QList<QList<QLineEdit *>> m_streamDetailsSubtitles;
     QLabel *m_backgroundLabel;
-    void updateImages(QList<int> images);
+    void updateImages(QList<ImageType> images);
 };
 
 #endif // MOVIEWIDGET_H

--- a/music/Album.cpp
+++ b/music/Album.cpp
@@ -195,12 +195,12 @@ void Album::setYear(int year)
     setHasChanged(true);
 }
 
-QList<Poster> Album::images(int imageType) const
+QList<Poster> Album::images(ImageType imageType) const
 {
     return m_images.value(imageType);
 }
 
-void Album::addImage(int imageType, Poster image)
+void Album::addImage(ImageType imageType, Poster image)
 {
     if (!m_images.contains(imageType)) {
         m_images.insert(imageType, QList<Poster>());
@@ -209,18 +209,18 @@ void Album::addImage(int imageType, Poster image)
     setHasChanged(true);
 }
 
-QByteArray Album::rawImage(int imageType)
+QByteArray Album::rawImage(ImageType imageType)
 {
     return m_rawImages.value(imageType);
 }
 
-void Album::setRawImage(int imageType, QByteArray image)
+void Album::setRawImage(ImageType imageType, QByteArray image)
 {
     m_rawImages.insert(imageType, image);
     setHasChanged(true);
 }
 
-void Album::removeImage(int imageType)
+void Album::removeImage(ImageType imageType)
 {
     if (!m_rawImages.value(imageType, QByteArray()).isNull()) {
         m_rawImages.remove(imageType);
@@ -325,17 +325,17 @@ void Album::setNfoContent(const QString &nfoContent)
     m_nfoContent = nfoContent;
 }
 
-QList<int> Album::imageTypes()
+QList<ImageType> Album::imageTypes()
 {
-    return QList<int>() << ImageType::AlbumThumb << ImageType::AlbumCdArt;
+    return {ImageType::AlbumThumb, ImageType::AlbumCdArt};
 }
 
-QList<int> Album::imagesToRemove() const
+QList<ImageType> Album::imagesToRemove() const
 {
     return m_imagesToRemove;
 }
 
-void Album::setImagesToRemove(const QList<int> &imagesToRemove)
+void Album::setImagesToRemove(const QList<ImageType> &imagesToRemove)
 {
     m_imagesToRemove = imagesToRemove;
 }

--- a/music/Album.cpp
+++ b/music/Album.cpp
@@ -238,7 +238,7 @@ void Album::clearImages()
 
 void Album::clear()
 {
-    QList<int> infos;
+    QList<MusicScraperInfos> infos;
     infos << MusicScraperInfos::Title       //
           << MusicScraperInfos::Artist      //
           << MusicScraperInfos::Genres      //
@@ -255,7 +255,7 @@ void Album::clear()
     m_nfoContent.clear();
 }
 
-void Album::clear(QList<int> infos)
+void Album::clear(QList<MusicScraperInfos> infos)
 {
     if (infos.contains(MusicScraperInfos::Artist)) {
         m_artist.clear();

--- a/music/Album.h
+++ b/music/Album.h
@@ -77,7 +77,7 @@ public:
     void clearImages();
 
     void clear();
-    void clear(QList<int> infos);
+    void clear(QList<MusicScraperInfos> infos);
 
     MusicModelItem *modelItem() const;
     void setModelItem(MusicModelItem *item);

--- a/music/Album.h
+++ b/music/Album.h
@@ -68,12 +68,12 @@ public:
     int year() const;
     void setYear(int year);
 
-    QList<Poster> images(int imageType) const;
-    void addImage(int imageType, Poster image);
+    QList<Poster> images(ImageType imageType) const;
+    void addImage(ImageType imageType, Poster image);
 
-    QByteArray rawImage(int imageType);
-    void setRawImage(int imageType, QByteArray image);
-    void removeImage(int imageType);
+    QByteArray rawImage(ImageType imageType);
+    void setRawImage(ImageType imageType, QByteArray image);
+    void removeImage(ImageType imageType);
     void clearImages();
 
     void clear();
@@ -85,10 +85,10 @@ public:
     QString nfoContent() const;
     void setNfoContent(const QString &nfoContent);
 
-    static QList<int> imageTypes();
+    static QList<ImageType> imageTypes();
 
-    QList<int> imagesToRemove() const;
-    void setImagesToRemove(const QList<int> &imagesToRemove);
+    QList<ImageType> imagesToRemove() const;
+    void setImagesToRemove(const QList<ImageType> &imagesToRemove);
 
     int databaseId() const;
     void setDatabaseId(int databaseId);
@@ -131,9 +131,9 @@ private:
     QString m_label;
     qreal m_rating;
     int m_year;
-    QMap<int, QList<Poster>> m_images;
-    QMap<int, QByteArray> m_rawImages;
-    QList<int> m_imagesToRemove;
+    QMap<ImageType, QList<Poster>> m_images;
+    QMap<ImageType, QByteArray> m_rawImages;
+    QList<ImageType> m_imagesToRemove;
     MusicModelItem *m_modelItem;
     QString m_nfoContent;
     int m_databaseId;

--- a/music/AlbumController.cpp
+++ b/music/AlbumController.cpp
@@ -90,17 +90,17 @@ void AlbumController::setInfoFromNfoLoaded(bool infoFromNfoLoaded)
     m_infoFromNfoLoaded = infoFromNfoLoaded;
 }
 
-void AlbumController::loadImage(int type, QUrl url)
+void AlbumController::loadImage(ImageType type, QUrl url)
 {
     DownloadManagerElement d;
     d.album = m_album;
     d.imageType = type;
     d.url = url;
-    emit sigLoadingImages(m_album, QList<int>() << type);
+    emit sigLoadingImages(m_album, {type});
     m_downloadManager->addDownload(d);
 }
 
-void AlbumController::loadImages(int type, QList<QUrl> urls)
+void AlbumController::loadImages(ImageType type, QList<QUrl> urls)
 {
     bool started = false;
     foreach (const QUrl &url, urls) {
@@ -109,7 +109,7 @@ void AlbumController::loadImages(int type, QList<QUrl> urls)
         d.imageType = type;
         d.url = url;
         if (!started) {
-            emit sigLoadingImages(m_album, QList<int>() << type);
+            emit sigLoadingImages(m_album, {type});
             started = true;
         }
         m_downloadManager->addDownload(d);
@@ -158,18 +158,18 @@ void AlbumController::scraperLoadDone(MusicScraperInterface *scraper)
     emit sigInfoLoadDone(m_album);
 
     if (!scraper) {
-        onFanartLoadDone(m_album, QMap<int, QList<Poster>>());
+        onFanartLoadDone(m_album, QMap<ImageType, QList<Poster>>());
         return;
     }
 
-    QList<int> images;
+    QList<ImageType> images;
     if (m_infosToLoad.contains(MusicScraperInfos::Cover)) {
         images << ImageType::AlbumThumb;
-        m_album->clear(QList<int>() << MusicScraperInfos::Cover);
+        m_album->clear({MusicScraperInfos::Cover});
     }
     if (m_infosToLoad.contains(MusicScraperInfos::CdArt)) {
         images << ImageType::AlbumCdArt;
-        m_album->clear(QList<int>() << MusicScraperInfos::CdArt);
+        m_album->clear({MusicScraperInfos::CdArt});
     }
 
     if (!images.isEmpty() && !m_album->mbReleaseGroupId().isEmpty()) {
@@ -181,29 +181,29 @@ void AlbumController::scraperLoadDone(MusicScraperInterface *scraper)
             }
         }
         if (!imageProvider) {
-            onFanartLoadDone(m_album, QMap<int, QList<Poster>>());
+            onFanartLoadDone(m_album, QMap<ImageType, QList<Poster>>());
             return;
         }
         connect(imageProvider,
-            SIGNAL(sigImagesLoaded(Album *, QMap<int, QList<Poster>>)),
+            SIGNAL(sigImagesLoaded(Album *, QMap<ImageType, QList<Poster>>)),
             this,
-            SLOT(onFanartLoadDone(Album *, QMap<int, QList<Poster>>)),
+            SLOT(onFanartLoadDone(Album *, QMap<ImageType, QList<Poster>>)),
             Qt::UniqueConnection);
         imageProvider->albumImages(m_album, m_album->mbReleaseGroupId(), images);
     } else {
-        onFanartLoadDone(m_album, QMap<int, QList<Poster>>());
+        onFanartLoadDone(m_album, QMap<ImageType, QList<Poster>>());
     }
 }
 
-void AlbumController::onFanartLoadDone(Album *album, QMap<int, QList<Poster>> posters)
+void AlbumController::onFanartLoadDone(Album *album, QMap<ImageType, QList<Poster>> posters)
 {
     if (album != m_album) {
         return;
     }
 
     QList<DownloadManagerElement> downloads;
-    QList<int> imageTypes;
-    QMapIterator<int, QList<Poster>> it(posters);
+    QList<ImageType> imageTypes;
+    QMapIterator<ImageType, QList<Poster>> it(posters);
     while (it.hasNext()) {
         it.next();
         if (it.value().isEmpty()) {

--- a/music/AlbumController.cpp
+++ b/music/AlbumController.cpp
@@ -147,7 +147,10 @@ bool AlbumController::downloadsInProgress() const
     return m_downloadsInProgress;
 }
 
-void AlbumController::loadData(QString id, QString id2, MusicScraperInterface *scraperInterface, QList<int> infos)
+void AlbumController::loadData(QString id,
+    QString id2,
+    MusicScraperInterface *scraperInterface,
+    QList<MusicScraperInfos> infos)
 {
     m_infosToLoad = infos;
     scraperInterface->loadData(id, id2, m_album, infos);

--- a/music/AlbumController.h
+++ b/music/AlbumController.h
@@ -31,15 +31,15 @@ public:
     bool downloadsInProgress() const;
     void abortDownloads();
 
-    void loadImage(int type, QUrl url);
-    void loadImages(int type, QList<QUrl> urls);
+    void loadImage(ImageType type, QUrl url);
+    void loadImages(ImageType type, QList<QUrl> urls);
     void scraperLoadDone(MusicScraperInterface *scraper);
 
 signals:
     void sigInfoLoadDone(Album *);
-    void sigLoadingImages(Album *, QList<int>);
+    void sigLoadingImages(Album *, QList<ImageType>);
     void sigLoadDone(Album *);
-    void sigImage(Album *, int, QByteArray);
+    void sigImage(Album *, ImageType, QByteArray);
     void sigLoadImagesStarted(Album *);
     void sigDownloadProgress(Album *, int, int);
     void sigSaved(Album *);
@@ -47,7 +47,7 @@ signals:
 private slots:
     void onAllDownloadsFinished();
     void onDownloadFinished(DownloadManagerElement elem);
-    void onFanartLoadDone(Album *album, QMap<int, QList<Poster>> posters);
+    void onFanartLoadDone(Album *album, QMap<ImageType, QList<Poster>> posters);
 
 private:
     Album *m_album;

--- a/music/AlbumController.h
+++ b/music/AlbumController.h
@@ -20,7 +20,7 @@ public:
 
     bool saveData(MediaCenterInterface *mediaCenterInterface);
     bool loadData(MediaCenterInterface *mediaCenterInterface, bool force = false, bool reloadFromNfo = true);
-    void loadData(QString id, QString id2, MusicScraperInterface *scraperInterface, QList<int> infos);
+    void loadData(QString id, QString id2, MusicScraperInterface *scraperInterface, QList<MusicScraperInfos> infos);
 
     bool infoLoaded() const;
     void setInfoLoaded(bool infoLoaded);
@@ -57,7 +57,7 @@ private:
     bool m_downloadsInProgress;
     int m_downloadsSize;
     int m_downloadsLeft;
-    QList<int> m_infosToLoad;
+    QList<MusicScraperInfos> m_infosToLoad;
 };
 
 #endif // ALBUMCONTROLLER_H

--- a/music/Artist.cpp
+++ b/music/Artist.cpp
@@ -236,7 +236,7 @@ void Artist::setHasChanged(bool hasChanged)
 
 void Artist::clear()
 {
-    QList<int> infos;
+    QList<MusicScraperInfos> infos;
     infos << MusicScraperInfos::Name        //
           << MusicScraperInfos::Genres      //
           << MusicScraperInfos::Styles      //
@@ -256,7 +256,7 @@ void Artist::clear()
     m_nfoContent.clear();
 }
 
-void Artist::clear(QList<int> infos)
+void Artist::clear(QList<MusicScraperInfos> infos)
 {
     if (infos.contains(MusicScraperInfos::Genres)) {
         m_genres.clear();

--- a/music/Artist.cpp
+++ b/music/Artist.cpp
@@ -178,12 +178,12 @@ void Artist::setBiography(const QString &biography)
     setHasChanged(true);
 }
 
-QList<Poster> Artist::images(int imageType) const
+QList<Poster> Artist::images(ImageType imageType) const
 {
     return m_images.value(imageType);
 }
 
-void Artist::addImage(int imageType, Poster image)
+void Artist::addImage(ImageType imageType, Poster image)
 {
     if (!m_images.contains(imageType)) {
         m_images.insert(imageType, QList<Poster>());
@@ -192,18 +192,18 @@ void Artist::addImage(int imageType, Poster image)
     setHasChanged(true);
 }
 
-QByteArray Artist::rawImage(int imageType)
+QByteArray Artist::rawImage(ImageType imageType)
 {
     return m_rawImages.value(imageType);
 }
 
-void Artist::setRawImage(int imageType, QByteArray image)
+void Artist::setRawImage(ImageType imageType, QByteArray image)
 {
     m_rawImages.insert(imageType, image);
     setHasChanged(true);
 }
 
-void Artist::removeImage(int imageType)
+void Artist::removeImage(ImageType imageType)
 {
     if (!m_rawImages.value(imageType, QByteArray()).isNull()) {
         m_rawImages.remove(imageType);
@@ -338,17 +338,17 @@ void Artist::setNfoContent(const QString &nfoContent)
     m_nfoContent = nfoContent;
 }
 
-QList<int> Artist::imageTypes()
+QList<ImageType> Artist::imageTypes()
 {
-    return QList<int>() << ImageType::ArtistThumb << ImageType::ArtistLogo << ImageType::ArtistFanart;
+    return {ImageType::ArtistThumb, ImageType::ArtistLogo, ImageType::ArtistFanart};
 }
 
-QList<int> Artist::imagesToRemove() const
+QList<ImageType> Artist::imagesToRemove() const
 {
     return m_imagesToRemove;
 }
 
-void Artist::setImagesToRemove(const QList<int> &imagesToRemove)
+void Artist::setImagesToRemove(const QList<ImageType> &imagesToRemove)
 {
     m_imagesToRemove = imagesToRemove;
 }

--- a/music/Artist.h
+++ b/music/Artist.h
@@ -69,7 +69,7 @@ public:
     void setHasChanged(bool hasChanged);
 
     void clear();
-    void clear(QList<int> infos);
+    void clear(QList<MusicScraperInfos> infos);
 
     MusicModelItem *modelItem() const;
     void setModelItem(MusicModelItem *modelItem);

--- a/music/Artist.h
+++ b/music/Artist.h
@@ -57,12 +57,12 @@ public:
     QString biography() const;
     void setBiography(const QString &biography);
 
-    QList<Poster> images(int imageType) const;
-    void addImage(int imageType, Poster image);
+    QList<Poster> images(ImageType imageType) const;
+    void addImage(ImageType imageType, Poster image);
 
-    QByteArray rawImage(int imageType);
-    void setRawImage(int imageType, QByteArray image);
-    void removeImage(int imageType);
+    QByteArray rawImage(ImageType imageType);
+    void setRawImage(ImageType imageType, QByteArray image);
+    void removeImage(ImageType imageType);
     void clearImages();
 
     bool hasChanged() const;
@@ -77,10 +77,10 @@ public:
     QString nfoContent() const;
     void setNfoContent(const QString &nfoContent);
 
-    static QList<int> imageTypes();
+    static QList<ImageType> imageTypes();
 
-    QList<int> imagesToRemove() const;
-    void setImagesToRemove(const QList<int> &imagesToRemove);
+    QList<ImageType> imagesToRemove() const;
+    void setImagesToRemove(const QList<ImageType> &imagesToRemove);
 
     int databaseId() const;
     void setDatabaseId(int databaseId);
@@ -129,9 +129,9 @@ private:
     QString m_died;
     QString m_disbanded;
     bool m_hasChanged;
-    QMap<int, QList<Poster>> m_images;
-    QMap<int, QByteArray> m_rawImages;
-    QList<int> m_imagesToRemove;
+    QMap<ImageType, QList<Poster>> m_images;
+    QMap<ImageType, QByteArray> m_rawImages;
+    QList<ImageType> m_imagesToRemove;
     MusicModelItem *m_modelItem;
     QString m_nfoContent;
     int m_databaseId;

--- a/music/ArtistController.cpp
+++ b/music/ArtistController.cpp
@@ -150,7 +150,7 @@ bool ArtistController::downloadsInProgress() const
     return m_downloadsInProgress;
 }
 
-void ArtistController::loadData(QString id, MusicScraperInterface *scraperInterface, QList<int> infos)
+void ArtistController::loadData(QString id, MusicScraperInterface *scraperInterface, QList<MusicScraperInfos> infos)
 {
     m_infosToLoad = infos;
     scraperInterface->loadData(id, m_artist, infos);

--- a/music/ArtistController.cpp
+++ b/music/ArtistController.cpp
@@ -91,17 +91,17 @@ void ArtistController::setInfoLoaded(bool infoLoaded)
     m_infoLoaded = infoLoaded;
 }
 
-void ArtistController::loadImage(int type, QUrl url)
+void ArtistController::loadImage(ImageType type, QUrl url)
 {
     DownloadManagerElement d;
     d.artist = m_artist;
     d.imageType = type;
     d.url = url;
-    emit sigLoadingImages(m_artist, QList<int>() << type);
+    emit sigLoadingImages(m_artist, {type});
     m_downloadManager->addDownload(d);
 }
 
-void ArtistController::loadImages(int type, QList<QUrl> urls)
+void ArtistController::loadImages(ImageType type, QList<QUrl> urls)
 {
     bool started = false;
     foreach (const QUrl &url, urls) {
@@ -110,7 +110,7 @@ void ArtistController::loadImages(int type, QList<QUrl> urls)
         d.imageType = type;
         d.url = url;
         if (!started) {
-            emit sigLoadingImages(m_artist, QList<int>() << type);
+            emit sigLoadingImages(m_artist, {type});
             started = true;
         }
         m_downloadManager->addDownload(d);
@@ -161,25 +161,25 @@ void ArtistController::scraperLoadDone(MusicScraperInterface *scraper)
     emit sigInfoLoadDone(m_artist);
 
     if (!scraper) {
-        onFanartLoadDone(m_artist, QMap<int, QList<Poster>>());
+        onFanartLoadDone(m_artist, QMap<ImageType, QList<Poster>>());
         return;
     }
 
-    QList<int> images;
+    QList<ImageType> images;
     if (m_infosToLoad.contains(MusicScraperInfos::Thumb)) {
         images << ImageType::ArtistThumb;
-        m_artist->clear(QList<int>() << MusicScraperInfos::Thumb);
+        m_artist->clear({MusicScraperInfos::Thumb});
     }
     if (m_infosToLoad.contains(MusicScraperInfos::Fanart)) {
         images << ImageType::ArtistFanart;
-        m_artist->clear(QList<int>() << MusicScraperInfos::Fanart);
+        m_artist->clear({MusicScraperInfos::Fanart});
     }
     if (m_infosToLoad.contains(MusicScraperInfos::ExtraFanarts)) {
         images << ImageType::ArtistExtraFanart;
     }
     if (m_infosToLoad.contains(MusicScraperInfos::Logo)) {
         images << ImageType::ArtistLogo;
-        m_artist->clear(QList<int>() << MusicScraperInfos::Logo);
+        m_artist->clear({MusicScraperInfos::Logo});
     }
 
     if (!images.isEmpty() && !m_artist->mbId().isEmpty()) {
@@ -191,29 +191,29 @@ void ArtistController::scraperLoadDone(MusicScraperInterface *scraper)
             }
         }
         if (!imageProvider) {
-            onFanartLoadDone(m_artist, QMap<int, QList<Poster>>());
+            onFanartLoadDone(m_artist, QMap<ImageType, QList<Poster>>());
             return;
         }
         connect(imageProvider,
-            SIGNAL(sigImagesLoaded(Artist *, QMap<int, QList<Poster>>)),
+            SIGNAL(sigImagesLoaded(Artist *, QMap<ImageType, QList<Poster>>)),
             this,
-            SLOT(onFanartLoadDone(Artist *, QMap<int, QList<Poster>>)),
+            SLOT(onFanartLoadDone(Artist *, QMap<ImageType, QList<Poster>>)),
             Qt::UniqueConnection);
         imageProvider->artistImages(m_artist, m_artist->mbId(), images);
     } else {
-        onFanartLoadDone(m_artist, QMap<int, QList<Poster>>());
+        onFanartLoadDone(m_artist, QMap<ImageType, QList<Poster>>());
     }
 }
 
-void ArtistController::onFanartLoadDone(Artist *artist, QMap<int, QList<Poster>> posters)
+void ArtistController::onFanartLoadDone(Artist *artist, QMap<ImageType, QList<Poster>> posters)
 {
     if (artist != m_artist) {
         return;
     }
 
     QList<DownloadManagerElement> downloads;
-    QList<int> imageTypes;
-    QMapIterator<int, QList<Poster>> it(posters);
+    QList<ImageType> imageTypes;
+    QMapIterator<ImageType, QList<Poster>> it(posters);
     while (it.hasNext()) {
         it.next();
         if (it.value().isEmpty()) {

--- a/music/ArtistController.h
+++ b/music/ArtistController.h
@@ -22,7 +22,7 @@ public:
 
     bool saveData(MediaCenterInterface *mediaCenterInterface);
     bool loadData(MediaCenterInterface *mediaCenterInterface, bool force = false, bool reloadFromNfo = true);
-    void loadData(QString id, MusicScraperInterface *scraperInterface, QList<int> infos);
+    void loadData(QString id, MusicScraperInterface *scraperInterface, QList<MusicScraperInfos> infos);
 
     bool infoLoaded() const;
     void setInfoLoaded(bool infoLoaded);
@@ -59,7 +59,7 @@ private:
     bool m_downloadsInProgress;
     int m_downloadsSize;
     int m_downloadsLeft;
-    QList<int> m_infosToLoad;
+    QList<MusicScraperInfos> m_infosToLoad;
 };
 
 #endif // ARTISTCONTROLLER_H

--- a/music/ArtistController.h
+++ b/music/ArtistController.h
@@ -33,15 +33,15 @@ public:
     bool downloadsInProgress() const;
     void abortDownloads();
 
-    void loadImage(int type, QUrl url);
-    void loadImages(int type, QList<QUrl> urls);
+    void loadImage(ImageType type, QUrl url);
+    void loadImages(ImageType type, QList<QUrl> urls);
     void scraperLoadDone(MusicScraperInterface *scraper);
 
 signals:
     void sigInfoLoadDone(Artist *);
-    void sigLoadingImages(Artist *, QList<int>);
+    void sigLoadingImages(Artist *, QList<ImageType>);
     void sigLoadDone(Artist *);
-    void sigImage(Artist *, int, QByteArray);
+    void sigImage(Artist *, ImageType, QByteArray);
     void sigLoadImagesStarted(Artist *);
     void sigDownloadProgress(Artist *, int, int);
     void sigSaved(Artist *);
@@ -49,7 +49,7 @@ signals:
 private slots:
     void onAllDownloadsFinished();
     void onDownloadFinished(DownloadManagerElement elem);
-    void onFanartLoadDone(Artist *artist, QMap<int, QList<Poster>> posters);
+    void onFanartLoadDone(Artist *artist, QMap<ImageType, QList<Poster>> posters);
 
 private:
     Artist *m_artist;

--- a/music/MusicMultiScrapeDialog.cpp
+++ b/music/MusicMultiScrapeDialog.cpp
@@ -20,30 +20,30 @@ MusicMultiScrapeDialog::MusicMultiScrapeDialog(QWidget *parent) : QDialog(parent
     m_currentArtist = nullptr;
     m_currentAlbum = nullptr;
 
-    ui->chkName->setMyData(MusicScraperInfos::Name);
-    ui->chkBorn->setMyData(MusicScraperInfos::Born);
-    ui->chkFormed->setMyData(MusicScraperInfos::Formed);
-    ui->chkYearsActive->setMyData(MusicScraperInfos::YearsActive);
-    ui->chkDisbanded->setMyData(MusicScraperInfos::Disbanded);
-    ui->chkDied->setMyData(MusicScraperInfos::Died);
-    ui->chkBiography->setMyData(MusicScraperInfos::Biography);
-    ui->chkArtist->setMyData(MusicScraperInfos::Artist);
-    ui->chkLabel->setMyData(MusicScraperInfos::Label);
-    ui->chkReview->setMyData(MusicScraperInfos::Review);
-    ui->chkYear->setMyData(MusicScraperInfos::Year);
-    ui->chkRating->setMyData(MusicScraperInfos::Rating);
-    ui->chkReleaseDate->setMyData(MusicScraperInfos::ReleaseDate);
-    ui->chkTitle->setMyData(MusicScraperInfos::Title);
-    ui->chkGenres->setMyData(MusicScraperInfos::Genres);
-    ui->chkStyles->setMyData(MusicScraperInfos::Styles);
-    ui->chkMoods->setMyData(MusicScraperInfos::Moods);
-    ui->chkThumbnail->setMyData(MusicScraperInfos::Thumb);
-    ui->chkFanart->setMyData(MusicScraperInfos::Fanart);
-    ui->chkExtraFanarts->setMyData(MusicScraperInfos::ExtraFanarts);
-    ui->chkLogo->setMyData(MusicScraperInfos::Logo);
-    ui->chkCover->setMyData(MusicScraperInfos::Cover);
-    ui->chkCdArt->setMyData(MusicScraperInfos::CdArt);
-    ui->chkDiscography->setMyData(MusicScraperInfos::Discography);
+    ui->chkName->setMyData(static_cast<int>(MusicScraperInfos::Name));
+    ui->chkBorn->setMyData(static_cast<int>(MusicScraperInfos::Born));
+    ui->chkFormed->setMyData(static_cast<int>(MusicScraperInfos::Formed));
+    ui->chkYearsActive->setMyData(static_cast<int>(MusicScraperInfos::YearsActive));
+    ui->chkDisbanded->setMyData(static_cast<int>(MusicScraperInfos::Disbanded));
+    ui->chkDied->setMyData(static_cast<int>(MusicScraperInfos::Died));
+    ui->chkBiography->setMyData(static_cast<int>(MusicScraperInfos::Biography));
+    ui->chkArtist->setMyData(static_cast<int>(MusicScraperInfos::Artist));
+    ui->chkLabel->setMyData(static_cast<int>(MusicScraperInfos::Label));
+    ui->chkReview->setMyData(static_cast<int>(MusicScraperInfos::Review));
+    ui->chkYear->setMyData(static_cast<int>(MusicScraperInfos::Year));
+    ui->chkRating->setMyData(static_cast<int>(MusicScraperInfos::Rating));
+    ui->chkReleaseDate->setMyData(static_cast<int>(MusicScraperInfos::ReleaseDate));
+    ui->chkTitle->setMyData(static_cast<int>(MusicScraperInfos::Title));
+    ui->chkGenres->setMyData(static_cast<int>(MusicScraperInfos::Genres));
+    ui->chkStyles->setMyData(static_cast<int>(MusicScraperInfos::Styles));
+    ui->chkMoods->setMyData(static_cast<int>(MusicScraperInfos::Moods));
+    ui->chkThumbnail->setMyData(static_cast<int>(MusicScraperInfos::Thumb));
+    ui->chkFanart->setMyData(static_cast<int>(MusicScraperInfos::Fanart));
+    ui->chkExtraFanarts->setMyData(static_cast<int>(MusicScraperInfos::ExtraFanarts));
+    ui->chkLogo->setMyData(static_cast<int>(MusicScraperInfos::Logo));
+    ui->chkCover->setMyData(static_cast<int>(MusicScraperInfos::Cover));
+    ui->chkCdArt->setMyData(static_cast<int>(MusicScraperInfos::CdArt));
+    ui->chkDiscography->setMyData(static_cast<int>(MusicScraperInfos::Discography));
 
     foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
         if (box->myData().toInt() > 0) {
@@ -79,10 +79,10 @@ void MusicMultiScrapeDialog::onChkToggled()
             continue;
         }
         if (box->property("type").toString() == "artist" || box->property("type").toString() == "both") {
-            m_artistInfosToLoad.append(box->myData().toInt());
+            m_artistInfosToLoad.append(MusicScraperInfos(box->myData().toInt()));
         }
         if (box->property("type").toString() == "album" || box->property("type").toString() == "both") {
-            m_albumInfosToLoad.append(box->myData().toInt());
+            m_albumInfosToLoad.append(MusicScraperInfos(box->myData().toInt()));
         }
     }
     ui->chkUnCheckAll->setChecked(allToggled);

--- a/music/MusicMultiScrapeDialog.h
+++ b/music/MusicMultiScrapeDialog.h
@@ -51,8 +51,8 @@ private:
     bool m_executed;
     Artist *m_currentArtist;
     Album *m_currentAlbum;
-    QList<int> m_artistInfosToLoad;
-    QList<int> m_albumInfosToLoad;
+    QList<MusicScraperInfos> m_artistInfosToLoad;
+    QList<MusicScraperInfos> m_albumInfosToLoad;
     QList<Artist *> m_artists;
     QList<Album *> m_albums;
     MusicScraperInterface *m_scraperInterface;

--- a/music/MusicSearch.cpp
+++ b/music/MusicSearch.cpp
@@ -62,7 +62,7 @@ QString MusicSearch::scraperId2()
     return ui->musicSearchWidget->scraperId2();
 }
 
-QList<int> MusicSearch::infosToLoad()
+QList<MusicScraperInfos> MusicSearch::infosToLoad()
 {
     return ui->musicSearchWidget->infosToLoad();
 }

--- a/music/MusicSearch.h
+++ b/music/MusicSearch.h
@@ -25,7 +25,7 @@ public slots:
     int scraperNo();
     QString scraperId();
     QString scraperId2();
-    QList<int> infosToLoad();
+    QList<MusicScraperInfos> infosToLoad();
 
 private:
     Ui::MusicSearch *ui;

--- a/music/MusicSearchWidget.cpp
+++ b/music/MusicSearchWidget.cpp
@@ -24,30 +24,30 @@ MusicSearchWidget::MusicSearchWidget(QWidget *parent) : QWidget(parent), ui(new 
     connect(ui->searchString, SIGNAL(returnPressed()), this, SLOT(search()));
     connect(ui->results, SIGNAL(itemClicked(QTableWidgetItem *)), this, SLOT(resultClicked(QTableWidgetItem *)));
 
-    ui->chkName->setMyData(MusicScraperInfos::Name);
-    ui->chkBorn->setMyData(MusicScraperInfos::Born);
-    ui->chkFormed->setMyData(MusicScraperInfos::Formed);
-    ui->chkYearsActive->setMyData(MusicScraperInfos::YearsActive);
-    ui->chkDisbanded->setMyData(MusicScraperInfos::Disbanded);
-    ui->chkDied->setMyData(MusicScraperInfos::Died);
-    ui->chkBiography->setMyData(MusicScraperInfos::Biography);
-    ui->chkArtist->setMyData(MusicScraperInfos::Artist);
-    ui->chkLabel->setMyData(MusicScraperInfos::Label);
-    ui->chkReview->setMyData(MusicScraperInfos::Review);
-    ui->chkYear->setMyData(MusicScraperInfos::Year);
-    ui->chkRating->setMyData(MusicScraperInfos::Rating);
-    ui->chkReleaseDate->setMyData(MusicScraperInfos::ReleaseDate);
-    ui->chkTitle->setMyData(MusicScraperInfos::Title);
-    ui->chkGenres->setMyData(MusicScraperInfos::Genres);
-    ui->chkStyles->setMyData(MusicScraperInfos::Styles);
-    ui->chkMoods->setMyData(MusicScraperInfos::Moods);
-    ui->chkThumb->setMyData(MusicScraperInfos::Thumb);
-    ui->chkFanart->setMyData(MusicScraperInfos::Fanart);
-    ui->chkExtraFanarts->setMyData(MusicScraperInfos::ExtraFanarts);
-    ui->chkLogo->setMyData(MusicScraperInfos::Logo);
-    ui->chkCover->setMyData(MusicScraperInfos::Cover);
-    ui->chkCdArt->setMyData(MusicScraperInfos::CdArt);
-    ui->chkDiscography->setMyData(MusicScraperInfos::Discography);
+    ui->chkName->setMyData(static_cast<int>(MusicScraperInfos::Name));
+    ui->chkBorn->setMyData(static_cast<int>(MusicScraperInfos::Born));
+    ui->chkFormed->setMyData(static_cast<int>(MusicScraperInfos::Formed));
+    ui->chkYearsActive->setMyData(static_cast<int>(MusicScraperInfos::YearsActive));
+    ui->chkDisbanded->setMyData(static_cast<int>(MusicScraperInfos::Disbanded));
+    ui->chkDied->setMyData(static_cast<int>(MusicScraperInfos::Died));
+    ui->chkBiography->setMyData(static_cast<int>(MusicScraperInfos::Biography));
+    ui->chkArtist->setMyData(static_cast<int>(MusicScraperInfos::Artist));
+    ui->chkLabel->setMyData(static_cast<int>(MusicScraperInfos::Label));
+    ui->chkReview->setMyData(static_cast<int>(MusicScraperInfos::Review));
+    ui->chkYear->setMyData(static_cast<int>(MusicScraperInfos::Year));
+    ui->chkRating->setMyData(static_cast<int>(MusicScraperInfos::Rating));
+    ui->chkReleaseDate->setMyData(static_cast<int>(MusicScraperInfos::ReleaseDate));
+    ui->chkTitle->setMyData(static_cast<int>(MusicScraperInfos::Title));
+    ui->chkGenres->setMyData(static_cast<int>(MusicScraperInfos::Genres));
+    ui->chkStyles->setMyData(static_cast<int>(MusicScraperInfos::Styles));
+    ui->chkMoods->setMyData(static_cast<int>(MusicScraperInfos::Moods));
+    ui->chkThumb->setMyData(static_cast<int>(MusicScraperInfos::Thumb));
+    ui->chkFanart->setMyData(static_cast<int>(MusicScraperInfos::Fanart));
+    ui->chkExtraFanarts->setMyData(static_cast<int>(MusicScraperInfos::ExtraFanarts));
+    ui->chkLogo->setMyData(static_cast<int>(MusicScraperInfos::Logo));
+    ui->chkCover->setMyData(static_cast<int>(MusicScraperInfos::Cover));
+    ui->chkCdArt->setMyData(static_cast<int>(MusicScraperInfos::CdArt));
+    ui->chkDiscography->setMyData(static_cast<int>(MusicScraperInfos::Discography));
 
     foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
         if (box->myData().toInt() > 0) {
@@ -145,7 +145,7 @@ void MusicSearchWidget::chkToggled()
     bool allToggled = true;
     foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
         if (box->isChecked() && box->myData().toInt() > 0 && box->isEnabled() && !box->isHidden()) {
-            m_infosToLoad.append(box->myData().toInt());
+            m_infosToLoad.append(MusicScraperInfos(box->myData().toInt()));
         }
         if (!box->isChecked() && box->myData().toInt() > 0 && box->isEnabled() && !box->isHidden()) {
             allToggled = false;
@@ -182,21 +182,21 @@ QString MusicSearchWidget::scraperId2()
     return m_scraperId2;
 }
 
-QList<int> MusicSearchWidget::infosToLoad()
+QList<MusicScraperInfos> MusicSearchWidget::infosToLoad()
 {
     return m_infosToLoad;
 }
 
-void MusicSearchWidget::setChkBoxesEnabled(QList<int> scraperSupports)
+void MusicSearchWidget::setChkBoxesEnabled(QList<MusicScraperInfos> scraperSupports)
 {
     int scraperNo = ui->comboScraper->itemData(ui->comboScraper->currentIndex(), Qt::UserRole).toInt();
-    QList<int> infos =
-        Settings::instance()->scraperInfos(MainWidgets::Music, m_type + "/" + QString::number(scraperNo));
+    QList<MusicScraperInfos> infos =
+        Settings::instance()->scraperInfos<MusicScraperInfos>(m_type + "/" + QString::number(scraperNo));
 
     foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
-        box->setEnabled(scraperSupports.contains(box->myData().toInt()));
-        box->setChecked((infos.contains(box->myData().toInt()) || infos.isEmpty())
-                        && scraperSupports.contains(box->myData().toInt()));
+        box->setEnabled(scraperSupports.contains(MusicScraperInfos(box->myData().toInt())));
+        box->setChecked((infos.contains(MusicScraperInfos(box->myData().toInt())) || infos.isEmpty())
+                        && scraperSupports.contains(MusicScraperInfos(box->myData().toInt())));
     }
     chkToggled();
 }

--- a/music/MusicSearchWidget.h
+++ b/music/MusicSearchWidget.h
@@ -25,7 +25,7 @@ public slots:
     int scraperNo();
     QString scraperId();
     QString scraperId2();
-    QList<int> infosToLoad();
+    QList<MusicScraperInfos> infosToLoad();
     void setType(const QString &type);
     void setArtistName(const QString &artistName);
 
@@ -45,13 +45,13 @@ private:
     int m_scraperNo;
     QString m_scraperId;
     QString m_scraperId2;
-    QList<int> m_infosToLoad;
+    QList<MusicScraperInfos> m_infosToLoad;
     QString m_type;
     QString m_artistName;
     QSignalMapper *m_signalMapper;
 
     void clear();
-    void setChkBoxesEnabled(QList<int> scraperSupports);
+    void setChkBoxesEnabled(QList<MusicScraperInfos> scraperSupports);
 };
 
 #endif // MUSICSEARCHWIDGET_H

--- a/music/MusicWidgetAlbum.cpp
+++ b/music/MusicWidgetAlbum.cpp
@@ -125,7 +125,7 @@ void MusicWidgetAlbum::setAlbum(Album *album)
     connect(m_album->controller(),   &AlbumController::sigInfoLoadDone,             this, &MusicWidgetAlbum::onInfoLoadDone,          Qt::UniqueConnection);
     connect(m_album->controller(),   &AlbumController::sigLoadDone,                 this, &MusicWidgetAlbum::onLoadDone,              Qt::UniqueConnection);
     connect(m_album->controller(),   &AlbumController::sigDownloadProgress,         this, &MusicWidgetAlbum::onDownloadProgress,      Qt::UniqueConnection);
-    connect(m_album->controller(),   SIGNAL(sigLoadingImages(Album *, QList<int>)), this, SLOT(onLoadingImages(Album *, QList<int>)), Qt::UniqueConnection);
+    connect(m_album->controller(),   &AlbumController::sigLoadingImages,            this, &MusicWidgetAlbum::onLoadingImages,         Qt::UniqueConnection);
     connect(m_album->controller(),   &AlbumController::sigLoadImagesStarted,        this, &MusicWidgetAlbum::onLoadImagesStarted,     Qt::UniqueConnection);
     connect(m_album->controller(),   &AlbumController::sigImage,                    this, &MusicWidgetAlbum::onSetImage,              Qt::UniqueConnection);
     connect(m_album->bookletModel(), &ImageModel::hasChangedChanged,                this, &MusicWidgetAlbum::onBookletModelChanged,   Qt::UniqueConnection);
@@ -290,7 +290,7 @@ void MusicWidgetAlbum::updateAlbumInfo()
     }
 }
 
-void MusicWidgetAlbum::updateImage(int imageType, ClosableImage *image)
+void MusicWidgetAlbum::updateImage(ImageType imageType, ClosableImage *image)
 {
     if (!m_album->rawImage(imageType).isNull()) {
         image->setImage(m_album->rawImage(imageType));
@@ -452,7 +452,7 @@ void MusicWidgetAlbum::onDeleteImage()
     ui->buttonRevert->setVisible(true);
 }
 
-void MusicWidgetAlbum::onImageDropped(int imageType, QUrl imageUrl)
+void MusicWidgetAlbum::onImageDropped(ImageType imageType, QUrl imageUrl)
 {
     if (!m_album) {
         return;
@@ -492,13 +492,13 @@ void MusicWidgetAlbum::onDownloadProgress(Album *album, int current, int maximum
     emit sigDownloadsProgress(maximum - current, maximum, Constants::MusicAlbumProgressMessageId + album->databaseId());
 }
 
-void MusicWidgetAlbum::onLoadingImages(Album *album, QList<int> imageTypes)
+void MusicWidgetAlbum::onLoadingImages(Album *album, QList<ImageType> imageTypes)
 {
     if (m_album != album) {
         return;
     }
 
-    foreach (const int &imageType, imageTypes) {
+    for (const auto imageType : imageTypes) {
         foreach (ClosableImage *cImage, ui->groupBox_3->findChildren<ClosableImage *>()) {
             if (cImage->imageType() == imageType) {
                 cImage->setLoading(true);
@@ -518,7 +518,7 @@ void MusicWidgetAlbum::onLoadImagesStarted(Album *album)
     emit sigDownloadsStarted(tr("Downloading images..."), Constants::MusicAlbumProgressMessageId + album->databaseId());
 }
 
-void MusicWidgetAlbum::onSetImage(Album *album, int type, QByteArray data)
+void MusicWidgetAlbum::onSetImage(Album *album, ImageType type, QByteArray data)
 {
     if (m_album != album) {
         return;

--- a/music/MusicWidgetAlbum.h
+++ b/music/MusicWidgetAlbum.h
@@ -46,13 +46,13 @@ private slots:
     void onRemoveCloudItem(QString text);
     void onChooseImage();
     void onDeleteImage();
-    void onImageDropped(int imageType, QUrl imageUrl);
+    void onImageDropped(ImageType imageType, QUrl imageUrl);
     void onInfoLoadDone(Album *album);
     void onLoadDone(Album *album);
     void onDownloadProgress(Album *album, int current, int maximum);
-    void onLoadingImages(Album *album, QList<int> imageTypes);
+    void onLoadingImages(Album *album, QList<ImageType> imageTypes);
     void onLoadImagesStarted(Album *album);
-    void onSetImage(Album *album, int type, QByteArray data);
+    void onSetImage(Album *album, ImageType type, QByteArray data);
     void onBookletModelChanged();
     void onAddBooklet();
     void onBookletsDropped(QList<QUrl> urls);
@@ -64,7 +64,7 @@ private:
 
     void clearContents(QLineEdit *widget);
     void setContent(QLineEdit *widget, const QString &content);
-    void updateImage(int imageType, ClosableImage *image);
+    void updateImage(ImageType imageType, ClosableImage *image);
 };
 
 #endif // MUSICWIDGETALBUM_H

--- a/music/MusicWidgetArtist.cpp
+++ b/music/MusicWidgetArtist.cpp
@@ -120,7 +120,7 @@ void MusicWidgetArtist::setArtist(Artist *artist)
     connect(m_artist->controller(), &ArtistController::sigInfoLoadDone,             this, &MusicWidgetArtist::onInfoLoadDone,          Qt::UniqueConnection);
     connect(m_artist->controller(), &ArtistController::sigLoadDone,                 this, &MusicWidgetArtist::onLoadDone,              Qt::UniqueConnection);
     connect(m_artist->controller(), &ArtistController::sigDownloadProgress,         this, &MusicWidgetArtist::onDownloadProgress,      Qt::UniqueConnection);
-    connect(m_artist->controller(), SIGNAL(sigLoadingImages(Artist *, QList<int>)), this, SLOT(onLoadingImages(Artist *, QList<int>)), Qt::UniqueConnection);
+    connect(m_artist->controller(), &ArtistController::sigLoadingImages,            this, &MusicWidgetArtist::onLoadingImages,         Qt::UniqueConnection);
     connect(m_artist->controller(), &ArtistController::sigLoadImagesStarted,        this, &MusicWidgetArtist::onLoadImagesStarted,     Qt::UniqueConnection);
     connect(m_artist->controller(), &ArtistController::sigImage,                    this, &MusicWidgetArtist::onSetImage,              Qt::UniqueConnection);
     // clang-format on
@@ -274,10 +274,11 @@ void MusicWidgetArtist::updateArtistInfo()
     ui->moodCloud->setTags(moods, m_artist->moods());
 }
 
-void MusicWidgetArtist::updateImage(int imageType, ClosableImage *image)
+void MusicWidgetArtist::updateImage(ImageType imageType, ClosableImage *image)
 {
     if (!m_artist->rawImage(imageType).isNull()) {
         image->setImage(m_artist->rawImage(imageType));
+
     } else if (!m_artist->imagesToRemove().contains(imageType)) {
         QString imgFileName = Manager::instance()->mediaCenterInterface()->imageFileName(m_artist, imageType);
         if (!imgFileName.isEmpty()) {
@@ -419,7 +420,7 @@ void MusicWidgetArtist::onDeleteImage()
     ui->buttonRevert->setVisible(true);
 }
 
-void MusicWidgetArtist::onImageDropped(int imageType, QUrl imageUrl)
+void MusicWidgetArtist::onImageDropped(ImageType imageType, QUrl imageUrl)
 {
     if (!m_artist) {
         return;
@@ -458,13 +459,13 @@ void MusicWidgetArtist::onDownloadProgress(Artist *artist, int current, int maxi
         maximum - current, maximum, Constants::MusicArtistProgressMessageId + artist->databaseId());
 }
 
-void MusicWidgetArtist::onLoadingImages(Artist *artist, QList<int> imageTypes)
+void MusicWidgetArtist::onLoadingImages(Artist *artist, QList<ImageType> imageTypes)
 {
     if (m_artist != artist) {
         return;
     }
 
-    foreach (const int &imageType, imageTypes) {
+    for (const auto imageType : imageTypes) {
         foreach (ClosableImage *cImage, ui->groupBox_3->findChildren<ClosableImage *>()) {
             if (cImage->imageType() == imageType) {
                 cImage->setLoading(true);
@@ -485,7 +486,7 @@ void MusicWidgetArtist::onLoadImagesStarted(Artist *artist)
         tr("Downloading images..."), Constants::MusicArtistProgressMessageId + artist->databaseId());
 }
 
-void MusicWidgetArtist::onSetImage(Artist *artist, int type, QByteArray data)
+void MusicWidgetArtist::onSetImage(Artist *artist, ImageType type, QByteArray data)
 {
     if (artist != m_artist) {
         return;

--- a/music/MusicWidgetArtist.h
+++ b/music/MusicWidgetArtist.h
@@ -44,13 +44,13 @@ private slots:
     void onRemoveCloudItem(QString text);
     void onChooseImage();
     void onDeleteImage();
-    void onImageDropped(int imageType, QUrl imageUrl);
+    void onImageDropped(ImageType imageType, QUrl imageUrl);
     void onInfoLoadDone(Artist *artist);
     void onLoadDone(Artist *artist);
     void onDownloadProgress(Artist *artist, int current, int maximum);
-    void onLoadingImages(Artist *artist, QList<int> imageTypes);
+    void onLoadingImages(Artist *artist, QList<ImageType> imageTypes);
     void onLoadImagesStarted(Artist *artist);
-    void onSetImage(Artist *artist, int type, QByteArray data);
+    void onSetImage(Artist *artist, ImageType type, QByteArray data);
     void onRemoveExtraFanart(const QString &file);
     void onRemoveExtraFanart(const QByteArray &image);
     void onAddExtraFanart();
@@ -65,7 +65,7 @@ private:
 
     void clearContents(QLineEdit *widget);
     void setContent(QLineEdit *widget, const QString &content);
-    void updateImage(int imageType, ClosableImage *image);
+    void updateImage(ImageType imageType, ClosableImage *image);
 };
 
 #endif // MUSICWIDGETARTIST_H

--- a/scrapers/AEBN.cpp
+++ b/scrapers/AEBN.cpp
@@ -74,12 +74,12 @@ bool AEBN::isAdult()
     return true;
 }
 
-QList<int> AEBN::scraperSupports()
+QList<MovieScraperInfos> AEBN::scraperSupports()
 {
     return m_scraperSupports;
 }
 
-QList<int> AEBN::scraperNativelySupports()
+QList<MovieScraperInfos> AEBN::scraperNativelySupports()
 {
     return m_scraperSupports;
 }
@@ -140,7 +140,7 @@ QList<ScraperSearchResult> AEBN::parseSearch(QString html)
     return results;
 }
 
-void AEBN::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos)
+void AEBN::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos)
 {
     movie->clear(infos);
 
@@ -164,7 +164,8 @@ void AEBN::onLoadFinished()
     if (reply->error() == QNetworkReply::NoError) {
         QString msg = QString::fromUtf8(reply->readAll());
         QStringList actorIds;
-        parseAndAssignInfos(msg, movie, reply->property("infosToLoad").value<Storage *>()->infosToLoad(), actorIds);
+        parseAndAssignInfos(
+            msg, movie, reply->property("infosToLoad").value<Storage *>()->movieInfosToLoad(), actorIds);
         if (!actorIds.isEmpty()) {
             downloadActors(movie, actorIds);
             return;
@@ -175,7 +176,7 @@ void AEBN::onLoadFinished()
     movie->controller()->scraperLoadDone(this);
 }
 
-void AEBN::parseAndAssignInfos(QString html, Movie *movie, QList<int> infos, QStringList &actorIds)
+void AEBN::parseAndAssignInfos(QString html, Movie *movie, QList<MovieScraperInfos> infos, QStringList &actorIds)
 {
     QRegExp rx;
     rx.setMinimal(true);

--- a/scrapers/AEBN.h
+++ b/scrapers/AEBN.h
@@ -16,12 +16,12 @@ public:
     QString name() override;
     QString identifier() override;
     void search(QString searchStr) override;
-    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos) override;
+    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos) override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
-    QList<int> scraperSupports() override;
-    QList<int> scraperNativelySupports() override;
+    QList<MovieScraperInfos> scraperSupports() override;
+    QList<MovieScraperInfos> scraperNativelySupports() override;
     QWidget *settingsWidget() override;
     bool isAdult() override;
 
@@ -35,14 +35,14 @@ private slots:
 
 private:
     QNetworkAccessManager m_qnam;
-    QList<int> m_scraperSupports;
+    QList<MovieScraperInfos> m_scraperSupports;
     QString m_language;
     QWidget *m_widget;
     QComboBox *m_box;
 
     QNetworkAccessManager *qnam();
     QList<ScraperSearchResult> parseSearch(QString html);
-    void parseAndAssignInfos(QString html, Movie *movie, QList<int> infos, QStringList &actorIds);
+    void parseAndAssignInfos(QString html, Movie *movie, QList<MovieScraperInfos> infos, QStringList &actorIds);
     void downloadActors(Movie *movie, QStringList actorIds);
     void parseAndAssignActor(QString html, Movie *movie, QString id);
 };

--- a/scrapers/AdultDvdEmpire.cpp
+++ b/scrapers/AdultDvdEmpire.cpp
@@ -41,12 +41,12 @@ bool AdultDvdEmpire::isAdult()
     return true;
 }
 
-QList<int> AdultDvdEmpire::scraperSupports()
+QList<MovieScraperInfos> AdultDvdEmpire::scraperSupports()
 {
     return m_scraperSupports;
 }
 
-QList<int> AdultDvdEmpire::scraperNativelySupports()
+QList<MovieScraperInfos> AdultDvdEmpire::scraperNativelySupports()
 {
     return m_scraperSupports;
 }
@@ -99,7 +99,7 @@ QList<ScraperSearchResult> AdultDvdEmpire::parseSearch(QString html)
     return results;
 }
 
-void AdultDvdEmpire::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos)
+void AdultDvdEmpire::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos)
 {
     movie->clear(infos);
     QUrl url(QString("https://www.adultdvdempire.com%1").arg(ids.values().first()));
@@ -119,7 +119,7 @@ void AdultDvdEmpire::onLoadFinished()
 
     if (reply->error() == QNetworkReply::NoError) {
         QString msg = QString::fromUtf8(reply->readAll());
-        parseAndAssignInfos(msg, movie, reply->property("infosToLoad").value<Storage *>()->infosToLoad());
+        parseAndAssignInfos(msg, movie, reply->property("infosToLoad").value<Storage *>()->movieInfosToLoad());
     } else {
         qWarning() << "Network Error" << reply->errorString();
     }
@@ -127,7 +127,7 @@ void AdultDvdEmpire::onLoadFinished()
     movie->controller()->scraperLoadDone(this);
 }
 
-void AdultDvdEmpire::parseAndAssignInfos(QString html, Movie *movie, QList<int> infos)
+void AdultDvdEmpire::parseAndAssignInfos(QString html, Movie *movie, QList<MovieScraperInfos> infos)
 {
     QTextDocument doc;
     QRegExp rx;

--- a/scrapers/AdultDvdEmpire.h
+++ b/scrapers/AdultDvdEmpire.h
@@ -15,12 +15,12 @@ public:
     QString name() override;
     QString identifier() override;
     void search(QString searchStr) override;
-    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos) override;
+    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos) override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
-    QList<int> scraperSupports() override;
-    QList<int> scraperNativelySupports() override;
+    QList<MovieScraperInfos> scraperSupports() override;
+    QList<MovieScraperInfos> scraperNativelySupports() override;
     QWidget *settingsWidget() override;
     bool isAdult() override;
 
@@ -33,11 +33,11 @@ private slots:
 
 private:
     QNetworkAccessManager m_qnam;
-    QList<int> m_scraperSupports;
+    QList<MovieScraperInfos> m_scraperSupports;
 
     QNetworkAccessManager *qnam();
     QList<ScraperSearchResult> parseSearch(QString html);
-    void parseAndAssignInfos(QString html, Movie *movie, QList<int> infos);
+    void parseAndAssignInfos(QString html, Movie *movie, QList<MovieScraperInfos> infos);
 };
 
 #endif // ADULTDVDEMPIRE_H

--- a/scrapers/CustomMovieScraper.cpp
+++ b/scrapers/CustomMovieScraper.cpp
@@ -70,7 +70,7 @@ void CustomMovieScraper::onTitleSearchDone(QList<ScraperSearchResult> results)
     }
 }
 
-QList<ScraperInterface *> CustomMovieScraper::scrapersNeedSearch(QList<int> infos,
+QList<ScraperInterface *> CustomMovieScraper::scrapersNeedSearch(QList<MovieScraperInfos> infos,
     QMap<ScraperInterface *, QString> alreadyLoadedIds)
 {
     QList<ScraperInterface *> scrapers;
@@ -107,7 +107,7 @@ QList<ScraperInterface *> CustomMovieScraper::scrapersNeedSearch(QList<int> info
         scrapers.append(scraper);
     }
 
-    foreach (const int &info, infos) {
+    for (const auto info : infos) {
         QString imageProviderId = Settings::instance()->customMovieScraper().value(info, "notset");
         if (imageProviderId == "images.fanarttv") {
             if (!imdbIdAvailable) {
@@ -135,7 +135,7 @@ QList<ScraperInterface *> CustomMovieScraper::scrapersNeedSearch(QList<int> info
     return scrapers;
 }
 
-void CustomMovieScraper::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos)
+void CustomMovieScraper::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos)
 {
     movie->clear(infos);
 
@@ -154,7 +154,7 @@ void CustomMovieScraper::loadData(QMap<ScraperInterface *, QString> ids, Movie *
     }
 
     bool needImdbId = false;
-    foreach (const int &info, infos) {
+    for (const auto info : infos) {
         ScraperInterface *scraper = scraperForInfo(info);
         if (!scraper) {
             continue;
@@ -186,7 +186,7 @@ void CustomMovieScraper::onLoadTmdbFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Movie *movie = reply->property("movie").value<Storage *>()->movie();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<MovieScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->movieInfosToLoad();
     QMap<ScraperInterface *, QString> ids = reply->property("ids").value<Storage *>()->ids();
     QString tmdbId = reply->property("tmdbId").toString();
 
@@ -218,12 +218,12 @@ void CustomMovieScraper::onLoadTmdbFinished()
 
 void CustomMovieScraper::loadAllData(QMap<ScraperInterface *, QString> ids,
     Movie *movie,
-    QList<int> infos,
+    QList<MovieScraperInfos> infos,
     QString tmdbId,
     QString imdbId)
 {
     QMap<ScraperInterface *, QString> scrapersWithIds;
-    foreach (const int &info, infos) {
+    for (const auto info : infos) {
         ScraperInterface *scraper = scraperForInfo(info);
         if (!scraper) {
             continue;
@@ -269,7 +269,7 @@ void CustomMovieScraper::loadAllData(QMap<ScraperInterface *, QString> ids,
     QMapIterator<ScraperInterface *, QString> itS(scrapersWithIds);
     while (itS.hasNext()) {
         itS.next();
-        QList<int> infosToLoad = infosForScraper(itS.key(), infos);
+        QList<MovieScraperInfos> infosToLoad = infosForScraper(itS.key(), infos);
         if (infosToLoad.isEmpty()) {
             continue;
         }
@@ -279,7 +279,7 @@ void CustomMovieScraper::loadAllData(QMap<ScraperInterface *, QString> ids,
     }
 }
 
-ScraperInterface *CustomMovieScraper::scraperForInfo(int info)
+ScraperInterface *CustomMovieScraper::scraperForInfo(MovieScraperInfos info)
 {
     QString identifier = Settings::instance()->customMovieScraper().value(info, "");
     if (identifier.isEmpty()) {
@@ -296,10 +296,10 @@ ScraperInterface *CustomMovieScraper::scraperForInfo(int info)
     return nullptr;
 }
 
-QList<ScraperInterface *> CustomMovieScraper::scrapersForInfos(QList<int> infos)
+QList<ScraperInterface *> CustomMovieScraper::scrapersForInfos(QList<MovieScraperInfos> infos)
 {
     QList<ScraperInterface *> scrapers;
-    foreach (const int &info, infos) {
+    for (const auto info : infos) {
         ScraperInterface *scraper = scraperForInfo(info);
         if (scraper && !scrapers.contains(scraper)) {
             scrapers.append(scraper);
@@ -315,10 +315,11 @@ QList<ScraperInterface *> CustomMovieScraper::scrapersForInfos(QList<int> infos)
     return scrapers;
 }
 
-QList<int> CustomMovieScraper::infosForScraper(ScraperInterface *scraper, QList<int> selectedInfos)
+QList<MovieScraperInfos> CustomMovieScraper::infosForScraper(ScraperInterface *scraper,
+    QList<MovieScraperInfos> selectedInfos)
 {
-    QList<int> infosForScraper;
-    foreach (const int &info, selectedInfos) {
+    QList<MovieScraperInfos> infosForScraper;
+    for (const auto info : selectedInfos) {
         if (scraper == scraperForInfo(info)) {
             infosForScraper.append(info);
         }
@@ -326,10 +327,10 @@ QList<int> CustomMovieScraper::infosForScraper(ScraperInterface *scraper, QList<
     return infosForScraper;
 }
 
-QList<int> CustomMovieScraper::scraperSupports()
+QList<MovieScraperInfos> CustomMovieScraper::scraperSupports()
 {
-    QList<int> supports;
-    QMapIterator<int, QString> it(Settings::instance()->customMovieScraper());
+    QList<MovieScraperInfos> supports;
+    QMapIterator<MovieScraperInfos, QString> it(Settings::instance()->customMovieScraper());
     while (it.hasNext()) {
         it.next();
         if (!it.value().isEmpty()) {
@@ -344,7 +345,7 @@ ScraperInterface *CustomMovieScraper::titleScraper()
     return scraperForInfo(MovieScraperInfos::Title);
 }
 
-QList<int> CustomMovieScraper::scraperNativelySupports()
+QList<MovieScraperInfos> CustomMovieScraper::scraperNativelySupports()
 {
     return scraperSupports();
 }

--- a/scrapers/CustomMovieScraper.h
+++ b/scrapers/CustomMovieScraper.h
@@ -16,17 +16,18 @@ public:
     QString name() override;
     QString identifier() override;
     void search(QString searchStr) override;
-    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos) override;
+    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos) override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
-    QList<int> scraperSupports() override;
-    QList<int> scraperNativelySupports() override;
-    QList<ScraperInterface *> scrapersNeedSearch(QList<int> infos, QMap<ScraperInterface *, QString> alreadyLoadedIds);
+    QList<MovieScraperInfos> scraperSupports() override;
+    QList<MovieScraperInfos> scraperNativelySupports() override;
+    QList<ScraperInterface *> scrapersNeedSearch(QList<MovieScraperInfos> infos,
+        QMap<ScraperInterface *, QString> alreadyLoadedIds);
     ScraperInterface *titleScraper();
     QWidget *settingsWidget() override;
     bool isAdult() override;
-    ScraperInterface *scraperForInfo(int info);
+    ScraperInterface *scraperForInfo(MovieScraperInfos info);
 
 private slots:
     void onTitleSearchDone(QList<ScraperSearchResult> results);
@@ -39,13 +40,16 @@ private:
     QList<ScraperInterface *> m_scrapers;
     QNetworkAccessManager m_qnam;
 
-    QList<ScraperInterface *> scrapersForInfos(QList<int> infos);
+    QList<ScraperInterface *> scrapersForInfos(QList<MovieScraperInfos> infos);
     ImageProviderInterface *imageProviderForInfo(int info);
-    QList<ImageProviderInterface *> imageProvidersForInfos(QList<int> infos);
+    QList<ImageProviderInterface *> imageProvidersForInfos(QList<MovieScraperInfos> infos);
 
-    QList<int> infosForScraper(ScraperInterface *scraper, QList<int> selectedInfos);
-    void
-    loadAllData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos, QString tmdbId, QString imdbId);
+    QList<MovieScraperInfos> infosForScraper(ScraperInterface *scraper, QList<MovieScraperInfos> selectedInfos);
+    void loadAllData(QMap<ScraperInterface *, QString> ids,
+        Movie *movie,
+        QList<MovieScraperInfos> infos,
+        QString tmdbId,
+        QString imdbId);
     QNetworkAccessManager *qnam();
 };
 

--- a/scrapers/HotMovies.cpp
+++ b/scrapers/HotMovies.cpp
@@ -33,12 +33,12 @@ bool HotMovies::isAdult()
     return true;
 }
 
-QList<int> HotMovies::scraperSupports()
+QList<MovieScraperInfos> HotMovies::scraperSupports()
 {
     return m_scraperSupports;
 }
 
-QList<int> HotMovies::scraperNativelySupports()
+QList<MovieScraperInfos> HotMovies::scraperNativelySupports()
 {
     return m_scraperSupports;
 }
@@ -92,7 +92,7 @@ QList<ScraperSearchResult> HotMovies::parseSearch(QString html)
     return results;
 }
 
-void HotMovies::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos)
+void HotMovies::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos)
 {
     movie->clear(infos);
 
@@ -111,14 +111,14 @@ void HotMovies::onLoadFinished()
     reply->deleteLater();
     if (reply->error() == QNetworkReply::NoError) {
         QString msg = QString::fromUtf8(reply->readAll());
-        parseAndAssignInfos(msg, movie, reply->property("infosToLoad").value<Storage *>()->infosToLoad());
+        parseAndAssignInfos(msg, movie, reply->property("infosToLoad").value<Storage *>()->movieInfosToLoad());
     } else {
         qWarning() << "Network Error" << reply->errorString();
     }
     movie->controller()->scraperLoadDone(this);
 }
 
-void HotMovies::parseAndAssignInfos(QString html, Movie *movie, QList<int> infos)
+void HotMovies::parseAndAssignInfos(QString html, Movie *movie, QList<MovieScraperInfos> infos)
 {
     QRegExp rx;
     rx.setMinimal(true);

--- a/scrapers/HotMovies.h
+++ b/scrapers/HotMovies.h
@@ -16,12 +16,12 @@ public:
     QString name() override;
     QString identifier() override;
     void search(QString searchStr) override;
-    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos) override;
+    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos) override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
-    QList<int> scraperSupports() override;
-    QList<int> scraperNativelySupports() override;
+    QList<MovieScraperInfos> scraperSupports() override;
+    QList<MovieScraperInfos> scraperNativelySupports() override;
     QWidget *settingsWidget() override;
     bool isAdult() override;
 
@@ -34,11 +34,11 @@ private slots:
 
 private:
     QNetworkAccessManager m_qnam;
-    QList<int> m_scraperSupports;
+    QList<MovieScraperInfos> m_scraperSupports;
 
     QNetworkAccessManager *qnam();
     QList<ScraperSearchResult> parseSearch(QString html);
-    void parseAndAssignInfos(QString html, Movie *movie, QList<int> infos);
+    void parseAndAssignInfos(QString html, Movie *movie, QList<MovieScraperInfos> infos);
 };
 
 #endif // HOTMOVIES_H

--- a/scrapers/IMDB.cpp
+++ b/scrapers/IMDB.cpp
@@ -74,12 +74,12 @@ void IMDB::saveSettings(QSettings &settings)
     settings.setValue("Scrapers/IMDb/LoadAllTags", m_loadAllTags);
 }
 
-QList<int> IMDB::scraperSupports()
+QList<MovieScraperInfos> IMDB::scraperSupports()
 {
     return m_scraperSupports;
 }
 
-QList<int> IMDB::scraperNativelySupports()
+QList<MovieScraperInfos> IMDB::scraperNativelySupports()
 {
     return m_scraperSupports;
 }
@@ -188,7 +188,7 @@ QList<ScraperSearchResult> IMDB::parseSearch(QString html)
     return results;
 }
 
-void IMDB::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos)
+void IMDB::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos)
 {
     QString imdbId = ids.values().first();
     movie->clear(infos);
@@ -209,7 +209,7 @@ void IMDB::onLoadFinished()
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     reply->deleteLater();
     Movie *movie = reply->property("storage").value<Storage *>()->movie();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<MovieScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->movieInfosToLoad();
     if (!movie) {
         return;
     }
@@ -269,7 +269,7 @@ void IMDB::onPosterLoadFinished()
     auto posterId = reply->url().fileName();
     reply->deleteLater();
     Movie *movie = reply->property("storage").value<Storage *>()->movie();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<MovieScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->movieInfosToLoad();
     if (!movie) {
         return;
     }
@@ -283,7 +283,7 @@ void IMDB::onPosterLoadFinished()
     movie->controller()->scraperLoadDone(this);
 }
 
-void IMDB::parseAndAssignInfos(QString html, Movie *movie, QList<int> infos)
+void IMDB::parseAndAssignInfos(QString html, Movie *movie, QList<MovieScraperInfos> infos)
 {
     QRegExp rx;
     rx.setMinimal(true);
@@ -604,7 +604,7 @@ void IMDB::parseAndAssignTags(const QString &html, Movie &movie)
     }
 }
 
-void IMDB::parseAndAssignPoster(QString html, QString posterId, Movie *movie, QList<int> infos)
+void IMDB::parseAndAssignPoster(QString html, QString posterId, Movie *movie, QList<MovieScraperInfos> infos)
 {
     // IMDB's media viewer contains all links to the gallery's image files.
     // We only want the poster, which has the id "viewerID".

--- a/scrapers/IMDB.h
+++ b/scrapers/IMDB.h
@@ -17,15 +17,15 @@ public:
     QString name() override;
     QString identifier() override;
     void search(QString searchStr) override;
-    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos) override;
+    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos) override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
-    QList<int> scraperSupports() override;
-    QList<int> scraperNativelySupports() override;
+    QList<MovieScraperInfos> scraperSupports() override;
+    QList<MovieScraperInfos> scraperNativelySupports() override;
     QWidget *settingsWidget() override;
     bool isAdult() override;
-    void parseAndAssignInfos(QString html, Movie *movie, QList<int> infos);
+    void parseAndAssignInfos(QString html, Movie *movie, QList<MovieScraperInfos> infos);
 
 signals:
     void searchDone(QList<ScraperSearchResult>) override;
@@ -43,10 +43,10 @@ private:
 
     bool m_loadAllTags;
     QNetworkAccessManager m_qnam;
-    QList<int> m_scraperSupports;
+    QList<MovieScraperInfos> m_scraperSupports;
 
     QList<ScraperSearchResult> parseSearch(QString html);
-    void parseAndAssignPoster(QString html, QString posterId, Movie *movie, QList<int> infos);
+    void parseAndAssignPoster(QString html, QString posterId, Movie *movie, QList<MovieScraperInfos> infos);
     QUrl parsePosters(QString html);
     void parseAndAssignTags(const QString &html, Movie &movie);
 };

--- a/scrapers/KinoDe.cpp
+++ b/scrapers/KinoDe.cpp
@@ -83,12 +83,12 @@ void KinoDe::saveSettings(QSettings &settings)
  * @brief Returns a list of infos available from the scraper
  * @return List of supported infos
  */
-QList<int> KinoDe::scraperSupports()
+QList<MovieScraperInfos> KinoDe::scraperSupports()
 {
     return m_scraperSupports;
 }
 
-QList<int> KinoDe::scraperNativelySupports()
+QList<MovieScraperInfos> KinoDe::scraperNativelySupports()
 {
     return m_scraperSupports;
 }
@@ -169,7 +169,7 @@ QList<ScraperSearchResult> KinoDe::parseSearch(const QString &html)
  * @param infos List of infos to load
  * @see KinoDe::loadFinished
  */
-void KinoDe::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos)
+void KinoDe::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos)
 {
     movie->clear(infos);
     const QUrl url{QStringLiteral("https://www.kino.de/film/%1/").arg(ids.values().first())};
@@ -188,7 +188,7 @@ void KinoDe::loadFinished()
 {
     auto reply = static_cast<QNetworkReply *const>(QObject::sender());
     Movie *const movie = reply->property("storage").value<Storage *>()->movie();
-    const QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    const QList<MovieScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->movieInfosToLoad();
     reply->deleteLater();
 
     if (movie == nullptr) {
@@ -214,7 +214,7 @@ void KinoDe::loadFinished()
  * @param movie Movie object
  * @param infos List of infos to load
  */
-void KinoDe::parseAndAssignInfos(const QString &html, Movie &movie, const QList<int> &infos)
+void KinoDe::parseAndAssignInfos(const QString &html, Movie &movie, const QList<MovieScraperInfos> &infos)
 {
     QRegExp rx;
     rx.setMinimal(true);
@@ -285,7 +285,7 @@ void KinoDe::parseAndAssignInfos(const QString &html, Movie &movie, const QList<
  * @param movie Movie object
  * @param infos List of infos to load
  */
-void KinoDe::parseAndAssignImages(const QString &html, Movie &movie, const QList<int> &infos)
+void KinoDe::parseAndAssignImages(const QString &html, Movie &movie, const QList<MovieScraperInfos> &infos)
 {
     if (infos.contains(MovieScraperInfos::Poster)) {
         parsePoster(html, movie);
@@ -301,7 +301,7 @@ void KinoDe::parseAndAssignImages(const QString &html, Movie &movie, const QList
  * @param movie Movie object
  * @param infos List of infos to load
  */
-void KinoDe::parseAndAssignActors(const QString &html, Movie &movie, const QList<int> &infos)
+void KinoDe::parseAndAssignActors(const QString &html, Movie &movie, const QList<MovieScraperInfos> &infos)
 {
     QRegExp rx;
     rx.setMinimal(true);

--- a/scrapers/KinoDe.h
+++ b/scrapers/KinoDe.h
@@ -19,12 +19,12 @@ public:
     QString name() override;
     QString identifier() override;
     void search(QString searchStr) override;
-    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos) override;
+    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos) override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
-    QList<int> scraperSupports() override;
-    QList<int> scraperNativelySupports() override;
+    QList<MovieScraperInfos> scraperSupports() override;
+    QList<MovieScraperInfos> scraperNativelySupports() override;
     QWidget *settingsWidget() override;
     bool isAdult() override;
 
@@ -37,14 +37,14 @@ private slots:
 
 private:
     QList<ScraperSearchResult> parseSearch(const QString &html);
-    void parseAndAssignInfos(const QString &html, Movie &movie, const QList<int> &infos);
-    void parseAndAssignActors(const QString &html, Movie &movie, const QList<int> &infos);
-    void parseAndAssignImages(const QString &html, Movie &movie, const QList<int> &infos);
+    void parseAndAssignInfos(const QString &html, Movie &movie, const QList<MovieScraperInfos> &infos);
+    void parseAndAssignActors(const QString &html, Movie &movie, const QList<MovieScraperInfos> &infos);
+    void parseAndAssignImages(const QString &html, Movie &movie, const QList<MovieScraperInfos> &infos);
     void parsePoster(const QString &html, Movie &movie);
     void parseBackdrops(const QString &html, Movie &movie);
 
     QNetworkAccessManager m_qnam;
-    QList<int> m_scraperSupports;
+    QList<MovieScraperInfos> m_scraperSupports;
 };
 
 #endif // CINEFACTS_H

--- a/scrapers/OFDb.cpp
+++ b/scrapers/OFDb.cpp
@@ -84,12 +84,12 @@ QNetworkAccessManager *OFDb::qnam()
  * @brief Returns a list of infos available from the scraper
  * @return List of supported infos
  */
-QList<int> OFDb::scraperSupports()
+QList<MovieScraperInfos> OFDb::scraperSupports()
 {
     return m_scraperSupports;
 }
 
-QList<int> OFDb::scraperNativelySupports()
+QList<MovieScraperInfos> OFDb::scraperNativelySupports()
 {
     return m_scraperSupports;
 }
@@ -222,7 +222,7 @@ QList<ScraperSearchResult> OFDb::parseSearch(QString xml, QString searchStr)
  * @param infos List of infos to load
  * @see OFDb::loadFinished
  */
-void OFDb::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos)
+void OFDb::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos)
 {
     movie->clear(infos);
 
@@ -245,7 +245,7 @@ void OFDb::loadFinished()
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Movie *movie = reply->property("storage").value<Storage *>()->movie();
     QString ofdbId = reply->property("ofdbId").toString();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<MovieScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->movieInfosToLoad();
     int notFoundCounter = reply->property("notFoundCounter").toInt();
     if (!movie) {
         return;
@@ -294,7 +294,7 @@ void OFDb::loadFinished()
  * @param movie Movie object
  * @param infos List of infos to load
  */
-void OFDb::parseAndAssignInfos(QString data, Movie *movie, QList<int> infos)
+void OFDb::parseAndAssignInfos(QString data, Movie *movie, QList<MovieScraperInfos> infos)
 {
     qDebug() << "Entered";
     QXmlStreamReader xml(data);

--- a/scrapers/OFDb.h
+++ b/scrapers/OFDb.h
@@ -18,12 +18,12 @@ public:
     QString name() override;
     QString identifier() override;
     void search(QString searchStr) override;
-    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos) override;
+    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos) override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
-    QList<int> scraperSupports() override;
-    QList<int> scraperNativelySupports() override;
+    QList<MovieScraperInfos> scraperSupports() override;
+    QList<MovieScraperInfos> scraperNativelySupports() override;
     QWidget *settingsWidget() override;
     bool isAdult() override;
 
@@ -36,11 +36,11 @@ private slots:
 
 private:
     QNetworkAccessManager m_qnam;
-    QList<int> m_scraperSupports;
+    QList<MovieScraperInfos> m_scraperSupports;
 
     QNetworkAccessManager *qnam();
     QList<ScraperSearchResult> parseSearch(QString html, QString searchStr);
-    void parseAndAssignInfos(QString data, Movie *movie, QList<int> infos);
+    void parseAndAssignInfos(QString data, Movie *movie, QList<MovieScraperInfos> infos);
 };
 
 #endif // OFDB_H

--- a/scrapers/TMDb.cpp
+++ b/scrapers/TMDb.cpp
@@ -184,12 +184,12 @@ void TMDb::saveSettings(QSettings &settings)
  * @brief Returns a list of infos available from the scraper
  * @return List of supported infos
  */
-QList<int> TMDb::scraperSupports()
+QList<MovieScraperInfos> TMDb::scraperSupports()
 {
     return m_scraperSupports;
 }
 
-QList<int> TMDb::scraperNativelySupports()
+QList<MovieScraperInfos> TMDb::scraperNativelySupports()
 {
     return m_scraperNativelySupports;
 }
@@ -426,7 +426,7 @@ QList<ScraperSearchResult> TMDb::parseSearch(QString json, int *nextPage, int pa
  * @see TMDb::loadImagesFinished
  * @see TMDb::loadReleasesFinished
  */
-void TMDb::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos)
+void TMDb::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos)
 {
     if (!ids.values().first().startsWith("tt")) {
         movie->setTmdbId(ids.values().first());
@@ -503,7 +503,7 @@ void TMDb::loadFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Movie *const movie = reply->property("storage").value<Storage *>()->movie();
-    const QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    const QList<MovieScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->movieInfosToLoad();
     reply->deleteLater();
     if (!movie) {
         return;
@@ -526,7 +526,7 @@ void TMDb::loadCastsFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Movie *const movie = reply->property("storage").value<Storage *>()->movie();
-    const QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    const QList<MovieScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->movieInfosToLoad();
     reply->deleteLater();
     if (!movie) {
         return;
@@ -549,7 +549,7 @@ void TMDb::loadTrailersFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Movie *const movie = reply->property("storage").value<Storage *>()->movie();
-    const QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    const QList<MovieScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->movieInfosToLoad();
     reply->deleteLater();
     if (!movie) {
         return;
@@ -572,7 +572,7 @@ void TMDb::loadImagesFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Movie *movie = reply->property("storage").value<Storage *>()->movie();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<MovieScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->movieInfosToLoad();
     reply->deleteLater();
     if (!movie) {
         return;
@@ -595,7 +595,7 @@ void TMDb::loadReleasesFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Movie *movie = reply->property("storage").value<Storage *>()->movie();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<MovieScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->movieInfosToLoad();
     reply->deleteLater();
     if (!movie) {
         return;
@@ -685,7 +685,7 @@ QUrl TMDb::getMovieUrl(const QString &title, ApiMovieDetails type, const UrlPara
  * @param movie Movie object
  * @param infos List of infos to load
  */
-void TMDb::parseAndAssignInfos(QString json, Movie *movie, QList<int> infos)
+void TMDb::parseAndAssignInfos(QString json, Movie *movie, QList<MovieScraperInfos> infos)
 {
     qDebug() << "Entered";
     QJsonParseError parseError;

--- a/scrapers/TMDb.h
+++ b/scrapers/TMDb.h
@@ -23,12 +23,12 @@ public:
     QString name() override;
     QString identifier() override;
     void search(QString searchStr) override;
-    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos) override;
+    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos) override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
-    QList<int> scraperSupports() override;
-    QList<int> scraperNativelySupports() override;
+    QList<MovieScraperInfos> scraperSupports() override;
+    QList<MovieScraperInfos> scraperNativelySupports() override;
     QWidget *settingsWidget() override;
     static QList<ScraperSearchResult> parseSearch(QString json, int *nextPage, int page);
     static QString apiKey();
@@ -51,8 +51,8 @@ private:
     QLocale m_locale;
     QString m_baseUrl;
     QMutex m_mutex;
-    QList<int> m_scraperSupports;
-    QList<int> m_scraperNativelySupports;
+    QList<MovieScraperInfos> m_scraperSupports;
+    QList<MovieScraperInfos> m_scraperNativelySupports;
     QWidget *m_widget;
     QComboBox *m_box;
 
@@ -81,7 +81,7 @@ private:
     QUrl getMovieUrl(const QString &title,
         ApiMovieDetails type,
         const UrlParameterMap &parameters = UrlParameterMap{}) const;
-    void parseAndAssignInfos(QString json, Movie *movie, QList<int> infos);
+    void parseAndAssignInfos(QString json, Movie *movie, QList<MovieScraperInfos> infos);
 };
 
 #endif // TMDB_H

--- a/scrapers/TMDbConcerts.cpp
+++ b/scrapers/TMDbConcerts.cpp
@@ -152,7 +152,7 @@ QNetworkAccessManager *TMDbConcerts::qnam()
  * @brief Returns a list of infos available from the scraper
  * @return List of supported infos
  */
-QList<int> TMDbConcerts::scraperSupports()
+QList<ConcertScraperInfos> TMDbConcerts::scraperSupports()
 {
     return m_scraperSupports;
 }
@@ -361,7 +361,7 @@ QList<ScraperSearchResult> TMDbConcerts::parseSearch(QString json, int &nextPage
  * @see TMDbConcerts::loadImagesFinished
  * @see TMDbConcerts::loadReleasesFinished
  */
-void TMDbConcerts::loadData(QString id, Concert *concert, QList<int> infos)
+void TMDbConcerts::loadData(QString id, Concert *concert, QList<ConcertScraperInfos> infos)
 {
     qDebug() << "Entered, id=" << id << "concert=" << concert->name();
     concert->setTmdbId(id);
@@ -432,7 +432,7 @@ void TMDbConcerts::loadFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Concert *concert = reply->property("storage").value<Storage *>()->concert();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<ConcertScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->concertInfosToLoad();
     reply->deleteLater();
     if (!concert) {
         return;
@@ -455,7 +455,7 @@ void TMDbConcerts::loadTrailersFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Concert *concert = reply->property("storage").value<Storage *>()->concert();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<ConcertScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->concertInfosToLoad();
     reply->deleteLater();
     if (!concert) {
         return;
@@ -478,7 +478,7 @@ void TMDbConcerts::loadImagesFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Concert *concert = reply->property("storage").value<Storage *>()->concert();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<ConcertScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->concertInfosToLoad();
     reply->deleteLater();
     if (!concert) {
         return;
@@ -501,7 +501,7 @@ void TMDbConcerts::loadReleasesFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Concert *concert = reply->property("storage").value<Storage *>()->concert();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<ConcertScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->concertInfosToLoad();
     reply->deleteLater();
     if (!concert) {
         return;
@@ -523,7 +523,7 @@ void TMDbConcerts::loadReleasesFinished()
  * @param concert Concert object
  * @param infos List of infos to load
  */
-void TMDbConcerts::parseAndAssignInfos(QString json, Concert *concert, QList<int> infos)
+void TMDbConcerts::parseAndAssignInfos(QString json, Concert *concert, QList<ConcertScraperInfos> infos)
 {
     qDebug() << "Entered";
     QJsonParseError parseError;

--- a/scrapers/TMDbConcerts.h
+++ b/scrapers/TMDbConcerts.h
@@ -21,11 +21,11 @@ public:
     ~TMDbConcerts() override = default;
     QString name() override;
     void search(QString searchStr) override;
-    void loadData(QString id, Concert *concert, QList<int> infos) override;
+    void loadData(QString id, Concert *concert, QList<ConcertScraperInfos> infos) override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
-    QList<int> scraperSupports() override;
+    QList<ConcertScraperInfos> scraperSupports() override;
     QWidget *settingsWidget() override;
 
 signals:
@@ -45,7 +45,7 @@ private:
     QLocale m_locale;
     QString m_language2;
     QString m_baseUrl;
-    QList<int> m_scraperSupports;
+    QList<ConcertScraperInfos> m_scraperSupports;
     QWidget *m_widget;
     QComboBox *m_box;
 
@@ -55,7 +55,7 @@ private:
     QString country() const;
     QNetworkAccessManager *qnam();
     QList<ScraperSearchResult> parseSearch(QString json, int &nextPage);
-    void parseAndAssignInfos(QString json, Concert *concert, QList<int> infos);
+    void parseAndAssignInfos(QString json, Concert *concert, QList<ConcertScraperInfos> infos);
 };
 
 #endif // TMDBCONCERTS_H

--- a/scrapers/TheTvDb.cpp
+++ b/scrapers/TheTvDb.cpp
@@ -235,7 +235,10 @@ QList<ScraperSearchResult> TheTvDb::parseSearch(QString xml)
  * @param show Tv show object
  * @see TheTvDb::onLoadFinished
  */
-void TheTvDb::loadTvShowData(QString id, TvShow *show, TvShowUpdateType updateType, QList<int> infosToLoad)
+void TheTvDb::loadTvShowData(QString id,
+    TvShow *show,
+    TvShowUpdateType updateType,
+    QList<TvShowScraperInfos> infosToLoad)
 {
     show->setTvdbId(id);
     QUrl url(QString("%1/api/%2/series/%3/all/%4.xml").arg(m_mirror).arg(m_apiKey).arg(id).arg(m_language));
@@ -261,7 +264,7 @@ void TheTvDb::onLoadFinished()
     reply->deleteLater();
     TvShow *show = reply->property("storage").value<Storage *>()->show();
     TvShowUpdateType updateType = static_cast<TvShowUpdateType>(reply->property("updateType").toInt());
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<TvShowScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->showInfosToLoad();
     if (!show) {
         return;
     }
@@ -300,7 +303,7 @@ void TheTvDb::onActorsFinished()
     reply->deleteLater();
     TvShow *show = reply->property("storage").value<Storage *>()->show();
     TvShowUpdateType updateType = static_cast<TvShowUpdateType>(reply->property("updateType").toInt());
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<TvShowScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->showInfosToLoad();
     QList<TvShowEpisode *> updatedEpisodes = reply->property("updatedEpisodes").value<Storage *>()->episodes();
     if (!show) {
         return;
@@ -336,7 +339,7 @@ void TheTvDb::onBannersFinished()
     reply->deleteLater();
     TvShow *show = reply->property("storage").value<Storage *>()->show();
     TvShowUpdateType updateType = static_cast<TvShowUpdateType>(reply->property("updateType").toInt());
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<TvShowScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->showInfosToLoad();
     QList<TvShowEpisode *> updatedEpisodes = reply->property("updatedEpisodes").value<Storage *>()->episodes();
     if (!show) {
         return;
@@ -375,7 +378,7 @@ void TheTvDb::onBannersFinished()
 void TheTvDb::parseAndAssignInfos(QString xml,
     TvShow *show,
     TvShowUpdateType updateType,
-    QList<int> infosToLoad,
+    QList<TvShowScraperInfos> infosToLoad,
     QList<TvShowEpisode *> &updatedEpisodes)
 {
     QDomDocument domDoc;
@@ -484,7 +487,7 @@ void TheTvDb::parseAndAssignInfos(QString xml,
 
 void TheTvDb::fillDatabaseWithAllEpisodes(QString xml, TvShow *show)
 {
-    QList<int> infosToLoad;
+    QList<TvShowScraperInfos> infosToLoad;
     infosToLoad << TvShowScraperInfos::Director   //
                 << TvShowScraperInfos::Title      //
                 << TvShowScraperInfos::FirstAired //
@@ -546,7 +549,10 @@ void TheTvDb::parseAndAssignActors(QString xml, TvShow *show)
  * @param xml XML data
  * @param show Tv Show object
  */
-void TheTvDb::parseAndAssignBanners(QString xml, TvShow *show, TvShowUpdateType updateType, QList<int> infosToLoad)
+void TheTvDb::parseAndAssignBanners(QString xml,
+    TvShow *show,
+    TvShowUpdateType updateType,
+    QList<TvShowScraperInfos> infosToLoad)
 {
     QDomDocument domDoc;
     domDoc.setContent(xml);
@@ -667,7 +673,9 @@ void TheTvDb::parseAndAssignBanners(QString xml, TvShow *show, TvShowUpdateType 
  * @param elem Dom element
  * @param episode Episode object
  */
-void TheTvDb::parseAndAssignSingleEpisodeInfos(QDomElement elem, TvShowEpisode *episode, QList<int> infosToLoad)
+void TheTvDb::parseAndAssignSingleEpisodeInfos(QDomElement elem,
+    TvShowEpisode *episode,
+    QList<TvShowScraperInfos> infosToLoad)
 {
     if (!elem.elementsByTagName("IMDB_ID").isEmpty()) {
         episode->setImdbId(elem.elementsByTagName("IMDB_ID").at(0).toElement().text());
@@ -725,7 +733,7 @@ void TheTvDb::parseAndAssignSingleEpisodeInfos(QDomElement elem, TvShowEpisode *
  * @param episode Episode object
  * @see TheTvDb::onEpisodeLoadFinished
  */
-void TheTvDb::loadTvShowEpisodeData(QString id, TvShowEpisode *episode, QList<int> infosToLoad)
+void TheTvDb::loadTvShowEpisodeData(QString id, TvShowEpisode *episode, QList<TvShowScraperInfos> infosToLoad)
 {
     qDebug() << "Entered, id=" << id << "episode=" << episode->name();
     episode->clear(infosToLoad);
@@ -756,7 +764,7 @@ void TheTvDb::loadTvShowEpisodeData(QString id, TvShowEpisode *episode, QList<in
 void TheTvDb::onEpisodeLoadFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<TvShowScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->showInfosToLoad();
     reply->deleteLater();
     TvShowEpisode *episode = reply->property("storage").value<Storage *>()->episode();
     if (!episode) {
@@ -778,7 +786,7 @@ void TheTvDb::onEpisodeLoadFinished()
     episode->scraperLoadDone();
 }
 
-bool TheTvDb::processEpisodeData(QString msg, TvShowEpisode *episode, QList<int> infos)
+bool TheTvDb::processEpisodeData(QString msg, TvShowEpisode *episode, QList<TvShowScraperInfos> infos)
 {
     parseEpisodeXml(msg, episode, infos);
     if (shouldLoadImdb(infos) && !episode->tvShow()->imdbId().isEmpty()) {
@@ -824,7 +832,7 @@ bool TheTvDb::processEpisodeData(QString msg, TvShowEpisode *episode, QList<int>
     return false;
 }
 
-void TheTvDb::parseEpisodeXml(QString msg, TvShowEpisode *episode, QList<int> infos)
+void TheTvDb::parseEpisodeXml(QString msg, TvShowEpisode *episode, QList<TvShowScraperInfos> infos)
 {
     QDomDocument domDoc;
     domDoc.setContent(msg);
@@ -912,10 +920,10 @@ void TheTvDb::getAiredSeasonAndEpisode(QString xml, TvShowEpisode *episode, int 
     episodeNumber = episode->episode();
 }
 
-bool TheTvDb::shouldLoadImdb(QList<int> infosToLoad)
+bool TheTvDb::shouldLoadImdb(QList<TvShowScraperInfos> infosToLoad)
 {
-    QMap<int, QString> scraperSettings = Settings::instance()->customTvScraper();
-    foreach (int info, infosToLoad) {
+    QMap<TvShowScraperInfos, QString> scraperSettings = Settings::instance()->customTvScraper();
+    for (const auto info : infosToLoad) {
         if (scraperSettings.value(info) == "imdb") {
             return true;
         }
@@ -924,9 +932,9 @@ bool TheTvDb::shouldLoadImdb(QList<int> infosToLoad)
     return false;
 }
 
-bool TheTvDb::shouldLoadFromImdb(int info, QList<int> infosToLoad)
+bool TheTvDb::shouldLoadFromImdb(TvShowScraperInfos info, QList<TvShowScraperInfos> infosToLoad)
 {
-    QMap<int, QString> scraperSettings = Settings::instance()->customTvScraper();
+    QMap<TvShowScraperInfos, QString> scraperSettings = Settings::instance()->customTvScraper();
     return infosToLoad.contains(info) && scraperSettings.value(info) == "imdb";
 }
 
@@ -935,7 +943,7 @@ void TheTvDb::onImdbFinished()
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     reply->deleteLater();
     TvShow *show = reply->property("storage").value<Storage *>()->show();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<TvShowScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->showInfosToLoad();
     TvShowUpdateType updateType = static_cast<TvShowUpdateType>(reply->property("updateType").toInt());
     QList<TvShowEpisode *> updatedEpisodes = reply->property("updatedEpisodes").value<Storage *>()->episodes();
 
@@ -959,7 +967,7 @@ void TheTvDb::onImdbFinished()
     loadEpisodes(show, updatedEpisodes, infos);
 }
 
-void TheTvDb::loadEpisodes(TvShow *show, QList<TvShowEpisode *> episodes, QList<int> infosToLoad)
+void TheTvDb::loadEpisodes(TvShow *show, QList<TvShowEpisode *> episodes, QList<TvShowScraperInfos> infosToLoad)
 {
     if (episodes.isEmpty()) {
         show->scraperLoadDone();
@@ -1024,7 +1032,7 @@ void TheTvDb::onEpisodesImdbSeasonFinished()
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     reply->deleteLater();
     TvShowEpisode *episode = reply->property("storage").value<Storage *>()->episode();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<TvShowScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->showInfosToLoad();
     QList<TvShowEpisode *> episodes = reply->property("episodes").value<Storage *>()->episodes();
     TvShow *show = reply->property("show").value<Storage *>()->show();
 
@@ -1064,7 +1072,7 @@ void TheTvDb::onEpisodesImdbEpisodeFinished()
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     reply->deleteLater();
     TvShowEpisode *episode = reply->property("storage").value<Storage *>()->episode();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<TvShowScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->showInfosToLoad();
     QList<TvShowEpisode *> episodes = reply->property("episodes").value<Storage *>()->episodes();
     TvShow *show = reply->property("show").value<Storage *>()->show();
 
@@ -1081,7 +1089,10 @@ void TheTvDb::onEpisodesImdbEpisodeFinished()
     loadEpisodes(show, episodes, infos);
 }
 
-void TheTvDb::parseAndAssignImdbInfos(QString xml, TvShow *show, TvShowUpdateType updateType, QList<int> infosToLoad)
+void TheTvDb::parseAndAssignImdbInfos(QString xml,
+    TvShow *show,
+    TvShowUpdateType updateType,
+    QList<TvShowScraperInfos> infosToLoad)
 {
     m_dummyMovie->clear();
     m_imdb->parseAndAssignInfos(xml, m_dummyMovie, m_movieInfos);
@@ -1121,21 +1132,21 @@ void TheTvDb::parseAndAssignImdbInfos(QString xml, TvShow *show, TvShowUpdateTyp
         }
 
         if (shouldLoadFromImdb(TvShowScraperInfos::Genres, infosToLoad) && !m_dummyMovie->genres().isEmpty()) {
-            show->clear(QList<int>() << TvShowScraperInfos::Genres);
+            show->clear(QList<TvShowScraperInfos>() << TvShowScraperInfos::Genres);
             foreach (const QString &genre, m_dummyMovie->genres()) {
                 show->addGenre(Helper::instance()->mapGenre(genre));
             }
         }
 
         if (shouldLoadFromImdb(TvShowScraperInfos::Tags, infosToLoad) && !m_dummyMovie->tags().isEmpty()) {
-            show->clear(QList<int>() << TvShowScraperInfos::Tags);
+            show->clear(QList<TvShowScraperInfos>() << TvShowScraperInfos::Tags);
             foreach (const QString &tag, m_dummyMovie->tags()) {
                 show->addTag(tag);
             }
         }
 
         if (shouldLoadFromImdb(TvShowScraperInfos::Actors, infosToLoad) && !m_dummyMovie->actors().isEmpty()) {
-            show->clear(QList<int>() << TvShowScraperInfos::Actors);
+            show->clear(QList<TvShowScraperInfos>() << TvShowScraperInfos::Actors);
             foreach (Actor actor, m_dummyMovie->actors()) {
                 Actor a;
                 a.id = actor.id;
@@ -1155,7 +1166,7 @@ void TheTvDb::onImdbSeasonFinished()
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     reply->deleteLater();
     TvShowEpisode *episode = reply->property("storage").value<Storage *>()->episode();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<TvShowScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->showInfosToLoad();
     int episodeNumber = reply->property("episodeNumber").toInt();
 
     if (!episode) {
@@ -1195,7 +1206,7 @@ void TheTvDb::onImdbEpisodeFinished()
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     reply->deleteLater();
     TvShowEpisode *episode = reply->property("storage").value<Storage *>()->episode();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<TvShowScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->showInfosToLoad();
 
     if (!episode) {
         return;
@@ -1221,7 +1232,7 @@ QString TheTvDb::getImdbIdForEpisode(QString html, int episodeNumber)
     return QString();
 }
 
-void TheTvDb::parseAndAssignImdbInfos(QString xml, TvShowEpisode *episode, QList<int> infosToLoad)
+void TheTvDb::parseAndAssignImdbInfos(QString xml, TvShowEpisode *episode, QList<TvShowScraperInfos> infosToLoad)
 {
     m_dummyMovie->clear();
     m_imdb->parseAndAssignInfos(xml, m_dummyMovie, m_movieInfos);
@@ -1264,7 +1275,7 @@ void TheTvDb::parseAndAssignImdbInfos(QString xml, TvShowEpisode *episode, QList
     }
 
     if (shouldLoadFromImdb(TvShowScraperInfos::Actors, infosToLoad) && !m_dummyMovie->actors().isEmpty()) {
-        episode->clear(QList<int>() << TvShowScraperInfos::Actors);
+        episode->clear(QList<TvShowScraperInfos>() << TvShowScraperInfos::Actors);
         foreach (Actor actor, m_dummyMovie->actors()) {
             Actor a;
             a.id = actor.id;

--- a/scrapers/TheTvDb.h
+++ b/scrapers/TheTvDb.h
@@ -21,8 +21,11 @@ public:
     QString name() override;
     QString identifier() override;
     void search(QString searchStr) override;
-    void loadTvShowData(QString id, TvShow *show, TvShowUpdateType updateType, QList<int> infosToLoad) override;
-    void loadTvShowEpisodeData(QString id, TvShowEpisode *episode, QList<int> infosToLoad) override;
+    void loadTvShowData(QString id,
+        TvShow *show,
+        TvShowUpdateType updateType,
+        QList<TvShowScraperInfos> infosToLoad) override;
+    void loadTvShowEpisodeData(QString id, TvShowEpisode *episode, QList<TvShowScraperInfos> infosToLoad) override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
@@ -64,27 +67,34 @@ private:
     QMap<QUrl, CacheElement> m_cache;
     IMDB *m_imdb;
     Movie *m_dummyMovie;
-    QList<int> m_movieInfos;
+    QList<MovieScraperInfos> m_movieInfos;
 
     QNetworkAccessManager *qnam();
     QList<ScraperSearchResult> parseSearch(QString xml);
     void parseAndAssignInfos(QString xml,
         TvShow *show,
         TvShowUpdateType updateType,
-        QList<int> infosToLoad,
+        QList<TvShowScraperInfos> infosToLoad,
         QList<TvShowEpisode *> &updatedEpisodes);
     void parseAndAssignActors(QString xml, TvShow *show);
-    void parseAndAssignBanners(QString xml, TvShow *show, TvShowUpdateType updateType, QList<int> infosToLoad);
-    void parseAndAssignSingleEpisodeInfos(QDomElement elem, TvShowEpisode *episode, QList<int> infosToLoad);
-    void parseAndAssignImdbInfos(QString xml, TvShow *show, TvShowUpdateType updateType, QList<int> infosToLoad);
-    void parseAndAssignImdbInfos(QString xml, TvShowEpisode *episode, QList<int> infosToLoad);
-    void parseEpisodeXml(QString msg, TvShowEpisode *episode, QList<int> infos);
-    bool shouldLoadImdb(QList<int> infosToLoad);
-    bool shouldLoadFromImdb(int info, QList<int> infosToLoad);
+    void parseAndAssignBanners(QString xml,
+        TvShow *show,
+        TvShowUpdateType updateType,
+        QList<TvShowScraperInfos> infosToLoad);
+    void
+    parseAndAssignSingleEpisodeInfos(QDomElement elem, TvShowEpisode *episode, QList<TvShowScraperInfos> infosToLoad);
+    void parseAndAssignImdbInfos(QString xml,
+        TvShow *show,
+        TvShowUpdateType updateType,
+        QList<TvShowScraperInfos> infosToLoad);
+    void parseAndAssignImdbInfos(QString xml, TvShowEpisode *episode, QList<TvShowScraperInfos> infosToLoad);
+    void parseEpisodeXml(QString msg, TvShowEpisode *episode, QList<TvShowScraperInfos> infos);
+    bool shouldLoadImdb(QList<TvShowScraperInfos> infosToLoad);
+    bool shouldLoadFromImdb(TvShowScraperInfos info, QList<TvShowScraperInfos> infosToLoad);
     void getAiredSeasonAndEpisode(QString xml, TvShowEpisode *episode, int &seasonNumber, int &episodeNumber);
     QString getImdbIdForEpisode(QString html, int episodeNumber);
-    bool processEpisodeData(QString msg, TvShowEpisode *episode, QList<int> infos);
-    void loadEpisodes(TvShow *show, QList<TvShowEpisode *> episodes, QList<int> infosToLoad);
+    bool processEpisodeData(QString msg, TvShowEpisode *episode, QList<TvShowScraperInfos> infos);
+    void loadEpisodes(TvShow *show, QList<TvShowEpisode *> episodes, QList<TvShowScraperInfos> infosToLoad);
 };
 
 #endif // THETVDB_H

--- a/scrapers/UniversalMusicScraper.cpp
+++ b/scrapers/UniversalMusicScraper.cpp
@@ -117,7 +117,7 @@ void UniversalMusicScraper::onSearchArtistFinished()
     emit sigSearchDone(results);
 }
 
-void UniversalMusicScraper::loadData(QString mbId, Artist *artist, QList<int> infos)
+void UniversalMusicScraper::loadData(QString mbId, Artist *artist, QList<MusicScraperInfos> infos)
 {
     // Otherwise deleted images are showing up again
     infos.removeOne(MusicScraperInfos::ExtraFanarts);
@@ -137,7 +137,7 @@ void UniversalMusicScraper::onArtistRelsFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Artist *artist = reply->property("storage").value<Storage *>()->artist();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<MusicScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->musicInfosToLoad();
     reply->deleteLater();
     if (!artist) {
         return;
@@ -222,7 +222,7 @@ void UniversalMusicScraper::onArtistLoadFinished()
 
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Artist *artist = reply->property("storage").value<Storage *>()->artist();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<MusicScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->musicInfosToLoad();
     reply->deleteLater();
 
     if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 302
@@ -299,7 +299,7 @@ void UniversalMusicScraper::onArtistLoadFinished()
     artist->controller()->scraperLoadDone(this);
 }
 
-void UniversalMusicScraper::processDownloadElement(DownloadElement elem, Artist *artist, QList<int> infos)
+void UniversalMusicScraper::processDownloadElement(DownloadElement elem, Artist *artist, QList<MusicScraperInfos> infos)
 {
     if (elem.type.startsWith("tadb_")) {
         QJsonParseError parseError;
@@ -438,7 +438,10 @@ void UniversalMusicScraper::onSearchAlbumFinished()
     emit sigSearchDone(results);
 }
 
-void UniversalMusicScraper::loadData(QString mbAlbumId, QString mbReleaseGroupId, Album *album, QList<int> infos)
+void UniversalMusicScraper::loadData(QString mbAlbumId,
+    QString mbReleaseGroupId,
+    Album *album,
+    QList<MusicScraperInfos> infos)
 {
     album->clear(infos);
     album->setMbAlbumId(mbAlbumId);
@@ -458,7 +461,7 @@ void UniversalMusicScraper::onAlbumRelsFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Album *album = reply->property("storage").value<Storage *>()->album();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<MusicScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->musicInfosToLoad();
     reply->deleteLater();
     if (!album) {
         return;
@@ -536,7 +539,7 @@ void UniversalMusicScraper::onAlbumLoadFinished()
 
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Album *album = reply->property("storage").value<Storage *>()->album();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<MusicScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->musicInfosToLoad();
     reply->deleteLater();
     if (!album) {
         return;
@@ -610,7 +613,7 @@ void UniversalMusicScraper::onAlbumLoadFinished()
     album->controller()->scraperLoadDone(this);
 }
 
-void UniversalMusicScraper::processDownloadElement(DownloadElement elem, Album *album, QList<int> infos)
+void UniversalMusicScraper::processDownloadElement(DownloadElement elem, Album *album, QList<MusicScraperInfos> infos)
 {
     if (elem.type == "tadb_data") {
         QJsonParseError parseError;
@@ -628,7 +631,9 @@ void UniversalMusicScraper::processDownloadElement(DownloadElement elem, Album *
     }
 }
 
-void UniversalMusicScraper::parseAndAssignTadbInfos(QJsonObject document, Artist *artist, QList<int> infos)
+void UniversalMusicScraper::parseAndAssignTadbInfos(QJsonObject document,
+    Artist *artist,
+    QList<MusicScraperInfos> infos)
 {
     // The JSON document contains an array "artists". We take the first one.
     const auto tadbArtist = document.value("artists").toArray().first().toObject();
@@ -680,7 +685,9 @@ void UniversalMusicScraper::parseAndAssignTadbInfos(QJsonObject document, Artist
     }
 }
 
-void UniversalMusicScraper::parseAndAssignTadbDiscography(QJsonObject document, Artist *artist, QList<int> infos)
+void UniversalMusicScraper::parseAndAssignTadbDiscography(QJsonObject document,
+    Artist *artist,
+    QList<MusicScraperInfos> infos)
 {
     if (!shouldLoad(MusicScraperInfos::Discography, infos, artist)) {
         return;
@@ -699,7 +706,7 @@ void UniversalMusicScraper::parseAndAssignTadbDiscography(QJsonObject document, 
     }
 }
 
-void UniversalMusicScraper::parseAndAssignAmInfos(QString html, Artist *artist, QList<int> infos)
+void UniversalMusicScraper::parseAndAssignAmInfos(QString html, Artist *artist, QList<MusicScraperInfos> infos)
 {
     QRegExp rx;
     rx.setMinimal(true);
@@ -786,7 +793,7 @@ void UniversalMusicScraper::parseAndAssignAmInfos(QString html, Artist *artist, 
     }
 }
 
-void UniversalMusicScraper::parseAndAssignAmBiography(QString html, Artist *artist, QList<int> infos)
+void UniversalMusicScraper::parseAndAssignAmBiography(QString html, Artist *artist, QList<MusicScraperInfos> infos)
 {
     if (shouldLoad(MusicScraperInfos::Biography, infos, artist)) {
         QRegExp rx(R"(<div class="text" itemprop="reviewBody">(.*)</div>)");
@@ -799,7 +806,7 @@ void UniversalMusicScraper::parseAndAssignAmBiography(QString html, Artist *arti
     }
 }
 
-void UniversalMusicScraper::parseAndAssignAmDiscography(QString html, Artist *artist, QList<int> infos)
+void UniversalMusicScraper::parseAndAssignAmDiscography(QString html, Artist *artist, QList<MusicScraperInfos> infos)
 {
     if (shouldLoad(MusicScraperInfos::Discography, infos, artist)) {
         QRegExp rx("<td class=\"year\" data\\-sort\\-value=\"[^\"]*\">[\\n\\s]*(.*)[\\n\\s]*</td>[\\n\\s]*<td "
@@ -818,7 +825,7 @@ void UniversalMusicScraper::parseAndAssignAmDiscography(QString html, Artist *ar
     }
 }
 
-void UniversalMusicScraper::parseAndAssignDiscogsInfos(QString html, Artist *artist, QList<int> infos)
+void UniversalMusicScraper::parseAndAssignDiscogsInfos(QString html, Artist *artist, QList<MusicScraperInfos> infos)
 {
     QRegExp rx;
     rx.setMinimal(true);
@@ -867,7 +874,7 @@ void UniversalMusicScraper::parseAndAssignDiscogsInfos(QString html, Artist *art
     }
 }
 
-void UniversalMusicScraper::parseAndAssignMusicbrainzInfos(QString xml, Album *album, QList<int> infos)
+void UniversalMusicScraper::parseAndAssignMusicbrainzInfos(QString xml, Album *album, QList<MusicScraperInfos> infos)
 {
     QDomDocument domDoc;
     domDoc.setContent(xml);
@@ -942,7 +949,7 @@ void UniversalMusicScraper::parseAndAssignMusicbrainzInfos(QString xml, Album *a
     }
 }
 
-void UniversalMusicScraper::parseAndAssignTadbInfos(QJsonObject document, Album *album, QList<int> infos)
+void UniversalMusicScraper::parseAndAssignTadbInfos(QJsonObject document, Album *album, QList<MusicScraperInfos> infos)
 {
     // The JSON document contains an array "album". We take the first one.
     const auto tadbAlbum = document.value("album").toArray().first().toObject();
@@ -988,7 +995,7 @@ void UniversalMusicScraper::parseAndAssignTadbInfos(QJsonObject document, Album 
     }
 }
 
-void UniversalMusicScraper::parseAndAssignAmInfos(QString html, Album *album, QList<int> infos)
+void UniversalMusicScraper::parseAndAssignAmInfos(QString html, Album *album, QList<MusicScraperInfos> infos)
 {
     QRegExp rx;
     rx.setMinimal(true);
@@ -1078,7 +1085,7 @@ void UniversalMusicScraper::parseAndAssignAmInfos(QString html, Album *album, QL
     }
 }
 
-void UniversalMusicScraper::parseAndAssignDiscogsInfos(QString html, Album *album, QList<int> infos)
+void UniversalMusicScraper::parseAndAssignDiscogsInfos(QString html, Album *album, QList<MusicScraperInfos> infos)
 {
     QRegExp rx;
     rx.setMinimal(true);
@@ -1162,17 +1169,33 @@ void UniversalMusicScraper::saveSettings(QSettings &settings)
     settings.setValue("Scrapers/UniversalMusicScraper/Prefer", m_prefer);
 }
 
-QList<int> UniversalMusicScraper::scraperSupports()
+QList<MusicScraperInfos> UniversalMusicScraper::scraperSupports()
 {
-    return QList<int>() << MusicScraperInfos::Name << MusicScraperInfos::Genres << MusicScraperInfos::Styles
-                        << MusicScraperInfos::Moods << MusicScraperInfos::Formed << MusicScraperInfos::Born
-                        << MusicScraperInfos::Died << MusicScraperInfos::Disbanded << MusicScraperInfos::Biography
-                        << MusicScraperInfos::Thumb << MusicScraperInfos::Fanart << MusicScraperInfos::Logo
-                        << MusicScraperInfos::Title << MusicScraperInfos::Artist << MusicScraperInfos::Review
-                        << MusicScraperInfos::Rating << MusicScraperInfos::Year << MusicScraperInfos::CdArt
-                        << MusicScraperInfos::Cover << MusicScraperInfos::YearsActive << MusicScraperInfos::ReleaseDate
-                        << MusicScraperInfos::Year << MusicScraperInfos::ExtraFanarts << MusicScraperInfos::Discography
-                        << MusicScraperInfos::Label;
+    return {MusicScraperInfos::Name,
+        MusicScraperInfos::Genres,
+        MusicScraperInfos::Styles,
+        MusicScraperInfos::Moods,
+        MusicScraperInfos::Formed,
+        MusicScraperInfos::Born,
+        MusicScraperInfos::Died,
+        MusicScraperInfos::Disbanded,
+        MusicScraperInfos::Biography,
+        MusicScraperInfos::Thumb,
+        MusicScraperInfos::Fanart,
+        MusicScraperInfos::Logo,
+        MusicScraperInfos::Title,
+        MusicScraperInfos::Artist,
+        MusicScraperInfos::Review,
+        MusicScraperInfos::Rating,
+        MusicScraperInfos::Year,
+        MusicScraperInfos::CdArt,
+        MusicScraperInfos::Cover,
+        MusicScraperInfos::YearsActive,
+        MusicScraperInfos::ReleaseDate,
+        MusicScraperInfos::Year,
+        MusicScraperInfos::ExtraFanarts,
+        MusicScraperInfos::Discography,
+        MusicScraperInfos::Label};
 }
 
 QWidget *UniversalMusicScraper::settingsWidget()
@@ -1185,7 +1208,7 @@ QString UniversalMusicScraper::trim(QString text)
     return text.replace(QRegExp("\\s{1,}"), " ").trimmed();
 }
 
-bool UniversalMusicScraper::shouldLoad(int info, QList<int> infos, Album *album)
+bool UniversalMusicScraper::shouldLoad(MusicScraperInfos info, QList<MusicScraperInfos> infos, Album *album)
 {
     if (!infos.contains(info)) {
         return false;
@@ -1208,7 +1231,7 @@ bool UniversalMusicScraper::shouldLoad(int info, QList<int> infos, Album *album)
     return false;
 }
 
-bool UniversalMusicScraper::shouldLoad(int info, QList<int> infos, Artist *artist)
+bool UniversalMusicScraper::shouldLoad(MusicScraperInfos info, QList<MusicScraperInfos> infos, Artist *artist)
 {
     if (!infos.contains(info)) {
         return false;
@@ -1232,9 +1255,9 @@ bool UniversalMusicScraper::shouldLoad(int info, QList<int> infos, Artist *artis
     return false;
 }
 
-bool UniversalMusicScraper::infosLeft(QList<int> infos, Album *album)
+bool UniversalMusicScraper::infosLeft(QList<MusicScraperInfos> infos, Album *album)
 {
-    foreach (int info, infos) {
+    for (const auto info : infos) {
         if (shouldLoad(info, infos, album)) {
             return true;
         }
@@ -1242,9 +1265,9 @@ bool UniversalMusicScraper::infosLeft(QList<int> infos, Album *album)
     return false;
 }
 
-bool UniversalMusicScraper::infosLeft(QList<int> infos, Artist *artist)
+bool UniversalMusicScraper::infosLeft(QList<MusicScraperInfos> infos, Artist *artist)
 {
-    foreach (int info, infos) {
+    for (const auto info : infos) {
         if (shouldLoad(info, infos, artist)) {
             return true;
         }

--- a/scrapers/UniversalMusicScraper.h
+++ b/scrapers/UniversalMusicScraper.h
@@ -19,12 +19,12 @@ public:
     QString identifier() override;
     void searchAlbum(QString artistName, QString searchStr) override;
     void searchArtist(QString searchStr) override;
-    void loadData(QString mbId, Artist *artist, QList<int> infos) override;
-    void loadData(QString mbAlbumId, QString mbReleaseGroupId, Album *album, QList<int> infos) override;
+    void loadData(QString mbId, Artist *artist, QList<MusicScraperInfos> infos) override;
+    void loadData(QString mbAlbumId, QString mbReleaseGroupId, Album *album, QList<MusicScraperInfos> infos) override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
-    QList<int> scraperSupports() override;
+    QList<MusicScraperInfos> scraperSupports() override;
     QWidget *settingsWidget() override;
 
 signals:
@@ -62,24 +62,24 @@ private:
 
     QNetworkAccessManager *qnam();
     QString trim(QString text);
-    bool shouldLoad(int info, QList<int> infos, Artist *artist);
-    bool shouldLoad(int info, QList<int> infos, Album *album);
-    bool infosLeft(QList<int> infos, Artist *artist);
-    bool infosLeft(QList<int> infos, Album *album);
+    bool shouldLoad(MusicScraperInfos info, QList<MusicScraperInfos> infos, Artist *artist);
+    bool shouldLoad(MusicScraperInfos info, QList<MusicScraperInfos> infos, Album *album);
+    bool infosLeft(QList<MusicScraperInfos> infos, Artist *artist);
+    bool infosLeft(QList<MusicScraperInfos> infos, Album *album);
     void appendDownloadElement(Artist *artist, QString source, QString type, QUrl url);
     void appendDownloadElement(Album *album, QString source, QString type, QUrl url);
-    void parseAndAssignMusicbrainzInfos(QString xml, Album *album, QList<int> infos);
-    void parseAndAssignTadbInfos(QJsonObject document, Artist *artist, QList<int> infos);
-    void parseAndAssignTadbInfos(QJsonObject document, Album *album, QList<int> infos);
-    void parseAndAssignTadbDiscography(QJsonObject document, Artist *artist, QList<int> infos);
-    void parseAndAssignAmInfos(QString html, Artist *artist, QList<int> infos);
-    void parseAndAssignAmInfos(QString html, Album *album, QList<int> infos);
-    void parseAndAssignAmBiography(QString html, Artist *artist, QList<int> infos);
-    void parseAndAssignAmDiscography(QString html, Artist *artist, QList<int> infos);
-    void parseAndAssignDiscogsInfos(QString html, Artist *artist, QList<int> infos);
-    void parseAndAssignDiscogsInfos(QString html, Album *album, QList<int> infos);
-    void processDownloadElement(DownloadElement elem, Artist *artist, QList<int> infos);
-    void processDownloadElement(DownloadElement elem, Album *album, QList<int> infos);
+    void parseAndAssignMusicbrainzInfos(QString xml, Album *album, QList<MusicScraperInfos> infos);
+    void parseAndAssignTadbInfos(QJsonObject document, Artist *artist, QList<MusicScraperInfos> infos);
+    void parseAndAssignTadbInfos(QJsonObject document, Album *album, QList<MusicScraperInfos> infos);
+    void parseAndAssignTadbDiscography(QJsonObject document, Artist *artist, QList<MusicScraperInfos> infos);
+    void parseAndAssignAmInfos(QString html, Artist *artist, QList<MusicScraperInfos> infos);
+    void parseAndAssignAmInfos(QString html, Album *album, QList<MusicScraperInfos> infos);
+    void parseAndAssignAmBiography(QString html, Artist *artist, QList<MusicScraperInfos> infos);
+    void parseAndAssignAmDiscography(QString html, Artist *artist, QList<MusicScraperInfos> infos);
+    void parseAndAssignDiscogsInfos(QString html, Artist *artist, QList<MusicScraperInfos> infos);
+    void parseAndAssignDiscogsInfos(QString html, Album *album, QList<MusicScraperInfos> infos);
+    void processDownloadElement(DownloadElement elem, Artist *artist, QList<MusicScraperInfos> infos);
+    void processDownloadElement(DownloadElement elem, Album *album, QList<MusicScraperInfos> infos);
 };
 
 #endif // UNIVERSALMUSICSCRAPER_H

--- a/scrapers/VideoBuster.cpp
+++ b/scrapers/VideoBuster.cpp
@@ -54,12 +54,12 @@ bool VideoBuster::isAdult()
  * @brief Returns a list of infos available from the scraper
  * @return List of supported infos
  */
-QList<int> VideoBuster::scraperSupports()
+QList<MovieScraperInfos> VideoBuster::scraperSupports()
 {
     return m_scraperSupports;
 }
 
-QList<int> VideoBuster::scraperNativelySupports()
+QList<MovieScraperInfos> VideoBuster::scraperNativelySupports()
 {
     return m_scraperSupports;
 }
@@ -132,7 +132,7 @@ QList<ScraperSearchResult> VideoBuster::parseSearch(QString html)
  * @param infos List of infos to load
  * @see VideoBuster::loadFinished
  */
-void VideoBuster::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos)
+void VideoBuster::loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos)
 {
     movie->clear(infos);
 
@@ -153,7 +153,7 @@ void VideoBuster::loadFinished()
 {
     auto reply = static_cast<QNetworkReply *>(QObject::sender());
     Movie *movie = reply->property("storage").value<Storage *>()->movie();
-    QList<int> infos = reply->property("infosToLoad").value<Storage *>()->infosToLoad();
+    QList<MovieScraperInfos> infos = reply->property("infosToLoad").value<Storage *>()->movieInfosToLoad();
     reply->deleteLater();
     if (!movie) {
         return;
@@ -175,7 +175,7 @@ void VideoBuster::loadFinished()
  * @param movie Movie object
  * @param infos List of infos to load
  */
-void VideoBuster::parseAndAssignInfos(QString html, Movie *movie, QList<int> infos)
+void VideoBuster::parseAndAssignInfos(QString html, Movie *movie, QList<MovieScraperInfos> infos)
 {
     qDebug() << "Entered";
     movie->clear(infos);

--- a/scrapers/VideoBuster.h
+++ b/scrapers/VideoBuster.h
@@ -19,12 +19,12 @@ public:
     QString name() override;
     QString identifier() override;
     void search(QString searchStr) override;
-    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<int> infos) override;
+    void loadData(QMap<ScraperInterface *, QString> ids, Movie *movie, QList<MovieScraperInfos> infos) override;
     bool hasSettings() override;
     void loadSettings(QSettings &settings) override;
     void saveSettings(QSettings &settings) override;
-    QList<int> scraperSupports() override;
-    QList<int> scraperNativelySupports() override;
+    QList<MovieScraperInfos> scraperSupports() override;
+    QList<MovieScraperInfos> scraperNativelySupports() override;
     QWidget *settingsWidget() override;
     bool isAdult() override;
 
@@ -37,11 +37,11 @@ private slots:
 
 private:
     QNetworkAccessManager m_qnam;
-    QList<int> m_scraperSupports;
+    QList<MovieScraperInfos> m_scraperSupports;
 
     QNetworkAccessManager *qnam();
     QList<ScraperSearchResult> parseSearch(QString html);
-    void parseAndAssignInfos(QString html, Movie *movie, QList<int> infos);
+    void parseAndAssignInfos(QString html, Movie *movie, QList<MovieScraperInfos> infos);
     QString replaceEntities(const QString msg);
 };
 

--- a/settings/DataFile.cpp
+++ b/settings/DataFile.cpp
@@ -14,7 +14,7 @@
  * @param fileName Name of this file
  * @param pos Position
  */
-DataFile::DataFile(int type, QString fileName, int pos) : m_fileName{fileName}, m_pos{pos}, m_type{type}
+DataFile::DataFile(DataFileType type, QString fileName, int pos) : m_fileName{fileName}, m_pos{pos}, m_type{type}
 {
 }
 
@@ -83,7 +83,7 @@ QString DataFile::saveFileName(const QString &fileName, int season, bool stacked
  * @brief Returns the type of this file
  * @return Type
  */
-int DataFile::type() const
+DataFileType DataFile::type() const
 {
     return m_type;
 }
@@ -99,7 +99,7 @@ bool DataFile::lessThan(DataFile a, DataFile b)
     return a.pos() < b.pos();
 }
 
-int DataFile::dataFileTypeForImageType(int imageType)
+DataFileType DataFile::dataFileTypeForImageType(ImageType imageType)
 {
     switch (imageType) {
     case ImageType::MovieBackdrop: return DataFileType::MovieBackdrop;
@@ -136,6 +136,6 @@ int DataFile::dataFileTypeForImageType(int imageType)
     case ImageType::ArtistLogo: return DataFileType::ArtistLogo;
     case ImageType::ArtistThumb: return DataFileType::ArtistThumb;
 
-    default: return -1;
+    default: return DataFileType::NoType;
     }
 }

--- a/settings/DataFile.h
+++ b/settings/DataFile.h
@@ -1,6 +1,8 @@
 #ifndef DATAFILE_H
 #define DATAFILE_H
 
+#include "globals/Globals.h"
+
 #include <QString>
 
 /**
@@ -9,20 +11,20 @@
 class DataFile
 {
 public:
-    DataFile(int type, QString fileName, int pos);
-    int type() const;
+    DataFile(DataFileType type, QString fileName, int pos);
+    DataFileType type() const;
     QString fileName() const;
     int pos() const;
     QString saveFileName(const QString &fileName, int season = -1, bool stacked = false);
     static bool lessThan(DataFile a, DataFile b);
     void setFileName(QString fileName);
 
-    static int dataFileTypeForImageType(int imageType);
+    static DataFileType dataFileTypeForImageType(ImageType imageType);
 
 private:
     QString m_fileName;
     int m_pos;
-    int m_type;
+    DataFileType m_type;
 };
 
 #endif // DATAFILE_H

--- a/settings/Settings.cpp
+++ b/settings/Settings.cpp
@@ -1012,9 +1012,7 @@ void Settings::setXbmcPort(int port)
 QList<int> Settings::scraperInfos(MainWidgets widget, QString scraperId)
 {
     QString item = "unknown";
-    if (widget == MainWidgets::Concerts) {
-        item = "Concerts";
-    } else if (widget == MainWidgets::Music) {
+    if (widget == MainWidgets::Music) {
         item = "Music";
     }
     if (item == "unknown") {
@@ -1030,6 +1028,19 @@ QList<int> Settings::scraperInfos(MainWidgets widget, QString scraperId)
         infos.clear();
     }
 
+    return infos;
+}
+
+template<>
+QList<ConcertScraperInfos> Settings::scraperInfos(QString scraperId)
+{
+    QList<ConcertScraperInfos> infos;
+    for (const auto &info : settings()->value(QString("Scrapers/Movies/%1").arg(scraperId)).toString().split(",")) {
+        infos << ConcertScraperInfos(info.toInt());
+    }
+    if (!infos.isEmpty() && static_cast<int>(infos.first()) == 0) {
+        infos.clear();
+    }
     return infos;
 }
 
@@ -1062,9 +1073,7 @@ QList<TvShowScraperInfos> Settings::scraperInfos(QString scraperId)
 void Settings::setScraperInfos(MainWidgets widget, QString scraperNo, QList<int> items)
 {
     QString item = "unknown";
-    if (widget == MainWidgets::Concerts) {
-        item = "Concerts";
-    } else if (widget == MainWidgets::Music) {
+    if (widget == MainWidgets::Music) {
         item = "Music";
     }
     if (item == "unknown") {
@@ -1098,6 +1107,16 @@ void Settings::setScraperInfos(MainWidgets widget, QString scraperNo, QList<TvSh
     settings()->setValue(QString("Scrapers/TvShows/%2").arg(scraperNo), infos.join(","));
 }
 
+void Settings::setScraperInfos(MainWidgets widget, QString scraperNo, QList<ConcertScraperInfos> items)
+{
+    Q_UNUSED(widget);
+    QStringList infos;
+    infos.reserve(items.size());
+    for (const auto info : items) {
+        infos << QString::number(static_cast<int>(info));
+    }
+    settings()->setValue(QString("Scrapers/Concerts/%2").arg(scraperNo), infos.join(","));
+}
 
 bool Settings::downloadActorImages()
 {

--- a/settings/Settings.cpp
+++ b/settings/Settings.cpp
@@ -1009,28 +1009,6 @@ void Settings::setXbmcPort(int port)
     m_xbmcPort = port;
 }
 
-QList<int> Settings::scraperInfos(MainWidgets widget, QString scraperId)
-{
-    QString item = "unknown";
-    if (widget == MainWidgets::Music) {
-        item = "Music";
-    }
-    if (item == "unknown") {
-        qWarning() << "Unknown main widget";
-    }
-    QList<int> infos;
-    foreach (const QString &info,
-        settings()->value(QString("Scrapers/%1/%2").arg(item).arg(scraperId)).toString().split(",")) {
-        infos << info.toInt();
-    }
-
-    if (!infos.isEmpty() && infos.first() == 0) {
-        infos.clear();
-    }
-
-    return infos;
-}
-
 template<>
 QList<ConcertScraperInfos> Settings::scraperInfos(QString scraperId)
 {
@@ -1070,20 +1048,19 @@ QList<TvShowScraperInfos> Settings::scraperInfos(QString scraperId)
     return infos;
 }
 
-void Settings::setScraperInfos(MainWidgets widget, QString scraperNo, QList<int> items)
+template<>
+QList<MusicScraperInfos> Settings::scraperInfos(QString scraperId)
 {
-    QString item = "unknown";
-    if (widget == MainWidgets::Music) {
-        item = "Music";
+    QList<MusicScraperInfos> infos;
+    for (const auto &info : settings()->value(QString("Scrapers/Music/%1").arg(scraperId)).toString().split(",")) {
+        infos << MusicScraperInfos(info.toInt());
     }
-    if (item == "unknown") {
-        qWarning() << "Unknown widget type";
+    if (!infos.isEmpty() && static_cast<int>(infos.first()) == 0) {
+        infos.clear();
     }
-    QStringList infos;
-    foreach (int info, items)
-        infos << QString("%1").arg(info);
-    settings()->setValue(QString("Scrapers/%1/%2").arg(item).arg(scraperNo), infos.join(","));
+    return infos;
 }
+
 
 void Settings::setScraperInfos(MainWidgets widget, QString scraperNo, QList<MovieScraperInfos> items)
 {
@@ -1117,6 +1094,18 @@ void Settings::setScraperInfos(MainWidgets widget, QString scraperNo, QList<Conc
     }
     settings()->setValue(QString("Scrapers/Concerts/%2").arg(scraperNo), infos.join(","));
 }
+
+void Settings::setScraperInfos(MainWidgets widget, QString scraperNo, QList<MusicScraperInfos> items)
+{
+    Q_UNUSED(widget);
+    QStringList infos;
+    infos.reserve(items.size());
+    for (const auto info : items) {
+        infos << QString::number(static_cast<int>(info));
+    }
+    settings()->setValue(QString("Scrapers/Music/%2").arg(scraperNo), infos.join(","));
+}
+
 
 bool Settings::downloadActorImages()
 {

--- a/settings/Settings.h
+++ b/settings/Settings.h
@@ -93,8 +93,6 @@ public:
     bool donated() const;
     QString lastImagePath();
 
-    QList<int> scraperInfos(MainWidgets widget, QString scraperId);
-
     template<typename T>
     QList<T> scraperInfos(QString scraperId);
 
@@ -137,10 +135,10 @@ public:
     void setXbmcPort(int port);
     void setXbmcUser(QString user);
     void setXbmcPassword(QString password);
-    void setScraperInfos(MainWidgets widget, QString scraperNo, QList<int> items);
     void setScraperInfos(MainWidgets widget, QString scraperNo, QList<MovieScraperInfos> items);
     void setScraperInfos(MainWidgets widget, QString scraperNo, QList<TvShowScraperInfos> items);
     void setScraperInfos(MainWidgets widget, QString scraperNo, QList<ConcertScraperInfos> items);
+    void setScraperInfos(MainWidgets widget, QString scraperNo, QList<MusicScraperInfos> items);
     void setRenamePatterns(int renameType,
         QString fileNamePattern,
         QString fileNamePatternMulti,

--- a/settings/Settings.h
+++ b/settings/Settings.h
@@ -58,10 +58,12 @@ public:
     QString debugLogPath();
     bool useYoutubePluginUrls();
     bool downloadActorImages();
-    QList<DataFile> dataFiles(int type);
-    QList<DataFile> dataFilesFrodo(int type = -1);
+    QList<DataFile> dataFiles(DataFileType dataType);
+    QList<DataFile> dataFiles(ImageType dataType);
+    QList<DataFile> dataFilesFrodo(DataFileType type = DataFileType::NoType);
     bool usePlotForOutline();
-    QList<int> scraperInfos(MainWidgets widget, QString scraperId);
+    template<typename T>
+    QList<T> scraperInfos(MainWidgets widget, QString scraperId);
     void renamePatterns(int renameType,
         QString &fileNamePattern,
         QString &fileNamePatternMulti,
@@ -75,8 +77,8 @@ public:
     QList<MediaStatusColumns> mediaStatusColumns() const;
     bool tvShowDvdOrder() const;
     bool dontShowDeleteImageConfirm() const;
-    QMap<int, QString> customMovieScraper() const;
-    QMap<int, QString> customTvScraper() const;
+    QMap<MovieScraperInfos, QString> customMovieScraper() const;
+    QMap<TvShowScraperInfos, QString> customTvScraper() const;
     int currentMovieScraper() const;
     bool keepDownloadSource() const;
     bool checkForUpdates() const;
@@ -90,6 +92,11 @@ public:
     QString startupSection();
     bool donated() const;
     QString lastImagePath();
+
+    QList<int> scraperInfos(MainWidgets widget, QString scraperId);
+
+    template<typename T>
+    QList<T> scraperInfos(QString scraperId);
 
     bool autoLoadStreamDetails();
 
@@ -131,6 +138,8 @@ public:
     void setXbmcUser(QString user);
     void setXbmcPassword(QString password);
     void setScraperInfos(MainWidgets widget, QString scraperNo, QList<int> items);
+    void setScraperInfos(MainWidgets widget, QString scraperNo, QList<MovieScraperInfos> items);
+    void setScraperInfos(MainWidgets widget, QString scraperNo, QList<TvShowScraperInfos> items);
     void setRenamePatterns(int renameType,
         QString fileNamePattern,
         QString fileNamePatternMulti,
@@ -144,8 +153,8 @@ public:
     void setMediaStatusColumns(QList<MediaStatusColumns> columns);
     void setTvShowDvdOrder(bool order);
     void setDontShowDeleteImageConfirm(bool show);
-    void setCustomMovieScraper(QMap<int, QString> customMovieScraper);
-    void setCustomTvScraper(QMap<int, QString> customTvScraper);
+    void setCustomMovieScraper(QMap<MovieScraperInfos, QString> customMovieScraper);
+    void setCustomTvScraper(QMap<TvShowScraperInfos, QString> customTvScraper);
     void setCurrentMovieScraper(int current);
     void setKeepDownloadSource(bool keep);
     void setCheckForUpdates(bool check);
@@ -217,8 +226,8 @@ private:
     QList<MediaStatusColumns> m_mediaStatusColumns;
     bool m_tvShowDvdOrder;
     bool m_dontShowDeleteImageConfirm;
-    QMap<int, QString> m_customMovieScraper;
-    QMap<int, QString> m_customTvScraper;
+    QMap<MovieScraperInfos, QString> m_customMovieScraper;
+    QMap<TvShowScraperInfos, QString> m_customTvScraper;
     int m_currentMovieScraper;
     bool m_keepDownloadSource;
     bool m_checkForUpdates;

--- a/settings/Settings.h
+++ b/settings/Settings.h
@@ -140,6 +140,7 @@ public:
     void setScraperInfos(MainWidgets widget, QString scraperNo, QList<int> items);
     void setScraperInfos(MainWidgets widget, QString scraperNo, QList<MovieScraperInfos> items);
     void setScraperInfos(MainWidgets widget, QString scraperNo, QList<TvShowScraperInfos> items);
+    void setScraperInfos(MainWidgets widget, QString scraperNo, QList<ConcertScraperInfos> items);
     void setRenamePatterns(int renameType,
         QString fileNamePattern,
         QString fileNamePatternMulti,

--- a/settings/SettingsWindow.cpp
+++ b/settings/SettingsWindow.cpp
@@ -133,41 +133,41 @@ SettingsWindow::SettingsWindow(QWidget *parent) :
     connect(ui->chkEnableAdultScrapers, &QAbstractButton::clicked, this, &SettingsWindow::onShowAdultScrapers);
     // clang-format on
 
-    ui->movieNfo->setProperty("dataFileType", DataFileType::MovieNfo);
-    ui->moviePoster->setProperty("dataFileType", DataFileType::MoviePoster);
-    ui->movieBackdrop->setProperty("dataFileType", DataFileType::MovieBackdrop);
-    ui->movieCdArt->setProperty("dataFileType", DataFileType::MovieCdArt);
-    ui->movieClearArt->setProperty("dataFileType", DataFileType::MovieClearArt);
-    ui->movieLogo->setProperty("dataFileType", DataFileType::MovieLogo);
-    ui->movieBanner->setProperty("dataFileType", DataFileType::MovieBanner);
-    ui->movieThumb->setProperty("dataFileType", DataFileType::MovieThumb);
-    ui->movieSetPosterFileName->setProperty("dataFileType", DataFileType::MovieSetPoster);
-    ui->movieSetFanartFileName->setProperty("dataFileType", DataFileType::MovieSetBackdrop);
-    ui->showBackdrop->setProperty("dataFileType", DataFileType::TvShowBackdrop);
-    ui->showBanner->setProperty("dataFileType", DataFileType::TvShowBanner);
-    ui->showCharacterArt->setProperty("dataFileType", DataFileType::TvShowCharacterArt);
-    ui->showClearArt->setProperty("dataFileType", DataFileType::TvShowClearArt);
-    ui->showEpisodeNfo->setProperty("dataFileType", DataFileType::TvShowEpisodeNfo);
-    ui->showEpisodeThumbnail->setProperty("dataFileType", DataFileType::TvShowEpisodeThumb);
-    ui->showLogo->setProperty("dataFileType", DataFileType::TvShowLogo);
-    ui->showThumb->setProperty("dataFileType", DataFileType::TvShowThumb);
-    ui->showNfo->setProperty("dataFileType", DataFileType::TvShowNfo);
-    ui->showPoster->setProperty("dataFileType", DataFileType::TvShowPoster);
-    ui->showSeasonBackdrop->setProperty("dataFileType", DataFileType::TvShowSeasonBackdrop);
-    ui->showSeasonBanner->setProperty("dataFileType", DataFileType::TvShowSeasonBanner);
-    ui->showSeasonPoster->setProperty("dataFileType", DataFileType::TvShowSeasonPoster);
-    ui->showSeasonThumb->setProperty("dataFileType", DataFileType::TvShowSeasonThumb);
-    ui->concertNfo->setProperty("dataFileType", DataFileType::ConcertNfo);
-    ui->concertPoster->setProperty("dataFileType", DataFileType::ConcertPoster);
-    ui->concertBackdrop->setProperty("dataFileType", DataFileType::ConcertBackdrop);
-    ui->concertLogo->setProperty("dataFileType", DataFileType::ConcertLogo);
-    ui->concertClearArt->setProperty("dataFileType", DataFileType::ConcertClearArt);
-    ui->concertDiscArt->setProperty("dataFileType", DataFileType::ConcertCdArt);
-    ui->artistFanart->setProperty("dataFileType", DataFileType::ArtistFanart);
-    ui->artistLogo->setProperty("dataFileType", DataFileType::ArtistLogo);
-    ui->artistThumb->setProperty("dataFileType", DataFileType::ArtistThumb);
-    ui->albumThumb->setProperty("dataFileType", DataFileType::AlbumThumb);
-    ui->albumDiscArt->setProperty("dataFileType", DataFileType::AlbumCdArt);
+    ui->movieNfo->setProperty("dataFileType", static_cast<int>(DataFileType::MovieNfo));
+    ui->moviePoster->setProperty("dataFileType", static_cast<int>(DataFileType::MoviePoster));
+    ui->movieBackdrop->setProperty("dataFileType", static_cast<int>(DataFileType::MovieBackdrop));
+    ui->movieCdArt->setProperty("dataFileType", static_cast<int>(DataFileType::MovieCdArt));
+    ui->movieClearArt->setProperty("dataFileType", static_cast<int>(DataFileType::MovieClearArt));
+    ui->movieLogo->setProperty("dataFileType", static_cast<int>(DataFileType::MovieLogo));
+    ui->movieBanner->setProperty("dataFileType", static_cast<int>(DataFileType::MovieBanner));
+    ui->movieThumb->setProperty("dataFileType", static_cast<int>(DataFileType::MovieThumb));
+    ui->movieSetPosterFileName->setProperty("dataFileType", static_cast<int>(DataFileType::MovieSetPoster));
+    ui->movieSetFanartFileName->setProperty("dataFileType", static_cast<int>(DataFileType::MovieSetBackdrop));
+    ui->showBackdrop->setProperty("dataFileType", static_cast<int>(DataFileType::TvShowBackdrop));
+    ui->showBanner->setProperty("dataFileType", static_cast<int>(DataFileType::TvShowBanner));
+    ui->showCharacterArt->setProperty("dataFileType", static_cast<int>(DataFileType::TvShowCharacterArt));
+    ui->showClearArt->setProperty("dataFileType", static_cast<int>(DataFileType::TvShowClearArt));
+    ui->showEpisodeNfo->setProperty("dataFileType", static_cast<int>(DataFileType::TvShowEpisodeNfo));
+    ui->showEpisodeThumbnail->setProperty("dataFileType", static_cast<int>(DataFileType::TvShowEpisodeThumb));
+    ui->showLogo->setProperty("dataFileType", static_cast<int>(DataFileType::TvShowLogo));
+    ui->showThumb->setProperty("dataFileType", static_cast<int>(DataFileType::TvShowThumb));
+    ui->showNfo->setProperty("dataFileType", static_cast<int>(DataFileType::TvShowNfo));
+    ui->showPoster->setProperty("dataFileType", static_cast<int>(DataFileType::TvShowPoster));
+    ui->showSeasonBackdrop->setProperty("dataFileType", static_cast<int>(DataFileType::TvShowSeasonBackdrop));
+    ui->showSeasonBanner->setProperty("dataFileType", static_cast<int>(DataFileType::TvShowSeasonBanner));
+    ui->showSeasonPoster->setProperty("dataFileType", static_cast<int>(DataFileType::TvShowSeasonPoster));
+    ui->showSeasonThumb->setProperty("dataFileType", static_cast<int>(DataFileType::TvShowSeasonThumb));
+    ui->concertNfo->setProperty("dataFileType", static_cast<int>(DataFileType::ConcertNfo));
+    ui->concertPoster->setProperty("dataFileType", static_cast<int>(DataFileType::ConcertPoster));
+    ui->concertBackdrop->setProperty("dataFileType", static_cast<int>(DataFileType::ConcertBackdrop));
+    ui->concertLogo->setProperty("dataFileType", static_cast<int>(DataFileType::ConcertLogo));
+    ui->concertClearArt->setProperty("dataFileType", static_cast<int>(DataFileType::ConcertClearArt));
+    ui->concertDiscArt->setProperty("dataFileType", static_cast<int>(DataFileType::ConcertCdArt));
+    ui->artistFanart->setProperty("dataFileType", static_cast<int>(DataFileType::ArtistFanart));
+    ui->artistLogo->setProperty("dataFileType", static_cast<int>(DataFileType::ArtistLogo));
+    ui->artistThumb->setProperty("dataFileType", static_cast<int>(DataFileType::ArtistThumb));
+    ui->albumThumb->setProperty("dataFileType", static_cast<int>(DataFileType::AlbumThumb));
+    ui->albumDiscArt->setProperty("dataFileType", static_cast<int>(DataFileType::AlbumCdArt));
 
 #ifdef Q_OS_MAC
     ui->btnCancel->setVisible(false);
@@ -341,11 +341,11 @@ void SettingsWindow::loadSettings()
     ui->movieSetArtworkDir->setText(m_settings->movieSetArtworkDirectory());
     onComboMovieSetArtworkChanged();
 
-    foreach (QLineEdit *lineEdit, findChildren<QLineEdit *>()) {
+    for (auto lineEdit : findChildren<QLineEdit *>()) {
         if (lineEdit->property("dataFileType").isNull()) {
             continue;
         }
-        int dataFileType = lineEdit->property("dataFileType").toInt();
+        DataFileType dataFileType = DataFileType(lineEdit->property("dataFileType").toInt());
         QList<DataFile> dataFiles = m_settings->dataFiles(dataFileType);
         QStringList filenames;
         foreach (DataFile dataFile, dataFiles)
@@ -353,20 +353,33 @@ void SettingsWindow::loadSettings()
         lineEdit->setText(filenames.join(","));
     }
 
-    QList<int> infos =
-        QList<int>() << MovieScraperInfos::Title << MovieScraperInfos::Set << MovieScraperInfos::Tagline
-                     << MovieScraperInfos::Rating << MovieScraperInfos::Released << MovieScraperInfos::Runtime
-                     << MovieScraperInfos::Director << MovieScraperInfos::Writer << MovieScraperInfos::Certification
-                     << MovieScraperInfos::Trailer << MovieScraperInfos::Overview << MovieScraperInfos::Poster
-                     << MovieScraperInfos::Backdrop << MovieScraperInfos::Actors << MovieScraperInfos::Genres
-                     << MovieScraperInfos::Studios << MovieScraperInfos::Countries << MovieScraperInfos::Logo
-                     << MovieScraperInfos::ClearArt << MovieScraperInfos::CdArt << MovieScraperInfos::Banner
-                     << MovieScraperInfos::Thumb;
+    QList<MovieScraperInfos> infos = {MovieScraperInfos::Title,
+        MovieScraperInfos::Set,
+        MovieScraperInfos::Tagline,
+        MovieScraperInfos::Rating,
+        MovieScraperInfos::Released,
+        MovieScraperInfos::Runtime,
+        MovieScraperInfos::Director,
+        MovieScraperInfos::Writer,
+        MovieScraperInfos::Certification,
+        MovieScraperInfos::Trailer,
+        MovieScraperInfos::Overview,
+        MovieScraperInfos::Poster,
+        MovieScraperInfos::Backdrop,
+        MovieScraperInfos::Actors,
+        MovieScraperInfos::Genres,
+        MovieScraperInfos::Studios,
+        MovieScraperInfos::Countries,
+        MovieScraperInfos::Logo,
+        MovieScraperInfos::ClearArt,
+        MovieScraperInfos::CdArt,
+        MovieScraperInfos::Banner,
+        MovieScraperInfos::Thumb};
 
     ui->customScraperTable->clearContents();
     ui->customScraperTable->setRowCount(0);
 
-    foreach (const int &info, infos) {
+    for (const auto info : infos) {
         int row = ui->customScraperTable->rowCount();
         ui->customScraperTable->insertRow(row);
         ui->customScraperTable->setItem(row, 0, new QTableWidgetItem(titleForMovieScraperInfo(info)));
@@ -374,22 +387,22 @@ void SettingsWindow::loadSettings()
     }
 
 
-    QList<int> tvInfos = QList<int>() << TvShowScraperInfos::Title         //
-                                      << TvShowScraperInfos::Rating        //
-                                      << TvShowScraperInfos::FirstAired    //
-                                      << TvShowScraperInfos::Runtime       //
-                                      << TvShowScraperInfos::Director      //
-                                      << TvShowScraperInfos::Writer        //
-                                      << TvShowScraperInfos::Certification //
-                                      << TvShowScraperInfos::Overview      //
-                                      << TvShowScraperInfos::Genres        //
-                                      << TvShowScraperInfos::Tags          //
-                                      << TvShowScraperInfos::Actors;
+    QList<TvShowScraperInfos> tvInfos = {TvShowScraperInfos::Title,
+        TvShowScraperInfos::Rating,
+        TvShowScraperInfos::FirstAired,
+        TvShowScraperInfos::Runtime,
+        TvShowScraperInfos::Director,
+        TvShowScraperInfos::Writer,
+        TvShowScraperInfos::Certification,
+        TvShowScraperInfos::Overview,
+        TvShowScraperInfos::Genres,
+        TvShowScraperInfos::Tags,
+        TvShowScraperInfos::Actors};
 
     ui->tvScraperTable->clearContents();
     ui->tvScraperTable->setRowCount(0);
 
-    foreach (const int &info, tvInfos) {
+    for (const auto info : tvInfos) {
         int row = ui->tvScraperTable->rowCount();
         ui->tvScraperTable->insertRow(row);
         ui->tvScraperTable->setItem(row, 0, new QTableWidgetItem(titleForTvScraperInfo(info)));
@@ -411,7 +424,7 @@ void SettingsWindow::saveSettings()
             continue;
         }
         int pos = 0;
-        int dataFileType = lineEdit->property("dataFileType").toInt();
+        DataFileType dataFileType = DataFileType(lineEdit->property("dataFileType").toInt());
         QStringList filenames = lineEdit->text().split(",", QString::SkipEmptyParts);
         foreach (const QString &filename, filenames) {
             DataFile df(dataFileType, filename.trimmed(), pos++);
@@ -482,20 +495,20 @@ void SettingsWindow::saveSettings()
     m_settings->setMovieSetArtworkDirectory(ui->movieSetArtworkDir->text());
 
     // Custom movie scraper
-    QMap<int, QString> customMovieScraper;
+    QMap<MovieScraperInfos, QString> customMovieScraper;
     for (int row = 0, n = ui->customScraperTable->rowCount(); row < n; ++row) {
         auto box = static_cast<QComboBox *>(ui->customScraperTable->cellWidget(row, 1));
-        int info = box->itemData(0, Qt::UserRole + 1).toInt();
+        MovieScraperInfos info = MovieScraperInfos(box->itemData(0, Qt::UserRole + 1).toInt());
         QString scraper = box->itemData(box->currentIndex()).toString();
         customMovieScraper.insert(info, scraper);
     }
     m_settings->setCustomMovieScraper(customMovieScraper);
 
     // tv scraper
-    QMap<int, QString> tvScraper;
+    QMap<TvShowScraperInfos, QString> tvScraper;
     for (int row = 0, n = ui->tvScraperTable->rowCount(); row < n; ++row) {
         auto box = static_cast<QComboBox *>(ui->tvScraperTable->cellWidget(row, 1));
-        int info = box->itemData(0, Qt::UserRole + 1).toInt();
+        TvShowScraperInfos info = TvShowScraperInfos(box->itemData(0, Qt::UserRole + 1).toInt());
         QString scraper = box->itemData(box->currentIndex()).toString();
         tvScraper.insert(info, scraper);
     }
@@ -723,7 +736,7 @@ void SettingsWindow::onTemplateUninstalled(ExportTemplate *exportTemplate, bool 
     }
 }
 
-QComboBox *SettingsWindow::comboForMovieScraperInfo(const int &info)
+QComboBox *SettingsWindow::comboForMovieScraperInfo(const MovieScraperInfos info)
 {
     QString currentScraper = m_settings->customMovieScraper().value(info, "notset");
 
@@ -731,7 +744,7 @@ QComboBox *SettingsWindow::comboForMovieScraperInfo(const int &info)
     int index = 0;
     if (info != MovieScraperInfos::Title) {
         box->addItem(tr("Don't use"), "");
-        box->setItemData(0, info, Qt::UserRole + 1);
+        box->setItemData(0, static_cast<int>(info), Qt::UserRole + 1);
         index = 1;
     }
     foreach (ScraperInterface *scraper, Manager::instance()->scrapers()) {
@@ -740,7 +753,7 @@ QComboBox *SettingsWindow::comboForMovieScraperInfo(const int &info)
         }
         if (scraper->scraperNativelySupports().contains(info)) {
             box->addItem(scraper->name(), scraper->identifier());
-            box->setItemData(index, info, Qt::UserRole + 1);
+            box->setItemData(index, static_cast<int>(info), Qt::UserRole + 1);
             if (scraper->identifier() == currentScraper || (currentScraper == "notset" && index == 1)) {
                 box->setCurrentIndex(index);
             }
@@ -748,15 +761,19 @@ QComboBox *SettingsWindow::comboForMovieScraperInfo(const int &info)
         }
     }
 
-    QList<int> images;
-    images << MovieScraperInfos::Backdrop << MovieScraperInfos::Logo << MovieScraperInfos::ClearArt
-           << MovieScraperInfos::CdArt << MovieScraperInfos::Banner << MovieScraperInfos::Thumb
-           << MovieScraperInfos::Poster;
+    QList<MovieScraperInfos> images{MovieScraperInfos::Backdrop,
+        MovieScraperInfos::Logo,
+        MovieScraperInfos::ClearArt,
+        MovieScraperInfos::CdArt,
+        MovieScraperInfos::Banner,
+        MovieScraperInfos::Thumb,
+        MovieScraperInfos::Poster};
+
     if (images.contains(info)) {
-        foreach (ImageProviderInterface *img, Manager::instance()->imageProviders()) {
+        for (const auto img : Manager::instance()->imageProviders()) {
             if (img->identifier() == "images.fanarttv") {
                 box->addItem(img->name(), img->identifier());
-                box->setItemData(index, info, Qt::UserRole + 1);
+                box->setItemData(index, static_cast<int>(info), Qt::UserRole + 1);
                 if (img->identifier() == currentScraper || (currentScraper == "notset" && index == 1)) {
                     box->setCurrentIndex(index);
                 }
@@ -769,7 +786,7 @@ QComboBox *SettingsWindow::comboForMovieScraperInfo(const int &info)
     return box;
 }
 
-QString SettingsWindow::titleForMovieScraperInfo(const int &info)
+QString SettingsWindow::titleForMovieScraperInfo(MovieScraperInfos info)
 {
     switch (info) {
     case MovieScraperInfos::Title: return tr("Title");
@@ -799,16 +816,16 @@ QString SettingsWindow::titleForMovieScraperInfo(const int &info)
     }
 }
 
-QComboBox *SettingsWindow::comboForTvScraperInfo(const int &info)
+QComboBox *SettingsWindow::comboForTvScraperInfo(const TvShowScraperInfos info)
 {
     QString currentScraper = m_settings->customTvScraper().value(info, "notset");
 
     auto box = new QComboBox();
     box->addItem("The TV DB", "tvdb");
-    box->setItemData(0, info, Qt::UserRole + 1);
+    box->setItemData(0, static_cast<int>(info), Qt::UserRole + 1);
 
     box->addItem("IMDB", "imdb");
-    box->setItemData(1, info, Qt::UserRole + 1);
+    box->setItemData(1, static_cast<int>(info), Qt::UserRole + 1);
 
     if (currentScraper == "imdb") {
         box->setCurrentIndex(1);
@@ -817,7 +834,7 @@ QComboBox *SettingsWindow::comboForTvScraperInfo(const int &info)
     return box;
 }
 
-QString SettingsWindow::titleForTvScraperInfo(const int &info)
+QString SettingsWindow::titleForTvScraperInfo(const TvShowScraperInfos info)
 {
     switch (info) {
     case TvShowScraperInfos::Title: return tr("Title");

--- a/settings/SettingsWindow.h
+++ b/settings/SettingsWindow.h
@@ -67,10 +67,10 @@ private:
     void loadSettings();
     void saveSettings();
     void loadRemoteTemplates();
-    QComboBox *comboForMovieScraperInfo(const int &info);
-    QString titleForMovieScraperInfo(const int &info);
-    QComboBox *comboForTvScraperInfo(const int &info);
-    QString titleForTvScraperInfo(const int &info);
+    QComboBox *comboForMovieScraperInfo(MovieScraperInfos info);
+    QString titleForMovieScraperInfo(MovieScraperInfos info);
+    QComboBox *comboForTvScraperInfo(TvShowScraperInfos info);
+    QString titleForTvScraperInfo(TvShowScraperInfos info);
 };
 
 #endif // SETTINGSWINDOW_H

--- a/smallWidgets/ClosableImage.cpp
+++ b/smallWidgets/ClosableImage.cpp
@@ -426,12 +426,12 @@ QString ClosableImage::title() const
     return m_title;
 }
 
-void ClosableImage::setImageType(const int &type)
+void ClosableImage::setImageType(ImageType type)
 {
     m_imageType = type;
 }
 
-int ClosableImage::imageType() const
+ImageType ClosableImage::imageType() const
 {
     return m_imageType;
 }

--- a/smallWidgets/ClosableImage.h
+++ b/smallWidgets/ClosableImage.h
@@ -1,6 +1,8 @@
 #ifndef CLOSABLEIMAGE_H
 #define CLOSABLEIMAGE_H
 
+#include "globals/Globals.h"
+
 #include <QLabel>
 #include <QMouseEvent>
 #include <QMovie>
@@ -37,8 +39,8 @@ public:
     void setLoading(const bool &loading);
     void setTitle(const QString &text);
     QString title() const;
-    void setImageType(const int &type);
-    int imageType() const;
+    void setImageType(ImageType type);
+    ImageType imageType() const;
 
     bool showCapture() const;
     void setShowCapture(bool showCapture);
@@ -47,7 +49,7 @@ signals:
     void sigClose();
     void sigCapture();
     void clicked();
-    void sigImageDropped(int, QUrl);
+    void sigImageDropped(ImageType, QUrl);
 
 protected:
     void paintEvent(QPaintEvent *event) override;
@@ -87,7 +89,7 @@ private:
     QRect captureRect();
     bool confirmDeleteImage();
     void drawTitle(QPainter &p);
-    int m_imageType;
+    ImageType m_imageType;
     QPixmap m_emptyPixmap;
 };
 

--- a/tvShows/TvShowMultiScrapeDialog.cpp
+++ b/tvShows/TvShowMultiScrapeDialog.cpp
@@ -30,28 +30,28 @@ TvShowMultiScrapeDialog::TvShowMultiScrapeDialog(QWidget *parent) : QDialog(pare
     m_currentShow = nullptr;
     m_currentEpisode = nullptr;
 
-    ui->chkActors->setMyData(TvShowScraperInfos::Actors);
-    ui->chkBanner->setMyData(TvShowScraperInfos::Banner);
-    ui->chkCertification->setMyData(TvShowScraperInfos::Certification);
-    ui->chkDirector->setMyData(TvShowScraperInfos::Director);
-    ui->chkFanart->setMyData(TvShowScraperInfos::Fanart);
-    ui->chkFirstAired->setMyData(TvShowScraperInfos::FirstAired);
-    ui->chkGenres->setMyData(TvShowScraperInfos::Genres);
-    ui->chkTags->setMyData(TvShowScraperInfos::Tags);
-    ui->chkNetwork->setMyData(TvShowScraperInfos::Network);
-    ui->chkOverview->setMyData(TvShowScraperInfos::Overview);
-    ui->chkPoster->setMyData(TvShowScraperInfos::Poster);
-    ui->chkRating->setMyData(TvShowScraperInfos::Rating);
-    ui->chkSeasonPoster->setMyData(TvShowScraperInfos::SeasonPoster);
-    ui->chkSeasonFanart->setMyData(TvShowScraperInfos::SeasonBackdrop);
-    ui->chkSeasonBanner->setMyData(TvShowScraperInfos::SeasonBanner);
-    ui->chkSeasonThumb->setMyData(TvShowScraperInfos::SeasonThumb);
-    ui->chkEpisodeThumbnail->setMyData(TvShowScraperInfos::Thumbnail);
-    ui->chkTitle->setMyData(TvShowScraperInfos::Title);
-    ui->chkWriter->setMyData(TvShowScraperInfos::Writer);
-    ui->chkExtraArts->setMyData(TvShowScraperInfos::ExtraArts);
-    ui->chkRuntime->setMyData(TvShowScraperInfos::Runtime);
-    ui->chkStatus->setMyData(TvShowScraperInfos::Status);
+    ui->chkActors->setMyData(static_cast<int>(TvShowScraperInfos::Actors));
+    ui->chkBanner->setMyData(static_cast<int>(TvShowScraperInfos::Banner));
+    ui->chkCertification->setMyData(static_cast<int>(TvShowScraperInfos::Certification));
+    ui->chkDirector->setMyData(static_cast<int>(TvShowScraperInfos::Director));
+    ui->chkFanart->setMyData(static_cast<int>(TvShowScraperInfos::Fanart));
+    ui->chkFirstAired->setMyData(static_cast<int>(TvShowScraperInfos::FirstAired));
+    ui->chkGenres->setMyData(static_cast<int>(TvShowScraperInfos::Genres));
+    ui->chkTags->setMyData(static_cast<int>(TvShowScraperInfos::Tags));
+    ui->chkNetwork->setMyData(static_cast<int>(TvShowScraperInfos::Network));
+    ui->chkOverview->setMyData(static_cast<int>(TvShowScraperInfos::Overview));
+    ui->chkPoster->setMyData(static_cast<int>(TvShowScraperInfos::Poster));
+    ui->chkRating->setMyData(static_cast<int>(TvShowScraperInfos::Rating));
+    ui->chkSeasonPoster->setMyData(static_cast<int>(TvShowScraperInfos::SeasonPoster));
+    ui->chkSeasonFanart->setMyData(static_cast<int>(TvShowScraperInfos::SeasonBackdrop));
+    ui->chkSeasonBanner->setMyData(static_cast<int>(TvShowScraperInfos::SeasonBanner));
+    ui->chkSeasonThumb->setMyData(static_cast<int>(TvShowScraperInfos::SeasonThumb));
+    ui->chkEpisodeThumbnail->setMyData(static_cast<int>(TvShowScraperInfos::Thumbnail));
+    ui->chkTitle->setMyData(static_cast<int>(TvShowScraperInfos::Title));
+    ui->chkWriter->setMyData(static_cast<int>(TvShowScraperInfos::Writer));
+    ui->chkExtraArts->setMyData(static_cast<int>(TvShowScraperInfos::ExtraArts));
+    ui->chkRuntime->setMyData(static_cast<int>(TvShowScraperInfos::Runtime));
+    ui->chkStatus->setMyData(static_cast<int>(TvShowScraperInfos::Status));
 
     foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
         if (box->myData().toInt() > 0) {
@@ -170,9 +170,9 @@ void TvShowMultiScrapeDialog::onChkToggled()
 {
     m_infosToLoad.clear();
     bool allToggled = true;
-    foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
+    for (const auto box : ui->groupBox->findChildren<MyCheckBox *>()) {
         if (box->isEnabled() && box->isChecked() && box->myData().toInt() > 0) {
-            m_infosToLoad.append(box->myData().toInt());
+            m_infosToLoad.append(TvShowScraperInfos(box->myData().toInt()));
         }
         if (box->isEnabled() && !box->isChecked() && box->myData().toInt() > 0) {
             allToggled = false;
@@ -379,23 +379,25 @@ void TvShowMultiScrapeDialog::onInfoLoadDone(TvShow *show)
         show->fillMissingEpisodes();
     }
 
-    QList<int> types;
-    types << ImageType::TvShowClearArt << ImageType::TvShowLogos << ImageType::TvShowCharacterArt
-          << ImageType::TvShowThumb << ImageType::TvShowSeasonThumb;
+    QList<ImageType> types = {ImageType::TvShowClearArt,
+        ImageType::TvShowLogos,
+        ImageType::TvShowCharacterArt,
+        ImageType::TvShowThumb,
+        ImageType::TvShowSeasonThumb};
     if (!show->tvdbId().isEmpty() && m_infosToLoad.contains(TvShowScraperInfos::ExtraArts)) {
         Manager::instance()->fanartTv()->tvShowImages(show, show->tvdbId(), types);
         connect(Manager::instance()->fanartTv(),
-            SIGNAL(sigImagesLoaded(TvShow *, QMap<int, QList<Poster>>)),
+            SIGNAL(sigImagesLoaded(TvShow *, QMap<ImageType, QList<Poster>>)),
             this,
-            SLOT(onLoadDone(TvShow *, QMap<int, QList<Poster>>)),
+            SLOT(onLoadDone(TvShow *, QMap<ImageType, QList<Poster>>)),
             Qt::UniqueConnection);
     } else {
-        QMap<int, QList<Poster>> map;
+        QMap<ImageType, QList<Poster>> map;
         onLoadDone(show, map);
     }
 }
 
-void TvShowMultiScrapeDialog::onLoadDone(TvShow *show, QMap<int, QList<Poster>> posters)
+void TvShowMultiScrapeDialog::onLoadDone(TvShow *show, QMap<ImageType, QList<Poster>> posters)
 {
     if (!m_executed) {
         return;
@@ -422,7 +424,7 @@ void TvShowMultiScrapeDialog::onLoadDone(TvShow *show, QMap<int, QList<Poster>> 
     }
 
     QList<int> thumbsForSeasons;
-    QMapIterator<int, QList<Poster>> it(posters);
+    QMapIterator<ImageType, QList<Poster>> it(posters);
     while (it.hasNext()) {
         it.next();
         if (m_infosToLoad.contains(TvShowScraperInfos::ExtraArts) && it.key() == ImageType::TvShowClearArt
@@ -491,7 +493,7 @@ void TvShowMultiScrapeDialog::onLoadDone(TvShow *show, QMap<int, QList<Poster>> 
     }
 }
 
-void TvShowMultiScrapeDialog::addDownload(int imageType, QUrl url, TvShow *show, int season)
+void TvShowMultiScrapeDialog::addDownload(ImageType imageType, QUrl url, TvShow *show, int season)
 {
     DownloadManagerElement d;
     d.imageType = imageType;
@@ -501,7 +503,7 @@ void TvShowMultiScrapeDialog::addDownload(int imageType, QUrl url, TvShow *show,
     m_downloadManager->addDownload(d);
 }
 
-void TvShowMultiScrapeDialog::addDownload(int imageType, QUrl url, TvShow *show, Actor *actor)
+void TvShowMultiScrapeDialog::addDownload(ImageType imageType, QUrl url, TvShow *show, Actor *actor)
 {
     DownloadManagerElement d;
     d.imageType = imageType;
@@ -511,7 +513,7 @@ void TvShowMultiScrapeDialog::addDownload(int imageType, QUrl url, TvShow *show,
     m_downloadManager->addDownload(d);
 }
 
-void TvShowMultiScrapeDialog::addDownload(int imageType, QUrl url, TvShowEpisode *episode)
+void TvShowMultiScrapeDialog::addDownload(ImageType imageType, QUrl url, TvShowEpisode *episode)
 {
     DownloadManagerElement d;
     d.imageType = imageType;

--- a/tvShows/TvShowMultiScrapeDialog.h
+++ b/tvShows/TvShowMultiScrapeDialog.h
@@ -44,7 +44,7 @@ private slots:
     void scrapeNext();
     void onInfoLoadDone(TvShow *show);
     void onEpisodeLoadDone();
-    void onLoadDone(TvShow *show, QMap<int, QList<Poster>> posters);
+    void onLoadDone(TvShow *show, QMap<ImageType, QList<Poster>> posters);
     void onDownloadFinished(DownloadManagerElement elem);
     void onDownloadsFinished();
     void onChkDvdOrderToggled();
@@ -54,7 +54,7 @@ private:
     QList<TvShow *> m_shows;
     QList<TvShowEpisode *> m_episodes;
     bool m_executed;
-    QList<int> m_infosToLoad;
+    QList<TvShowScraperInfos> m_infosToLoad;
     QQueue<TvShow *> m_showQueue;
     QQueue<TvShowEpisode *> m_episodeQueue;
     QPointer<TvShow> m_currentShow;
@@ -64,9 +64,9 @@ private:
     QMap<QString, QString> m_showIds;
 
     void setChkBoxesEnabled();
-    void addDownload(int imageType, QUrl url, TvShow *show, int season = -1);
-    void addDownload(int imageType, QUrl url, TvShow *show, Actor *actor);
-    void addDownload(int imageType, QUrl url, TvShowEpisode *episode);
+    void addDownload(ImageType imageType, QUrl url, TvShow *show, int season = -1);
+    void addDownload(ImageType imageType, QUrl url, TvShow *show, Actor *actor);
+    void addDownload(ImageType imageType, QUrl url, TvShowEpisode *episode);
 };
 
 #endif // TVSHOWMULTISCRAPEDIALOG_H

--- a/tvShows/TvShowSearch.cpp
+++ b/tvShows/TvShowSearch.cpp
@@ -2,6 +2,7 @@
 #include "ui_TvShowSearch.h"
 
 #include "globals/Manager.h"
+#include "settings/Settings.h"
 #include "smallWidgets/MyCheckBox.h"
 
 /**
@@ -33,27 +34,27 @@ TvShowSearch::TvShowSearch(QWidget *parent) : QDialog(parent), ui(new Ui::TvShow
     connect(ui->chkDvdOrder,  &QAbstractButton::clicked,        this, &TvShowSearch::onChkDvdOrderToggled);
     // clang-format on
 
-    ui->chkActors->setMyData(TvShowScraperInfos::Actors);
-    ui->chkBanner->setMyData(TvShowScraperInfos::Banner);
-    ui->chkCertification->setMyData(TvShowScraperInfos::Certification);
-    ui->chkDirector->setMyData(TvShowScraperInfos::Director);
-    ui->chkFanart->setMyData(TvShowScraperInfos::Fanart);
-    ui->chkFirstAired->setMyData(TvShowScraperInfos::FirstAired);
-    ui->chkGenres->setMyData(TvShowScraperInfos::Genres);
-    ui->chkTags->setMyData(TvShowScraperInfos::Tags);
-    ui->chkNetwork->setMyData(TvShowScraperInfos::Network);
-    ui->chkOverview->setMyData(TvShowScraperInfos::Overview);
-    ui->chkPoster->setMyData(TvShowScraperInfos::Poster);
-    ui->chkRating->setMyData(TvShowScraperInfos::Rating);
-    ui->chkSeasonPoster->setMyData(TvShowScraperInfos::SeasonPoster);
-    ui->chkSeasonBackdrop->setMyData(TvShowScraperInfos::SeasonBackdrop);
-    ui->chkSeasonBanner->setMyData(TvShowScraperInfos::SeasonBanner);
-    ui->chkThumbnail->setMyData(TvShowScraperInfos::Thumbnail);
-    ui->chkTitle->setMyData(TvShowScraperInfos::Title);
-    ui->chkWriter->setMyData(TvShowScraperInfos::Writer);
-    ui->chkExtraArts->setMyData(TvShowScraperInfos::ExtraArts);
-    ui->chkRuntime->setMyData(TvShowScraperInfos::Runtime);
-    ui->chkStatus->setMyData(TvShowScraperInfos::Status);
+    ui->chkActors->setMyData(static_cast<int>(TvShowScraperInfos::Actors));
+    ui->chkBanner->setMyData(static_cast<int>(TvShowScraperInfos::Banner));
+    ui->chkCertification->setMyData(static_cast<int>(TvShowScraperInfos::Certification));
+    ui->chkDirector->setMyData(static_cast<int>(TvShowScraperInfos::Director));
+    ui->chkFanart->setMyData(static_cast<int>(TvShowScraperInfos::Fanart));
+    ui->chkFirstAired->setMyData(static_cast<int>(TvShowScraperInfos::FirstAired));
+    ui->chkGenres->setMyData(static_cast<int>(TvShowScraperInfos::Genres));
+    ui->chkTags->setMyData(static_cast<int>(TvShowScraperInfos::Tags));
+    ui->chkNetwork->setMyData(static_cast<int>(TvShowScraperInfos::Network));
+    ui->chkOverview->setMyData(static_cast<int>(TvShowScraperInfos::Overview));
+    ui->chkPoster->setMyData(static_cast<int>(TvShowScraperInfos::Poster));
+    ui->chkRating->setMyData(static_cast<int>(TvShowScraperInfos::Rating));
+    ui->chkSeasonPoster->setMyData(static_cast<int>(TvShowScraperInfos::SeasonPoster));
+    ui->chkSeasonBackdrop->setMyData(static_cast<int>(TvShowScraperInfos::SeasonBackdrop));
+    ui->chkSeasonBanner->setMyData(static_cast<int>(TvShowScraperInfos::SeasonBanner));
+    ui->chkThumbnail->setMyData(static_cast<int>(TvShowScraperInfos::Thumbnail));
+    ui->chkTitle->setMyData(static_cast<int>(TvShowScraperInfos::Title));
+    ui->chkWriter->setMyData(static_cast<int>(TvShowScraperInfos::Writer));
+    ui->chkExtraArts->setMyData(static_cast<int>(TvShowScraperInfos::ExtraArts));
+    ui->chkRuntime->setMyData(static_cast<int>(TvShowScraperInfos::Runtime));
+    ui->chkStatus->setMyData(static_cast<int>(TvShowScraperInfos::Status));
 
     foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
         if (box->myData().toInt() > 0) {
@@ -200,7 +201,7 @@ void TvShowSearch::onChkToggled()
     bool allToggled = true;
     foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
         if (box->isChecked() && box->myData().toInt() > 0 && box->isEnabled()) {
-            m_infosToLoad.append(box->myData().toInt());
+            m_infosToLoad.append(TvShowScraperInfos(box->myData().toInt()));
         }
         if (!box->isChecked() && box->myData().toInt() > 0 && box->isEnabled()) {
             allToggled = false;
@@ -227,7 +228,7 @@ void TvShowSearch::onChkAllToggled()
     onChkToggled();
 }
 
-QList<int> TvShowSearch::infosToLoad()
+QList<TvShowScraperInfos> TvShowSearch::infosToLoad()
 {
     return m_infosToLoad;
 }
@@ -257,7 +258,8 @@ void TvShowSearch::onComboIndexChanged()
     } else {
         Settings::instance()->setTvShowUpdateOption(ui->comboUpdate->currentIndex());
     }
-    QList<int> infos = Settings::instance()->scraperInfos(MainWidgets::TvShows, QString::number(scraperNo));
+    QList<TvShowScraperInfos> infos =
+        Settings::instance()->scraperInfos<TvShowScraperInfos>(QString::number(scraperNo));
 
     TvShowUpdateType type = updateType();
     if (type == UpdateShow) {
@@ -307,8 +309,10 @@ void TvShowSearch::onComboIndexChanged()
         ui->chkStatus->setEnabled(false);
     }
 
-    foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>())
-        box->setChecked((infos.contains(box->myData().toInt()) || infos.isEmpty()) && box->isEnabled());
+    for (auto box : ui->groupBox->findChildren<MyCheckBox *>()) {
+        box->setChecked(
+            (infos.contains(TvShowScraperInfos(box->myData().toInt())) || infos.isEmpty()) && box->isEnabled());
+    }
     onChkToggled();
 }
 

--- a/tvShows/TvShowSearch.h
+++ b/tvShows/TvShowSearch.h
@@ -21,7 +21,7 @@ public:
     explicit TvShowSearch(QWidget *parent = nullptr);
     ~TvShowSearch() override;
     QString scraperId();
-    QList<int> infosToLoad();
+    QList<TvShowScraperInfos> infosToLoad();
     void setSearchType(TvShowType type);
     TvShowUpdateType updateType();
 
@@ -43,7 +43,7 @@ private:
     Ui::TvShowSearch *ui;
     void clear();
     QString m_scraperId;
-    QList<int> m_infosToLoad;
+    QList<TvShowScraperInfos> m_infosToLoad;
     TvShowType m_searchType;
 };
 

--- a/tvShows/TvShowSearchEpisode.cpp
+++ b/tvShows/TvShowSearchEpisode.cpp
@@ -19,15 +19,15 @@ TvShowSearchEpisode::TvShowSearchEpisode(QWidget *parent) : QWidget(parent), ui(
     connect(ui->searchString, &QLineEdit::returnPressed, this, &TvShowSearchEpisode::onSearch);
     connect(ui->results, &QTableWidget::itemClicked, this, &TvShowSearchEpisode::onResultClicked);
 
-    ui->chkCertification->setMyData(TvShowScraperInfos::Certification);
-    ui->chkDirector->setMyData(TvShowScraperInfos::Director);
-    ui->chkFirstAired->setMyData(TvShowScraperInfos::FirstAired);
-    ui->chkNetwork->setMyData(TvShowScraperInfos::Network);
-    ui->chkOverview->setMyData(TvShowScraperInfos::Overview);
-    ui->chkRating->setMyData(TvShowScraperInfos::Rating);
-    ui->chkThumbnail->setMyData(TvShowScraperInfos::Thumbnail);
-    ui->chkTitle->setMyData(TvShowScraperInfos::Title);
-    ui->chkWriter->setMyData(TvShowScraperInfos::Writer);
+    ui->chkCertification->setMyData(static_cast<int>(TvShowScraperInfos::Certification));
+    ui->chkDirector->setMyData(static_cast<int>(TvShowScraperInfos::Director));
+    ui->chkFirstAired->setMyData(static_cast<int>(TvShowScraperInfos::FirstAired));
+    ui->chkNetwork->setMyData(static_cast<int>(TvShowScraperInfos::Network));
+    ui->chkOverview->setMyData(static_cast<int>(TvShowScraperInfos::Overview));
+    ui->chkRating->setMyData(static_cast<int>(TvShowScraperInfos::Rating));
+    ui->chkThumbnail->setMyData(static_cast<int>(TvShowScraperInfos::Thumbnail));
+    ui->chkTitle->setMyData(static_cast<int>(TvShowScraperInfos::Title));
+    ui->chkWriter->setMyData(static_cast<int>(TvShowScraperInfos::Writer));
 
     foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
         if (box->myData().toInt() > 0) {
@@ -52,9 +52,9 @@ void TvShowSearchEpisode::onChkToggled()
 {
     m_infosToLoad.clear();
     bool allToggled = true;
-    foreach (MyCheckBox *box, ui->groupBox->findChildren<MyCheckBox *>()) {
+    for (auto box : ui->groupBox->findChildren<MyCheckBox *>()) {
         if (box->isChecked() && box->myData().toInt() > 0 && box->isEnabled()) {
-            m_infosToLoad.append(box->myData().toInt());
+            m_infosToLoad.append(TvShowScraperInfos(box->myData().toInt()));
         }
         if (!box->isChecked() && box->myData().toInt() > 0 && box->isEnabled()) {
             allToggled = false;
@@ -77,7 +77,7 @@ void TvShowSearchEpisode::onChkAllToggled()
     onChkToggled();
 }
 
-QList<int> TvShowSearchEpisode::infosToLoad()
+QList<TvShowScraperInfos> TvShowSearchEpisode::infosToLoad()
 {
     return m_infosToLoad;
 }

--- a/tvShows/TvShowSearchEpisode.h
+++ b/tvShows/TvShowSearchEpisode.h
@@ -18,7 +18,7 @@ public:
     explicit TvShowSearchEpisode(QWidget *parent = nullptr);
     ~TvShowSearchEpisode() override;
     QString scraperId();
-    QList<int> infosToLoad();
+    QList<TvShowScraperInfos> infosToLoad();
 
 public slots:
     void search(QString searchString, QString id);
@@ -37,7 +37,7 @@ private:
     Ui::TvShowSearchEpisode *ui;
     void clear();
     QString m_scraperId;
-    QList<int> m_infosToLoad;
+    QList<TvShowScraperInfos> m_infosToLoad;
 };
 
 #endif // TVSHOWSEARCHEPISODE_H

--- a/tvShows/TvShowWidgetEpisode.cpp
+++ b/tvShows/TvShowWidgetEpisode.cpp
@@ -683,7 +683,7 @@ void TvShowWidgetEpisode::onChooseThumbnail()
     }
 }
 
-void TvShowWidgetEpisode::onImageDropped(int imageType, QUrl imageUrl)
+void TvShowWidgetEpisode::onImageDropped(ImageType imageType, QUrl imageUrl)
 {
     Q_UNUSED(imageType);
 

--- a/tvShows/TvShowWidgetEpisode.h
+++ b/tvShows/TvShowWidgetEpisode.h
@@ -46,7 +46,7 @@ private slots:
     void onRemoveWriter();
     void onChooseThumbnail();
     void onDeleteThumbnail();
-    void onImageDropped(int imageType, QUrl imageUrl);
+    void onImageDropped(ImageType imageType, QUrl imageUrl);
     void onPosterDownloadFinished(DownloadManagerElement elem);
     void onLoadDone();
     void onRevertChanges();

--- a/tvShows/TvShowWidgetSeason.cpp
+++ b/tvShows/TvShowWidgetSeason.cpp
@@ -111,8 +111,10 @@ void TvShowWidgetSeason::updateSeasonInfo()
     emit sigSetActionSearchEnabled(false, MainWidgets::TvShows);
     ui->title->setText(m_show->name() + " - " + tr("Season %1").arg(m_season));
 
-    updateImages(QList<int>() << ImageType::TvShowSeasonPoster << ImageType::TvShowSeasonBackdrop
-                              << ImageType::TvShowSeasonBanner << ImageType::TvShowSeasonThumb);
+    updateImages(QList<ImageType>{ImageType::TvShowSeasonPoster,
+        ImageType::TvShowSeasonBackdrop,
+        ImageType::TvShowSeasonBanner,
+        ImageType::TvShowSeasonThumb});
 
     ui->missingLabel->setVisible(m_show->isDummySeason(m_season));
     if (m_show->isDummySeason(m_season)) {
@@ -125,9 +127,9 @@ void TvShowWidgetSeason::updateSeasonInfo()
     emit sigSetActionSaveEnabled(!m_show->downloadsInProgress(), MainWidgets::TvShows);
 }
 
-void TvShowWidgetSeason::updateImages(QList<int> images)
+void TvShowWidgetSeason::updateImages(QList<ImageType> images)
 {
-    foreach (const int &imageType, images) {
+    for (const auto imageType : images) {
         ClosableImage *image = nullptr;
 
         foreach (ClosableImage *cImage, ui->groupBox_3->findChildren<ClosableImage *>()) {
@@ -266,10 +268,10 @@ void TvShowWidgetSeason::onDeleteImage()
     }
 
     m_show->removeImage(image->imageType(), m_season);
-    updateImages(QList<int>() << image->imageType());
+    updateImages({image->imageType()});
 }
 
-void TvShowWidgetSeason::onImageDropped(int imageType, QUrl imageUrl)
+void TvShowWidgetSeason::onImageDropped(ImageType imageType, QUrl imageUrl)
 {
     if (!m_show) {
         return;

--- a/tvShows/TvShowWidgetSeason.h
+++ b/tvShows/TvShowWidgetSeason.h
@@ -39,7 +39,7 @@ signals:
 private slots:
     void onChooseImage();
     void onDeleteImage();
-    void onImageDropped(int imageType, QUrl imageUrl);
+    void onImageDropped(ImageType imageType, QUrl imageUrl);
 
     void onRevertChanges();
     void onDownloadFinished(DownloadManagerElement elem);
@@ -51,7 +51,7 @@ private:
     QLabel *m_savingWidget;
     QMovie *m_loadingMovie;
     DownloadManager *m_downloadManager;
-    void updateImages(QList<int> images);
+    void updateImages(QList<ImageType> images);
 };
 
 #endif // TVSHOWWIDGETSEASON_H

--- a/tvShows/TvShowWidgetTvShow.cpp
+++ b/tvShows/TvShowWidgetTvShow.cpp
@@ -368,9 +368,13 @@ void TvShowWidgetTvShow::updateTvShowInfo()
     ui->certification->addItems(certifications);
     ui->certification->setCurrentIndex(certifications.indexOf(m_show->certification()));
 
-    updateImages(QList<int>() << ImageType::TvShowPoster << ImageType::TvShowBackdrop << ImageType::TvShowBanner
-                              << ImageType::TvShowCharacterArt << ImageType::TvShowClearArt << ImageType::TvShowLogos
-                              << ImageType::TvShowThumb);
+    updateImages(QList<ImageType>() << ImageType::TvShowPoster       //
+                                    << ImageType::TvShowBackdrop     //
+                                    << ImageType::TvShowBanner       //
+                                    << ImageType::TvShowCharacterArt //
+                                    << ImageType::TvShowClearArt     //
+                                    << ImageType::TvShowLogos        //
+                                    << ImageType::TvShowThumb);
     ui->fanarts->setImages(m_show->extraFanarts(Manager::instance()->mediaCenterInterfaceTvShow()));
 
     ui->badgeTuneExisting->setVisible(m_show->hasTune());
@@ -387,9 +391,9 @@ void TvShowWidgetTvShow::updateTvShowInfo()
     ui->buttonRevert->setVisible(m_show->hasChanged());
 }
 
-void TvShowWidgetTvShow::updateImages(QList<int> images)
+void TvShowWidgetTvShow::updateImages(QList<ImageType> images)
 {
-    foreach (const int &imageType, images) {
+    for (const auto imageType : images) {
         ClosableImage *image = nullptr;
 
         foreach (ClosableImage *cImage, ui->artStackedWidget->findChildren<ClosableImage *>()) {
@@ -482,9 +486,13 @@ void TvShowWidgetTvShow::onInfoLoadDone(TvShow *show)
         show->clearMissingEpisodes();
         show->fillMissingEpisodes();
     }
-    QList<int> types;
-    types << ImageType::TvShowClearArt << ImageType::TvShowLogos << ImageType::TvShowCharacterArt
-          << ImageType::TvShowThumb << ImageType::TvShowSeasonThumb;
+
+    QList<ImageType> types{ImageType::TvShowClearArt,
+        ImageType::TvShowLogos,
+        ImageType::TvShowCharacterArt,
+        ImageType::TvShowThumb,
+        ImageType::TvShowSeasonThumb};
+
     if (!show->tvdbId().isEmpty() && !types.isEmpty() && show->infosToLoad().contains(TvShowScraperInfos::ExtraArts)) {
         Manager::instance()->fanartTv()->tvShowImages(show, show->tvdbId(), types);
         connect(Manager::instance()->fanartTv(),
@@ -493,7 +501,7 @@ void TvShowWidgetTvShow::onInfoLoadDone(TvShow *show)
             SLOT(onLoadDone(TvShow *, QMap<int, QList<Poster>>)),
             Qt::UniqueConnection);
     } else {
-        QMap<int, QList<Poster>> map;
+        QMap<ImageType, QList<Poster>> map;
         onLoadDone(show, map);
     }
     NotificationBox::instance()->hideProgressBar(show->property("progressBarId").toInt());
@@ -505,7 +513,7 @@ void TvShowWidgetTvShow::onInfoLoadDone(TvShow *show)
  * @param show Tv Show
  * @param posters
  */
-void TvShowWidgetTvShow::onLoadDone(TvShow *show, QMap<int, QList<Poster>> posters)
+void TvShowWidgetTvShow::onLoadDone(TvShow *show, QMap<ImageType, QList<Poster>> posters)
 {
     qDebug() << "Entered";
     if (m_show == nullptr) {
@@ -559,7 +567,7 @@ void TvShowWidgetTvShow::onLoadDone(TvShow *show, QMap<int, QList<Poster>> poste
     }
 
     QList<int> thumbsForSeasons;
-    QMapIterator<int, QList<Poster>> it(posters);
+    QMapIterator<ImageType, QList<Poster>> it(posters);
     while (it.hasNext()) {
         it.next();
         if (it.key() == ImageType::TvShowClearArt && !it.value().isEmpty()) {
@@ -1161,11 +1169,11 @@ void TvShowWidgetTvShow::onDeleteImage()
     }
 
     m_show->removeImage(image->imageType());
-    updateImages(QList<int>() << image->imageType());
+    updateImages({image->imageType()});
     ui->buttonRevert->setVisible(true);
 }
 
-void TvShowWidgetTvShow::onImageDropped(int imageType, QUrl imageUrl)
+void TvShowWidgetTvShow::onImageDropped(ImageType imageType, QUrl imageUrl)
 {
     if (!m_show) {
         return;

--- a/tvShows/TvShowWidgetTvShow.h
+++ b/tvShows/TvShowWidgetTvShow.h
@@ -52,11 +52,11 @@ private slots:
     void onAddActor();
     void onRemoveActor();
     void onInfoLoadDone(TvShow *show);
-    void onLoadDone(TvShow *show, QMap<int, QList<Poster>> posters);
+    void onLoadDone(TvShow *show, QMap<ImageType, QList<Poster>> posters);
 
     void onChooseImage();
     void onDeleteImage();
-    void onImageDropped(int imageType, QUrl imageUrl);
+    void onImageDropped(ImageType imageType, QUrl imageUrl);
 
     void onPosterDownloadFinished(DownloadManagerElement elem);
     void onDownloadsFinished(TvShow *show);
@@ -96,7 +96,7 @@ private:
     QLabel *m_savingWidget;
     QMovie *m_loadingMovie;
     DownloadManager *m_posterDownloadManager;
-    void updateImages(QList<int> images);
+    void updateImages(QList<ImageType> images);
 };
 
 #endif // TVSHOWWIDGETTVSHOW_H


### PR DESCRIPTION
What has bothered me for some time now is that all `__ScraperInfos` are just integers whereas they should be enums. `QList<int>` just doesn't show what information is actually stored.

This PR replaces `QList<int>` with `QList<__ScraperInfos>`.

@Komet As this is again a rather huge PR, I'd like to request your review. :smiley: 