### PR TITLE
[Actors] Fix actors having wrong image after removing one actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
  - Fix audio codec recognition for newer MediaInfoLib versions (#797)
  - Fix "Add to synchronization queue" feature for episodes and TV shows (#850)
  - Allow IMDb IDs with 8 digits (previously only 7 digits allows) (#855)
+ - Fix actors having wrong image after removing one actor (#859)
 
 ### Improvements
 

--- a/src/export/SimpleEngine.cpp
+++ b/src/export/SimpleEngine.cpp
@@ -158,9 +158,9 @@ void SimpleEngine::replaceVars(QString& m, Movie* movie, bool subDir)
 
     QStringList actorNames;
     QStringList actorRoles;
-    for (const Actor& actor : movie->actors()) {
-        actorNames << actor.name;
-        actorRoles << actor.role;
+    for (const Actor* actor : movie->actors()) {
+        actorNames << actor->name;
+        actorRoles << actor->role;
     }
     replaceMultiBlock(m, "ACTORS", {"ACTOR.NAME", "ACTOR.ROLE"}, QVector<QStringList>() << actorNames << actorRoles);
 
@@ -352,9 +352,9 @@ void SimpleEngine::replaceVars(QString& m, const TvShow* show, bool subDir)
 
     QStringList actorNames;
     QStringList actorRoles;
-    for (const Actor& actor : show->actors()) {
-        actorNames << actor.name;
-        actorRoles << actor.role;
+    for (const Actor* actor : show->actors()) {
+        actorNames << actor->name;
+        actorRoles << actor->role;
     }
     replaceMultiBlock(m,
         "ACTORS",

--- a/src/globals/JsonRequest.cpp
+++ b/src/globals/JsonRequest.cpp
@@ -23,7 +23,7 @@ JsonPostRequest::JsonPostRequest(QUrl url, QJsonObject body)
         QJsonDocument parsedJson;
 
         if (reply->error() == QNetworkReply::NoError) {
-            QJsonParseError parseError;
+            QJsonParseError parseError{};
             parsedJson = QJsonDocument::fromJson(reply->readAll(), &parseError);
 
             if (parseError.error != QJsonParseError::NoError) {

--- a/src/media_centers/KodiXml.cpp
+++ b/src/media_centers/KodiXml.cpp
@@ -175,13 +175,13 @@ bool KodiXml::saveMovie(Movie* movie)
         }
     }
 
-    for (const Actor& actor : movie->actors()) {
-        if (!actor.image.isNull()) {
+    for (const Actor* actor : movie->actors()) {
+        if (!actor->image.isNull()) {
             QDir dir;
             dir.mkdir(fi.absolutePath() + "/" + ".actors");
-            QString actorName = actor.name;
+            QString actorName = actor->name;
             actorName = actorName.replace(" ", "_");
-            saveFile(fi.absolutePath() + "/" + ".actors" + "/" + actorName + ".jpg", actor.image);
+            saveFile(fi.absolutePath() + "/" + ".actors" + "/" + actorName + ".jpg", actor->image);
         }
     }
 
@@ -1029,13 +1029,13 @@ bool KodiXml::saveTvShow(TvShow* show)
         }
     }
 
-    for (const Actor& actor : show->actors()) {
-        if (!actor.image.isNull()) {
+    for (const Actor* actor : show->actors()) {
+        if (!actor->image.isNull()) {
             QDir dir;
             dir.mkdir(show->dir() + "/" + ".actors");
-            QString actorName = actor.name;
+            QString actorName = actor->name;
             actorName = actorName.replace(" ", "_");
-            saveFile(show->dir() + "/" + ".actors" + "/" + actorName + ".jpg", actor.image);
+            saveFile(show->dir() + "/" + ".actors" + "/" + actorName + ".jpg", actor->image);
         }
     }
 
@@ -1126,13 +1126,13 @@ bool KodiXml::saveTvShowEpisode(TvShowEpisode* episode)
     }
 
     fi.setFile(episode->files().at(0));
-    for (const Actor& actor : episode->actors()) {
-        if (!actor.image.isNull()) {
+    for (const Actor* actor : episode->actors()) {
+        if (!actor->image.isNull()) {
             QDir dir;
             dir.mkdir(fi.absolutePath() + "/" + ".actors");
-            QString actorName = actor.name;
+            QString actorName = actor->name;
             actorName = actorName.replace(" ", "_");
-            saveFile(fi.absolutePath() + "/" + ".actors" + "/" + actorName + ".jpg", actor.image);
+            saveFile(fi.absolutePath() + "/" + ".actors" + "/" + actorName + ".jpg", actor->image);
         }
     }
 

--- a/src/media_centers/kodi/v16/EpisodeXmlWriterV16.cpp
+++ b/src/media_centers/kodi/v16/EpisodeXmlWriterV16.cpp
@@ -74,12 +74,12 @@ void EpisodeXmlWriterV16::writeSingleEpisodeDetails(QXmlStreamWriter& xml, TvSho
         xml.writeTextElement("thumb", episode->thumbnail().toString());
     }
 
-    for (const Actor& actor : episode->actors()) {
+    for (const Actor* actor : episode->actors()) {
         xml.writeStartElement("actor");
-        xml.writeTextElement("name", actor.name);
-        xml.writeTextElement("role", actor.role);
-        if (!actor.thumb.isEmpty() && Settings::instance()->advanced()->writeThumbUrlsToNfo()) {
-            xml.writeTextElement("thumb", actor.thumb);
+        xml.writeTextElement("name", actor->name);
+        xml.writeTextElement("role", actor->role);
+        if (!actor->thumb.isEmpty() && Settings::instance()->advanced()->writeThumbUrlsToNfo()) {
+            xml.writeTextElement("thumb", actor->thumb);
         }
         xml.writeEndElement();
     }

--- a/src/media_centers/kodi/v16/MovieXmlWriterV16.cpp
+++ b/src/media_centers/kodi/v16/MovieXmlWriterV16.cpp
@@ -131,17 +131,17 @@ QByteArray MovieXmlWriterV16::getMovieXml()
 
     KodiXml::removeChildNodes(doc, "actor");
 
-    for (const Actor& actor : m_movie.actors()) {
+    for (const Actor* actor : m_movie.actors()) {
         QDomElement elem = doc.createElement("actor");
         QDomElement elemName = doc.createElement("name");
         QDomElement elemRole = doc.createElement("role");
-        elemName.appendChild(doc.createTextNode(actor.name));
-        elemRole.appendChild(doc.createTextNode(actor.role));
+        elemName.appendChild(doc.createTextNode(actor->name));
+        elemRole.appendChild(doc.createTextNode(actor->role));
         elem.appendChild(elemName);
         elem.appendChild(elemRole);
-        if (!actor.thumb.isEmpty() && Settings::instance()->advanced()->writeThumbUrlsToNfo()) {
+        if (!actor->thumb.isEmpty() && Settings::instance()->advanced()->writeThumbUrlsToNfo()) {
             QDomElement elemThumb = doc.createElement("thumb");
-            elemThumb.appendChild(doc.createTextNode(actor.thumb));
+            elemThumb.appendChild(doc.createTextNode(actor->thumb));
             elem.appendChild(elemThumb);
         }
         KodiXml::appendXmlNode(doc, elem);

--- a/src/media_centers/kodi/v16/TvShowXmlWriterV16.cpp
+++ b/src/media_centers/kodi/v16/TvShowXmlWriterV16.cpp
@@ -90,17 +90,17 @@ QByteArray TvShowXmlWriterV16::getTvShowXml()
 
     KodiXml::removeChildNodes(doc, "actor");
 
-    for (const Actor& actor : m_show.actors()) {
+    for (const Actor* actor : m_show.actors()) {
         QDomElement elem = doc.createElement("actor");
         QDomElement elemName = doc.createElement("name");
         QDomElement elemRole = doc.createElement("role");
-        elemName.appendChild(doc.createTextNode(actor.name));
-        elemRole.appendChild(doc.createTextNode(actor.role));
+        elemName.appendChild(doc.createTextNode(actor->name));
+        elemRole.appendChild(doc.createTextNode(actor->role));
         elem.appendChild(elemName);
         elem.appendChild(elemRole);
-        if (!actor.thumb.isEmpty() && Settings::instance()->advanced()->writeThumbUrlsToNfo()) {
+        if (!actor->thumb.isEmpty() && Settings::instance()->advanced()->writeThumbUrlsToNfo()) {
             QDomElement elemThumb = doc.createElement("thumb");
-            elemThumb.appendChild(doc.createTextNode(actor.thumb));
+            elemThumb.appendChild(doc.createTextNode(actor->thumb));
             elem.appendChild(elemThumb);
         }
         KodiXml::appendXmlNode(doc, elem);

--- a/src/media_centers/kodi/v17/EpisodeXmlWriterV17.cpp
+++ b/src/media_centers/kodi/v17/EpisodeXmlWriterV17.cpp
@@ -106,13 +106,13 @@ void EpisodeXmlWriterV17::writeSingleEpisodeDetails(QXmlStreamWriter& xml, TvSho
         xml.writeTextElement("thumb", episode->thumbnail().toString());
     }
 
-    for (const Actor& actor : episode->actors()) {
+    for (const Actor* actor : episode->actors()) {
         xml.writeStartElement("actor");
-        xml.writeTextElement("name", actor.name);
-        xml.writeTextElement("role", actor.role);
-        xml.writeTextElement("order", QString::number(actor.order));
-        if (!actor.thumb.isEmpty() && Settings::instance()->advanced()->writeThumbUrlsToNfo()) {
-            xml.writeTextElement("thumb", actor.thumb);
+        xml.writeTextElement("name", actor->name);
+        xml.writeTextElement("role", actor->role);
+        xml.writeTextElement("order", QString::number(actor->order));
+        if (!actor->thumb.isEmpty() && Settings::instance()->advanced()->writeThumbUrlsToNfo()) {
+            xml.writeTextElement("thumb", actor->thumb);
         }
         xml.writeEndElement();
     }

--- a/src/media_centers/kodi/v17/MovieXmlWriterV17.cpp
+++ b/src/media_centers/kodi/v17/MovieXmlWriterV17.cpp
@@ -162,14 +162,14 @@ QByteArray MovieXmlWriterV17::getMovieXml()
     KodiXml::writeStreamDetails(doc, m_movie.streamDetails(), m_movie.subtitles());
 
     KodiXml::removeChildNodes(doc, "actor");
-    for (const Actor& actor : m_movie.actors()) {
+    for (const Actor* actor : m_movie.actors()) {
         QDomElement elem = doc.createElement("actor");
         QDomElement elemName = doc.createElement("name");
         QDomElement elemRole = doc.createElement("role");
         QDomElement elemOrder = doc.createElement("order");
-        elemName.appendChild(doc.createTextNode(actor.name));
-        elemRole.appendChild(doc.createTextNode(actor.role));
-        elemOrder.appendChild(doc.createTextNode(QString::number(actor.order)));
+        elemName.appendChild(doc.createTextNode(actor->name));
+        elemRole.appendChild(doc.createTextNode(actor->role));
+        elemOrder.appendChild(doc.createTextNode(QString::number(actor->order)));
         elem.appendChild(elemName);
         elem.appendChild(elemRole);
         elem.appendChild(elemOrder);
@@ -177,7 +177,7 @@ QByteArray MovieXmlWriterV17::getMovieXml()
             // create a thumb tag even if its value is empty
             // Kodi does the same
             QDomElement elemThumb = doc.createElement("thumb");
-            elemThumb.appendChild(doc.createTextNode(actor.thumb));
+            elemThumb.appendChild(doc.createTextNode(actor->thumb));
             elem.appendChild(elemThumb);
         }
         KodiXml::appendXmlNode(doc, elem);

--- a/src/media_centers/kodi/v17/TvShowXmlWriterV17.cpp
+++ b/src/media_centers/kodi/v17/TvShowXmlWriterV17.cpp
@@ -237,20 +237,20 @@ QByteArray TvShowXmlWriterV17::getTvShowXml()
 
     KodiXml::removeChildNodes(doc, "actor");
 
-    for (const Actor& actor : m_show.actors()) {
+    for (const Actor* actor : m_show.actors()) {
         QDomElement elem = doc.createElement("actor");
         QDomElement elemName = doc.createElement("name");
         QDomElement elemRole = doc.createElement("role");
         QDomElement elemOrder = doc.createElement("order");
-        elemName.appendChild(doc.createTextNode(actor.name));
-        elemRole.appendChild(doc.createTextNode(actor.role));
-        elemOrder.appendChild(doc.createTextNode(QString::number(actor.order)));
+        elemName.appendChild(doc.createTextNode(actor->name));
+        elemRole.appendChild(doc.createTextNode(actor->role));
+        elemOrder.appendChild(doc.createTextNode(QString::number(actor->order)));
         elem.appendChild(elemName);
         elem.appendChild(elemRole);
         elem.appendChild(elemOrder);
         if (Settings::instance()->advanced()->writeThumbUrlsToNfo()) {
             QDomElement elemThumb = doc.createElement("thumb");
-            elemThumb.appendChild(doc.createTextNode(actor.thumb));
+            elemThumb.appendChild(doc.createTextNode(actor->thumb));
             elem.appendChild(elemThumb);
         }
         KodiXml::appendXmlNode(doc, elem);

--- a/src/movies/Movie.cpp
+++ b/src/movies/Movie.cpp
@@ -159,8 +159,8 @@ void Movie::clear(QVector<MovieScraperInfos> infos)
 void Movie::clearImages()
 {
     m_movieImages.clearImages();
-    for (Actor& actor : m_crew.actors()) {
-        actor.image = QByteArray();
+    for (auto& actor : m_crew.actors()) {
+        actor->image = QByteArray();
     }
 }
 
@@ -344,12 +344,12 @@ QUrl Movie::trailer() const
     return m_trailer;
 }
 
-const QVector<Actor>& Movie::actors() const
+QVector<const Actor*> Movie::actors() const
 {
     return m_crew.actors();
 }
 
-QVector<Actor>& Movie::actors()
+QVector<Actor*> Movie::actors()
 {
     return m_crew.actors();
 }
@@ -1151,11 +1151,11 @@ QDebug operator<<(QDebug dbg, const Movie& movie)
     for (const QString& country : movie.countries()) {
         out.append(QString("  Country:       ").append(country)).append(nl);
     }
-    for (const Actor& actor : movie.actors()) {
+    for (const Actor* actor : movie.actors()) {
         out.append(QString("  Actor:         ").append(nl));
-        out.append(QString("    Name:  ").append(actor.name)).append(nl);
-        out.append(QString("    Role:  ").append(actor.role)).append(nl);
-        out.append(QString("    Thumb: ").append(actor.thumb)).append(nl);
+        out.append(QString("    Name:  ").append(actor->name)).append(nl);
+        out.append(QString("    Role:  ").append(actor->role)).append(nl);
+        out.append(QString("    Thumb: ").append(actor->thumb)).append(nl);
     }
     for (const Poster& poster : movie.constImages().posters()) {
         out.append(QString("  Poster:       ")).append(nl);

--- a/src/movies/Movie.h
+++ b/src/movies/Movie.h
@@ -67,8 +67,8 @@ public:
     QStringList tags() const;
     QVector<QString*> studiosPointer();
     QUrl trailer() const;
-    const QVector<Actor>& actors() const;
-    QVector<Actor>& actors();
+    QVector<const Actor*> actors() const;
+    QVector<Actor*> actors();
     QStringList files() const;
     QString folderName() const;
     int playcount() const;

--- a/src/movies/MovieController.cpp
+++ b/src/movies/MovieController.cpp
@@ -307,14 +307,14 @@ void MovieController::onFanartLoadDone(Movie* movie, QMap<ImageType, QVector<Pos
 
     QVector<DownloadManagerElement> downloads;
     if (infosToLoad().contains(MovieScraperInfos::Actors) && Settings::instance()->downloadActorImages()) {
-        for (auto& actor : m_movie->actors()) {
-            if (actor.thumb.isEmpty()) {
+        for (Actor* actor : m_movie->actors()) {
+            if (actor->thumb.isEmpty()) {
                 continue;
             }
             DownloadManagerElement d;
             d.imageType = ImageType::Actor;
-            d.url = QUrl(actor.thumb);
-            d.actor = &actor;
+            d.url = QUrl(actor->thumb);
+            d.actor = actor;
             d.movie = movie;
             downloads.append(d);
         }

--- a/src/movies/MovieCrew.cpp
+++ b/src/movies/MovieCrew.cpp
@@ -11,14 +11,22 @@ QString MovieCrew::director() const
     return m_director;
 }
 
-const QVector<Actor>& MovieCrew::actors() const
+QVector<Actor*> MovieCrew::actors()
 {
-    return m_actors;
+    QVector<Actor*> actorPtrs;
+    for (const auto& actor : m_actors) {
+        actorPtrs.push_back(actor.get());
+    }
+    return actorPtrs;
 }
 
-QVector<Actor>& MovieCrew::actors()
+QVector<const Actor*> MovieCrew::actors() const
 {
-    return m_actors;
+    QVector<const Actor*> actorPtrs;
+    for (const auto& actor : m_actors) {
+        actorPtrs.push_back(actor.get());
+    }
+    return actorPtrs;
 }
 
 void MovieCrew::setWriter(QString writer)
@@ -33,22 +41,25 @@ void MovieCrew::setDirector(QString director)
 
 void MovieCrew::setActors(QVector<Actor> actors)
 {
-    m_actors = actors;
+    m_actors.clear();
+    for (const Actor& actor : actors) {
+        m_actors.push_back(std::make_unique<Actor>(actor));
+    }
 }
 
 void MovieCrew::addActor(Actor actor)
 {
-    if (actor.order == 0 && !m_actors.isEmpty()) {
-        actor.order = m_actors.last().order + 1;
+    if (actor.order == 0 && !m_actors.empty()) {
+        actor.order = m_actors.back()->order + 1;
     }
-    m_actors.append(actor);
+    m_actors.push_back(std::make_unique<Actor>(actor));
 }
 
 void MovieCrew::removeActor(Actor* actor)
 {
     for (int i = 0, n = m_actors.size(); i < n; ++i) {
-        if (&m_actors[i] == actor) {
-            m_actors.removeAt(i);
+        if (m_actors[i].get() == actor) {
+            m_actors.erase(m_actors.begin() + i);
             break;
         }
     }

--- a/src/movies/MovieCrew.h
+++ b/src/movies/MovieCrew.h
@@ -5,14 +5,16 @@
 
 #include <QString>
 #include <QVector>
+#include <memory>
+#include <vector>
 
 class MovieCrew
 {
 public:
     QString writer() const;
     QString director() const;
-    const QVector<Actor>& actors() const;
-    QVector<Actor>& actors();
+    QVector<Actor*> actors();
+    QVector<const Actor*> actors() const;
 
     void setWriter(QString writer);
     void setDirector(QString director);
@@ -23,5 +25,8 @@ public:
 private:
     QString m_writer;
     QString m_director;
-    QVector<Actor> m_actors;
+    /// Actors of this crew. Need to use a unique_ptr because some UI logic
+    /// stores the address of the actor in some widget as Qt::UserRole...
+    /// And QVector needs a default constructible type...
+    std::vector<std::unique_ptr<Actor>> m_actors;
 };

--- a/src/scrapers/image/FanartTv.cpp
+++ b/src/scrapers/image/FanartTv.cpp
@@ -773,7 +773,8 @@ void FanartTv::insertPoster(QVector<Poster>& posters, Poster b, QString language
         if (posters[i].language == language && (posters[i].hint == "HD" || posters[i].hint == preferredDiscType)) {
             lastInPreferredLangAndHd = i;
         }
-        if (posters[i].language == language) {
+        if (posters[i].language == language || posters[i].language.isEmpty()) {
+            // if "language" is empty then the poster is language-agnostic
             lastInPreferredLang = i;
         }
         if (posters[i].hint == "HD" || posters[i].hint == preferredDiscType) {

--- a/src/scrapers/movie/AEBN.cpp
+++ b/src/scrapers/movie/AEBN.cpp
@@ -293,8 +293,8 @@ void AEBN::parseAndAssignInfos(QString html, Movie* movie, QVector<MovieScraperI
             offset += rx.matchedLength();
 
             const bool actorAlreadyAdded =
-                std::any_of(movie->actors().cbegin(), movie->actors().cend(), [&rx](Actor a) { //
-                    return a.name == rx.cap(5);                                                //
+                std::any_of(movie->actors().cbegin(), movie->actors().cend(), [&rx](const Actor* a) { //
+                    return a->name == rx.cap(5);                                                      //
                 });
 
             if (actorAlreadyAdded) {
@@ -316,8 +316,8 @@ void AEBN::parseAndAssignInfos(QString html, Movie* movie, QVector<MovieScraperI
         while ((offset = rx.indexIn(html, offset)) != -1) {
             offset += rx.matchedLength();
             const bool actorAlreadyAdded =
-                std::any_of(movie->actors().cbegin(), movie->actors().cend(), [&rx](Actor a) { //
-                    return a.name == rx.cap(2);                                                //
+                std::any_of(movie->actors().cbegin(), movie->actors().cend(), [&rx](const Actor* a) { //
+                    return a->name == rx.cap(2);                                                      //
                 });
 
             if (!actorAlreadyAdded) {
@@ -370,9 +370,9 @@ void AEBN::parseAndAssignActor(QString html, Movie* movie, QString id)
     QRegExp rx(R"lit(<img itemprop="image" src="([^"]*)" alt="([^"]*)" class="star" />)lit");
     rx.setMinimal(true);
     if (rx.indexIn(html) != -1) {
-        for (Actor& a : movie->actors()) {
-            if (a.id == id) {
-                a.thumb = QStringLiteral("https:") + rx.cap(1);
+        for (Actor* a : movie->actors()) {
+            if (a->id == id) {
+                a->thumb = QStringLiteral("https:") + rx.cap(1);
             }
         }
     }

--- a/src/scrapers/movie/TMDb.cpp
+++ b/src/scrapers/movie/TMDb.cpp
@@ -929,7 +929,6 @@ void TMDb::parseAndAssignInfos(QString json, Movie* movie, QVector<MovieScraperI
                     helper::formatTrailerUrl(QStringLiteral("https://www.youtube.com/watch?v=%1").arg(youtubeSrc))));
                 break;
             }
-            continue;
         }
     }
 

--- a/src/scrapers/tv_show/TheTvDb.cpp
+++ b/src/scrapers/tv_show/TheTvDb.cpp
@@ -574,8 +574,7 @@ void TheTvDb::onEpisodesImdbEpisodeLoaded()
     TvShow* show = reply->property("show").value<Storage*>()->show();
 
     if (episode == nullptr) {
-        qWarning() << "[TheTvDb] Couldn't get episode* from storage";
-        episode->scraperLoadDone();
+        qCritical() << "[TheTvDb] Couldn't get episode* from storage";
         return;
     }
 

--- a/src/scrapers/tv_show/TheTvDb.cpp
+++ b/src/scrapers/tv_show/TheTvDb.cpp
@@ -343,8 +343,8 @@ void TheTvDb::parseAndAssignImdbInfos(const QString& html,
 
     if (shouldLoadFromImdb(TvShowScraperInfos::Actors, infosToLoad) && !m_dummyMovie->actors().isEmpty()) {
         show.clear({TvShowScraperInfos::Actors});
-        for (const auto& actor : m_dummyMovie->actors()) {
-            show.addActor(actor);
+        for (const Actor* actor : m_dummyMovie->actors()) {
+            show.addActor(*actor);
         }
     }
 }
@@ -427,15 +427,15 @@ void TheTvDb::parseAndAssignImdbInfos(const QString& html,
 
     if (shouldLoadFromImdb(TvShowScraperInfos::Actors, infosToLoad) && !m_dummyMovie->actors().isEmpty()) {
         episode.clear(QVector<TvShowScraperInfos>() << TvShowScraperInfos::Actors);
-        for (const auto& actor : m_dummyMovie->actors()) {
+        for (const auto* actor : m_dummyMovie->actors()) {
             Actor a;
-            a.id = actor.id;
-            a.image = actor.image;
-            a.imageHasChanged = actor.imageHasChanged;
-            a.name = actor.name;
-            a.role = actor.role;
-            a.thumb = actor.thumb;
-            episode.addActor(a);
+            a.id = actor->id;
+            a.image = actor->image;
+            a.imageHasChanged = actor->imageHasChanged;
+            a.name = actor->name;
+            a.role = actor->role;
+            a.thumb = actor->thumb;
+            episode.addActor(std::move(a));
         }
     }
 }

--- a/src/scrapers/tv_show/TheTvDb/EpisodeParser.cpp
+++ b/src/scrapers/tv_show/TheTvDb/EpisodeParser.cpp
@@ -13,7 +13,7 @@ namespace thetvdb {
 
 void EpisodeParser::parseInfos(const QString& json)
 {
-    QJsonParseError parseError;
+    QJsonParseError parseError{};
     const auto parsedJson = QJsonDocument::fromJson(json.toUtf8(), &parseError).object();
     const auto episodeObj = parsedJson.value("data").toObject();
 
@@ -93,7 +93,7 @@ void EpisodeParser::parseInfos(const QJsonObject& episodeObj)
 
 void EpisodeParser::parseIdFromSeason(const QString& json)
 {
-    QJsonParseError parseError;
+    QJsonParseError parseError{};
     const auto parsedJson = QJsonDocument::fromJson(json.toUtf8(), &parseError).object();
     const auto seasonData = parsedJson.value("data").toArray();
 

--- a/src/scrapers/tv_show/TheTvDb/Search.cpp
+++ b/src/scrapers/tv_show/TheTvDb/Search.cpp
@@ -28,7 +28,7 @@ void Search::search(QString searchStr)
 
 QVector<ScraperSearchResult> Search::parseSearch(const QString& json)
 {
-    QJsonParseError parseError;
+    QJsonParseError parseError{};
     const auto parsedJson = QJsonDocument::fromJson(json.toUtf8(), &parseError).object();
 
     if (parseError.error != QJsonParseError::NoError) {

--- a/src/scrapers/tv_show/TheTvDb/ShowParser.cpp
+++ b/src/scrapers/tv_show/TheTvDb/ShowParser.cpp
@@ -17,7 +17,7 @@ namespace thetvdb {
 
 void ShowParser::parseInfos(const QString& json)
 {
-    QJsonParseError parseError;
+    QJsonParseError parseError{};
     const auto parsedJson = QJsonDocument::fromJson(json.toUtf8(), &parseError).object();
     const auto showData = parsedJson.value("data").toObject();
 
@@ -85,7 +85,7 @@ void ShowParser::parseActors(const QString& json)
         return;
     }
 
-    QJsonParseError parseError;
+    QJsonParseError parseError{};
     const auto parsedJson = QJsonDocument::fromJson(json.toUtf8(), &parseError).object();
     const auto actors = parsedJson.value("data").toArray();
 
@@ -109,7 +109,7 @@ void ShowParser::parseActors(const QString& json)
 
 void ShowParser::parseImages(const QString& json)
 {
-    QJsonParseError parseError;
+    QJsonParseError parseError{};
     const auto parsedJson = QJsonDocument::fromJson(json.toUtf8(), &parseError).object();
     const auto images = parsedJson.value("data").toArray();
 
@@ -167,7 +167,7 @@ Paginate ShowParser::parseEpisodes(const QString& json, QVector<TvShowScraperInf
         return Paginate{};
     }
 
-    QJsonParseError parseError;
+    QJsonParseError parseError{};
     const auto parsedJson = QJsonDocument::fromJson(json.toUtf8(), &parseError).object();
     const auto paginateObj = parsedJson.value("links").toObject();
     const auto episodesArray = parsedJson.value("data").toArray();

--- a/src/settings/AdvancedSettings.h
+++ b/src/settings/AdvancedSettings.h
@@ -98,7 +98,7 @@ public:
     bool writeThumbUrlsToNfo() const;
     mediaelch::ThumbnailDimensions episodeThumbnailDimensions() const;
 
-    bool isFileExcluded(QString dir) const;
+    bool isFileExcluded(QString file) const;
     bool isFolderExcluded(QString dir) const;
 
     friend class AdvancedSettingsXmlReader;

--- a/src/tv_shows/TvShow.h
+++ b/src/tv_shows/TvShow.h
@@ -14,6 +14,7 @@
 #include <QStringList>
 #include <QVector>
 #include <chrono>
+#include <memory>
 
 class MediaCenterInterface;
 class TvShowModelItem;
@@ -49,8 +50,8 @@ public:
     ImdbId imdbId() const;
     QString episodeGuideUrl() const;
     QVector<Certification> certifications() const;
-    const QVector<Actor>& actors() const;
-    QVector<Actor>& actors();
+    QVector<const Actor*> actors() const;
+    QVector<Actor*> actors();
     QVector<Poster> posters() const;
     QVector<Poster> backdrops() const;
     QVector<Poster> banners() const;
@@ -200,7 +201,7 @@ private:
     TvDbId m_id;
     ImdbId m_imdbId;
     QString m_episodeGuideUrl;
-    QVector<Actor> m_actors;
+    std::vector<std::unique_ptr<Actor>> m_actors;
     QVector<Poster> m_posters;
     QVector<Poster> m_backdrops;
     QVector<Poster> m_banners;

--- a/src/tv_shows/TvShowEpisode.cpp
+++ b/src/tv_shows/TvShowEpisode.cpp
@@ -865,25 +865,38 @@ bool TvShowEpisode::isDummy() const
     return m_isDummy;
 }
 
-QVector<Actor> TvShowEpisode::actors() const
+QVector<const Actor*> TvShowEpisode::actors() const
 {
-    return m_actors;
+    QVector<const Actor*> actorPtrs;
+    for (const auto& actor : m_actors) {
+        actorPtrs.push_back(actor.get());
+    }
+    return actorPtrs;
+}
+
+QVector<Actor*> TvShowEpisode::actors()
+{
+    QVector<Actor*> actorPtrs;
+    for (const auto& actor : m_actors) {
+        actorPtrs.push_back(actor.get());
+    }
+    return actorPtrs;
 }
 
 void TvShowEpisode::addActor(Actor actor)
 {
-    if (actor.order == 0 && !m_actors.isEmpty()) {
-        actor.order = m_actors.last().order + 1;
+    if (actor.order == 0 && !m_actors.empty()) {
+        actor.order = m_actors.back()->order + 1;
     }
-    m_actors.append(actor);
+    m_actors.push_back(std::make_unique<Actor>(actor));
     setChanged(true);
 }
 
 void TvShowEpisode::removeActor(Actor* actor)
 {
     for (int i = 0, n = m_actors.size(); i < n; ++i) {
-        if (&m_actors[i] == actor) {
-            m_actors.removeAt(i);
+        if (m_actors[i].get() == actor) {
+            m_actors.erase(m_actors.begin() + i);
             break;
         }
     }

--- a/src/tv_shows/TvShowEpisode.h
+++ b/src/tv_shows/TvShowEpisode.h
@@ -14,6 +14,8 @@
 #include <QMetaType>
 #include <QObject>
 #include <QStringList>
+#include <memory>
+#include <vector>
 
 class MediaCenterInterface;
 class StreamDetails;
@@ -106,7 +108,8 @@ public:
     void removeWriter(QString* writer);
     void removeDirector(QString* director);
 
-    QVector<Actor> actors() const;
+    QVector<const Actor*> actors() const;
+    QVector<Actor*> actors();
     void addActor(Actor actor);
     void removeActor(Actor* actor);
 
@@ -172,7 +175,7 @@ private:
     QVector<TvShowScraperInfos> m_infosToLoad;
     QVector<ImageType> m_imagesToRemove;
     bool m_isDummy = false;
-    QVector<Actor> m_actors;
+    std::vector<std::unique_ptr<Actor>> m_actors;
 };
 
 QDebug operator<<(QDebug dbg, const TvShowEpisode& episode);

--- a/src/ui/tv_show/TvShowMultiScrapeDialog.cpp
+++ b/src/ui/tv_show/TvShowMultiScrapeDialog.cpp
@@ -462,11 +462,11 @@ void TvShowMultiScrapeDialog::onLoadDone(TvShow* show, QMap<ImageType, QVector<P
     }
 
     if (m_infosToLoad.contains(TvShowScraperInfos::Actors) && Settings::instance()->downloadActorImages()) {
-        for (auto& actor : show->actors()) {
-            if (actor.thumb.isEmpty()) {
+        for (Actor* actor : show->actors()) {
+            if (actor->thumb.isEmpty()) {
                 continue;
             }
-            addDownload(ImageType::Actor, QUrl(actor.thumb), show, &actor);
+            addDownload(ImageType::Actor, QUrl(actor->thumb), show, actor);
             downloadsSize++;
         }
     }

--- a/src/ui/tv_show/TvShowWidgetEpisode.cpp
+++ b/src/ui/tv_show/TvShowWidgetEpisode.cpp
@@ -381,13 +381,13 @@ void TvShowWidgetEpisode::updateEpisodeInfo()
     ui->writers->blockSignals(false);
 
     ui->actors->blockSignals(true);
-    for (Actor& actor : m_episode->actors()) {
-        int row = ui->actors->rowCount();
+    for (Actor* actor : m_episode->actors()) {
+        const int row = ui->actors->rowCount();
         ui->actors->insertRow(row);
-        ui->actors->setItem(row, 0, new QTableWidgetItem(actor.name));
-        ui->actors->setItem(row, 1, new QTableWidgetItem(actor.role));
-        ui->actors->item(row, 0)->setData(Qt::UserRole, actor.thumb);
-        ui->actors->item(row, 1)->setData(Qt::UserRole, QVariant::fromValue(&actor));
+        ui->actors->setItem(row, 0, new QTableWidgetItem(actor->name));
+        ui->actors->setItem(row, 1, new QTableWidgetItem(actor->role));
+        ui->actors->item(row, 0)->setData(Qt::UserRole, actor->thumb);
+        ui->actors->item(row, 1)->setData(Qt::UserRole, QVariant::fromValue(actor));
     }
     ui->actors->blockSignals(false);
 
@@ -1047,14 +1047,14 @@ void TvShowWidgetEpisode::onAddActor()
     a.role = tr("Unknown Role");
     m_episode->addActor(a);
 
-    Actor& actor = m_episode->actors().last();
+    Actor* actor = m_episode->actors().back();
 
     ui->actors->blockSignals(true);
     int row = ui->actors->rowCount();
     ui->actors->insertRow(row);
-    ui->actors->setItem(row, 0, new QTableWidgetItem(actor.name));
-    ui->actors->setItem(row, 1, new QTableWidgetItem(actor.role));
-    ui->actors->item(row, 1)->setData(Qt::UserRole, QVariant::fromValue(&actor));
+    ui->actors->setItem(row, 0, new QTableWidgetItem(actor->name));
+    ui->actors->setItem(row, 1, new QTableWidgetItem(actor->role));
+    ui->actors->item(row, 1)->setData(Qt::UserRole, QVariant::fromValue(actor));
     ui->actors->scrollToBottom();
     ui->actors->blockSignals(false);
     ui->buttonRevert->setVisible(true);

--- a/src/ui/tv_show/TvShowWidgetTvShow.cpp
+++ b/src/ui/tv_show/TvShowWidgetTvShow.cpp
@@ -354,13 +354,13 @@ void TvShowWidgetTvShow::updateTvShowInfo()
     }
 
     ui->actors->blockSignals(true);
-    for (Actor& actor : m_show->actors()) {
+    for (Actor* actor : m_show->actors()) {
         int row = ui->actors->rowCount();
         ui->actors->insertRow(row);
-        ui->actors->setItem(row, 0, new QTableWidgetItem(actor.name));
-        ui->actors->setItem(row, 1, new QTableWidgetItem(actor.role));
-        ui->actors->item(row, 0)->setData(Qt::UserRole, actor.thumb);
-        ui->actors->item(row, 1)->setData(Qt::UserRole, QVariant::fromValue(&actor));
+        ui->actors->setItem(row, 0, new QTableWidgetItem(actor->name));
+        ui->actors->setItem(row, 1, new QTableWidgetItem(actor->role));
+        ui->actors->item(row, 0)->setData(Qt::UserRole, actor->thumb);
+        ui->actors->item(row, 1)->setData(Qt::UserRole, QVariant::fromValue(actor));
     }
     ui->actors->blockSignals(false);
 
@@ -647,14 +647,14 @@ void TvShowWidgetTvShow::onLoadDone(TvShow* show, QMap<ImageType, QVector<Poster
     }
 
     if (show->infosToLoad().contains(TvShowScraperInfos::Actors) && Settings::instance()->downloadActorImages()) {
-        for (auto& actor : show->actors()) {
-            if (actor.thumb.isEmpty()) {
+        for (Actor* actor : show->actors()) {
+            if (actor->thumb.isEmpty()) {
                 continue;
             }
             DownloadManagerElement d;
             d.imageType = ImageType::Actor;
-            d.url = QUrl(actor.thumb);
-            d.actor = &actor;
+            d.url = QUrl(actor->thumb);
+            d.actor = actor;
             d.show = show;
             m_posterDownloadManager->addDownload(d);
             downloadsSize++;
@@ -867,14 +867,14 @@ void TvShowWidgetTvShow::onAddActor()
     a.role = tr("Unknown Role");
     m_show->addActor(a);
 
-    Actor& actor = m_show->actors().last();
+    Actor* actor = m_show->actors().back();
 
     ui->actors->blockSignals(true);
     int row = ui->actors->rowCount();
     ui->actors->insertRow(row);
-    ui->actors->setItem(row, 0, new QTableWidgetItem(actor.name));
-    ui->actors->setItem(row, 1, new QTableWidgetItem(actor.role));
-    ui->actors->item(row, 1)->setData(Qt::UserRole, QVariant::fromValue(&actor));
+    ui->actors->setItem(row, 0, new QTableWidgetItem(actor->name));
+    ui->actors->setItem(row, 1, new QTableWidgetItem(actor->role));
+    ui->actors->item(row, 1)->setData(Qt::UserRole, QVariant::fromValue(actor));
     ui->actors->scrollToBottom();
     ui->actors->blockSignals(false);
     ui->buttonRevert->setVisible(true);

--- a/test/scrapers/TheTvDb/testShowLoader.cpp
+++ b/test/scrapers/TheTvDb/testShowLoader.cpp
@@ -51,7 +51,7 @@ TEST_CASE("TheTvDb ShowLoader scrapes show data", "[scraper][TheTvDb][load_data]
 
         const auto& actors = t.actors();
         REQUIRE(actors.size() > 0);
-        CHECK(actors[0].name == "Aloma Wright");
+        CHECK(actors[0]->name == "Aloma Wright");
 
         const auto& genres = t.genres();
         REQUIRE(genres.size() > 0);

--- a/test/scrapers/testAdultDvdEmpire.cpp
+++ b/test/scrapers/testAdultDvdEmpire.cpp
@@ -62,8 +62,8 @@ TEST_CASE("AdultDvdEmpire scrapes correct movie details", "[scraper][AdultDvdEmp
         bool foundActor = false;
         for (const auto& actor : actors) {
             foundActor = foundActor
-                         || (actor.name == "Adriana Chechik"
-                                && actor.thumb == "https://imgs1cdn.adultempire.com/actors/652646h.jpg");
+                         || (actor->name == "Adriana Chechik"
+                                && actor->thumb == "https://imgs1cdn.adultempire.com/actors/652646h.jpg");
         }
         CHECK(foundActor);
     }

--- a/test/scrapers/testHotMovies.cpp
+++ b/test/scrapers/testHotMovies.cpp
@@ -61,10 +61,10 @@ TEST_CASE("HotMovies scrapes correct movie details", "[scraper][HotMovies][load_
 
         const auto actors = m.actors();
         REQUIRE(actors.size() > 15);
-        CHECK(actors[0].name == "Adriana Chechik");
-        CHECK(actors[0].thumb == "https://img2.vod.com/image2/star/163/Adriana_Chechik-163576.4.jpg");
-        CHECK(actors[1].name == "Amirah Adara");
-        CHECK(actors[1].thumb == "https://img3.vod.com/image2/star/153/Amirah_Adara-153021.2.jpg");
+        CHECK(actors[0]->name == "Adriana Chechik");
+        CHECK(actors[0]->thumb == "https://img2.vod.com/image2/star/163/Adriana_Chechik-163576.4.jpg");
+        CHECK(actors[1]->name == "Amirah Adara");
+        CHECK(actors[1]->thumb == "https://img3.vod.com/image2/star/153/Amirah_Adara-153021.2.jpg");
     }
 
     SECTION("Movie has correct set")

--- a/test/scrapers/testIMDb.cpp
+++ b/test/scrapers/testIMDb.cpp
@@ -107,10 +107,10 @@ TEST_CASE("IMDb scrapes correct movie details", "[scraper][IMDb][load_data][requ
 
         const auto actors = m.actors();
         REQUIRE(actors.size() >= 2);
-        CHECK(actors[0].name == "Ellen DeGeneres");
-        CHECK(actors[0].role == "Dory");
-        CHECK(actors[1].name == "Albert Brooks");
-        CHECK(actors[1].role == "Marlin");
+        CHECK(actors[0]->name == "Ellen DeGeneres");
+        CHECK(actors[0]->role == "Dory");
+        CHECK(actors[1]->name == "Albert Brooks");
+        CHECK(actors[1]->role == "Marlin");
     }
 
     SECTION("'Top 250' movie has correct details")
@@ -160,10 +160,10 @@ TEST_CASE("IMDb scrapes correct movie details", "[scraper][IMDb][load_data][requ
 
         const auto actors = m.actors();
         REQUIRE(actors.size() >= 2);
-        CHECK(actors[0].name == "Tim Robbins");
-        CHECK(actors[0].role == "Andy Dufresne");
-        CHECK(actors[1].name == "Morgan Freeman");
-        CHECK(actors[1].role == "Ellis Boyd 'Red' Redding");
+        CHECK(actors[0]->name == "Tim Robbins");
+        CHECK(actors[0]->role == "Andy Dufresne");
+        CHECK(actors[1]->name == "Morgan Freeman");
+        CHECK(actors[1]->role == "Ellis Boyd 'Red' Redding");
     }
 
     SECTION("Loads tags correctly")
@@ -246,15 +246,15 @@ TEST_CASE("IMDb scrapes correct movie details", "[scraper][IMDb][load_data][requ
 
         const auto actors = m.actors();
         REQUIRE(actors.size() >= 5);
-        CHECK(actors[0].name == "Anil Kapoor");
-        CHECK(actors[0].role == "Sagar 'Majnu' Pandey");
-        CHECK(actors[1].name == "Nana Patekar");
-        CHECK(actors[1].role == "Uday Shankar Shetty");
-        CHECK(actors[2].name == "Dimple Kapadia");
-        CHECK_THAT(actors[2].role, Contains("Poonam"));
-        CHECK(actors[3].name == "John Abraham");
-        CHECK_THAT(actors[3].role, Contains("Ajju Bhai"));
-        CHECK(actors[4].name == "Shruti Haasan");
-        CHECK_THAT(actors[4].role, Contains("Ranjana Shetty"));
+        CHECK(actors[0]->name == "Anil Kapoor");
+        CHECK(actors[0]->role == "Sagar 'Majnu' Pandey");
+        CHECK(actors[1]->name == "Nana Patekar");
+        CHECK(actors[1]->role == "Uday Shankar Shetty");
+        CHECK(actors[2]->name == "Dimple Kapadia");
+        CHECK_THAT(actors[2]->role, Contains("Poonam"));
+        CHECK(actors[3]->name == "John Abraham");
+        CHECK_THAT(actors[3]->role, Contains("Ajju Bhai"));
+        CHECK(actors[4]->name == "Shruti Haasan");
+        CHECK_THAT(actors[4]->role, Contains("Ranjana Shetty"));
     }
 }

--- a/test/scrapers/testTMDb.cpp
+++ b/test/scrapers/testTMDb.cpp
@@ -76,10 +76,10 @@ TEST_CASE("TMDb scrapes correct movie details", "[scraper][TMDb][load_data][requ
 
         const auto actors = m.actors();
         REQUIRE(actors.size() >= 2);
-        CHECK(actors[0].name == "Ellen DeGeneres");
-        CHECK(actors[0].role == "Dory (voice)");
-        CHECK(actors[1].name == "Albert Brooks");
-        CHECK(actors[1].role == "Marlin (voice)");
+        CHECK(actors[0]->name == "Ellen DeGeneres");
+        CHECK(actors[0]->role == "Dory (voice)");
+        CHECK(actors[1]->name == "Albert Brooks");
+        CHECK(actors[1]->role == "Marlin (voice)");
     }
 
 

--- a/test/scrapers/testVideoBuster.cpp
+++ b/test/scrapers/testVideoBuster.cpp
@@ -76,7 +76,7 @@ TEST_CASE("VideoBuster scrapes correct movie details", "[scraper][VideoBuster][l
         // Note: German voices
         const auto actors = m.actors();
         REQUIRE(actors.size() >= 2);
-        CHECK(actors[0].name == "Lucia Geddes");
-        CHECK(actors[1].name == "Jerome Ranft");
+        CHECK(actors[0]->name == "Lucia Geddes");
+        CHECK(actors[1]->name == "Jerome Ranft");
     }
 }


### PR DESCRIPTION
 - fix #859 

Due to the UI requiring pointers to actors, we took the address of
actors inside a QVector<Actor>. But when that vector is resized
and potientially reallocated, all prior pointers become invalid.