### PR TITLE
[AdvancedSettings] Fix audio codec mapping

### DIFF
--- a/data/StreamDetails.cpp
+++ b/data/StreamDetails.cpp
@@ -294,13 +294,13 @@ QString StreamDetails::audioFormat(const QString &codec, const QString &profile)
     } else if (codec == "MPA1L3") {
         xbmcFormat = "mp3";
     } else {
-        xbmcFormat = codec;
+        xbmcFormat = codec.toLower();
     }
 
     if (Settings::instance()->advanced()->audioCodecMappings().contains(xbmcFormat)) {
         return Settings::instance()->advanced()->audioCodecMappings().value(xbmcFormat);
     }
-    return xbmcFormat.toLower();
+    return xbmcFormat;
 }
 
 QString StreamDetails::stereoFormat(const QString &format) const

--- a/doc/advancedsettings.xml
+++ b/doc/advancedsettings.xml
@@ -112,8 +112,9 @@
         the audio codec "MPA1L3" with "MP3".
     -->
     <audioCodecs>
-        <map from="MPA1L2" to="MP2" />
-        <map from="MPA1L3" to="MP3" />
+        <map from="mpa1l2" to="mp2" />
+        <map from="mpa1l3" to="mp3" />
+        <map from="aac lc" to="aac" />
     </audioCodecs>
 
     <!--

--- a/settings/AdvancedSettings.cpp
+++ b/settings/AdvancedSettings.cpp
@@ -31,8 +31,9 @@ void AdvancedSettings::reset()
     m_writeThumbUrlsToNfo = true;
     m_useFirstStudioOnly = false;
 
-    m_audioCodecMappings.insert("MPA1L2", "MP2");
-    m_audioCodecMappings.insert("MPA1L3", "MP3");
+    m_audioCodecMappings.insert("mpa1l2", "mp2");
+    m_audioCodecMappings.insert("mpa1l3", "mp3");
+    m_audioCodecMappings.insert("aac lc", "aac");
     m_videoCodecMappings.insert("v_mpeg4/iso/avc", "h264");
 
     const auto videoFiles = QStringList{"*.mkv",


### PR DESCRIPTION
 - the user is presented with an audio codec which
   (if put in advancedsettings.xml) may not be used because
   lowercase/uppercase may differ
 - add "aac lc" to "aac" mapping