### PR TITLE
[DownloadManager] Use QMutex when assigning a download element value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ https://mediaelch.github.io/mediaelch-doc/faq.html#where-are-mediaelchs-settings
  - Fix ADE scraper (#703, #725)
  - Fix TV shows always beeing reloaded (#732)
  - Fix incompatibilities with Kodi v17 NFO files (#719)
+ - Fix race-condition in DownloadManager (#766)
 
 ### Improvements
 

--- a/src/globals/DownloadManager.h
+++ b/src/globals/DownloadManager.h
@@ -51,7 +51,7 @@ private slots:
 
 private:
     template<class T>
-    void startNextDownloadType();
+    void checkAllDownloadsFinished();
     QNetworkAccessManager* qnam();
 
     QNetworkReply* m_currentReply = nullptr;


### PR DESCRIPTION
The DownloadManager isn't really thread safe. I don't know how it worked in the past. Well, this is more like a quickfix that hopefully fixes  #716