### PR TITLE
[TvShow] Fix editing of writers/directors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
  - Downloads Section: Fix invalid file sizes (#829)  
    Due to a bug, files above 2GB had the wrong file size. Furthermore MediaElch
    showed file sizes in MiB, GiB, etc. even though MB, GB, etc. were displayed.
+ - TV episodes: Manually edited writers and directors were not saved (#933)
 
 ### Changes
 

--- a/src/globals/ComboDelegate.cpp
+++ b/src/globals/ComboDelegate.cpp
@@ -98,7 +98,7 @@ void ComboDelegate::setEditorData(QWidget* editor, const QModelIndex& index) con
 
 void ComboDelegate::setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const
 {
-    auto box = dynamic_cast<QComboBox*>(editor);
+    auto* box = dynamic_cast<QComboBox*>(editor);
     QString value = box->currentText();
     model->setData(index, value, Qt::EditRole);
 }
@@ -113,6 +113,6 @@ void ComboDelegate::updateEditorGeometry(QWidget* editor,
 
 QSize ComboDelegate::sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const
 {
-    int width = QItemDelegate::sizeHint(option, index).width();
+    const int width = QItemDelegate::sizeHint(option, index).width();
     return {width, 25};
 }

--- a/src/ui/tv_show/TvShowWidgetEpisode.cpp
+++ b/src/ui/tv_show/TvShowWidgetEpisode.cpp
@@ -109,6 +109,8 @@ TvShowWidgetEpisode::TvShowWidgetEpisode(QWidget* parent) :
     connect(ui->videoScantype, &QLineEdit::textEdited, this, &TvShowWidgetEpisode::onStreamDetailsEdited);
     connect(ui->stereoMode, SIGNAL(currentIndexChanged(int)), this, SLOT(onStreamDetailsEdited()));
     connect(ui->actors, &QTableWidget::itemChanged, this, &TvShowWidgetEpisode::onActorEdited);
+    connect(ui->directors, &QTableWidget::itemChanged, this, &TvShowWidgetEpisode::onDirectorEdited);
+    connect(ui->writers, &QTableWidget::itemChanged, this, &TvShowWidgetEpisode::onWriterEdited);
 
     m_loadingMovie = new QMovie(":/img/spinner.gif", QByteArray(), this);
     m_loadingMovie->start();
@@ -771,7 +773,7 @@ void TvShowWidgetEpisode::onRemoveDirector()
         return;
     }
 
-    auto director = ui->directors->item(row, 0)->data(Qt::UserRole).value<QString*>();
+    auto* director = ui->directors->item(row, 0)->data(Qt::UserRole).value<QString*>();
     m_episode->removeDirector(director);
     ui->directors->blockSignals(true);
     ui->directors->removeRow(row);
@@ -785,7 +787,7 @@ void TvShowWidgetEpisode::onRemoveDirector()
  */
 void TvShowWidgetEpisode::onDirectorEdited(QTableWidgetItem* item)
 {
-    auto director = ui->directors->item(item->row(), 0)->data(Qt::UserRole).value<QString*>();
+    QString* director = ui->directors->item(item->row(), 0)->data(Qt::UserRole).value<QString*>();
     director->clear();
     director->append(item->text());
     m_episode->setChanged(true);


### PR DESCRIPTION
Two missing signal/slot handlers were the cause that writers/
directors were not saved after being manually edited.

Fix #933