### PR TITLE
[Movie/TvShow] Only use premiered tag if it contains a valid date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
  - Fix TMDb scraper language in dialog window (#813)  
    Scraper language wasn't the one saved in settings but always "English".
  - About Dialog: Fix MediaInfo version string in developer information (#790)
+ - Movie/TvShow: Only parse valid `premiered` tags (#827)
 
 ### Improvements
 

--- a/src/media_centers/kodi/MovieXmlReader.cpp
+++ b/src/media_centers/kodi/MovieXmlReader.cpp
@@ -72,8 +72,11 @@ void MovieXmlReader::parseNfoDom(QDomDocument domDoc)
     }
     // will overwrite the release date set by <year>
     if (!domDoc.elementsByTagName("premiered").isEmpty()) {
-        QString value = domDoc.elementsByTagName("premiered").at(0).toElement().text();
-        m_movie.setReleased(QDate::fromString(value, "yyyy-MM-dd"));
+        QString value = domDoc.elementsByTagName("premiered").at(0).toElement().text().trimmed();
+        QDate released = QDate::fromString(value, "yyyy-MM-dd");
+        if (released.isValid()) {
+            m_movie.setReleased(released);
+        }
     }
 
     if (!domDoc.elementsByTagName("runtime").isEmpty()) {

--- a/src/media_centers/kodi/TvShowXmlReader.cpp
+++ b/src/media_centers/kodi/TvShowXmlReader.cpp
@@ -137,8 +137,11 @@ void TvShowXmlReader::parseNfoDom(QDomDocument domDoc)
     }
     // will override the first-aired date set by <year>
     if (!domDoc.elementsByTagName("premiered").isEmpty()) {
-        m_show.setFirstAired(
-            QDate::fromString(domDoc.elementsByTagName("premiered").at(0).toElement().text(), "yyyy-MM-dd"));
+        QString value = domDoc.elementsByTagName("premiered").at(0).toElement().text().trimmed();
+        QDate released = QDate::fromString(value, "yyyy-MM-dd");
+        if (released.isValid()) {
+            m_show.setFirstAired(released);
+        }
     }
     if (!domDoc.elementsByTagName("dateadded").isEmpty()) {
         m_show.setDateAdded(QDateTime::fromString(


### PR DESCRIPTION
If an NFO contains a valid `<year>` tag but invalid `<premiered>` tag, the date was always set to an invalid `QDate` (the UI shows `2019`).

 - related issue #821
