### PR TITLE
[Style] Fix label color not shown for movies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - Fix hanging window if the custom movie scraper is selected but no valid scraper is found.  
    This can happen if MediaElch's settings are in an inconsistent state (#792)
  - Fix `{{ *.RATING }}` not being replaced in exports if a media item has no rating
+ - Fix movie label color not being shown (#803)
 
 ### Internal Improvements and Changes
 

--- a/src/ui/default.css
+++ b/src/ui/default.css
@@ -81,13 +81,11 @@ QComboBox#comboStatus:disabled {
     background-color: #ffffff;
     selection-color: #ffffff;
     color: #395265;
-    border: none;
 }
 #centralWidget QTableWidget::item,
 #centralWidget QTableView::item,
 #centralWidget QTreeView::item {
     color: #395265;
-    border: none;
 }
 #centralWidget QTableWidget::item:selected,
 #centralWidget QTableView::item:selected,


### PR DESCRIPTION
 - Remove `border:none` from QTableWidget
 - Note from Qt docs (QTableWidget):
   https://doc.qt.io/qt-5/stylesheet-reference.html

   "If you only set a background-color on a QTableCornerButton,
   the background may not appear unless you set the border property
   to some value. This is because, by default, the QTableCornerButton
   draws a native border which completely overlaps the
   background-color."
 - bug introduced in 629786b2b4ee92c8ab6495b2ae2ffcdf243c3d64
   (Mon Feb 18 08:45:19 2019 +0100)

### TODO
 - [ ] Test if it still works with a dark theme as we partly revert "[UI] Fix table/list layout for dark theme"