### PR TITLE
[Release] Prepare release of v2.6.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,8 +24,8 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **MediaElch Version:**
- - [ ] 2.6.3-dev (nightly)
- - [ ] 2.6.2 stable
+ - [ ] 2.6.5-dev (nightly)
+ - [ ] 2.6.4 stable
 <!-- older stable versions are not supported; please update -->
 
 **Operating System:**

--- a/.github/ISSUE_TEMPLATE/scraper-does-not-work.md
+++ b/.github/ISSUE_TEMPLATE/scraper-does-not-work.md
@@ -24,8 +24,8 @@ assignees: ''
 Add a list of information that is not loaded correctly.
 
 **MediaElch Version:**
- - [ ] 2.6.3-dev (nightly)
- - [ ] 2.6.2 stable
+ - [ ] 2.6.5-dev (nightly)
+ - [ ] 2.6.4 stable
 
 **Operating System:**
  - [ ] Windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Next Release (*tbd*)
+## 2.6.2 - Ferenginar (2020-02-16)
 
 ### Bugfixes
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.13.0 FATAL_ERROR)
 
 project(
   mediaelch
-  VERSION 2.6.3
+  VERSION 2.6.4
   DESCRIPTION "Media Manager for Kodi"
   HOMEPAGE_URL "https://mediaelch.github.io/"
 )

--- a/MediaElch.plist
+++ b/MediaElch.plist
@@ -7,11 +7,11 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleGetInfoString</key>
-    <string>2.6.3</string>
+    <string>2.6.4</string>
     <key>CFBundleVersion</key>
-    <string>2.6.3</string>
+    <string>2.6.4</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.6.3</string>
+    <string>2.6.4</string>
     <key>CFBundleExecutable</key>
     <string>MediaElch</string>
     <key>CFBundleHelpBookFolder</key>

--- a/Version.h
+++ b/Version.h
@@ -9,8 +9,8 @@ namespace mediaelch {
 namespace constants {
 
 constexpr char AppName[] = "MediaElch";
-constexpr char AppVersionStr[] = "2.6.3";         // major.minor.patch
-constexpr char AppVersionFullStr[] = "2.6.3-dev"; // major.minor.patch-identifier
+constexpr char AppVersionStr[] = "2.6.4";         // major.minor.patch
+constexpr char AppVersionFullStr[] = "2.6.4";    // major.minor.patch-identifier
 constexpr char VersionName[] = "Ferenginar";
 constexpr char OrganizationName[] = "kvibes";
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,40 @@
+mediaelch (2.6.4-1) vivid; urgency=low
+
+ * Fix TV shows sorting and possible crashes if "Show missing episodes" is enabled (#789, #883)
+ * Fix hanging window if the custom movie scraper is selected but no valid scraper is found.
+ * Fix `{{ *.RATING }}` not being replaced in exports if a media item has no rating
+ * Fix movie label color not being shown (#803)
+ * Fix default language selection in movie scraper dialog
+ * NFO: Only write `<originaltitle>` if it's different from `<title>` (#812)
+ * Fix IMDb runtime scraping (#810)
+ * Update TMDb base URL for downloading images (#807)
+   The very old subdomain has been taken offline. We now use the new one.
+ * Fix TMDb scraper language in dialog window (#813)
+   Scraper language wasn't the one saved in settings but always "English".
+ * About Dialog: Fix MediaInfo version string in developer information (#790)
+ * Movie/TvShow: Only parse valid `premiered` tags (#827)
+ * Fix crash when no TV show is selected
+ * Fix missing TheTvDb ID in episode NFO files (#788)
+ * Don't write TheTvDb v1 episode-guide URLs to TV show NFOs (#652)
+ * Show "Dolby TrueHD" media flag for "truehd" audio codec
+ * Fix audio codec recognition for newer MediaInfoLib versions (#797)
+ * Fix "Add to synchronization queue" feature for episodes and TV shows (#850)
+ * Allow IMDb IDs with 8 digits (previously only 7 digits allows) (#855)
+ * Fix actors having wrong image after removing one actor (#859)
+ * TMDb: Load more movie collection details (#800)
+ * ADA search: Don't filter for DVDs, fix overview scraping of some movies (#819)
+ * Movie Search Dialog: Add error message label
+ * TheTvDb: Use API v2 (JSON API instead of old XML API) (#487, #432, #528)
+ * Episode widget: add TheTvDb ID and IMDb ID fields
+ * AdvancedSettings: Better input validation (issues are printed to the debug log) (#743)
+ * AdvancedSettings: Add experimental exclude patterns (#840)
+ * Add `en_US` language file for better singular/plural handling
+ * Better network error reporting for scraping TV shows and movies (#870)
+ * Better error reporting in the image dialog (#864, #874)
+
+ -- Andre Meyering <info@andremeyering.de>  Sun, 16 Feb 2020 19:00:00 +0200
+
+
 mediaelch (2.6.2-1) vivid; urgency=low
 
   * Fix IMDb tag scraping (#649)

--- a/docs/admin/release.md
+++ b/docs/admin/release.md
@@ -111,7 +111,7 @@ GitHub Releases or otherwise chocolatey will have issues.
 
 Resources:
  - https://github.com/Komet/MediaElch/issues/544
- - https://github.com/sumo300/chocolatey-mediaelch
+ - https://github.com/mediaelch/chocolatey-mediaelch
 
 [choco]: https://chocolatey.org/packages/MediaElch/
 

--- a/docs/admin/release.md
+++ b/docs/admin/release.md
@@ -23,10 +23,13 @@ See [transifex.md](transifex.md)
 
 Change the version in following files:
 
+ 1. `CMakeLists.txt`
  1. `Version.h`
- 2. `MediaElch.plist`
- 3. `obs/MediaElch.spec`
- 4. `obs/README.md`
+ 1. `MediaElch.plist`
+ 1. `obs/MediaElch.spec`
+ 1. `obs/README.md`
+ 1. `.github/ISSUE_TEMPLATE/bug_report.md`
+ 1. `.github/ISSUE_TEMPLATE/scraper-does-not-work.md`
 
 If done then search for the old version string to ensure that no other
 file was missed. In the latter case, update the list above.

--- a/obs/MediaElch.changes
+++ b/obs/MediaElch.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Sun Feb 16 18:00:00 UTC 2020 - info@andremeyering.de
+
+ - Updated MediaElch to v2.6.4
+
+-------------------------------------------------------------------
 Sun Sep 13 18:00:00 UTC 2019 - info@andremeyering.de
 
  - Updated MediaElch to v2.6.2

--- a/obs/MediaElch.spec
+++ b/obs/MediaElch.spec
@@ -3,7 +3,7 @@
 #
 
 Name:           MediaElch
-Version:        2.6.3
+Version:        2.6.4
 Release:        1%{?dist}
 License:        LGPL-2.1+
 Summary:        A Media Manager for Kodi

--- a/obs/README.md
+++ b/obs/README.md
@@ -59,7 +59,7 @@ osc commit
 ## Compress MediaElch (`.tar.gz`)
 
 ```sh
-export ME_VERSION=2.6.3
+export ME_VERSION=2.6.4
 # Clone latest version.
 git clone https://github.com/Komet/MediaElch.git MediaElch
 cd MediaElch


### PR DESCRIPTION
This PR prepares the release of MediaElch v2.6.4. Please note that I plan to release the next version on 2020-02-16 but if I for some reason cannot hold that deadline, it will be released a month later. :-)

Todo:
- [x] Change version strings
- [x] Update documentation
- [x] Prepare Blog Post (see [here](https://github.com/mediaelch/mediaelch-blog/pull/1))
- [x] Prepare Forum Post (German / English)

After merging this PR:
- [ ] Release Windows Version (upload to GitHub Releases)
- [ ] Release macOS Version (upload to GitHub Releases)
- [ ] Release Linux AppImage Version (upload to GitHub Releases)
- [ ] Release openSUSE version (repository)
- [ ] Release Ubuntu version (repository)


Ping @sumo300 (windows), @Komet (owner), @scottfurry (other linux repo)

To all packagers: There are two useful compile flags:
 - `USE_EXTERN_QUAZIP` (see #756)
 - `DISABLE_UPDATER`(see #763)