### PR TITLE
[AEBN] Fix segmentation fault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugfixes
 
- - nothing, yet
+ - Fix AEBN crash when scraping a movie (#910)
 
 ### Improvements
 

--- a/scripts/packaging/package.sh
+++ b/scripts/packaging/package.sh
@@ -172,7 +172,7 @@ package_appimage() {
 		print_info "Downloading ffmpeg"
 		# Use static ffmpeg
 		wget -c https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz -O ffmpeg.tar.xz
-		ffmpeg_md5="01bbccaf5da4681ccd3f2c6a759dc7d6  ffmpeg.tar.xz"
+		ffmpeg_md5="c542bca4e9375c53aa4055c71d5b6691  ffmpeg.tar.xz" # 4.2.2
 		if [ "$(md5sum ffmpeg.tar.xz)" = "${ffmpeg_md5}" ]; then
 			print_info "FFMPEG MD5 checksum is valid"
 		else

--- a/src/scrapers/movie/AEBN.cpp
+++ b/src/scrapers/movie/AEBN.cpp
@@ -295,10 +295,12 @@ void AEBN::parseAndAssignInfos(QString html, Movie* movie, QVector<MovieScraperI
         while ((offset = rx.indexIn(html, offset)) != -1) {
             offset += rx.matchedLength();
 
-            const bool actorAlreadyAdded =
-                std::any_of(movie->actors().cbegin(), movie->actors().cend(), [&rx](const Actor* a) { //
-                    return a->name == rx.cap(5);                                                      //
-                });
+            const QString actorName = rx.cap(5);
+            const QVector<Actor*> actors = movie->actors();
+
+            const bool actorAlreadyAdded = std::any_of(actors.cbegin(), actors.cend(), [&actorName](const Actor* a) { //
+                return a->name == actorName;                                                                          //
+            });
 
             if (actorAlreadyAdded) {
                 continue;
@@ -318,10 +320,13 @@ void AEBN::parseAndAssignInfos(QString html, Movie* movie, QVector<MovieScraperI
                       "itemprop=\"name\">(.*)</span></a>");
         while ((offset = rx.indexIn(html, offset)) != -1) {
             offset += rx.matchedLength();
-            const bool actorAlreadyAdded =
-                std::any_of(movie->actors().cbegin(), movie->actors().cend(), [&rx](const Actor* a) { //
-                    return a->name == rx.cap(2);                                                      //
-                });
+
+            const QString actorName = rx.cap(2);
+            const QVector<Actor*> actors = movie->actors();
+
+            const bool actorAlreadyAdded = std::any_of(actors.cbegin(), actors.cend(), [&actorName](const Actor* a) { //
+                return a->name == actorName;                                                                          //
+            });
 
             if (!actorAlreadyAdded) {
                 Actor a;

--- a/travis-ci/package.sh
+++ b/travis-ci/package.sh
@@ -134,7 +134,7 @@ create_appimage() {
 	print_info "Downloading ffmpeg"
 	# Use static ffmpeg
 	wget -c https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz -O ffmpeg.tar.xz
-	ffmpeg_md5="01bbccaf5da4681ccd3f2c6a759dc7d6  ffmpeg.tar.xz"
+	ffmpeg_md5="c542bca4e9375c53aa4055c71d5b6691  ffmpeg.tar.xz" # 4.2.2
 	if [ "$(md5sum ffmpeg.tar.xz)" = "${ffmpeg_md5}" ]; then
 		print_info "FFMPEG MD5 checksum is valid"
 	else


### PR DESCRIPTION
`std::any_of(movie->actors().cbegin(), movie->actors().cend(),` did not
work because two temporary *different* QVector objects were used to
iterate the actors.

Fix #910 