### PR TITLE
[TrailerDialog] Fix signal slot

### DIFF
--- a/globals/TrailerDialog.cpp
+++ b/globals/TrailerDialog.cpp
@@ -62,7 +62,10 @@ TrailerDialog::TrailerDialog(QWidget *parent) : QDialog(parent), ui(new Ui::Trai
     connect(m_mediaPlayer, &QMediaPlayer::stateChanged, this, &TrailerDialog::onStateChanged);
     connect(m_mediaPlayer, &QMediaPlayer::durationChanged, this, &TrailerDialog::onNewTotalTime);
     connect(m_mediaPlayer, &QMediaPlayer::positionChanged, this, &TrailerDialog::onUpdateTime);
-    connect(m_mediaPlayer, SIGNAL(error(QMediaPlayer::Error)), this, SIGNAL(onTrailerError(QMediaPlayer::Error)));
+    QObject::connect(m_mediaPlayer,
+        static_cast<void (QMediaPlayer::*)(QMediaPlayer::Error)>(&QMediaPlayer::error),
+        this,
+        &TrailerDialog::onTrailerError);
     connect(ui->btnPlayPause, &QAbstractButton::clicked, this, &TrailerDialog::onPlayPause);
     connect(ui->seekSlider, &QAbstractSlider::sliderReleased, this, &TrailerDialog::onSliderPositionChanged);
 }


### PR DESCRIPTION
For some reason that I just don't unterstand, Qt 5.11 couldn't find the correct slot in `TrailerDialog.cpp`. 