### PR TITLE
[TMDb] Fix defaultLanguageKey() and return the locale, not just language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugfixes
 
  - Fix AEBN crash when scraping a movie (#910)
+ - Select correct language for TMDb in the movie search dialog (#916)
 
 ### Improvements
 

--- a/src/scrapers/movie/TMDb.cpp
+++ b/src/scrapers/movie/TMDb.cpp
@@ -235,13 +235,14 @@ std::vector<ScraperLanguage> TMDb::supportedLanguages()
 
 void TMDb::changeLanguage(QString languageKey)
 {
-    // Does not store the new language in settings.
-    m_locale = languageKey;
+    // Do not store the new language in settings.
+    // QLocale uses de_DE and not de-DE like TMDb
+    m_locale = languageKey.replace('-', '_');
 }
 
 QString TMDb::defaultLanguageKey()
 {
-    return language();
+    return localeForTMDb();
 }
 
 /**


### PR DESCRIPTION
defaultLanguageKey() is supposed to return the language key, e.g. de-DE.
Prior to this commit however, only the language was returned, e.g. "de".
Due to this the combo box did not select the correct language and nearly
always selected "Arabic", i.e. the first entry.

Fix #916