### PR TITLE
Enable CONFIG setting for building against external quazip(CMake)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,11 @@ option(ENABLE_CLANG_TIDY_FIX   "Analyze code with clang-tidy and fix errors."   
 option(ENABLE_COVERAGE         "Add coverage information to binaries."               OFF)
 option(ENABLE_COLOR_OUTPUT     "Force produce ANSI-colored output (GNU/Clang only)."  ON)
 option(ENABLE_LTO              "Enable link-time-optimization. Increases link time." OFF)
+option(USE_EXTERN_QUAZIP       "Enable link-time-optimization. Increases link time." OFF)
+
+if(USE_EXTERN_QUAZIP)
+  add_definitions(-DEXTERN_QUAZIP)
+endif()
 # cmake-format: on
 
 find_package(Sanitizers)
@@ -109,11 +114,16 @@ find_package(
 # Subdirectories and main executable
 
 add_subdirectory(docs)
-add_subdirectory(third_party EXCLUDE_FROM_ALL)
+if(NOT USE_EXTERN_QUAZIP)
+  add_subdirectory(third_party EXCLUDE_FROM_ALL)
+endif()
 add_subdirectory(src)
 
 add_executable(mediaelch src/main.cpp)
 target_link_libraries(mediaelch PRIVATE libmediaelch)
+if(USE_EXTERN_QUAZIP)
+  add_library(quazip5 SHARED IMPORTED)
+endif()
 set_target_properties(mediaelch PROPERTIES OUTPUT_NAME "MediaElch")
 mediaelch_post_target_defaults(mediaelch)
 

--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -6,6 +6,12 @@ include(${CMAKE_CURRENT_LIST_DIR}/Gcov.cmake)
 
 set(COVERAGE_ENABLED OFF BOOL)
 
+if(NOT USE_EXTERN_QUAZIP)
+  SET(LCOV_THIRDPARTY "\"*/third_party/*\"")
+else()
+  SET(LCOV_THIRDPARTY "\"*/third_party/catch2/*\"")
+endif()
+
 set(
   LCOV_EXCLUDE_COVERAGE
   ${LCOV_EXCLUDE_COVERAGE}
@@ -14,7 +20,7 @@ set(
   "\"*v1*\""
   "\"/usr/*\""
   "\"*/external/*\""
-  "\"*/third_party/*\""
+  ${LCOV_THIRDPARTY}
 )
 
 # Function to register a target for enabled coverage report. Use this function


### PR DESCRIPTION
From PR #756, comment was made for need to add commit to CMake Build system files as well.
This commit implements PR#756 into project CMake files.

Executing on the command line:

`cmake ... -DUSE_EXTERN_QUAZIP=ON ...`

will do the same as PR#756, that is internally set a flag in CMake to test, set a define
for project files during compile, and add the library reference to external libquazip5.