### PR TITLE
[Concert] Fix scanning of concerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
  - Fix AEBN crash when scraping a movie (#910)
  - Select correct language for TMDb in the movie search dialog (#916)
+ - Windows: Fix scanning of concerts (#814)
 
 ### Improvements
 


### PR DESCRIPTION
Due to a string comparison, scanning of concerts did not work on
Windows. That is because one of two paths (as strings) used the native
path separators (i.e. backslash) and one was "normalized" and used
the normal forward slash.

Fix #814