### PR TITLE
Enable CONFIG setting for building against external quazip

### DIFF
--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -2,21 +2,37 @@
 lessThan(QT_MAJOR_VERSION, 5): error(Qt 4 is not supported!)
 lessThan(QT_MINOR_VERSION, 5): error(Qt 5.5 or higher is required!)
 
-DEFINES += QUAZIP_BUILD
-DEFINES += QUAZIP_STATIC # Required by Quazip to export symbols
-include(third_party/quazip/quazip/quazip.pri)
+contains ( CONFIG, USE_EXTERN_QUAZIP ) {
+    DEFINES += EXTERN_QUAZIP
+}
+
+! contains ( DEFINES, EXTERN_QUAZIP ) {
+    # using internal 3rd party QUAZIP
+    DEFINES += QUAZIP_BUILD
+    DEFINES += QUAZIP_STATIC # Required by Quazip to export symbols
+    include(third_party/quazip/quazip/quazip.pri)
+}
 
 TEMPLATE = app
 TARGET = MediaElch
 INCLUDEPATH += $$PWD/src
-INCLUDEPATH += $$PWD/third_party
+! contains ( DEFINES, EXTERN_QUAZIP ) {
+    # using internal 3rd party QUAZIP
+    INCLUDEPATH += $$PWD/third_party
+}
 
 QT += core gui network xml sql widgets multimedia multimediawidgets \
       concurrent qml quick quickwidgets opengl
 
 CONFIG += warn_on c++14
 
-LIBS += -lz
+! contains ( DEFINES, EXTERN_QUAZIP ) {
+    # using internal 3rd party QUAZIP
+    LIBS += -lz
+} else {
+    #using external quazip
+    LIBS += -lz -lquazip5
+}
 
 unix:LIBS += -lcurl
 macx:LIBS += -framework Foundation

--- a/src/export/ExportTemplateLoader.cpp
+++ b/src/export/ExportTemplateLoader.cpp
@@ -6,8 +6,13 @@
 #include <QNetworkReply>
 #include <QXmlStreamReader>
 
-#include "quazip/quazip/quazip.h"
-#include "quazip/quazip/quazipfile.h"
+#ifndef EXTERN_QUAZIP
+    #include "quazip/quazip/quazip.h"
+    #include "quazip/quazip/quazipfile.h"
+#else
+    #include "quazip5/quazip.h"
+    #include "quazip5/quazipfile.h"
+#endif
 #include "settings/Settings.h"
 
 #include "data/Storage.h"

--- a/src/tv_shows/TvShowUpdater.cpp
+++ b/src/tv_shows/TvShowUpdater.cpp
@@ -8,8 +8,13 @@
 #include "data/Storage.h"
 #include "globals/Globals.h"
 #include "globals/Manager.h"
-#include "quazip/quazip/quazip.h"
-#include "quazip/quazip/quazipfile.h"
+#ifndef EXTERN_QUAZIP
+    #include "quazip/quazip/quazip.h"
+    #include "quazip/quazip/quazipfile.h"
+#else
+    #include "quazip5/quazip.h"
+    #include "quazip5/quazipfile.h"
+#endif
 #include "scrapers/tv_show/TheTvDb.h"
 #include "tv_shows/TvShow.h"
 #include "ui/notifications/NotificationBox.h"


### PR DESCRIPTION
Some downstream package maintainers will resort to maintaining patches
against MediaElch sources to enable build against external quazip libraries.

Commit establishes a convenience CONFIG flag:

`CONFIG += USE_EXTERN_QUAZIP`

that enables a DEFINE statement that is used to switch out thirdparty/quazip
references with external quazip sources.