### PR TITLE
[Fanart] Explicitly handle 404 response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Improvements
 
  - Always write the episode guide URL to TV show NFOs using TheTvDb format (#652)
+ - Fanart.tv: Print better error messages for shows and movies that cannot be found (#900)
+ - TMDb: Update available languages to support official translations (#901)
 
 ### Internal Improvements and Changes
 

--- a/src/globals/ImageDialog.cpp
+++ b/src/globals/ImageDialog.cpp
@@ -974,6 +974,7 @@ void ImageDialog::onResultClicked(QTableWidgetItem* item)
 void ImageDialog::onProviderImagesLoaded(QVector<Poster> images, ScraperLoadError error)
 {
     if (error.hasError()) {
+        qDebug() << "Error while querying image provider:" << error.message;
         showError(tr("Error while querying image provider: %1").arg(error.message));
     }
     setDownloads(images, false);

--- a/src/scrapers/image/FanartTv.cpp
+++ b/src/scrapers/image/FanartTv.cpp
@@ -327,7 +327,9 @@ void FanartTv::onLoadMovieDataFinished()
     reply->deleteLater();
 
     if (reply->error() != QNetworkReply::NoError) {
-        emit sigImagesLoaded({}, {ScraperLoadError::ErrorType::NetworkError, reply->errorString()});
+        const bool notFound = (reply->error() == QNetworkReply::ContentNotFoundError);
+        const QString error = notFound ? tr("Movie not found on Fanart.tv") : reply->errorString();
+        emit sigImagesLoaded({}, {ScraperLoadError::ErrorType::NetworkError, error});
         return;
     }
 
@@ -345,13 +347,17 @@ void FanartTv::onLoadAllMovieDataFinished()
     auto* reply = dynamic_cast<QNetworkReply*>(QObject::sender());
     Movie* movie = reply->property("storage").value<Storage*>()->movie();
     reply->deleteLater();
-    QMap<ImageType, QVector<Poster>> posters;
-    if (reply->error() == QNetworkReply::NoError) {
-        QString msg = QString::fromUtf8(reply->readAll());
-        for (const auto type : reply->property("infosToLoad").value<Storage*>()->imageInfosToLoad()) {
-            posters.insert(type, parseMovieData(msg, type));
-        }
+
+    if (reply->error() != QNetworkReply::NoError) {
+        emit sigMovieImagesLoaded(movie, {});
     }
+
+    QMap<ImageType, QVector<Poster>> posters;
+    QString msg = QString::fromUtf8(reply->readAll());
+    for (const auto type : reply->property("infosToLoad").value<Storage*>()->imageInfosToLoad()) {
+        posters.insert(type, parseMovieData(msg, type));
+    }
+
     emit sigMovieImagesLoaded(movie, posters);
 }
 
@@ -364,13 +370,17 @@ void FanartTv::onLoadAllConcertDataFinished()
     auto* reply = dynamic_cast<QNetworkReply*>(QObject::sender());
     Concert* concert = reply->property("storage").value<Storage*>()->concert();
     reply->deleteLater();
-    QMap<ImageType, QVector<Poster>> posters;
-    if (reply->error() == QNetworkReply::NoError) {
-        QString msg = QString::fromUtf8(reply->readAll());
-        for (const auto type : reply->property("infosToLoad").value<Storage*>()->imageInfosToLoad()) {
-            posters.insert(type, parseMovieData(msg, type));
-        }
+
+    if (reply->error() != QNetworkReply::NoError) {
+        emit sigConcertImagesLoaded(concert, {});
     }
+
+    QMap<ImageType, QVector<Poster>> posters;
+    QString msg = QString::fromUtf8(reply->readAll());
+    for (const auto type : reply->property("infosToLoad").value<Storage*>()->imageInfosToLoad()) {
+        posters.insert(type, parseMovieData(msg, type));
+    }
+
     emit sigConcertImagesLoaded(concert, posters);
 }
 
@@ -514,7 +524,9 @@ void FanartTv::onLoadTvShowDataFinished()
     reply->deleteLater();
 
     if (reply->error() != QNetworkReply::NoError) {
-        emit sigImagesLoaded({}, {ScraperLoadError::ErrorType::NetworkError, reply->errorString()});
+        const bool notFound = (reply->error() == QNetworkReply::ContentNotFoundError);
+        const QString error = notFound ? tr("TV show not found on Fanart.tv") : reply->errorString();
+        emit sigImagesLoaded({}, {ScraperLoadError::ErrorType::NetworkError, error});
         return;
     }
 


### PR DESCRIPTION
Fanart.tv may respond with a 404 message. As of 2020-02-23 this happens
for the show "For Life" which does not have any images on fanart.tv.
Prior to this commit, a non-user-friendly message was shown.

Fixes #900 