### PR TITLE
[DownloadWidget] Fix wrong file sizes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
   only:
   - master
 
-matrix:
+jobs:
   include:
 
   #----------------------------------------------------------------------------
@@ -27,7 +27,7 @@ matrix:
 
   - name: "cmake-format check"
     language: python
-    python: ['3.6']
+    python: '3.8'
     addons: { apt: { packages: ['python3-setuptools', 'python3-pip'] } }
     install:
       - pip install cmake_format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
  - Fix AEBN crash when scraping a movie (#910)
  - Select correct language for TMDb in the movie search dialog (#916)
  - Windows: Fix scanning of concerts (#814)
+ - Downloads Section: Fix crash when importing items (#828)
+ - Downloads Section: Fix invalid file sizes (#829)  
+   Due to a bug, files above 2GB had the wrong file size. Furthermore MediaElch
+   showed file sizes in MiB, GiB, etc. even though MB, GB, etc. were displayed.
 
 ### Improvements
 

--- a/src/globals/Helper.cpp
+++ b/src/globals/Helper.cpp
@@ -305,18 +305,20 @@ QString mapCountry(const QString& text)
     return text;
 }
 
-QString formatFileSize(const qint64& size)
+QString formatFileSize(double size, const QLocale& locale)
 {
-    if (size > 1024 * 1024 * 1024) {
-        return QString("%1 GB").arg(QString::number(static_cast<double>(size) / 1024.0 / 1024.0 / 1024.0, 'f', 2));
+    // We use the decimal system, i.e. 1000 and not the binary system with 1000.
+    // Otherwise the units would be GiB, Mib and kiB.
+    if (size > 1000. * 1000. * 1000.) {
+        return QString("%1 GB").arg(locale.toString(size / 1000.0 / 1000.0 / 1000.0, 'f', 2));
     }
-    if (size > 1024 * 1024) {
-        return QString("%1 MB").arg(QString::number(static_cast<double>(size) / 1024.0 / 1024.0, 'f', 2));
+    if (size > 1000. * 1000.) {
+        return QString("%1 MB").arg(locale.toString(size / 1000.0 / 1000.0, 'f', 2));
     }
-    if (size > 1024) {
-        return QString("%1 kB").arg(QString::number(static_cast<double>(size) / 1024.0, 'f', 2));
+    if (size > 1000.) {
+        return QString("%1 kB").arg(locale.toString(size / 1000.0, 'f', 2));
     }
-    return QString("%1 B").arg(QString::number(static_cast<double>(size), 'f', 2));
+    return QString("%1 B").arg(locale.toString(size, 'f', 2));
 }
 
 void removeFocusRect(QWidget* widget)

--- a/src/globals/Helper.h
+++ b/src/globals/Helper.h
@@ -6,6 +6,7 @@
 #include <QComboBox>
 #include <QImage>
 #include <QLabel>
+#include <QLocale>
 #include <QObject>
 #include <QPushButton>
 #include <QString>
@@ -37,7 +38,7 @@ QStringList mapGenre(const QStringList& genres);
 Certification mapCertification(const Certification& certification);
 QString mapStudio(const QString& text);
 QString mapCountry(const QString& text);
-QString formatFileSize(const qint64& size);
+QString formatFileSize(double size, const QLocale& locale);
 void removeFocusRect(QWidget* widget);
 void applyStyle(QWidget* widget, bool removeFocus = true, bool isTable = false);
 void applyEffect(QWidget* parent);

--- a/src/ui/downloads/DownloadsWidget.h
+++ b/src/ui/downloads/DownloadsWidget.h
@@ -21,7 +21,9 @@ class DownloadsWidget : public QWidget
     {
         QString baseName;
         QStringList files;
-        int64_t size;
+        /// Size in Bytes of this package.
+        /// Not an int to allow sizes >4GB on 32bit systems
+        double size;
     };
 
     struct Import
@@ -29,7 +31,9 @@ class DownloadsWidget : public QWidget
         QString baseName;
         QStringList files;
         QStringList extraFiles;
-        int64_t size;
+        /// Size in Bytes of this import.
+        /// Not an int to allow sizes >4GB on 32bit systems
+        double size;
     };
 
 public:

--- a/src/ui/downloads/MakeMkvDialog.cpp
+++ b/src/ui/downloads/MakeMkvDialog.cpp
@@ -172,13 +172,14 @@ void MakeMkvDialog::onScanDrive()
 
 void MakeMkvDialog::onScanFinished(QString title, QMap<int, MakeMkvCon::Track> tracks)
 {
+    const QLocale locale = Settings::instance()->advanced()->locale();
     QMapIterator<int, MakeMkvCon::Track> it(tracks);
     while (it.hasNext()) {
         it.next();
         QListWidgetItem* item = new QListWidgetItem(QString("%1 (%3, %2)")
                                                         .arg(it.value().name)
                                                         .arg(it.value().duration)
-                                                        .arg(helper::formatFileSize(it.value().size)));
+                                                        .arg(helper::formatFileSize(it.value().size, locale)));
         item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsUserCheckable);
         item->setCheckState(Qt::Unchecked);
         item->setData(Qt::UserRole, it.key());

--- a/src/ui/small_widgets/MyTableWidgetItem.cpp
+++ b/src/ui/small_widgets/MyTableWidgetItem.cpp
@@ -3,34 +3,30 @@
 #include <QDebug>
 
 #include "globals/Helper.h"
+#include "settings/Settings.h"
 
 MyTableWidgetItem::MyTableWidgetItem(QString text) : QTableWidgetItem(text), m_isSize{false}
 {
 }
 
-MyTableWidgetItem::MyTableWidgetItem(QString text, qreal number) :
-    QTableWidgetItem(static_cast<int>(number)), m_isSize{false}
+MyTableWidgetItem::MyTableWidgetItem(QString text, double number) : QTableWidgetItem(text), m_isSize{false}
 {
-    setData(1000, number);
+    setData(m_dataRole, number);
     setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    setText(text);
 }
 
-MyTableWidgetItem::MyTableWidgetItem(int64_t number, bool isSize) : MyTableWidgetItem(static_cast<int>(number), isSize)
+MyTableWidgetItem::MyTableWidgetItem(double number, bool isSize) :
+    QTableWidgetItem(QString::number(number)), m_isSize{isSize}
 {
-}
-
-MyTableWidgetItem::MyTableWidgetItem(int number, bool isSize) : QTableWidgetItem(number), m_isSize{isSize}
-{
-    setData(1000, number);
+    setData(m_dataRole, number);
     setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    setText(QString::number(number));
 }
 
 QVariant MyTableWidgetItem::data(int role) const
 {
+    QLocale locale = Settings::instance()->advanced()->locale();
     if (role == Qt::DisplayRole && m_isSize) {
-        return helper::formatFileSize(QTableWidgetItem::data(Qt::DisplayRole).toLongLong());
+        return helper::formatFileSize(QTableWidgetItem::data(Qt::DisplayRole).toDouble(), locale);
     }
 
     return QTableWidgetItem::data(role);
@@ -38,8 +34,8 @@ QVariant MyTableWidgetItem::data(int role) const
 
 bool MyTableWidgetItem::operator<(const QTableWidgetItem& other) const
 {
-    if (!data(1000).toString().isEmpty()) {
-        return data(1000).toReal() < other.data(1000).toReal();
+    if (!data(m_dataRole).toString().isEmpty()) {
+        return data(m_dataRole).toDouble() < other.data(m_dataRole).toDouble();
     }
 
     return data(Qt::DisplayRole).toString() < other.data(Qt::DisplayRole).toString();

--- a/src/ui/small_widgets/MyTableWidgetItem.h
+++ b/src/ui/small_widgets/MyTableWidgetItem.h
@@ -6,12 +6,14 @@ class MyTableWidgetItem : public QTableWidgetItem
 {
 public:
     explicit MyTableWidgetItem(QString text);
-    MyTableWidgetItem(QString text, qreal number);
-    MyTableWidgetItem(int64_t number, bool isSize = false);
-    MyTableWidgetItem(int number, bool isSize = false);
+    MyTableWidgetItem(QString text, double number);
+    MyTableWidgetItem(double number, bool isSize = false);
+
     QVariant data(int role) const;
     virtual bool operator<(const QTableWidgetItem& other) const;
 
 private:
     bool m_isSize;
+
+    const int m_dataRole = 1000;
 };


### PR DESCRIPTION
Due to a bug, files above 2GB had the wrong file size. That is because
an integer (32bit) was used to store the file size in Byte.
Furthermore MediaElch showed file sizes in MiB, GiB, etc. even though
MB, GB, etc. were displayed.

Fix #829