### PR TITLE
[MediaInfoFile] Update audio recognition for latest MediaInfoLib (v19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
    For example: Start MediaElch -> click "TvShow" -> click "Sync Kodi" -> click "Close" -> Crash
  - Fix missing TheTvDb ID in episode NFO files (#788)
  - Don't write TheTvDb v1 episode-guide URLs to TV show NFOs (#652)
+ - Show "Dolby TrueHD" media flag for "truehd" audio codec
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
  - Fix missing TheTvDb ID in episode NFO files (#788)
  - Don't write TheTvDb v1 episode-guide URLs to TV show NFOs (#652)
  - Show "Dolby TrueHD" media flag for "truehd" audio codec
+ - Fix audio codec recognition for newer MediaInfoLib versions (#797)
 
 ### Improvements
 

--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -101,6 +101,7 @@ QMAKE_INFO_PLIST = MediaElch.plist
 
 SOURCES += src/main.cpp \
     src/concerts/ConcertController.cpp \
+    src/data/MediaInfoFile.cpp \
     src/ui/concerts/ConcertFilesWidget.cpp \
     src/ui/concerts/ConcertSearch.cpp \
     src/ui/concerts/ConcertSearchWidget.cpp \
@@ -349,6 +350,7 @@ macx {
 
 HEADERS  += Version.h \
     src/concerts/ConcertController.h \
+    src/data/MediaInfoFile.h \
     src/ui/concerts/ConcertFilesWidget.h \
     src/ui/concerts/ConcertSearch.h \
     src/ui/concerts/ConcertSearchWidget.h \

--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(
   Database.cpp
   ImageCache.cpp
   ImdbId.cpp
+  MediaInfoFile.cpp
   Rating.cpp
   ResumeTime.cpp
   Storage.cpp

--- a/src/data/MediaInfoFile.cpp
+++ b/src/data/MediaInfoFile.cpp
@@ -1,0 +1,241 @@
+#include "data/MediaInfoFile.h"
+
+#include "globals/Helper.h"
+#include "settings/Settings.h"
+
+#include "MediaInfoDLL/MediaInfoDLL.h"
+
+#include <ZenLib/Ztring.h>
+#include <ZenLib/ZtringListList.h>
+
+#include <QDebug>
+
+#ifdef Q_OS_WIN
+#define QString2MI(_DATA) QString(_DATA).toStdWString()
+#define MI2QString(_DATA) QString::fromStdWString(_DATA)
+#else
+#define QString2MI(_DATA) QString{_DATA}.toUtf8().data()
+#define MI2QString(_DATA) QString((_DATA).c_str())
+#endif
+
+MediaInfoFile::MediaInfoFile(const QString& filepath) : m_mediaInfo{std::make_unique<MediaInfoDLL::MediaInfo>()}
+{
+    // VERSION;APP_NAME;APP_VERSION"
+    m_mediaInfo->Option(__T("Info_Version"), __T("19.09;MediaElch;2.6"));
+    m_mediaInfo->Option(__T("Internet"), __T("no"));
+    m_mediaInfo->Option(__T("Complete"), __T("1"));
+    m_mediaInfo->Open(QString2MI(filepath));
+    if (!m_mediaInfo->IsReady()) {
+        qCritical() << "[MediaInfo] Not able to load libmediainfo!";
+    }
+}
+
+MediaInfoFile::~MediaInfoFile()
+{
+    m_mediaInfo->Close();
+}
+
+int MediaInfoFile::subtitleCount() const
+{
+    return getGeneral(0, "TextCount").toInt();
+}
+
+int MediaInfoFile::videoStreamCount() const
+{
+    return getGeneral(0, "VideoCount").toInt();
+}
+
+int MediaInfoFile::audioStreamCount() const
+{
+    return getGeneral(0, "AudioCount").toInt();
+}
+
+std::chrono::milliseconds MediaInfoFile::duration(int streamIndex) const
+{
+    return std::chrono::milliseconds(getGeneral(streamIndex, "Duration").toLongLong());
+}
+
+std::size_t MediaInfoFile::videoWidth(int streamIndex) const
+{
+    long long width = getVideo(streamIndex, "Width").toLongLong();
+    return width < 0 ? 0 : width;
+}
+
+std::size_t MediaInfoFile::videoHeight(int streamIndex) const
+{
+    long long height = getVideo(streamIndex, "Height").toLongLong();
+    return height < 0 ? 0 : height;
+}
+
+double MediaInfoFile::aspectRatio(int streamIndex) const
+{
+    return getVideo(streamIndex, "DisplayAspectRatio").toDouble();
+}
+
+QString MediaInfoFile::codec(int streamIndex) const
+{
+    QString codec = getVideo(streamIndex, "Format");
+    if (codec.isEmpty()) {
+        codec = getVideo(streamIndex, "CodecID");
+    }
+    return codec;
+}
+
+QString MediaInfoFile::mpegVersion(int streamIndex) const
+{
+    return getVideo(streamIndex, "Format_Version");
+}
+
+QString MediaInfoFile::scanType(int streamIndex) const
+{
+    if (getVideo(streamIndex, "CodecID") == "V_MPEGH/ISO/HEVC") {
+        return "progressive";
+    }
+    QString scanType = getVideo(streamIndex, "ScanType");
+    if (scanType == "MBAFF") {
+        return "interlaced";
+    }
+    return scanType.toLower();
+}
+
+QString MediaInfoFile::stereoFormat(int streamIndex) const
+{
+    QString multiView = getVideo(streamIndex, "MultiView_Layout").toLower();
+    if (helper::stereoModes().values().contains(multiView)) {
+        return helper::stereoModes().key(multiView);
+    }
+    return "";
+}
+
+QString MediaInfoFile::format(int streamIndex) const
+{
+    return parseVideoFormat(codec(streamIndex), mpegVersion(streamIndex));
+}
+
+QString MediaInfoFile::audioLanguage(int streamIndex) const
+{
+    QString lang = getAudio(streamIndex, "Language/String3");
+    if (lang.isEmpty()) {
+        lang = getAudio(streamIndex, "Language/String2");
+    }
+    if (lang.isEmpty()) {
+        lang = getAudio(streamIndex, "Language/String1");
+    }
+    if (lang.isEmpty()) {
+        lang = getAudio(streamIndex, "Language/String");
+    }
+    return lang;
+}
+
+QString MediaInfoFile::audioCodec(int streamIndex) const
+{
+    QString format = getAudio(streamIndex, "Format");
+    QString codecId = getAudio(streamIndex, "CodecID");
+    return parseAudioFormat(format, codecId);
+}
+
+QString MediaInfoFile::audioChannels(int streamIndex) const
+{
+    QString channels = getAudio(streamIndex, "Channel(s)");
+    QString channelsOriginal = getAudio(streamIndex, "Channel(s)_Original");
+    if (!channelsOriginal.isEmpty()) {
+        channels = channelsOriginal;
+    }
+    QRegExp rx(R"(^\D*(\d*)\D*)");
+    if (rx.indexIn(channels, 0) != -1) {
+        channels = rx.cap(1);
+    } else {
+        channels = "";
+    }
+    return channels;
+}
+
+QString MediaInfoFile::subtitleLang(int streamIndex) const
+{
+    QString lang = getText(streamIndex, "Language/String3");
+    if (lang.isEmpty()) {
+        lang = getText(streamIndex, "Language/String2");
+    }
+    if (lang.isEmpty()) {
+        lang = getText(streamIndex, "Language/String1");
+    }
+    if (lang.isEmpty()) {
+        lang = getText(streamIndex, "Language/String");
+    }
+    return lang;
+}
+
+/// Returns a modified audio format
+/// @param codec Original codec format, given by libmediainfo
+/// @return Modified format
+QString MediaInfoFile::parseAudioFormat(const QString& codec, const QString& profile) const
+{
+    QString xbmcFormat;
+    if (codec == "DTS-HD" && profile == "MA / Core") {
+        xbmcFormat = "dtshd_ma";
+    } else if (codec == "DTS-HD" && profile == "HRA / Core") {
+        xbmcFormat = "dtshd_hra";
+    } else if (codec == "DTS-HD" && profile == "X / MA / Core") {
+        xbmcFormat = "dtshd_x";
+    } else if (codec == "AC3" || codec == "AC-3") {
+        xbmcFormat = "ac3";
+    } else if (codec == "AC3+" || codec == "E-AC-3") {
+        xbmcFormat = "eac3";
+    } else if (codec == "TrueHD / AC3") {
+        xbmcFormat = "truehd";
+    } else if (codec == "TrueHD" && profile == "TrueHD+Atmos / TrueHD") {
+        xbmcFormat = "atmos";
+    } else if (codec == "FLAC") {
+        xbmcFormat = "flac";
+    } else if (codec == "MPA1L3") {
+        xbmcFormat = "mp3";
+    } else if (codec == "AAC LC" || codec == "AAC") {
+        xbmcFormat = "aac";
+    } else {
+        xbmcFormat = codec.toLower();
+    }
+
+    if (Settings::instance()->advanced()->audioCodecMappings().contains(xbmcFormat)) {
+        return Settings::instance()->advanced()->audioCodecMappings().value(xbmcFormat);
+    }
+    return xbmcFormat;
+}
+
+
+/**
+ * @brief Modifies a video format name
+ * @param format Original format, given by libmediainfo
+ * @param version Version, given by libmediainfo
+ * @return Modified format
+ */
+QString MediaInfoFile::parseVideoFormat(QString format, QString version) const
+{
+    format = format.toLower();
+    if (!format.isEmpty() && format == "mpeg video") {
+        format = (version.toLower() == "version 2") ? "mpeg2" : "mpeg";
+    }
+    if (Settings::instance()->advanced()->videoCodecMappings().contains(format)) {
+        return Settings::instance()->advanced()->videoCodecMappings().value(format);
+    }
+    return format.toLower();
+}
+
+QString MediaInfoFile::getGeneral(int streamIndex, const char* parameter) const
+{
+    return MI2QString(m_mediaInfo->Get(MediaInfoDLL::Stream_General, streamIndex, QString2MI(parameter)));
+}
+
+QString MediaInfoFile::getAudio(int streamIndex, const char* parameter) const
+{
+    return MI2QString(m_mediaInfo->Get(MediaInfoDLL::Stream_Audio, streamIndex, QString2MI(parameter)));
+}
+
+QString MediaInfoFile::getVideo(int streamIndex, const char* parameter) const
+{
+    return MI2QString(m_mediaInfo->Get(MediaInfoDLL::Stream_Video, streamIndex, QString2MI(parameter)));
+}
+
+QString MediaInfoFile::getText(int streamIndex, const char* parameter) const
+{
+    return MI2QString(m_mediaInfo->Get(MediaInfoDLL::Stream_Text, streamIndex, QString2MI(parameter)));
+}

--- a/src/data/MediaInfoFile.h
+++ b/src/data/MediaInfoFile.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <QString>
+#include <chrono>
+#include <memory>
+
+namespace MediaInfoDLL {
+class MediaInfo;
+}
+
+/// Represents a single media file whose information we want to get using MediaInfo.
+/// Essentially just a wrapper with some sanity checks.
+class MediaInfoFile
+{
+public:
+    MediaInfoFile(const QString& filepath);
+    ~MediaInfoFile();
+
+    int subtitleCount() const;
+    int videoStreamCount() const;
+    int audioStreamCount() const;
+
+    std::chrono::milliseconds duration(int streamIndex) const;
+    std::size_t videoWidth(int streamIndex) const;
+    std::size_t videoHeight(int streamIndex) const;
+    double aspectRatio(int streamIndex) const;
+    QString codec(int streamIndex) const;
+    QString mpegVersion(int streamIndex) const;
+    QString scanType(int streamIndex) const;
+    QString stereoFormat(int streamIndex) const;
+    QString format(int streamIndex) const;
+
+    QString audioLanguage(int streamIndex) const;
+    QString audioCodec(int streamIndex) const;
+    QString audioChannels(int streamIndex) const;
+
+    QString subtitleLang(int streamIndex) const;
+
+private:
+    QString parseAudioFormat(const QString& codec, const QString& profile) const;
+    QString parseVideoFormat(QString format, QString version) const;
+
+    QString getGeneral(int streamIndex, const char* parameter) const;
+    QString getVideo(int streamIndex, const char* parameter) const;
+    QString getAudio(int streamIndex, const char* parameter) const;
+    QString getText(int streamIndex, const char* parameter) const;
+
+private:
+    // We don't want the MediaInfoLib include here so we avoid it by
+    // using the forward declaration of the class MediaInfo
+    std::unique_ptr<MediaInfoDLL::MediaInfo> m_mediaInfo;
+};

--- a/src/data/MediaInfoFile.h
+++ b/src/data/MediaInfoFile.h
@@ -37,12 +37,12 @@ public:
     QString subtitleLang(int streamIndex) const;
 
 private:
-    QString parseAudioFormat(const QString& codec, const QString& profile) const;
     QString parseVideoFormat(QString format, QString version) const;
 
     QString getGeneral(int streamIndex, const char* parameter) const;
     QString getVideo(int streamIndex, const char* parameter) const;
     QString getAudio(int streamIndex, const char* parameter) const;
+    QStringList getAudio(int streamIndex, QStringList parameters) const;
     QString getText(int streamIndex, const char* parameter) const;
 
 private:

--- a/src/data/StreamDetails.h
+++ b/src/data/StreamDetails.h
@@ -4,11 +4,8 @@
 #include <QObject>
 #include <QVector>
 
-/**
- * @brief The StreamDetails class
- *        This class makes use of libstreaminfo and handles
- *        video and audio stream details
- */
+/// This class makes use of libmediainfo and handles
+/// video and audio stream details as well as subtitles
 class StreamDetails : public QObject
 {
     Q_OBJECT
@@ -56,9 +53,6 @@ public:
     virtual QVector<QMap<SubtitleDetails, QString>> subtitleDetails() const;
 
 private:
-    QString videoFormat(QString format, QString version) const;
-    QString audioFormat(const QString& codec, const QString& profile) const;
-    QString stereoFormat(const QString& format) const;
     void loadWithLibrary();
 
     QStringList m_files;

--- a/src/globals/Helper.cpp
+++ b/src/globals/Helper.cpp
@@ -825,4 +825,15 @@ QString secondsToTimeCode(quint32 duration)
     return res.sprintf("%dd%02d:%02d:%02d", days, hours, minutes, seconds);
 }
 
+bool containsIgnoreCase(const QStringList& list, const QString& compare)
+{
+    QString compareLower = compare.toLower();
+    for (const auto& item : list) {
+        if (item.toLower().contains(compareLower)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 } // namespace helper

--- a/src/globals/Helper.h
+++ b/src/globals/Helper.h
@@ -59,4 +59,7 @@ QString matchResolution(int width, int height, const QString& scanType);
 QImage getImage(QString path);
 QString secondsToTimeCode(quint32 duration);
 
+// String Utils
+bool containsIgnoreCase(const QStringList& list, const QString& compare);
+
 } // namespace helper

--- a/src/ui/small_widgets/MediaFlags.cpp
+++ b/src/ui/small_widgets/MediaFlags.cpp
@@ -148,6 +148,9 @@ void MediaFlags::setupAudio(StreamDetails* streamDetails)
         if (codec == "atmos") {
             codec = "dolbyatmos";
         }
+        if (codec == "truehd") {
+            codec = "dolbytruehd";
+        }
         if (codec == "aac" || codec == "aac lc") {
             codec = "aac";
         }


### PR DESCRIPTION
 - fixes #797, related issue: #796

MediaInfoLib 18 and newer have changed quite a few properties. `Codec` is deprecated, `Format_Profile` may return nothing, etc.

This PR aims to make MediaElch compatible with the latest MediaInfoLib versions. A user on the [Kodi forum](https://forum.kodi.tv/showthread.php?tid=136333&pid=2910256#pid2910256) gave a few examples and I was able to reproduce these issues by using some [samples](https://kodi.wiki/view/Samples).

I had a look at TinyMediaManager and how they handle such stuff and copied some parts of their logic. A comments mentions this. A big THANK YOU to them. :-)

Ping @monisriz (as you had issues with audio codecs in the past)  
If you experience any issues after this PR is merged, please let me know. I've tested quite a few sample files and everything seems to work.