### PR TITLE
[StreamDetails] Use scoped enums instead of strings

### DIFF
--- a/concerts/ConcertController.cpp
+++ b/concerts/ConcertController.cpp
@@ -123,7 +123,8 @@ void ConcertController::loadData(QString id,
 void ConcertController::loadStreamDetailsFromFile()
 {
     m_concert->streamDetails()->loadStreamDetails();
-    m_concert->setRuntime(qFloor(m_concert->streamDetails()->videoDetails().value("durationinseconds").toInt() / 60));
+    m_concert->setRuntime(qFloor(
+        m_concert->streamDetails()->videoDetails().value(StreamDetails::VideoDetails::DurationInSeconds).toInt() / 60));
     m_concert->setStreamDetailsLoaded(true);
     m_concert->setChanged(true);
 }

--- a/concerts/ConcertWidget.cpp
+++ b/concerts/ConcertWidget.cpp
@@ -282,10 +282,11 @@ void ConcertWidget::setConcert(Concert *concert)
     m_concert = concert;
     if (!concert->streamDetailsLoaded() && Settings::instance()->autoLoadStreamDetails()) {
         concert->controller()->loadStreamDetailsFromFile();
+        const auto videoDetails = concert->streamDetails()->videoDetails();
         if (concert->streamDetailsLoaded()
-            && concert->streamDetails()->videoDetails().value("durationinseconds").toInt() != 0) {
+            && videoDetails.value(StreamDetails::VideoDetails::DurationInSeconds).toInt() != 0) {
             concert->setRuntime(
-                qFloor(concert->streamDetails()->videoDetails().value("durationinseconds").toInt() / 60));
+                qFloor(videoDetails.value(StreamDetails::VideoDetails::DurationInSeconds).toInt() / 60));
         }
     }
     updateConcertInfo();
@@ -548,22 +549,24 @@ void ConcertWidget::updateStreamDetails(bool reloadFromFile)
     }
 
     StreamDetails *streamDetails = m_concert->streamDetails();
-    ui->videoWidth->setValue(streamDetails->videoDetails().value("width").toInt());
-    ui->videoHeight->setValue(streamDetails->videoDetails().value("height").toInt());
-    ui->videoAspectRatio->setValue(QString{streamDetails->videoDetails().value("aspect")}.replace(",", ".").toDouble());
-    ui->videoCodec->setText(streamDetails->videoDetails().value("codec"));
-    ui->videoScantype->setText(streamDetails->videoDetails().value("scantype"));
+    const auto videoDetails = streamDetails->videoDetails();
+    ui->videoWidth->setValue(videoDetails.value(StreamDetails::VideoDetails::Width).toInt());
+    ui->videoHeight->setValue(videoDetails.value(StreamDetails::VideoDetails::Height).toInt());
+    ui->videoAspectRatio->setValue(
+        QString{videoDetails.value(StreamDetails::VideoDetails::Aspect)}.replace(",", ".").toDouble());
+    ui->videoCodec->setText(videoDetails.value(StreamDetails::VideoDetails::Codec));
+    ui->videoScantype->setText(videoDetails.value(StreamDetails::VideoDetails::ScanType));
     ui->stereoMode->setCurrentIndex(0);
     for (int i = 0, n = ui->stereoMode->count(); i < n; ++i) {
-        if (ui->stereoMode->itemData(i).toString() == streamDetails->videoDetails().value("stereomode")) {
+        if (ui->stereoMode->itemData(i).toString() == videoDetails.value(StreamDetails::VideoDetails::StereoMode)) {
             ui->stereoMode->setCurrentIndex(i);
         }
     }
     QTime time(0, 0, 0, 0);
-    time = time.addSecs(streamDetails->videoDetails().value("durationinseconds").toInt());
+    time = time.addSecs(videoDetails.value(StreamDetails::VideoDetails::DurationInSeconds).toInt());
     ui->videoDuration->setTime(time);
     if (reloadFromFile) {
-        ui->runtime->setValue(qFloor(streamDetails->videoDetails().value("durationinseconds").toInt() / 60));
+        ui->runtime->setValue(qFloor(videoDetails.value(StreamDetails::VideoDetails::DurationInSeconds).toInt() / 60));
     }
 
     foreach (QWidget *widget, m_streamDetailsWidgets)
@@ -572,13 +575,14 @@ void ConcertWidget::updateStreamDetails(bool reloadFromFile)
     m_streamDetailsAudio.clear();
     m_streamDetailsSubtitles.clear();
 
-    int audioTracks = streamDetails->audioDetails().count();
+    const auto audioDetails = streamDetails->audioDetails();
+    int audioTracks = audioDetails.count();
     for (int i = 0; i < audioTracks; ++i) {
         QLabel *label = new QLabel(tr("Track %1").arg(i + 1));
         ui->streamDetails->addWidget(label, 8 + i, 0);
-        QLineEdit *edit1 = new QLineEdit(streamDetails->audioDetails().at(i).value("language"));
-        QLineEdit *edit2 = new QLineEdit(streamDetails->audioDetails().at(i).value("codec"));
-        QLineEdit *edit3 = new QLineEdit(streamDetails->audioDetails().at(i).value("channels"));
+        QLineEdit *edit1 = new QLineEdit(audioDetails.at(i).value(StreamDetails::AudioDetails::Language));
+        QLineEdit *edit2 = new QLineEdit(audioDetails.at(i).value(StreamDetails::AudioDetails::Codec));
+        QLineEdit *edit3 = new QLineEdit(audioDetails.at(i).value(StreamDetails::AudioDetails::Channels));
         edit3->setMaximumWidth(50);
         edit1->setToolTip(tr("Language"));
         edit2->setToolTip(tr("Codec"));
@@ -610,7 +614,8 @@ void ConcertWidget::updateStreamDetails(bool reloadFromFile)
         for (int i = 0, n = streamDetails->subtitleDetails().count(); i < n; ++i) {
             QLabel *label = new QLabel(tr("Track %1").arg(i + 1));
             ui->streamDetails->addWidget(label, 9 + audioTracks + i, 0);
-            QLineEdit *edit1 = new QLineEdit(streamDetails->subtitleDetails().at(i).value("language"));
+            QLineEdit *edit1 =
+                new QLineEdit(streamDetails->subtitleDetails().at(i).value(StreamDetails::SubtitleDetails::Language));
             edit1->setToolTip(tr("Language"));
             edit1->setPlaceholderText(tr("Language"));
             auto layout = new QHBoxLayout();
@@ -956,21 +961,22 @@ void ConcertWidget::onOverviewChange()
 void ConcertWidget::onStreamDetailsEdited()
 {
     StreamDetails *details = m_concert->streamDetails();
-    details->setVideoDetail("codec", ui->videoCodec->text());
-    details->setVideoDetail("aspect", ui->videoAspectRatio->text());
-    details->setVideoDetail("width", ui->videoWidth->text());
-    details->setVideoDetail("height", ui->videoHeight->text());
-    details->setVideoDetail("scantype", ui->videoScantype->text());
-    details->setVideoDetail("durationinseconds", QString("%1").arg(-ui->videoDuration->time().secsTo(QTime(0, 0))));
-    details->setVideoDetail("stereomode", ui->stereoMode->currentData().toString());
+    details->setVideoDetail(StreamDetails::VideoDetails::Codec, ui->videoCodec->text());
+    details->setVideoDetail(StreamDetails::VideoDetails::Aspect, ui->videoAspectRatio->text());
+    details->setVideoDetail(StreamDetails::VideoDetails::Width, ui->videoWidth->text());
+    details->setVideoDetail(StreamDetails::VideoDetails::Height, ui->videoHeight->text());
+    details->setVideoDetail(StreamDetails::VideoDetails::ScanType, ui->videoScantype->text());
+    details->setVideoDetail(StreamDetails::VideoDetails::DurationInSeconds,
+        QString("%1").arg(-ui->videoDuration->time().secsTo(QTime(0, 0))));
+    details->setVideoDetail(StreamDetails::VideoDetails::StereoMode, ui->stereoMode->currentData().toString());
 
     for (int i = 0, n = m_streamDetailsAudio.count(); i < n; ++i) {
-        details->setAudioDetail(i, "language", m_streamDetailsAudio[i][0]->text());
-        details->setAudioDetail(i, "codec", m_streamDetailsAudio[i][1]->text());
-        details->setAudioDetail(i, "channels", m_streamDetailsAudio[i][2]->text());
+        details->setAudioDetail(i, StreamDetails::AudioDetails::Language, m_streamDetailsAudio[i][0]->text());
+        details->setAudioDetail(i, StreamDetails::AudioDetails::Codec, m_streamDetailsAudio[i][1]->text());
+        details->setAudioDetail(i, StreamDetails::AudioDetails::Channels, m_streamDetailsAudio[i][2]->text());
     }
     for (int i = 0, n = m_streamDetailsSubtitles.count(); i < n; ++i) {
-        details->setSubtitleDetail(i, "language", m_streamDetailsSubtitles[i][0]->text());
+        details->setSubtitleDetail(i, StreamDetails::SubtitleDetails::Language, m_streamDetailsSubtitles[i][0]->text());
     }
 
     m_concert->setChanged(true);

--- a/data/StreamDetails.cpp
+++ b/data/StreamDetails.cpp
@@ -29,18 +29,45 @@ using namespace ZenLib;
  * @param parent
  * @param file
  */
-StreamDetails::StreamDetails(QObject *parent, QStringList files) : QObject(parent)
+StreamDetails::StreamDetails(QObject *parent, QStringList files) :
+    QObject(parent),
+    m_hdAudioCodecs{"dtshd_ma", "dtshd_hra", "truehd"},
+    m_normalAudioCodecs{"DTS", "dts", "ac3", "eac3", "flac"},
+    m_files(files),
+    m_sdAudioCodecs{"mp3"}
 {
-    m_files = files;
-    m_hdAudioCodecs << "dtshd_ma"
-                    << "dtshd_hra"
-                    << "truehd";
-    m_normalAudioCodecs << "DTS"
-                        << "dts"
-                        << "ac3"
-                        << "eac3"
-                        << "flac";
-    m_sdAudioCodecs << "mp3";
+}
+
+QString StreamDetails::detailToString(VideoDetails details)
+{
+    switch (details) {
+    case VideoDetails::Codec: return "codec";
+    case VideoDetails::Aspect: return "aspect";
+    case VideoDetails::Width: return "width";
+    case VideoDetails::Height: return "height";
+    case VideoDetails::DurationInSeconds: return "durationinseconds";
+    case VideoDetails::ScanType: return "scantype";
+    case VideoDetails::StereoMode: return "stereomode";
+    default: qWarning() << "Undefined video detail: no string representation"; return "undefined";
+    }
+}
+
+QString StreamDetails::detailToString(AudioDetails details)
+{
+    switch (details) {
+    case StreamDetails::AudioDetails::Codec: return "codec";
+    case StreamDetails::AudioDetails::Language: return "language";
+    case StreamDetails::AudioDetails::Channels: return "channels";
+    default: qWarning() << "Undefined audio detail: no string representation"; return "undefined";
+    }
+}
+
+QString StreamDetails::detailToString(SubtitleDetails details)
+{
+    switch (details) {
+    case StreamDetails::SubtitleDetails::Language: return "language";
+    default: qWarning() << "Undefined subtitle detail: no string representation"; return "undefined";
+    }
 }
 
 /**
@@ -77,10 +104,7 @@ void StreamDetails::loadStreamDetails()
         qint64 biggestSize = 0;
         QFileInfo fi(m_files.first());
         foreach (const QFileInfo &fiVob,
-            fi.dir().entryInfoList(QStringList() << "VTS_*.VOB"
-                                                 << "vts_*.vob",
-                QDir::Files,
-                QDir::Name)) {
+            fi.dir().entryInfoList(QStringList{"VTS_*.VOB", "vts_*.vob"}, QDir::Files, QDir::Name)) {
             QRegExp rx("VTS_([0-9]*)_[0-9]*.VOB");
             rx.setMinimal(true);
             rx.setCaseSensitivity(Qt::CaseInsensitive);
@@ -134,7 +158,7 @@ void StreamDetails::loadWithLibrary()
     int textCount = MI2QString(MI.Get(Stream_General, 0, QString2MI("TextCount"))).toInt();
 
     if (m_files.count() > 1) {
-        foreach (const QString &file, m_files) {
+        for (const QString &file : m_files) {
             MediaInfo MI_duration;
             MI_duration.Option(__T("Info_Version"), __T("0.7.70;MediaElch;2"));
             MI_duration.Option(__T("Internet"), __T("no"));
@@ -147,7 +171,7 @@ void StreamDetails::loadWithLibrary()
         duration += qRound(MI2QString(MI.Get(Stream_General, 0, QString2MI("Duration"))).toFloat() / 1000);
     }
 
-    setVideoDetail("durationinseconds", QString("%1").arg(duration));
+    setVideoDetail(StreamDetails::VideoDetails::DurationInSeconds, QString::number(duration));
 
     if (videoCount > 0) {
         double aspectRatio = MI2QString(MI.Get(Stream_Video, 0, QString2MI("DisplayAspectRatio"))).toDouble();
@@ -176,12 +200,12 @@ void StreamDetails::loadWithLibrary()
         
         QString multiView = MI2QString(MI.Get(Stream_Video, 0, QString2MI("MultiView_Layout")));
 
-        setVideoDetail("codec", videoCodec);
-        setVideoDetail("aspect", QString("%1").arg(aspectRatio));
-        setVideoDetail("width", QString("%1").arg(width));
-        setVideoDetail("height", QString("%1").arg(height));
-        setVideoDetail("scantype", scanType.toLower());
-        setVideoDetail("stereomode", stereoFormat(multiView));
+        setVideoDetail(VideoDetails::Codec, videoCodec);
+        setVideoDetail(VideoDetails::Aspect, QString("%1").arg(aspectRatio));
+        setVideoDetail(VideoDetails::Width, QString("%1").arg(width));
+        setVideoDetail(VideoDetails::Height, QString("%1").arg(height));
+        setVideoDetail(VideoDetails::ScanType, scanType.toLower());
+        setVideoDetail(VideoDetails::StereoMode, stereoFormat(multiView));
     }
 
     for (int i = 0; i < audioCount; ++i) {
@@ -207,9 +231,9 @@ void StreamDetails::loadWithLibrary()
         } else {
             channels = "";
         }
-        setAudioDetail(i, "language", lang);
-        setAudioDetail(i, "codec", audioCodec);
-        setAudioDetail(i, "channels", channels);
+        setAudioDetail(i, AudioDetails::Language, lang);
+        setAudioDetail(i, AudioDetails::Codec, audioCodec);
+        setAudioDetail(i, AudioDetails::Channels, channels);
     }
 
     for (int i = 0; i < textCount; ++i) {
@@ -223,7 +247,7 @@ void StreamDetails::loadWithLibrary()
         if (lang.isEmpty()) {
             lang = MI2QString(MI.Get(Stream_Text, i, QString2MI("Language/String")));
         }
-        setSubtitleDetail(i, "language", lang);
+        setSubtitleDetail(i, StreamDetails::SubtitleDetails::Language, lang);
     }
 
     MI.Close();
@@ -292,7 +316,7 @@ QString StreamDetails::stereoFormat(const QString &format) const
  * @param key The key (aspect, width, height...)
  * @param value The value
  */
-void StreamDetails::setVideoDetail(QString key, QString value)
+void StreamDetails::setVideoDetail(VideoDetails key, QString value)
 {
     m_videoDetails.insert(key, value);
 }
@@ -303,25 +327,27 @@ void StreamDetails::setVideoDetail(QString key, QString value)
  * @param key Key (language, codec or channels)
  * @param value Value
  */
-void StreamDetails::setAudioDetail(int streamNumber, QString key, QString value)
+void StreamDetails::setAudioDetail(int streamNumber, AudioDetails key, QString value)
 {
     if (streamNumber >= m_audioDetails.count()) {
-        m_audioDetails.insert(streamNumber, QMap<QString, QString>());
+        m_audioDetails.insert(streamNumber, QMap<AudioDetails, QString>());
     }
     if (streamNumber >= m_audioDetails.count()) {
         return;
     }
     m_audioDetails[streamNumber].insert(key, value);
 
-    if (key == "channels" && !m_availableChannels.contains(value.toInt())) {
+    if (key == AudioDetails::Channels && !m_availableChannels.contains(value.toInt())) {
         m_availableChannels.append(value.toInt());
     }
-    if (key == "codec" && m_hdAudioCodecs.contains(value) && !m_availableQualities.contains("hd")) {
-        m_availableQualities.append("hd");
-    } else if (key == "codec" && m_normalAudioCodecs.contains(value) && !m_availableQualities.contains("normal")) {
-        m_availableQualities.append("normal");
-    } else if (key == "codec" && m_sdAudioCodecs.contains(value) && !m_availableQualities.contains("sd")) {
-        m_availableQualities.append("sd");
+    if (key == AudioDetails::Codec) {
+        if (m_hdAudioCodecs.contains(value) && !m_availableQualities.contains("hd")) {
+            m_availableQualities.append("hd");
+        } else if (m_normalAudioCodecs.contains(value) && !m_availableQualities.contains("normal")) {
+            m_availableQualities.append("normal");
+        } else if (m_sdAudioCodecs.contains(value) && !m_availableQualities.contains("sd")) {
+            m_availableQualities.append("sd");
+        }
     }
 }
 
@@ -331,10 +357,10 @@ void StreamDetails::setAudioDetail(int streamNumber, QString key, QString value)
  * @param key Key (language)
  * @param value Language
  */
-void StreamDetails::setSubtitleDetail(int streamNumber, QString key, QString value)
+void StreamDetails::setSubtitleDetail(int streamNumber, SubtitleDetails key, QString value)
 {
     if (streamNumber >= m_subtitles.count()) {
-        m_subtitles.insert(streamNumber, QMap<QString, QString>());
+        m_subtitles.insert(streamNumber, QMap<SubtitleDetails, QString>());
     }
     if (streamNumber >= m_subtitles.count()) {
         return;
@@ -346,7 +372,7 @@ void StreamDetails::setSubtitleDetail(int streamNumber, QString key, QString val
  * @brief Access video details
  * @return
  */
-QMap<QString, QString> StreamDetails::videoDetails() const
+QMap<StreamDetails::VideoDetails, QString> StreamDetails::videoDetails() const
 {
     return m_videoDetails;
 }
@@ -355,7 +381,7 @@ QMap<QString, QString> StreamDetails::videoDetails() const
  * @brief Access audio details
  * @return
  */
-QList<QMap<QString, QString>> StreamDetails::audioDetails() const
+QList<QMap<StreamDetails::AudioDetails, QString>> StreamDetails::audioDetails() const
 {
     return m_audioDetails;
 }
@@ -364,7 +390,7 @@ QList<QMap<QString, QString>> StreamDetails::audioDetails() const
  * @brief Access subtitles
  * @return
  */
-QList<QMap<QString, QString>> StreamDetails::subtitleDetails() const
+QList<QMap<StreamDetails::SubtitleDetails, QString>> StreamDetails::subtitleDetails() const
 {
     return m_subtitles;
 }
@@ -396,7 +422,7 @@ QString StreamDetails::audioCodec() const
     QString normalCodec;
     QString sdCodec;
     for (int i = 0, n = m_audioDetails.count(); i < n; ++i) {
-        QString codec = m_audioDetails.at(i).value("codec");
+        QString codec = m_audioDetails.at(i).value(AudioDetails::Codec);
         if (m_hdAudioCodecs.contains(codec)) {
             hdCodec = codec;
         }
@@ -422,5 +448,5 @@ QString StreamDetails::audioCodec() const
 
 QString StreamDetails::videoCodec() const
 {
-    return m_videoDetails.value("codec");
+    return m_videoDetails.value(VideoDetails::Codec);
 }

--- a/data/StreamDetails.h
+++ b/data/StreamDetails.h
@@ -16,10 +16,36 @@ class StreamDetails : public QObject
     Q_OBJECT
 public:
     explicit StreamDetails(QObject *parent, QStringList files);
+
+    enum class VideoDetails
+    {
+        DurationInSeconds,
+        Codec,
+        Aspect,
+        Width,
+        Height,
+        ScanType,
+        StereoMode
+    };
+    enum class AudioDetails
+    {
+        Language,
+        Codec,
+        Channels
+    };
+    enum class SubtitleDetails
+    {
+        Language
+    };
+
+    static QString detailToString(VideoDetails details);
+    static QString detailToString(AudioDetails details);
+    static QString detailToString(SubtitleDetails details);
+
     void loadStreamDetails();
-    void setVideoDetail(QString key, QString value);
-    void setAudioDetail(int streamNumber, QString key, QString value);
-    void setSubtitleDetail(int streamNumber, QString key, QString value);
+    void setVideoDetail(VideoDetails key, QString value);
+    void setAudioDetail(int streamNumber, AudioDetails key, QString value);
+    void setSubtitleDetail(int streamNumber, SubtitleDetails key, QString value);
     void clear();
     bool hasAudioChannels(int channels) const;
     bool hasAudioQuality(QString quality) const;
@@ -27,9 +53,9 @@ public:
     QString audioCodec() const;
     QString videoCodec() const;
 
-    virtual QMap<QString, QString> videoDetails() const;
-    virtual QList<QMap<QString, QString>> audioDetails() const;
-    virtual QList<QMap<QString, QString>> subtitleDetails() const;
+    virtual QMap<VideoDetails, QString> videoDetails() const;
+    virtual QList<QMap<AudioDetails, QString>> audioDetails() const;
+    virtual QList<QMap<SubtitleDetails, QString>> subtitleDetails() const;
 
 private:
     QString videoFormat(QString format, QString version) const;
@@ -38,9 +64,9 @@ private:
     void loadWithLibrary();
 
     QStringList m_files;
-    QMap<QString, QString> m_videoDetails;
-    QList<QMap<QString, QString>> m_audioDetails;
-    QList<QMap<QString, QString>> m_subtitles;
+    QMap<VideoDetails, QString> m_videoDetails;
+    QList<QMap<AudioDetails, QString>> m_audioDetails;
+    QList<QMap<SubtitleDetails, QString>> m_subtitles;
     QList<int> m_availableChannels;
     QList<QString> m_availableQualities;
 

--- a/downloads/ImportDialog.cpp
+++ b/downloads/ImportDialog.cpp
@@ -436,6 +436,7 @@ void ImportDialog::onImport()
 
     if (m_type == "movie") {
         QDir dir(importDir());
+        const auto videoDetails = m_movie->streamDetails()->videoDetails();
         if (m_separateFolders) {
             QString newFolderName = ui->directoryNaming->text();
             Renamer::replace(newFolderName, "title", m_movie->name());
@@ -444,13 +445,13 @@ void ImportDialog::onImport()
             Renamer::replace(newFolderName, "year", m_movie->released().toString("yyyy"));
             Renamer::replace(newFolderName,
                 "resolution",
-                Helper::instance()->matchResolution(m_movie->streamDetails()->videoDetails().value("width").toInt(),
-                    m_movie->streamDetails()->videoDetails().value("height").toInt(),
-                    m_movie->streamDetails()->videoDetails().value("scantype")));
+                Helper::instance()->matchResolution(videoDetails.value(StreamDetails::VideoDetails::Width).toInt(),
+                    videoDetails.value(StreamDetails::VideoDetails::Height).toInt(),
+                    videoDetails.value(StreamDetails::VideoDetails::ScanType)));
             Renamer::replaceCondition(newFolderName, "bluray", m_movie->discType() == DiscType::BluRay);
             Renamer::replaceCondition(newFolderName, "dvd", m_movie->discType() == DiscType::Dvd);
             Renamer::replaceCondition(
-                newFolderName, "3D", m_movie->streamDetails()->videoDetails().value("stereomode") != "");
+                newFolderName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
             Renamer::replaceCondition(newFolderName, "movieset", m_movie->set());
             Helper::instance()->sanitizeFileName(newFolderName);
             if (!dir.mkdir(newFolderName)) {
@@ -471,13 +472,13 @@ void ImportDialog::onImport()
             Renamer::replace(newFileName, "extension", fi.suffix());
             Renamer::replace(newFileName,
                 "resolution",
-                Helper::instance()->matchResolution(m_movie->streamDetails()->videoDetails().value("width").toInt(),
-                    m_movie->streamDetails()->videoDetails().value("height").toInt(),
-                    m_movie->streamDetails()->videoDetails().value("scantype")));
+                Helper::instance()->matchResolution(videoDetails.value(StreamDetails::VideoDetails::Width).toInt(),
+                    videoDetails.value(StreamDetails::VideoDetails::Height).toInt(),
+                    videoDetails.value(StreamDetails::VideoDetails::ScanType)));
             Renamer::replaceCondition(newFileName, "imdbId", m_movie->id());
             Renamer::replaceCondition(newFileName, "movieset", m_movie->set());
             Renamer::replaceCondition(
-                newFileName, "3D", m_movie->streamDetails()->videoDetails().value("stereomode") != "");
+                newFileName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
             Helper::instance()->sanitizeFileName(newFileName);
             m_filesToMove.insert(file, dir.absolutePath() + QDir::separator() + newFileName);
             if (files().contains(file)) {
@@ -487,6 +488,7 @@ void ImportDialog::onImport()
         ui->labelLoading->setText(tr("Importing movie..."));
 
     } else if (m_type == "tvshow") {
+        const auto videoDetails = m_episode->streamDetails()->videoDetails();
         QDir dir(m_show->dir());
         if (ui->chkSeasonDirectories->isChecked()) {
             QString newFolderName = ui->seasonNaming->text();
@@ -508,11 +510,12 @@ void ImportDialog::onImport()
             Renamer::replace(newFileName, "season", m_episode->seasonString());
             Renamer::replace(newFileName,
                 "resolution",
-                Helper::instance()->matchResolution(m_episode->streamDetails()->videoDetails().value("width").toInt(),
-                    m_episode->streamDetails()->videoDetails().value("height").toInt(),
-                    m_episode->streamDetails()->videoDetails().value("scantype")));
-            Renamer::replaceCondition(
-                newFileName, "3D", m_episode->streamDetails()->videoDetails().value("stereomode") != "");
+                Helper::instance()->matchResolution(videoDetails.value(StreamDetails::VideoDetails::Width).toInt(),
+                    videoDetails.value(StreamDetails::VideoDetails::Height).toInt(),
+                    videoDetails.value(StreamDetails::VideoDetails::ScanType)));
+            Renamer::replaceCondition(newFileName,
+                "3D",
+                m_episode->streamDetails()->videoDetails().value(StreamDetails::VideoDetails::StereoMode) != "");
             Helper::instance()->sanitizeFileName(newFileName);
             m_filesToMove.insert(file, dir.absolutePath() + QDir::separator() + newFileName);
             if (files().contains(file)) {
@@ -523,6 +526,7 @@ void ImportDialog::onImport()
         ui->labelLoading->setText(tr("Importing episode..."));
 
     } else if (m_type == "concert") {
+        const auto videoDetails = m_concert->streamDetails()->videoDetails();
         QDir dir(importDir());
         if (m_separateFolders) {
             QString newFolderName = ui->directoryNaming->text();
@@ -532,13 +536,13 @@ void ImportDialog::onImport()
             Renamer::replace(newFolderName, "year", m_concert->released().toString("yyyy"));
             Renamer::replace(newFolderName,
                 "resolution",
-                Helper::instance()->matchResolution(m_concert->streamDetails()->videoDetails().value("width").toInt(),
-                    m_concert->streamDetails()->videoDetails().value("height").toInt(),
-                    m_concert->streamDetails()->videoDetails().value("scantype")));
+                Helper::instance()->matchResolution(videoDetails.value(StreamDetails::VideoDetails::Width).toInt(),
+                    videoDetails.value(StreamDetails::VideoDetails::Height).toInt(),
+                    videoDetails.value(StreamDetails::VideoDetails::ScanType)));
             Renamer::replaceCondition(newFolderName, "bluray", m_concert->discType() == DiscType::BluRay);
             Renamer::replaceCondition(newFolderName, "dvd", m_concert->discType() == DiscType::Dvd);
             Renamer::replaceCondition(
-                newFolderName, "3D", m_concert->streamDetails()->videoDetails().value("stereomode") != "");
+                newFolderName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
             Helper::instance()->sanitizeFileName(newFolderName);
             if (!dir.mkdir(newFolderName)) {
                 QMessageBox::warning(this,
@@ -558,11 +562,11 @@ void ImportDialog::onImport()
             Renamer::replace(newFileName, "extension", fi.suffix());
             Renamer::replace(newFileName,
                 "resolution",
-                Helper::instance()->matchResolution(m_concert->streamDetails()->videoDetails().value("width").toInt(),
-                    m_concert->streamDetails()->videoDetails().value("height").toInt(),
-                    m_concert->streamDetails()->videoDetails().value("scantype")));
+                Helper::instance()->matchResolution(videoDetails.value(StreamDetails::VideoDetails::Width).toInt(),
+                    videoDetails.value(StreamDetails::VideoDetails::Height).toInt(),
+                    videoDetails.value(StreamDetails::VideoDetails::ScanType)));
             Renamer::replaceCondition(
-                newFileName, "3D", m_concert->streamDetails()->videoDetails().value("stereomode") != "");
+                newFileName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
             Helper::instance()->sanitizeFileName(newFileName);
             m_filesToMove.insert(file, dir.absolutePath() + QDir::separator() + newFileName);
             if (files().contains(file)) {

--- a/export/ExportDialog.cpp
+++ b/export/ExportDialog.cpp
@@ -525,19 +525,22 @@ void ExportDialog::replaceVars(QString &m, TvShowEpisode *episode, QDir dir, boo
 
 void ExportDialog::replaceStreamDetailsVars(QString &m, StreamDetails *streamDetails)
 {
-    m.replace("{{ FILEINFO.WIDTH }}", streamDetails->videoDetails().value("width", "0"));
-    m.replace("{{ FILEINFO.HEIGHT }}", streamDetails->videoDetails().value("height", "0"));
-    m.replace("{{ FILEINFO.ASPECT }}", streamDetails->videoDetails().value("aspect", "0"));
-    m.replace("{{ FILEINFO.CODEC }}", streamDetails->videoDetails().value("codec", ""));
-    m.replace("{{ FILEINFO.DURATION }}", streamDetails->videoDetails().value("durationinseconds", "0"));
+    const auto videoDetails = streamDetails->videoDetails();
+    const auto audioDetails = streamDetails->audioDetails();
+
+    m.replace("{{ FILEINFO.WIDTH }}", videoDetails.value(StreamDetails::VideoDetails::Width, "0"));
+    m.replace("{{ FILEINFO.HEIGHT }}", videoDetails.value(StreamDetails::VideoDetails::Height, "0"));
+    m.replace("{{ FILEINFO.ASPECT }}", videoDetails.value(StreamDetails::VideoDetails::Aspect, "0"));
+    m.replace("{{ FILEINFO.CODEC }}", videoDetails.value(StreamDetails::VideoDetails::Codec, ""));
+    m.replace("{{ FILEINFO.DURATION }}", videoDetails.value(StreamDetails::VideoDetails::DurationInSeconds, "0"));
 
     QStringList audioCodecs;
     QStringList audioChannels;
     QStringList audioLanguages;
-    for (int i = 0, n = streamDetails->audioDetails().count(); i < n; ++i) {
-        audioCodecs << streamDetails->audioDetails().at(i).value("codec");
-        audioChannels << streamDetails->audioDetails().at(i).value("channels");
-        audioLanguages << streamDetails->audioDetails().at(i).value("language");
+    for (int i = 0, n = audioDetails.count(); i < n; ++i) {
+        audioCodecs << audioDetails.at(i).value(StreamDetails::AudioDetails::Codec);
+        audioChannels << audioDetails.at(i).value(StreamDetails::AudioDetails::Channels);
+        audioLanguages << audioDetails.at(i).value(StreamDetails::AudioDetails::Language);
     }
     m.replace("{{ FILEINFO.AUDIO.CODEC }}", audioCodecs.join("|"));
     m.replace("{{ FILEINFO.AUDIO.CHANNELS }}", audioChannels.join("|"));

--- a/globals/Filter.cpp
+++ b/globals/Filter.cpp
@@ -168,7 +168,10 @@ bool Filter::accepts(Movie *movie)
         return (m_hasInfo && movie->director() == m_shortText) || (!m_hasInfo && movie->director().isEmpty());
     }
     if (m_info == MovieFilters::VideoCodec) {
-        return (m_hasInfo && movie->streamDetails()->videoDetails().value("codec") == m_shortText) || (!m_hasInfo && movie->streamDetails()->videoDetails().value("codec").isEmpty());
+        return (m_hasInfo
+                   && movie->streamDetails()->videoDetails().value(StreamDetails::VideoDetails::Codec) == m_shortText)
+               || (!m_hasInfo
+                      && movie->streamDetails()->videoDetails().value(StreamDetails::VideoDetails::Codec).isEmpty());
     }
     if (m_info == MovieFilters::ImdbId) {
         return (m_hasInfo && movie->id() == m_shortText) || (!m_hasInfo && movie->id().isEmpty());
@@ -185,15 +188,15 @@ bool Filter::accepts(Movie *movie)
     }
 
     if (m_info == MovieFilters::Quality) {
+        const int width = movie->streamDetails()->videoDetails().value(StreamDetails::VideoDetails::Width).toInt();
         if (m_shortText == "2160p") {
-            return movie->streamDetails()->videoDetails().value("width").toInt() == 3840;
+            return width == 3840;
         } else if (m_shortText == "1080p") {
-            return movie->streamDetails()->videoDetails().value("width").toInt() == 1920;
+            return width == 1920;
         } else if (m_shortText == "720p") {
-            return movie->streamDetails()->videoDetails().value("width").toInt() == 1280;
+            return width == 1280;
         } else if (m_shortText == "SD") {
-            return movie->streamDetails()->videoDetails().value("width").toInt() > 0
-                   && movie->streamDetails()->videoDetails().value("width").toInt() <= 720;
+            return width > 0 && width <= 720;
         } else if (m_shortText == "BluRay") {
             return movie->discType() == DiscType::BluRay;
         } else if (m_shortText == "DVD") {

--- a/image/Image.cpp
+++ b/image/Image.cpp
@@ -51,7 +51,7 @@ void Image::setRawData(const QByteArray &rawData)
     emit rawDataChanged();
 }
 
-int Image::imageId()
+int Image::imageId() const
 {
     return m_imageId;
 }

--- a/image/Image.h
+++ b/image/Image.h
@@ -23,7 +23,7 @@ public:
     QByteArray rawData() const;
     void setRawData(const QByteArray &rawData);
 
-    int imageId();
+    int imageId() const;
 
     void load();
 

--- a/image/ImageCapture.cpp
+++ b/image/ImageCapture.cpp
@@ -14,10 +14,10 @@ ImageCapture::ImageCapture(QObject *parent) : QObject(parent)
 
 bool ImageCapture::captureImage(QString file, StreamDetails *streamDetails, QImage &img)
 {
-    if (streamDetails->videoDetails().value("durationinseconds", nullptr) == nullptr) {
+    if (streamDetails->videoDetails().value(StreamDetails::VideoDetails::DurationInSeconds, nullptr) == nullptr) {
         streamDetails->loadStreamDetails();
     }
-    if (streamDetails->videoDetails().value("durationinseconds", nullptr) == nullptr) {
+    if (streamDetails->videoDetails().value(StreamDetails::VideoDetails::DurationInSeconds, nullptr) == nullptr) {
         NotificationBox::instance()->showMessage(
             tr("Could not get duration of file"), NotificationBox::NotificationError);
         return false;
@@ -33,7 +33,7 @@ bool ImageCapture::captureImage(QString file, StreamDetails *streamDetails, QIma
 
     QProcess ffmpeg;
     qsrand(QTime::currentTime().msec());
-    int duration = streamDetails->videoDetails().value("durationinseconds", nullptr).toInt();
+    int duration = streamDetails->videoDetails().value(StreamDetails::VideoDetails::DurationInSeconds, nullptr).toInt();
     if (duration == 0) {
         NotificationBox::instance()->showMessage(
             tr("Could not detect runtime of file"), NotificationBox::NotificationError);

--- a/movies/MovieController.cpp
+++ b/movies/MovieController.cpp
@@ -164,7 +164,8 @@ void MovieController::loadData(QMap<ScraperInterface *, QString> ids,
 void MovieController::loadStreamDetailsFromFile()
 {
     m_movie->streamDetails()->loadStreamDetails();
-    m_movie->setRuntime(qFloor(m_movie->streamDetails()->videoDetails().value("durationinseconds").toInt() / 60));
+    m_movie->setRuntime(qFloor(
+        m_movie->streamDetails()->videoDetails().value(StreamDetails::VideoDetails::DurationInSeconds).toInt() / 60));
     m_movie->setStreamDetailsLoaded(true);
     m_movie->setChanged(true);
 }

--- a/renamer/Renamer.cpp
+++ b/renamer/Renamer.cpp
@@ -292,6 +292,7 @@ void Renamer::renameMovies(QList<Movie *> movies,
         if (!isBluRay && !isDvd && renameFiles) {
             newMovieFiles.clear();
             int partNo = 0;
+            const auto videoDetails = movie->streamDetails()->videoDetails();
             foreach (const QString &file, movie->files()) {
                 newFileName = (movie->files().count() == 1) ? filePattern : filePatternMulti;
                 QFileInfo fi(file);
@@ -308,13 +309,13 @@ void Renamer::renameMovies(QList<Movie *> movies,
                 Renamer::replace(newFileName, "channels", QString::number(movie->streamDetails()->audioChannels()));
                 Renamer::replace(newFileName,
                     "resolution",
-                    Helper::instance()->matchResolution(movie->streamDetails()->videoDetails().value("width").toInt(),
-                        movie->streamDetails()->videoDetails().value("height").toInt(),
-                        movie->streamDetails()->videoDetails().value("scantype")));
+                    Helper::instance()->matchResolution(videoDetails.value(StreamDetails::VideoDetails::Width).toInt(),
+                        videoDetails.value(StreamDetails::VideoDetails::Height).toInt(),
+                        videoDetails.value(StreamDetails::VideoDetails::ScanType)));
                 Renamer::replaceCondition(newFileName, "imdbId", movie->id());
                 Renamer::replaceCondition(newFileName, "movieset", movie->set());
                 Renamer::replaceCondition(
-                    newFileName, "3D", movie->streamDetails()->videoDetails().value("stereomode") != "");
+                    newFileName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
                 Helper::instance()->sanitizeFileName(newFileName);
                 if (fi.fileName() != newFileName) {
                     int row = addResult(fi.fileName(), newFileName, OperationRename);
@@ -613,6 +614,7 @@ void Renamer::renameMovies(QList<Movie *> movies,
         int renameRow = -1;
         QString newMovieFolder = dir.path();
         QString extension = (!movie->files().isEmpty()) ? QFileInfo(movie->files().first()).suffix() : "";
+        const auto videoDetails = movie->streamDetails()->videoDetails();
         // rename dir for already existe films dir
         if (renameDirectories && movie->inSeparateFolder()) {
             Renamer::replace(newFolderName, "title", movie->name());
@@ -625,13 +627,13 @@ void Renamer::renameMovies(QList<Movie *> movies,
             Renamer::replace(newFolderName, "channels", QString::number(movie->streamDetails()->audioChannels()));
             Renamer::replace(newFolderName,
                 "resolution",
-                Helper::instance()->matchResolution(movie->streamDetails()->videoDetails().value("width").toInt(),
-                    movie->streamDetails()->videoDetails().value("height").toInt(),
-                    movie->streamDetails()->videoDetails().value("scantype")));
+                Helper::instance()->matchResolution(videoDetails.value(StreamDetails::VideoDetails::Width).toInt(),
+                    videoDetails.value(StreamDetails::VideoDetails::Height).toInt(),
+                    videoDetails.value(StreamDetails::VideoDetails::ScanType)));
             Renamer::replaceCondition(newFolderName, "bluray", isBluRay);
             Renamer::replaceCondition(newFolderName, "dvd", isDvd);
             Renamer::replaceCondition(
-                newFolderName, "3D", movie->streamDetails()->videoDetails().value("stereomode") != "");
+                newFolderName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
             Renamer::replaceCondition(newFolderName, "movieset", movie->set());
             Renamer::replaceCondition(newFolderName, "imdbId", movie->id());
             Helper::instance()->sanitizeFileName(newFolderName);
@@ -651,13 +653,13 @@ void Renamer::renameMovies(QList<Movie *> movies,
             Renamer::replace(newFolderName, "channels", QString::number(movie->streamDetails()->audioChannels()));
             Renamer::replace(newFolderName,
                 "resolution",
-                Helper::instance()->matchResolution(movie->streamDetails()->videoDetails().value("width").toInt(),
-                    movie->streamDetails()->videoDetails().value("height").toInt(),
-                    movie->streamDetails()->videoDetails().value("scantype")));
+                Helper::instance()->matchResolution(videoDetails.value(StreamDetails::VideoDetails::Width).toInt(),
+                    videoDetails.value(StreamDetails::VideoDetails::Height).toInt(),
+                    videoDetails.value(StreamDetails::VideoDetails::ScanType)));
             Renamer::replaceCondition(newFolderName, "bluray", isBluRay);
             Renamer::replaceCondition(newFolderName, "dvd", isDvd);
             Renamer::replaceCondition(
-                newFolderName, "3D", movie->streamDetails()->videoDetails().value("stereomode") != "");
+                newFolderName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
             Renamer::replaceCondition(newFolderName, "movieset", movie->set());
             Renamer::replaceCondition(newFolderName, "imdbId", movie->id());
             Helper::instance()->sanitizeFileName(newFolderName);
@@ -789,6 +791,7 @@ void Renamer::renameEpisodes(QList<TvShowEpisode *> episodes,
 
             newEpisodeFiles.clear();
             int partNo = 0;
+            const auto videoDetails = episode->streamDetails()->videoDetails();
             foreach (const QString &file, episode->files()) {
                 newFileName = (episode->files().count() == 1) ? filePattern : filePatternMulti;
                 QFileInfo fi(file);
@@ -805,11 +808,11 @@ void Renamer::renameEpisodes(QList<TvShowEpisode *> episodes,
                 Renamer::replace(newFileName, "channels", QString::number(episode->streamDetails()->audioChannels()));
                 Renamer::replace(newFileName,
                     "resolution",
-                    Helper::instance()->matchResolution(episode->streamDetails()->videoDetails().value("width").toInt(),
-                        episode->streamDetails()->videoDetails().value("height").toInt(),
-                        episode->streamDetails()->videoDetails().value("scantype")));
+                    Helper::instance()->matchResolution(videoDetails.value(StreamDetails::VideoDetails::Width).toInt(),
+                        videoDetails.value(StreamDetails::VideoDetails::Height).toInt(),
+                        videoDetails.value(StreamDetails::VideoDetails::ScanType)));
                 Renamer::replaceCondition(
-                    newFileName, "3D", episode->streamDetails()->videoDetails().value("stereomode") != "");
+                    newFileName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
 
                 if (multiEpisodes.count() > 1) {
                     QStringList episodeStrings;
@@ -1086,6 +1089,7 @@ void Renamer::renameConcerts(QList<Concert *> concerts,
         if (!isBluRay && !isDvd && renameFiles) {
             newConcertFiles.clear();
             int partNo = 0;
+            const auto videoDetails = concert->streamDetails()->videoDetails();
             foreach (const QString &file, concert->files()) {
                 newFileName = (concert->files().count() == 1) ? filePattern : filePatternMulti;
                 QFileInfo fi(file);
@@ -1103,11 +1107,11 @@ void Renamer::renameConcerts(QList<Concert *> concerts,
                 Renamer::replace(newFileName, "channels", QString::number(concert->streamDetails()->audioChannels()));
                 Renamer::replace(newFileName,
                     "resolution",
-                    Helper::instance()->matchResolution(concert->streamDetails()->videoDetails().value("width").toInt(),
-                        concert->streamDetails()->videoDetails().value("height").toInt(),
-                        concert->streamDetails()->videoDetails().value("scantype")));
+                    Helper::instance()->matchResolution(videoDetails.value(StreamDetails::VideoDetails::Width).toInt(),
+                        videoDetails.value(StreamDetails::VideoDetails::Height).toInt(),
+                        videoDetails.value(StreamDetails::VideoDetails::ScanType)));
                 Renamer::replaceCondition(
-                    newFileName, "3D", concert->streamDetails()->videoDetails().value("stereomode") != "");
+                    newFileName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
                 Helper::instance()->sanitizeFileName(newFileName);
                 if (fi.fileName() != newFileName) {
                     int row = addResult(fi.fileName(), newFileName, OperationRename);
@@ -1202,6 +1206,7 @@ void Renamer::renameConcerts(QList<Concert *> concerts,
 
         int renameRow = -1;
         if (renameDirectories && concert->inSeparateFolder()) {
+            const auto videoDetails = concert->streamDetails()->videoDetails();
             Renamer::replace(newFolderName, "title", concert->name());
             Renamer::replace(newFolderName, "artist", concert->artist());
             Renamer::replace(newFolderName, "album", concert->album());
@@ -1209,15 +1214,15 @@ void Renamer::renameConcerts(QList<Concert *> concerts,
             Renamer::replaceCondition(newFolderName, "bluray", isBluRay);
             Renamer::replaceCondition(newFolderName, "dvd", isDvd);
             Renamer::replaceCondition(
-                newFolderName, "3D", concert->streamDetails()->videoDetails().value("stereomode") != "");
+                newFolderName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
             Renamer::replace(newFolderName, "videoCodec", concert->streamDetails()->videoCodec());
             Renamer::replace(newFolderName, "audioCodec", concert->streamDetails()->audioCodec());
             Renamer::replace(newFolderName, "channels", QString::number(concert->streamDetails()->audioChannels()));
             Renamer::replace(newFolderName,
                 "resolution",
-                Helper::instance()->matchResolution(concert->streamDetails()->videoDetails().value("width").toInt(),
-                    concert->streamDetails()->videoDetails().value("height").toInt(),
-                    concert->streamDetails()->videoDetails().value("scantype")));
+                Helper::instance()->matchResolution(videoDetails.value(StreamDetails::VideoDetails::Width).toInt(),
+                    videoDetails.value(StreamDetails::VideoDetails::Height).toInt(),
+                    videoDetails.value(StreamDetails::VideoDetails::ScanType)));
             Helper::instance()->sanitizeFileName(newFolderName);
             if (dir.dirName() != newFolderName) {
                 renameRow = addResult(dir.dirName(), newFolderName, OperationRename);

--- a/smallWidgets/FilterWidget.cpp
+++ b/smallWidgets/FilterWidget.cpp
@@ -302,8 +302,8 @@ void FilterWidget::setupMovieFilters()
         if (!directors.contains(movie->director())) {
             directors.append(movie->director());
         }
-        if (!videocodecs.contains(movie->streamDetails()->videoDetails().value("codec"))) {
-            videocodecs.append(movie->streamDetails()->videoDetails().value("codec"));
+        if (!videocodecs.contains(movie->streamDetails()->videoDetails().value(StreamDetails::VideoDetails::Codec))) {
+            videocodecs.append(movie->streamDetails()->videoDetails().value(StreamDetails::VideoDetails::Codec));
         }
         if (movie->released().isValid() && !years.contains(QString("%1").arg(movie->released().year()))) {
             years.append(QString("%1").arg(movie->released().year()));

--- a/smallWidgets/MediaFlags.cpp
+++ b/smallWidgets/MediaFlags.cpp
@@ -51,9 +51,10 @@ void MediaFlags::setStreamDetails(StreamDetails *streamDetails)
  */
 void MediaFlags::setupResolution(StreamDetails *streamDetails)
 {
-    int height = streamDetails->videoDetails().value("height").toInt();
-    int width = streamDetails->videoDetails().value("width").toInt();
-    QString scanType = streamDetails->videoDetails().value("scantype");
+    const auto videoDetails = streamDetails->videoDetails();
+    const int height = videoDetails.value(StreamDetails::VideoDetails::Height).toInt();
+    const int width = videoDetails.value(StreamDetails::VideoDetails::Width).toInt();
+    QString scanType = videoDetails.value(StreamDetails::VideoDetails::ScanType);
     QString heightFlag = Helper::instance()->matchResolution(width, height, scanType);
     ui->mediaFlagResolution->setVisible(heightFlag != "");
     if (heightFlag != "") {
@@ -107,7 +108,7 @@ void MediaFlags::setupAspect(StreamDetails *streamDetails)
                                                  << "2.55"
                                                  << "2.73"
                                                  << "2.76";
-    double aspect = streamDetails->videoDetails().value("aspect").toDouble();
+    double aspect = streamDetails->videoDetails().value(StreamDetails::VideoDetails::Aspect).toDouble();
     QString aspectFlag = QString::number(aspect, 'f', 2);
     ui->mediaFlagAspect->setVisible(availableAspects.contains(aspectFlag));
     if (availableAspects.contains(aspectFlag)) {
@@ -133,7 +134,7 @@ void MediaFlags::setupCodec(StreamDetails *streamDetails)
                                                 << "vc-1"
                                                 << "wmv3"
                                                 << "xvid";
-    QString codec = streamDetails->videoDetails().value("codec").toLower();
+    QString codec = streamDetails->videoDetails().value(StreamDetails::VideoDetails::Codec).toLower();
     if (codec.startsWith("divx")) {
         codec = "divx";
     }
@@ -160,7 +161,7 @@ void MediaFlags::setupAudio(StreamDetails *streamDetails)
                                                 << "mp3"
                                                 << "mp2";
     if (streamDetails->audioDetails().count() > 0) {
-        QString codec = streamDetails->audioDetails().at(0).value("codec").toLower();
+        QString codec = streamDetails->audioDetails().at(0).value(StreamDetails::AudioDetails::Codec).toLower();
         if (codec == "dtshd-ma" || codec == "dts-hd" || codec == "dtshd_ma") {
             codec = "dtshdma";
         }
@@ -186,8 +187,8 @@ void MediaFlags::setupChannels(StreamDetails *streamDetails)
 {
     int channels = -1;
     for (int i = 0, n = streamDetails->audioDetails().count(); i < n; ++i) {
-        if (streamDetails->audioDetails().at(i).value("channels").toInt() > channels) {
-            channels = streamDetails->audioDetails().at(i).value("channels").toInt();
+        if (streamDetails->audioDetails().at(i).value(StreamDetails::AudioDetails::Channels).toInt() > channels) {
+            channels = streamDetails->audioDetails().at(i).value(StreamDetails::AudioDetails::Channels).toInt();
         }
     }
 
@@ -196,7 +197,7 @@ void MediaFlags::setupChannels(StreamDetails *streamDetails)
     }
 
     if (channels != -1) {
-        ui->mediaFlagChannels->setPixmap(colorIcon(QString(":/media/channels/%1").arg(channels)));
+        ui->mediaFlagChannels->setPixmap(colorIcon(QStringLiteral(":/media/channels/%1").arg(channels)));
     }
     ui->mediaFlagChannels->setVisible(channels != -1);
 }

--- a/trailerProviders/HdTrailers.cpp
+++ b/trailerProviders/HdTrailers.cpp
@@ -1,5 +1,6 @@
 #include "HdTrailers.h"
 
+#include <QQueue>
 #include <QRegExp>
 
 #include "globals/Helper.h"
@@ -10,38 +11,38 @@ HdTrailers::HdTrailers(QObject *parent) :
     m_loadReply{nullptr}
 {
     setParent(parent);
-    m_libraryPages.enqueue("0");
-    m_libraryPages.enqueue("a");
-    m_libraryPages.enqueue("b");
-    m_libraryPages.enqueue("c");
-    m_libraryPages.enqueue("d");
-    m_libraryPages.enqueue("e");
-    m_libraryPages.enqueue("f");
-    m_libraryPages.enqueue("g");
-    m_libraryPages.enqueue("h");
-    m_libraryPages.enqueue("i");
-    m_libraryPages.enqueue("j");
-    m_libraryPages.enqueue("k");
-    m_libraryPages.enqueue("l");
-    m_libraryPages.enqueue("m");
-    m_libraryPages.enqueue("n");
-    m_libraryPages.enqueue("o");
-    m_libraryPages.enqueue("p");
-    m_libraryPages.enqueue("q");
-    m_libraryPages.enqueue("r");
-    m_libraryPages.enqueue("s");
-    m_libraryPages.enqueue("t");
-    m_libraryPages.enqueue("u");
-    m_libraryPages.enqueue("v");
-    m_libraryPages.enqueue("w");
-    m_libraryPages.enqueue("x");
-    m_libraryPages.enqueue("y");
-    m_libraryPages.enqueue("z");
+    m_libraryPages.enqueue('0');
+    m_libraryPages.enqueue('a');
+    m_libraryPages.enqueue('b');
+    m_libraryPages.enqueue('c');
+    m_libraryPages.enqueue('d');
+    m_libraryPages.enqueue('e');
+    m_libraryPages.enqueue('f');
+    m_libraryPages.enqueue('g');
+    m_libraryPages.enqueue('h');
+    m_libraryPages.enqueue('i');
+    m_libraryPages.enqueue('j');
+    m_libraryPages.enqueue('k');
+    m_libraryPages.enqueue('l');
+    m_libraryPages.enqueue('m');
+    m_libraryPages.enqueue('n');
+    m_libraryPages.enqueue('o');
+    m_libraryPages.enqueue('p');
+    m_libraryPages.enqueue('q');
+    m_libraryPages.enqueue('r');
+    m_libraryPages.enqueue('s');
+    m_libraryPages.enqueue('t');
+    m_libraryPages.enqueue('u');
+    m_libraryPages.enqueue('v');
+    m_libraryPages.enqueue('w');
+    m_libraryPages.enqueue('x');
+    m_libraryPages.enqueue('y');
+    m_libraryPages.enqueue('z');
 }
 
 QString HdTrailers::name()
 {
-    return QString("HD-Trailers.net");
+    return QStringLiteral("HD-Trailers.net");
 }
 
 void HdTrailers::searchMovie(QString searchStr)
@@ -49,10 +50,10 @@ void HdTrailers::searchMovie(QString searchStr)
     m_currentSearch = searchStr;
 
     if (!m_libraryPages.isEmpty()) {
-        QUrl url(QString("https://www.hd-trailers.net/library/%1/").arg(m_libraryPages.dequeue()));
-        QNetworkRequest request(url);
+        QNetworkRequest request(getLibraryUrl(m_libraryPages.dequeue()));
         m_searchReply = m_qnam->get(request);
         connect(m_searchReply, &QNetworkReply::finished, this, &HdTrailers::onSearchFinished);
+
     } else {
         QList<ScraperSearchResult> results;
         QMapIterator<QString, QUrl> it(m_urls);
@@ -143,4 +144,9 @@ QList<TrailerResult> HdTrailers::parseTrailers(QString html)
         pos += rx.matchedLength();
     }
     return results;
+}
+
+QUrl HdTrailers::getLibraryUrl(char library)
+{
+    return QUrl(QStringLiteral("https://www.hd-trailers.net/library/%1/").arg(library));
 }

--- a/trailerProviders/HdTrailers.h
+++ b/trailerProviders/HdTrailers.h
@@ -35,7 +35,9 @@ private:
     QString m_currentSearch;
     QList<TrailerResult> parseTrailers(QString html);
     QMap<QString, QUrl> m_urls;
-    QQueue<QString> m_libraryPages;
+    QQueue<char> m_libraryPages;
+
+    QUrl getLibraryUrl(char library);
 };
 
 #endif // HDTRAILERS_H

--- a/tvShows/TvShowWidgetEpisode.cpp
+++ b/tvShows/TvShowWidgetEpisode.cpp
@@ -452,19 +452,21 @@ void TvShowWidgetEpisode::updateStreamDetails(bool reloadFromFile)
     }
 
     StreamDetails *streamDetails = m_episode->streamDetails();
-    ui->videoWidth->setValue(streamDetails->videoDetails().value("width").toInt());
-    ui->videoHeight->setValue(streamDetails->videoDetails().value("height").toInt());
-    ui->videoAspectRatio->setValue(QString{streamDetails->videoDetails().value("aspect")}.replace(",", ".").toDouble());
-    ui->videoCodec->setText(streamDetails->videoDetails().value("codec"));
-    ui->videoScantype->setText(streamDetails->videoDetails().value("scantype"));
+    const auto videoDetails = streamDetails->videoDetails();
+    ui->videoWidth->setValue(videoDetails.value(StreamDetails::VideoDetails::Width).toInt());
+    ui->videoHeight->setValue(videoDetails.value(StreamDetails::VideoDetails::Height).toInt());
+    ui->videoAspectRatio->setValue(
+        QString{videoDetails.value(StreamDetails::VideoDetails::Aspect)}.replace(",", ".").toDouble());
+    ui->videoCodec->setText(videoDetails.value(StreamDetails::VideoDetails::Codec));
+    ui->videoScantype->setText(videoDetails.value(StreamDetails::VideoDetails::ScanType));
     ui->stereoMode->setCurrentIndex(0);
     for (int i = 0, n = ui->stereoMode->count(); i < n; ++i) {
-        if (ui->stereoMode->itemData(i).toString() == streamDetails->videoDetails().value("stereomode")) {
+        if (ui->stereoMode->itemData(i).toString() == videoDetails.value(StreamDetails::VideoDetails::StereoMode)) {
             ui->stereoMode->setCurrentIndex(i);
         }
     }
     QTime time(0, 0, 0, 0);
-    time = time.addSecs(streamDetails->videoDetails().value("durationinseconds").toInt());
+    time = time.addSecs(videoDetails.value(StreamDetails::VideoDetails::DurationInSeconds).toInt());
     ui->videoDuration->setTime(time);
 
     foreach (QWidget *widget, m_streamDetailsWidgets)
@@ -474,12 +476,13 @@ void TvShowWidgetEpisode::updateStreamDetails(bool reloadFromFile)
     m_streamDetailsSubtitles.clear();
 
     int audioTracks = streamDetails->audioDetails().count();
+    const auto audioDetails = streamDetails->audioDetails();
     for (int i = 0; i < audioTracks; ++i) {
         QLabel *label = new QLabel(tr("Track %1").arg(i + 1));
         ui->streamDetails->addWidget(label, 8 + i, 0);
-        QLineEdit *edit1 = new QLineEdit(streamDetails->audioDetails().at(i).value("language"));
-        QLineEdit *edit2 = new QLineEdit(streamDetails->audioDetails().at(i).value("codec"));
-        QLineEdit *edit3 = new QLineEdit(streamDetails->audioDetails().at(i).value("channels"));
+        QLineEdit *edit1 = new QLineEdit(audioDetails.at(i).value(StreamDetails::AudioDetails::Language));
+        QLineEdit *edit2 = new QLineEdit(audioDetails.at(i).value(StreamDetails::AudioDetails::Codec));
+        QLineEdit *edit3 = new QLineEdit(audioDetails.at(i).value(StreamDetails::AudioDetails::Channels));
         edit3->setMaximumWidth(50);
         edit1->setToolTip(tr("Language"));
         edit2->setToolTip(tr("Codec"));
@@ -511,7 +514,8 @@ void TvShowWidgetEpisode::updateStreamDetails(bool reloadFromFile)
         for (int i = 0, n = streamDetails->subtitleDetails().count(); i < n; ++i) {
             QLabel *label = new QLabel(tr("Track %1").arg(i + 1));
             ui->streamDetails->addWidget(label, 9 + audioTracks + i, 0);
-            QLineEdit *edit1 = new QLineEdit(streamDetails->subtitleDetails().at(i).value("language"));
+            QLineEdit *edit1 =
+                new QLineEdit(streamDetails->subtitleDetails().at(i).value(StreamDetails::SubtitleDetails::Language));
             edit1->setToolTip(tr("Language"));
             edit1->setPlaceholderText(tr("Language"));
             auto layout = new QHBoxLayout();
@@ -972,21 +976,22 @@ void TvShowWidgetEpisode::onDeleteThumbnail()
 void TvShowWidgetEpisode::onStreamDetailsEdited()
 {
     StreamDetails *details = m_episode->streamDetails();
-    details->setVideoDetail("codec", ui->videoCodec->text());
-    details->setVideoDetail("aspect", ui->videoAspectRatio->text());
-    details->setVideoDetail("width", ui->videoWidth->text());
-    details->setVideoDetail("height", ui->videoHeight->text());
-    details->setVideoDetail("scantype", ui->videoScantype->text());
-    details->setVideoDetail("durationinseconds", QString("%1").arg(-ui->videoDuration->time().secsTo(QTime(0, 0))));
-    details->setVideoDetail("stereomode", ui->stereoMode->currentData().toString());
+    details->setVideoDetail(StreamDetails::VideoDetails::Codec, ui->videoCodec->text());
+    details->setVideoDetail(StreamDetails::VideoDetails::Aspect, ui->videoAspectRatio->text());
+    details->setVideoDetail(StreamDetails::VideoDetails::Width, ui->videoWidth->text());
+    details->setVideoDetail(StreamDetails::VideoDetails::Height, ui->videoHeight->text());
+    details->setVideoDetail(StreamDetails::VideoDetails::ScanType, ui->videoScantype->text());
+    details->setVideoDetail(StreamDetails::VideoDetails::DurationInSeconds,
+        QString("%1").arg(-ui->videoDuration->time().secsTo(QTime(0, 0))));
+    details->setVideoDetail(StreamDetails::VideoDetails::StereoMode, ui->stereoMode->currentData().toString());
 
     for (int i = 0, n = m_streamDetailsAudio.count(); i < n; ++i) {
-        details->setAudioDetail(i, "language", m_streamDetailsAudio[i][0]->text());
-        details->setAudioDetail(i, "codec", m_streamDetailsAudio[i][1]->text());
-        details->setAudioDetail(i, "channels", m_streamDetailsAudio[i][2]->text());
+        details->setAudioDetail(i, StreamDetails::AudioDetails::Language, m_streamDetailsAudio[i][0]->text());
+        details->setAudioDetail(i, StreamDetails::AudioDetails::Codec, m_streamDetailsAudio[i][1]->text());
+        details->setAudioDetail(i, StreamDetails::AudioDetails::Channels, m_streamDetailsAudio[i][2]->text());
     }
     for (int i = 0, n = m_streamDetailsSubtitles.count(); i < n; ++i) {
-        details->setSubtitleDetail(i, "language", m_streamDetailsSubtitles[i][0]->text());
+        details->setSubtitleDetail(i, StreamDetails::SubtitleDetails::Language, m_streamDetailsSubtitles[i][0]->text());
     }
 
     m_episode->setChanged(true);


### PR DESCRIPTION
Depends on #494 

This PR replaces strings with scoped enums to ensure type safety.
I'll rebase this PR when #494 is merged.