### PR TITLE
[Download Section] Show file size as a factor of 1024 in tool tip

### DIFF
--- a/src/ui/small_widgets/MyTableWidgetItem.cpp
+++ b/src/ui/small_widgets/MyTableWidgetItem.cpp
@@ -25,11 +25,16 @@ MyTableWidgetItem::MyTableWidgetItem(double number, bool isSize) :
 QVariant MyTableWidgetItem::data(int role) const
 {
     QLocale locale = Settings::instance()->advanced()->locale();
+    const double fileSizeByte = QTableWidgetItem::data(Qt::DisplayRole).toDouble();
+
     if (role == Qt::DisplayRole && m_isSize) {
-        const double fileSizeByte = QTableWidgetItem::data(Qt::DisplayRole).toDouble();
         const QString decimalSize = helper::formatFileSize(fileSizeByte, locale);
+        return decimalSize;
+    }
+
+    if (role == Qt::ToolTipRole && m_isSize) {
         const QString binarySize = helper::formatFileSizeBinary(fileSizeByte, locale);
-        return QStringLiteral("%1 (%2)").arg(decimalSize, binarySize);
+        return binarySize;
     }
 
     return QTableWidgetItem::data(role);


### PR DESCRIPTION
Instead of showing both, the file size as a power of 1000 (kB, MB, GB) and as a power of 1024 (kiB, MiB, GiB) we now only show the former and display the latter as a tool tip.