### PR TITLE
[TvShowModel] Only allow changes to underlying data through model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Bugfixes
 
+ - Fix TV shows sorting and possible crashes if "Show missing episodes" is enabled (#789, #883)
+   MediaElch could crash under certain circumstances due to improper use of Qt's
+   model/view system. You may experience that shows are deselected when " Show missing episodes"
+   is clicked the first time.
  - Fix hanging window if the custom movie scraper is selected but no valid scraper is found.  
    This can happen if MediaElch's settings are in an inconsistent state (#792)
  - Fix `{{ *.RATING }}` not being replaced in exports if a media item has no rating

--- a/src/tv_shows/TvShowEpisode.cpp
+++ b/src/tv_shows/TvShowEpisode.cpp
@@ -201,8 +201,8 @@ bool TvShowEpisode::saveData(MediaCenterInterface* mediaCenterInterface)
     if (!m_infoLoaded) {
         m_infoLoaded = saved;
     }
-    setChanged(false);
     setSyncNeeded(true);
+    setChanged(false);
     clearImages();
     return saved;
 }

--- a/src/tv_shows/TvShowFileSearcher.cpp
+++ b/src/tv_shows/TvShowFileSearcher.cpp
@@ -128,7 +128,7 @@ void TvShowFileSearcher::reloadEpisodes(QString showDir)
     TvShow* show = new TvShow(showDir, this);
     show->loadData(Manager::instance()->mediaCenterInterfaceTvShow());
     database().add(show, path);
-    TvShowModelItem* showItem = Manager::instance()->tvShowModel()->appendChild(show);
+    TvShowModelItem* showItem = Manager::instance()->tvShowModel()->appendShow(show);
 
     emit searchStarted(tr("Loading Episodes..."));
     emit currentDir(show->name());
@@ -451,7 +451,7 @@ void TvShowFileSearcher::setupShowsFromDatabase(QVector<TvShow*>& dbShows, int e
         }
 
         show->loadData(Manager::instance()->mediaCenterInterfaceTvShow(), false);
-        TvShowModelItem* showItem = Manager::instance()->tvShowModel()->appendChild(show);
+        TvShowModelItem* showItem = Manager::instance()->tvShowModel()->appendShow(show);
 
         QMap<SeasonNumber, SeasonModelItem*> seasonItems;
         QVector<TvShowEpisode*> episodes = database().episodes(show->databaseId());
@@ -512,7 +512,7 @@ void TvShowFileSearcher::setupShows(QMap<QString, QVector<QStringList>>& content
         show->loadData(Manager::instance()->mediaCenterInterfaceTvShow());
         emit currentDir(show->name());
         database().add(show, path);
-        TvShowModelItem* showItem = Manager::instance()->tvShowModel()->appendChild(show);
+        TvShowModelItem* showItem = Manager::instance()->tvShowModel()->appendShow(show);
 
         database().transaction();
         QMap<SeasonNumber, SeasonModelItem*> seasonItems;

--- a/src/tv_shows/TvShowModel.cpp
+++ b/src/tv_shows/TvShowModel.cpp
@@ -208,7 +208,7 @@ QModelIndex TvShowModel::index(int row, int column, const QModelIndex& parent) c
     return QModelIndex{};
 }
 
-TvShowModelItem* TvShowModel::appendChild(TvShow* show)
+TvShowModelItem* TvShowModel::appendShow(TvShow* show)
 {
     const int size = m_rootItem.shows().size();
 

--- a/src/tv_shows/TvShowModel.h
+++ b/src/tv_shows/TvShowModel.h
@@ -30,7 +30,7 @@ public:
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
     bool removeRows(int position, int rows, const QModelIndex& parent = QModelIndex()) override;
 
-    TvShowModelItem* appendChild(TvShow* show);
+    TvShowModelItem* appendShow(TvShow* show);
     void removeShow(TvShow* show);
     const TvShowBaseModelItem& getItem(const QModelIndex& index) const;
     TvShowBaseModelItem& getItem(const QModelIndex& index);

--- a/src/tv_shows/TvShowModel.h
+++ b/src/tv_shows/TvShowModel.h
@@ -30,8 +30,16 @@ public:
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
     bool removeRows(int position, int rows, const QModelIndex& parent = QModelIndex()) override;
 
-    TvShowModelItem* appendShow(TvShow* show);
-    void removeShow(TvShow* show);
+    /// Append a TV show and its seasons and episodes to the tree view.
+    void appendShow(TvShow* show);
+    /// Remove a show from the TreeView
+    /// \return true if the show was found and removed, false otherwise
+    bool removeShow(TvShow* show);
+    /// Update a show, i.e. remove it and add it again.
+    /// \todo Maybe add more specific functions like adding a season, etc.
+    /// \return true if the show was found and updated, false otherwise
+    bool updateShow(TvShow* show);
+
     const TvShowBaseModelItem& getItem(const QModelIndex& index) const;
     TvShowBaseModelItem& getItem(const QModelIndex& index);
     void clear();
@@ -42,6 +50,9 @@ public:
 private slots:
     void onSigChanged(TvShowModelItem* showItem, SeasonModelItem* seasonItem, EpisodeModelItem* episodeItem);
     void onShowChanged(TvShow* show);
+
+private:
+    TvShowModelItem* findModelForShow(TvShow* show);
 
 private:
     TvShowRootModelItem m_rootItem;

--- a/src/tv_shows/model/README.md
+++ b/src/tv_shows/model/README.md
@@ -1,0 +1,12 @@
+# TV Show Model
+
+This directory contains data containers that are used by the `TvShowModel`.
+Note that none of the files ending in `*Item.cpp` are actually models according
+to the QT model/view concept. They are solely data containers and do not
+provide any functionality for signaling the addition or removal of seasons,
+episodes, etc.
+
+If you intend to add seasons or episodes, go through `TvShowModel`.
+Special care needs to be taken when adding or removing rows from the model.
+That is, `beginInsertRows` and similar need to be called whenever rows are
+added or removed! None of the item classes in this directory so that.

--- a/src/ui/small_widgets/TvShowTreeView.h
+++ b/src/ui/small_widgets/TvShowTreeView.h
@@ -3,6 +3,7 @@
 #include "globals/Globals.h"
 
 #include <QPainter>
+#include <QPixmap>
 #include <QTreeView>
 #include <QWidget>
 

--- a/src/ui/tv_show/TvShowFilesWidget.cpp
+++ b/src/ui/tv_show/TvShowFilesWidget.cpp
@@ -46,8 +46,10 @@ TvShowFilesWidget::TvShowFilesWidget(QWidget* parent) :
     setupContextMenu();
 
     // clang-format off
-    connect(m_actionShowMissingEpisodes,           &QAction::triggered, this, &TvShowFilesWidget::showMissingEpisodes);
-    connect(m_actionHideSpecialsInMissingEpisodes, &QAction::triggered, this, &TvShowFilesWidget::hideSpecialsInMissingEpisodes);
+
+    /// \todo Maybe select the first row after other rows were removed.
+    // connect(m_tvShowProxyModel, &TvShowProxyModel::rowsAboutToBeRemoved, this,
+    //  [](const QModelIndex &parent, int first, int last){ /*...*/  });
 
     connect(ui->files,            &TvShowTreeView::customContextMenuRequested, this, &TvShowFilesWidget::showContextMenu);
     connect(ui->files->selectionModel(), &QItemSelectionModel::currentChanged, this, &TvShowFilesWidget::onItemSelected, Qt::QueuedConnection);
@@ -479,6 +481,8 @@ void TvShowFilesWidget::renewModel(bool force)
         return;
     }
 
+    /// \todo Check whether this code is really necessary after #883
+
     const int rowCount = ui->files->model()->rowCount();
     for (int row = 0; row < rowCount; ++row) {
         QModelIndex showIndex = ui->files->model()->index(row, 0);
@@ -626,10 +630,10 @@ void TvShowFilesWidget::onViewUpdated()
     }
 }
 
-void TvShowFilesWidget::updateProxy()
-{
-    m_tvShowProxyModel->invalidate();
-}
+// void TvShowFilesWidget::updateProxy()
+//{
+//    m_tvShowProxyModel->invalidate();
+//}
 
 void TvShowFilesWidget::playEpisode(QModelIndex idx)
 {
@@ -727,6 +731,12 @@ void TvShowFilesWidget::setupContextMenu()
 
     m_actionHideSpecialsInMissingEpisodes = new QAction(tr("Hide specials in missing episodes"), this);
     m_actionHideSpecialsInMissingEpisodes->setCheckable(true);
+
+    connect(m_actionShowMissingEpisodes, &QAction::triggered, this, &TvShowFilesWidget::showMissingEpisodes);
+    connect(m_actionHideSpecialsInMissingEpisodes,
+        &QAction::triggered,
+        this,
+        &TvShowFilesWidget::hideSpecialsInMissingEpisodes);
 
     m_contextMenu = new QMenu(ui->files);
     m_contextMenu->addAction(actionMultiScrape);

--- a/src/ui/tv_show/TvShowFilesWidget.cpp
+++ b/src/ui/tv_show/TvShowFilesWidget.cpp
@@ -472,6 +472,7 @@ void TvShowFilesWidget::setFilter(const QVector<Filter*>& filters, QString text)
 void TvShowFilesWidget::renewModel(bool force)
 {
     qDebug() << "Renewing model | Forced:" << force;
+
     if (!force) {
         // When not forced, just update the view.
         onViewUpdated();

--- a/src/ui/tv_show/TvShowFilesWidget.h
+++ b/src/ui/tv_show/TvShowFilesWidget.h
@@ -18,7 +18,9 @@ class TvShowFilesWidget;
 
 class TvShowBaseModelItem;
 
-/// @brief UI widget for showing TV shows in a table/list view.
+/// The TvShowFilesWidget class is responsible for showing a list of TV shows
+/// with correct sorting and filtering. Internally, a TvShowTreeView is used
+/// to display the TV shows with their seasons and episodes.
 class TvShowFilesWidget : public QWidget
 {
     Q_OBJECT

--- a/src/ui/tv_show/TvShowFilesWidget.h
+++ b/src/ui/tv_show/TvShowFilesWidget.h
@@ -39,7 +39,7 @@ public slots:
     void renewModel(bool force = false);
     void emitLastSelection();
     void multiScrape();
-    void updateProxy();
+    // void updateProxy();
 
 signals:
     void sigEpisodeSelected(TvShowEpisode* episode);

--- a/src/ui/tv_show/TvShowWidget.cpp
+++ b/src/ui/tv_show/TvShowWidget.cpp
@@ -135,17 +135,14 @@ void TvShowWidget::onSaveInformation()
 
     if (shows.count() == 1 && episodes.count() == 0 && seasons.count() == 0 && ui->stackedWidget->currentIndex() == 0) {
         ui->tvShowWidget->onSaveInformation();
-        TvShowFilesWidget::instance().updateProxy();
         return;
     }
     if (shows.count() == 0 && episodes.count() == 1 && seasons.count() == 0 && ui->stackedWidget->currentIndex() == 1) {
         ui->episodeWidget->onSaveInformation();
-        TvShowFilesWidget::instance().updateProxy();
         return;
     }
     if (shows.count() == 0 && episodes.count() == 0 && seasons.count() == 1 && ui->stackedWidget->currentIndex() == 2) {
         ui->seasonWidget->onSaveInformation();
-        TvShowFilesWidget::instance().updateProxy();
         return;
     }
 
@@ -155,7 +152,7 @@ void TvShowWidget::onSaveInformation()
         }
     }
 
-    int itemsToSave = shows.count() + episodes.count();
+    const int itemsToSave = shows.count() + episodes.count();
     int itemsSaved = 0;
     NotificationBox::instance()->showProgressBar(
         tr("Saving changed TV Shows and Episodes"), Constants::TvShowWidgetSaveProgressMessageId);
@@ -183,7 +180,6 @@ void TvShowWidget::onSaveInformation()
 
     NotificationBox::instance()->hideProgressBar(Constants::TvShowWidgetSaveProgressMessageId);
     NotificationBox::instance()->showSuccess(tr("TV Shows and Episodes Saved"));
-    TvShowFilesWidget::instance().updateProxy();
 }
 
 /**

--- a/src/ui/tv_show/TvShowWidgetEpisode.cpp
+++ b/src/ui/tv_show/TvShowWidgetEpisode.cpp
@@ -573,11 +573,12 @@ void TvShowWidgetEpisode::onSaveInformation()
 {
     qDebug() << "Entered";
     if (m_episode == nullptr) {
-        qWarning() << "My episode is invalid";
+        qCritical() << "My episode is invalid";
         return;
     }
 
     if (m_episode->isDummy()) {
+        // don't save dummys
         return;
     }
 

--- a/src/ui/tv_show/TvShowWidgetSeason.cpp
+++ b/src/ui/tv_show/TvShowWidgetSeason.cpp
@@ -170,7 +170,7 @@ void TvShowWidgetSeason::onSaveInformation()
     m_show->saveData(Manager::instance()->mediaCenterInterfaceTvShow());
     m_savingWidget->hide();
     onSetEnabled(true);
-    NotificationBox::instance()->showSuccess(tr("<b>\"%1\"</b> Saved").arg(m_show->name()));
+    NotificationBox::instance()->showSuccess(tr("<b>\"%1\"</b> saved").arg(m_show->name()));
 }
 
 void TvShowWidgetSeason::onSetEnabled(bool enabled)

--- a/src/ui/tv_show/TvShowWidgetTvShow.h
+++ b/src/ui/tv_show/TvShowWidgetTvShow.h
@@ -13,9 +13,6 @@ namespace Ui {
 class TvShowWidgetTvShow;
 }
 
-/**
- * @brief The TvShowWidgetTvShow class
- */
 class TvShowWidgetTvShow : public QWidget
 {
     Q_OBJECT


### PR DESCRIPTION
Fix #789  
Fix #865

SeasonModelItem, etc. are not exactly models but only data containers
for the model.

The issue that this commit fixes is with the TvShow model, i.e. the model that is responsible for displaying all TV shows in a tree-like widget. When MediaElch reads the list of shows it manages, each show is appended to the model one at a time. The Qt View/Model for the TreeView requires us to call `beginInsertRows` before adding a row. This is required for the TreeView to know that a change occurs and that the underlying data is about to change. We do this for TV shows only. When we add seasons or even single episodes to the TV show model, we used the TvShowModelItem which isn't an QAbstractItemModel but only the container for the underlying data. The model does not notice that rows have been added which resulted not only in unsorted TV shows but could possibly even lead to crashes. MediaElch added episodes to a TV show *after* the show itself was added to the view. That worked in the past because none of the shows was
expanded. If however one show was expanded "undefined behavior" occurred which I wasn't able to understand. The issue was made more obvious if the feature "Show missing episodes" was enabled as episodes were added a short period *after* the previous episodes were added. And that was exactly the first bug in regards to the TvShowFilesWidget that was found. MediaElch crashed if missing episodes were loaded and added to the tree.

Long story short: `beginInsertRows` and `endInsertRows` were missing.

This commit changes how MediaElch adds TV shows to the TreeView. All data changes have to go through the TvShowModel. No other class now has access to the underlying data (i.e. items like SeasonModelItem).