### PR TITLE
[XML] Fix set name; [TagCloud] Only load 150 inactive tags

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
  - Remove deprecated MediaPassion (#449)
  - Remove deprecated MovieMaze (#386)
  - Support KDE Breeze Dark theme (#407)
+ - Use new Kodi XML syntax for movie set names (#554)
  - Scrape TV show tags when using IMDb
  - Detect duplicate movies
  - Create subdirectories

--- a/scripts/build-scripts/package_functions.sh
+++ b/scripts/build-scripts/package_functions.sh
@@ -49,7 +49,7 @@ package_appimage() {
 
 	echo ""
 	print_important "Creating an AppImage for MediaElch ${VERSION_NAME}. This takes a while and may seem frozen."
-	$DEPLOYQT appdir/usr/share/applications/MediaElch.desktop -verbose=1 -bundle-non-qt-libs -qmldir=../ui
+	$DEPLOYQT appdir/usr/share/applications/MediaElch.desktop -verbose=1 -bundle-non-qt-libs -qmldir=../src/ui
 	$DEPLOYQT --appimage-extract
 	export PATH=$(readlink -f ./squashfs-root/usr/bin):$PATH
 	# Workaround to increase compatibility with older systems

--- a/src/concerts/ConcertWidget.cpp
+++ b/src/concerts/ConcertWidget.cpp
@@ -452,7 +452,7 @@ void ConcertWidget::updateConcertInfo()
     QStringList genres;
     QStringList tags;
     certifications.append("");
-    foreach (Concert *concert, Manager::instance()->concertModel()->concerts()) {
+    for (const Concert *concert : Manager::instance()->concertModel()->concerts()) {
         if (!certifications.contains(concert->certification()) && !concert->certification().isEmpty()) {
             certifications.append(concert->certification());
         }
@@ -463,6 +463,11 @@ void ConcertWidget::updateConcertInfo()
     ui->certification->addItems(certifications);
     ui->certification->setCurrentIndex(certifications.indexOf(m_concert->certification()));
     ui->certification->blockSignals(false);
+
+    // `setTags` requires distinct lists
+    genres.removeDuplicates();
+    tags.removeDuplicates();
+
     ui->genreCloud->setTags(genres, m_concert->genres());
     ui->tagCloud->setTags(tags, m_concert->tags());
 

--- a/src/movies/MovieWidget.cpp
+++ b/src/movies/MovieWidget.cpp
@@ -671,13 +671,19 @@ void MovieWidget::updateMovieInfo()
     QStringList tags;
     QStringList countries;
     QStringList studios;
-    foreach (Movie *movie, Manager::instance()->movieModel()->movies()) {
+    for (const Movie *movie : Manager::instance()->movieModel()->movies()) {
         genres << movie->genres();
         tags << movie->tags();
         countries << movie->countries();
         studios << movie->studios();
     }
+
+    // `setTags` requires distinct lists
+    genres.removeDuplicates();
+    tags.removeDuplicates();
+    countries.removeDuplicates();
     studios.removeDuplicates();
+
     ui->genreCloud->setTags(genres, m_movie->genres());
     ui->tagCloud->setTags(tags, m_movie->tags());
     ui->countryCloud->setTags(countries, m_movie->countries());

--- a/src/music/MusicWidgetAlbum.cpp
+++ b/src/music/MusicWidgetAlbum.cpp
@@ -265,7 +265,7 @@ void MusicWidgetAlbum::updateAlbumInfo()
     QStringList genres;
     QStringList styles;
     QStringList moods;
-    foreach (Artist *artist, Manager::instance()->musicModel()->artists()) {
+    for (const Artist *artist : Manager::instance()->musicModel()->artists()) {
         genres << artist->genres();
         styles << artist->styles();
         moods << artist->moods();
@@ -277,9 +277,12 @@ void MusicWidgetAlbum::updateAlbumInfo()
             }
         }
     }
+
+    // `setTags` requires distinct lists
     genres.removeDuplicates();
     styles.removeDuplicates();
     moods.removeDuplicates();
+
     ui->genreCloud->setTags(genres, m_album->genres());
     ui->styleCloud->setTags(styles, m_album->styles());
     ui->moodCloud->setTags(moods, m_album->moods());

--- a/src/music/MusicWidgetArtist.cpp
+++ b/src/music/MusicWidgetArtist.cpp
@@ -261,14 +261,17 @@ void MusicWidgetArtist::updateArtistInfo()
     QStringList genres;
     QStringList styles;
     QStringList moods;
-    foreach (Artist *artist, Manager::instance()->musicModel()->artists()) {
+    for (const Artist *artist : Manager::instance()->musicModel()->artists()) {
         genres << artist->genres();
         styles << artist->styles();
         moods << artist->moods();
     }
+
+    // `setTags` requires distinct lists
     genres.removeDuplicates();
     styles.removeDuplicates();
     moods.removeDuplicates();
+
     ui->genreCloud->setTags(genres, m_artist->genres());
     ui->styleCloud->setTags(styles, m_artist->styles());
     ui->moodCloud->setTags(moods, m_artist->moods());

--- a/src/smallWidgets/TagCloud.h
+++ b/src/smallWidgets/TagCloud.h
@@ -53,7 +53,7 @@ private:
     QStringList m_activeTags;
     QList<Badge *> m_badges;
     QPointer<QCompleter> m_completer;
-    void drawTags();
+    void drawTags(bool drawAll = false);
 };
 
 #endif // TAGCLOUD_H

--- a/src/tvShows/TvShowWidgetTvShow.cpp
+++ b/src/tvShows/TvShowWidgetTvShow.cpp
@@ -356,10 +356,15 @@ void TvShowWidgetTvShow::updateTvShowInfo()
 
     QStringList genres;
     QStringList tags;
-    foreach (TvShow *show, Manager::instance()->tvShowModel()->tvShows()) {
+    for (const TvShow *show : Manager::instance()->tvShowModel()->tvShows()) {
         genres.append(show->genres());
         tags.append(show->tags());
     }
+
+    // `setTags` requires distinct lists
+    genres.removeDuplicates();
+    tags.removeDuplicates();
+
     ui->genreCloud->setTags(genres, m_show->genres());
     ui->tagCloud->setTags(tags, m_show->tags());
 

--- a/travis-ci/package.sh
+++ b/travis-ci/package.sh
@@ -128,7 +128,7 @@ create_appimage() {
 	fold_start "linuxdeployqt"
 	print_info "Running linuxdeployqt"
 	print_important "Creating an AppImage for MediaElch ${VERSION_NAME}"
-	./linuxdeployqt appdir/usr/share/applications/MediaElch.desktop -verbose=2 -bundle-non-qt-libs -qmldir=../ui
+	./linuxdeployqt appdir/usr/share/applications/MediaElch.desktop -verbose=2 -bundle-non-qt-libs -qmldir=../src/ui
 	./linuxdeployqt --appimage-extract
 	export PATH=$(readlink -f ./squashfs-root/usr/bin):$PATH
 	# Workaround to increase compatibility with older systems
@@ -195,7 +195,7 @@ create_macos_dmg() {
 
 	fold_start "dmg"
 	print_important "Running macdeployqt"
-	/usr/local/opt/qt/bin/macdeployqt MediaElch.app -qmldir=../ui -verbose=2
+	/usr/local/opt/qt/bin/macdeployqt MediaElch.app -qmldir=../src/ui -verbose=2
 	print_info "Running create-dmg"
 	create-dmg/create-dmg \
 		--volname "MediaElch" \


### PR DESCRIPTION
Fixes #554 

- [x] stores set name in new syntax
- [x] can read new syntax
- [x] can read old syntax

Fixes #488 by using a workaround.

Fixes a packaging problem introduced by #576