### PR TITLE
[AdvancedSettings] Add exclude patterns to filter files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
  - TheTvDb: Use API v2 (JSON API instead of old XML API) (#487, #432, #528)
  - Episode widget: add TheTvDb ID and IMDb ID fields
  - AdvancedSettings: Better input validation (issues are printed to the debug log) (#743)
+ - AdvancedSettings: Add experimental exclude patterns (#840)
 
 ### Internal Improvements and Changes
 

--- a/docs/advancedsettings.xml
+++ b/docs/advancedsettings.xml
@@ -166,4 +166,23 @@
             *.idx,*.sub,*.srr,*.srt,*.ass,*.ttml
         </subtitle>
     </fileFilters>
+
+    <!--
+        Experimental Feature; may be removed or changed at any time
+        <exclude> may contain <pattern>s (regular expressions) that are used
+        to filter the list of directories to search for movies or filter
+        some files themselves. Patterns are case-sensitive.
+    -->
+    <exclude>
+        <!-- You have to specify what part of the path should be checked.
+             The "applyTo" attribute can be used for this. Possible values are:
+              - "filename" -> only the last segment is checked, e.g. "movie.mov"
+              - "folders" -> each foldername is checked (note the "s", not "folder")
+
+             The examples below make use of that. We can ignore files that begin with
+             an underscore or foldernames by an exact match (e.g. ".git" folders).
+        -->
+        <!-- <pattern applyTo="filename">^_</pattern> -->
+        <!-- <pattern applyTo="folders">^[.]git$</pattern> -->
+    </exclude>
 </advancedsettings>

--- a/src/movies/MovieFileSearcher.h
+++ b/src/movies/MovieFileSearcher.h
@@ -12,7 +12,7 @@
 /// MovieFileSearcher is responsible for (re-)loading all movie inside
 /// given directories.
 ///
-/// Usage:
+/// @example
 ///   MovieFileSearcher searcher;
 ///   searcher.setMovieDirectories(directories);
 ///
@@ -23,7 +23,7 @@ public:
     explicit MovieFileSearcher(QObject* parent = nullptr);
     ~MovieFileSearcher() override = default;
 
-    void setMovieDirectories(QVector<SettingsDir> directories);
+    void setMovieDirectories(const QVector<SettingsDir>& directories);
 
     void scanDir(QString startPath,
         QString path,

--- a/src/movies/MovieFilesOrganizer.cpp
+++ b/src/movies/MovieFilesOrganizer.cpp
@@ -21,6 +21,7 @@ void MovieFilesOrganizer::moveToDirs(QString path)
     QFileInfo fi(path);
     if (!fi.isDir()) {
         canceled(tr("Source %1 is no directory").arg(path));
+        return;
     }
 
     QVector<QStringList> contents;

--- a/src/settings/AdvancedSettings.cpp
+++ b/src/settings/AdvancedSettings.cpp
@@ -166,6 +166,26 @@ mediaelch::ThumbnailDimensions AdvancedSettings::episodeThumbnailDimensions() co
     return m_episodeThumbnailDimensions;
 }
 
+bool AdvancedSettings::isFileExcluded(QString file) const
+{
+    for (const auto& pattern : m_excludePatterns) {
+        if (pattern.matchFilename(file)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool AdvancedSettings::isFolderExcluded(QString dir) const
+{
+    for (const auto& pattern : m_excludePatterns) {
+        if (pattern.matchFoldername(dir)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool AdvancedSettings::useFirstStudioOnly() const
 {
     return m_useFirstStudioOnly;
@@ -177,11 +197,16 @@ QDebug operator<<(QDebug dbg, const AdvancedSettings& settings)
     QString s;
     QTextStream out(&s);
 
-    auto printMap = [&nl](QTextStream& stream, const QHash<QString, QString>& map) {
+    const auto printMap = [&nl](QTextStream& stream, const QHash<QString, QString>& map) {
         QHashIterator<QString, QString> i(map);
         while (i.hasNext()) {
             i.next();
             stream << "        " << i.key() << ": " << i.value() << nl;
+        }
+    };
+    const auto printExcludePatterns = [&nl, &out](const QVector<FileSearchExclude>& patterns) {
+        for (const auto& pattern : patterns) {
+            out << "        - " << pattern.toString() << nl;
         }
     };
 
@@ -219,6 +244,8 @@ QDebug operator<<(QDebug dbg, const AdvancedSettings& settings)
     out << "        height:              " << settings.m_episodeThumbnailDimensions.height << nl;
     out << "    bookletCut:              " << settings.m_bookletCut << nl;
     out << "    useFirstStudioOnly:      " << (settings.m_useFirstStudioOnly ? "true" : "false") << nl;
+    out << "    exclude patterns:        " << nl;
+    printExcludePatterns(settings.m_excludePatterns);
 
     dbg.nospace().noquote() << *out.string();
     return dbg.maybeSpace().maybeQuote();

--- a/src/settings/AdvancedSettingsXmlReader.h
+++ b/src/settings/AdvancedSettingsXmlReader.h
@@ -13,7 +13,8 @@ public:
         FileIsReadOnly,
         NoMainTag,
         UnsupportedTag,
-        InvalidValue
+        InvalidValue,
+        InvalidAttributeValue
     };
 
     struct ParseError
@@ -42,6 +43,7 @@ private:
     void loadSortTokens();
     void loadFilters();
     void loadMappings(QHash<QString, QString>& map);
+    void loadExcludePatterns();
 
     void addError(QString tag, ParseErrorType type);
     void addWarning(QString tag, ParseErrorType type);

--- a/src/ui/main/MainWindow.h
+++ b/src/ui/main/MainWindow.h
@@ -7,7 +7,6 @@
 
 #include "globals/Filter.h"
 #include "globals/Globals.h"
-#include "movies/MovieFileSearcher.h"
 #include "renamer/RenamerDialog.h"
 #include "settings/Settings.h"
 #include "ui/export/ExportDialog.h"

--- a/test/unit/settings/testAdvancedSettings.cpp
+++ b/test/unit/settings/testAdvancedSettings.cpp
@@ -121,4 +121,22 @@ TEST_CASE("Advanced Settings XML", "[settings]")
             CHECK(messages[2].tag == "unknown");
         }
     }
+
+    SECTION("exclude patterns")
+    {
+        SECTION("invalid attribute value")
+        {
+            QString xml = addBaseXml(R"xml(
+                <exclude>
+                    <pattern applyTo="invalid" />
+                </exclude>
+            )xml");
+
+            const auto messages = AdvancedSettingsXmlReader::loadFromXml(xml).second;
+
+            REQUIRE(messages.size() == 1);
+            CHECK(messages[0].tag == "pattern");
+            CHECK(messages[0].type == AdvancedSettingsXmlReader::ParseErrorType::InvalidAttributeValue);
+        }
+    }
 }


### PR DESCRIPTION
 - fix #840 

This PR adds an experimental feature that allows users to exclude certain files as well as directories. Only folder structures below the folders given in settings are checked and possibly excluded. No debug messages are given as this may spam the debug output if e.g. a folder exists in all movie directories. The patterns are regular expressions, so `<pattern applyTo="folders">.unknown</pattern>` will match not only `.unknown` but `aunknown`, etc. as well as the dot is a placeholder for "any character" in regular expressions.

### Todo

- [x] Filter movie files/directory
- [x]  Filter TV show files/directory
- [x]  Filter concert files/directory
- [x]  Filter music ~~files~~/directory
    - only folders can be filtered as we don't read any files (i.e. not songs)