### PR TITLE
[macOS] Fixed Trailer Dialog

### DIFF
--- a/globals/TrailerDialog.cpp
+++ b/globals/TrailerDialog.cpp
@@ -284,6 +284,11 @@ void TrailerDialog::cancelDownload()
 
     m_output.close();
     m_downloadInProgress = false;
+
+#ifdef Q_OS_MAC
+    TrailerDialog::resize(width() + 1,height() + 1);
+    TrailerDialog::resize(width() - 1,height() - 1);
+#endif
 }
 
 void TrailerDialog::downloadProgress(qint64 received, qint64 total)
@@ -369,6 +374,11 @@ void TrailerDialog::downloadFinished()
     ui->buttonClose3->setEnabled(true);
 
     m_downloadReply->deleteLater();
+
+#ifdef Q_OS_MAC
+    TrailerDialog::resize(width() + 1,height() + 1);
+    TrailerDialog::resize(width() - 1,height() - 1);
+#endif
 }
 
 void TrailerDialog::downloadReadyRead()
@@ -422,11 +432,27 @@ void TrailerDialog::onStateChanged(QMediaPlayer::State newState)
 
 void TrailerDialog::onPlayPause()
 {
+    #ifdef Q_OS_MAC
+        TrailerDialog::resize(width() + 1,height() + 1);
+        TrailerDialog::resize(width() - 1,height() - 1);
+    #endif
+
     switch (m_mediaPlayer->state()) {
     case QMediaPlayer::PlayingState: m_mediaPlayer->pause(); break;
     case QMediaPlayer::StoppedState:
+    
+    #ifdef Q_OS_MAC
+        TrailerDialog::resize(width() + 1,height() + 1);
+        TrailerDialog::resize(width() - 1,height() - 1);
+    #endif
+    
     case QMediaPlayer::PausedState: m_mediaPlayer->play(); break;
     }
+    
+    #ifdef Q_OS_MAC
+        TrailerDialog::resize(width() + 1,height() + 1);
+        TrailerDialog::resize(width() - 1,height() - 1);
+    #endif
 }
 
 void TrailerDialog::onAnimationFinished()


### PR DESCRIPTION
This is a really strange solution, but only one I could find to fix this:
![1](https://user-images.githubusercontent.com/12618414/42133860-2da0c55e-7d74-11e8-96a3-fe99fae12413.png)
![2](https://user-images.githubusercontent.com/12618414/42133861-3424f8fa-7d74-11e8-95df-886593f55411.png)
Qt 5.11 on macOS is extremely buggy!