### PR TITLE
[Export] Fix empty export name

### DIFF
--- a/src/export/ExportTemplateLoader.cpp
+++ b/src/export/ExportTemplateLoader.cpp
@@ -104,7 +104,6 @@ void ExportTemplateLoader::loadLocalTemplates()
         file.close();
 
         QXmlStreamReader xml(content);
-        xml.readNextStartElement();
 
         if (!xml.readNextStartElement()) {
             qWarning() << "[ExportTemplateLoader] Couldn't read XML root element of local template";


### PR DESCRIPTION
 - bug introduced in "[Project] Fix coverity warnings" : db6a5c4518354ef03d9d642e1d41070dcd94e7fc