### PR TITLE
[Qt] Revert requirement of Qt 5.6 due to Ubuntu 16.04 being on Qt 5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 
  - CMake: Fix Foundation framework include for macOS
  - Tests: Add more integration and unit tests
+ - Downgrade to Qt 5.5 as minimal requirement (#885)
 
 
 ## 2.6.2 - Ferenginar (2019-09-13)

--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -1,6 +1,6 @@
 # Check Qt versions
 lessThan(QT_MAJOR_VERSION, 5): error(Qt 4 is not supported!)
-lessThan(QT_MINOR_VERSION, 5): error(Qt 5.6 or higher is required!)
+lessThan(QT_MINOR_VERSION, 5): error(Qt 5.5 or higher is required!)
 
 contains(CONFIG, USE_EXTERN_QUAZIP) {
     DEFINES += EXTERN_QUAZIP

--- a/src/scrapers/ScraperInterface.cpp
+++ b/src/scrapers/ScraperInterface.cpp
@@ -19,7 +19,10 @@ public:
         case QNetworkReply::OperationCanceledError: msg = tr("Timeout by MediaElch"); break;
         case QNetworkReply::TimeoutError: msg = tr("Remote connection timed out"); break;
         case QNetworkReply::SslHandshakeFailedError: msg = tr("SSL handshake failed"); break;
+#if QT_VERSION >= 0x056000
+        // was introduced in Qt 5.6
         case QNetworkReply::TooManyRedirectsError: msg = tr("Too many redirects"); break;
+#endif
         case QNetworkReply::ConnectionRefusedError: msg = tr("Connection refused by host"); break;
         case QNetworkReply::HostNotFoundError: msg = tr("Host not found"); break;
         case QNetworkReply::UnknownNetworkError: msg = tr("Unknown network error"); break;

--- a/travis-ci/docker/Dockerfile.build-opensuse-leap-15
+++ b/travis-ci/docker/Dockerfile.build-opensuse-leap-15
@@ -7,6 +7,7 @@ FROM opensuse/leap:15
 #  - install ffmpeg which is a runtime dependency
 
 RUN zypper --non-interactive refresh && \
+    zypper --non-interactive update && \
     zypper --non-interactive install --type pattern devel_basis && \
     zypper --non-interactive install gcc gcc-c++ git \
         libmediainfo0 libmediainfo-devel libpulse-devel \

--- a/travis-ci/docker/Dockerfile.build-opensuse-leap-42.3
+++ b/travis-ci/docker/Dockerfile.build-opensuse-leap-42.3
@@ -7,6 +7,7 @@ FROM opensuse/leap:42.3
 #  - install ffmpeg which is a runtime dependency
 
 RUN zypper --non-interactive refresh && \
+    zypper --non-interactive update && \
     zypper --non-interactive install --type pattern devel_basis && \
     zypper --non-interactive install gcc7 gcc7-c++ git \
         libmediainfo0 libmediainfo-devel libpulse-devel \

--- a/travis-ci/docker/Dockerfile.build-opensuse-tumbleweed
+++ b/travis-ci/docker/Dockerfile.build-opensuse-tumbleweed
@@ -7,6 +7,7 @@ FROM opensuse/tumbleweed:latest
 #  - install ffmpeg which is a runtime dependency
 
 RUN zypper --non-interactive refresh && \
+    zypper --non-interactive update && \
     zypper --non-interactive install --type pattern devel_basis && \
     zypper --non-interactive install gcc gcc-c++ git \
         libmediainfo0 libmediainfo-devel libpulse-devel \

--- a/travis-ci/docker/Dockerfile.build-ubuntu-16.04
+++ b/travis-ci/docker/Dockerfile.build-ubuntu-16.04
@@ -1,6 +1,7 @@
 FROM ubuntu:xenial
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends software-properties-common && \
     # MediaElch requires a more modern GCC:
     add-apt-repository ppa:ubuntu-toolchain-r/test

--- a/travis-ci/docker/Dockerfile.build-ubuntu-18.04
+++ b/travis-ci/docker/Dockerfile.build-ubuntu-18.04
@@ -1,6 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get -y --no-install-recommends install \
         g++ gcc \
         build-essential \

--- a/travis-ci/docker/Dockerfile.build-ubuntu-19.04
+++ b/travis-ci/docker/Dockerfile.build-ubuntu-19.04
@@ -1,6 +1,7 @@
 FROM ubuntu:disco
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get -y --no-install-recommends install \
         g++ gcc \
         build-essential \


### PR DESCRIPTION
We still need to support Ubuntu 16.04 as it is still supported (LTS version)