### PR TITLE
[export] adding seconds to export folder

### DIFF
--- a/src/ui/export/ExportDialog.cpp
+++ b/src/ui/export/ExportDialog.cpp
@@ -73,7 +73,7 @@ void ExportDialog::onBtnExport()
 
     QDir dir(location);
     QString subDir =
-        QStringLiteral("MediaElch Export %1").arg(QDateTime::currentDateTime().toString("yyyy-MM-dd hh-mm"));
+        QStringLiteral("MediaElch Export %1").arg(QDateTime::currentDateTime().toString("yyyy-MM-dd hh-mm-ss"));
     if (!dir.mkdir(subDir)) {
         ui->message->setErrorMessage(tr("Could not create export directory."));
         return;


### PR DESCRIPTION
When developing an export-theme:
It is usual to export within minutes.
Currently the minutes are the "smallest change", which can collide frequently.
with this RP the seconds are appended, and prevent naming-collisions.
I think this will not cause any harm to existing documentation. But it could break automation.