### PR TITLE
 [MovieWidget] Make it possible to generate the poster from a screenshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,11 @@ CMakeLists.txt.user*
 # Dependencies
 ZenLib
 MediaInfoDLL
+ffmpeg
 
 # OS specific
 .directory
 .DS_Store
-MediaInfoDLL
-ZenLib
 
 # IDEs
 .vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@
  - TMDb: Update available languages to support official translations (#901)
  - Movies: If movies are sorted by "name", the movie's sort title is used if
    set and the name otherwise (#919)
+ - Movie Poster: Make it possible to set a random screenshot as the movie's poster (#934)
+   Just like for TV show episode thumbnails, a poster can be created which uses a
+   random screenshot from the movie file. Movies must have a format that is readable
+   by ffmpeg. The resolution is hard coded to 720x1080px which has a typical poster
+   aspect ratio of 2:3.
 
 ### Internal Improvements and Changes
 

--- a/src/image/ImageCapture.h
+++ b/src/image/ImageCapture.h
@@ -14,8 +14,18 @@ class ImageCapture : public QObject
 public:
     explicit ImageCapture(QObject* parent = nullptr);
     /// @brief Captures a screenshot of a given video file at a random time.
-    ///        Resizes it to the given dimension with respect to its aspect ratio.
-    static bool captureImage(QString file, StreamDetails* streamDetails, ThumbnailDimensions dim, QImage& img);
+    ///
+    /// Resizes it to the given dimension with respect to its aspect ratio.
+    /// If cropFromCenter is true then the image will be resized to *exactly*
+    /// the given dimensions and will crop a rectangle from the screenshot's
+    /// center. Otherwise the resulting image may be smaller in size or height
+    /// than the given dimensions.
+    ///
+    static bool captureImage(QString file,
+        StreamDetails* streamDetails,
+        ThumbnailDimensions dim,
+        QImage& img,
+        bool cropFromCenter = false);
 };
 
 } // namespace mediaelch

--- a/src/ui/movies/MovieWidget.h
+++ b/src/ui/movies/MovieWidget.h
@@ -57,6 +57,7 @@ private slots:
     void onDownloadProgress(Movie* movie, int current, int maximum);
     void onSetImage(Movie* movie, ImageType type, QByteArray imageData);
     void onImageDropped(ImageType imageType, QUrl imageUrl);
+    void onCaptureImage(ImageType type);
     void onExtraFanartDropped(QUrl imageUrl);
 
     void onChooseImage();

--- a/src/ui/small_widgets/ClosableImage.cpp
+++ b/src/ui/small_widgets/ClosableImage.cpp
@@ -82,6 +82,7 @@ void ClosableImage::mousePressEvent(QMouseEvent* ev)
         m_anim->start(QPropertyAnimation::DeleteWhenStopped);
         connect(m_anim.data(), &QAbstractAnimation::finished, this, &ClosableImage::sigClose);
         connect(m_anim.data(), &QAbstractAnimation::finished, this, &ClosableImage::closed, Qt::QueuedConnection);
+
     } else if ((!m_image.isNull() || !m_imagePath.isEmpty()) && m_showZoomAndResolution
                && zoomRect().contains(ev->pos())) {
         if (!m_image.isNull()) {
@@ -91,8 +92,10 @@ void ClosableImage::mousePressEvent(QMouseEvent* ev)
             ImagePreviewDialog::instance()->setImage(QPixmap::fromImage(QImage(m_imagePath)));
             ImagePreviewDialog::instance()->exec();
         }
+
     } else if (m_showCapture && captureRect().contains(ev->pos())) {
-        emit sigCapture();
+        emit sigCapture(m_imageType);
+
     } else if (m_clickable && imgRect().contains(ev->pos())) {
         emit clicked();
     }

--- a/src/ui/small_widgets/ClosableImage.h
+++ b/src/ui/small_widgets/ClosableImage.h
@@ -46,7 +46,7 @@ public:
 
 signals:
     void sigClose();
-    void sigCapture();
+    void sigCapture(ImageType type);
     void clicked();
     void sigImageDropped(ImageType, QUrl);
 

--- a/src/ui/tv_show/TvShowWidgetEpisode.cpp
+++ b/src/ui/tv_show/TvShowWidgetEpisode.cpp
@@ -1150,15 +1150,17 @@ void TvShowWidgetEpisode::onTop250Change(int value)
     ui->buttonRevert->setVisible(true);
 }
 
-void TvShowWidgetEpisode::onCaptureImage()
+void TvShowWidgetEpisode::onCaptureImage(ImageType type)
 {
+    using namespace mediaelch;
+
+    Q_UNUSED(type)
     if ((m_episode == nullptr) || m_episode->files().isEmpty()) {
         return;
     }
     auto dimensions = Settings::instance()->advanced()->episodeThumbnailDimensions();
     QImage img;
-    if (!mediaelch::ImageCapture::captureImage(
-            m_episode->files().first(), m_episode->streamDetails(), dimensions, img)) {
+    if (!ImageCapture::captureImage(m_episode->files().first(), m_episode->streamDetails(), dimensions, img, false)) {
         return;
     }
 

--- a/src/ui/tv_show/TvShowWidgetEpisode.h
+++ b/src/ui/tv_show/TvShowWidgetEpisode.h
@@ -49,7 +49,7 @@ private slots:
     void onPosterDownloadFinished(DownloadManagerElement elem);
     void onLoadDone();
     void onRevertChanges();
-    void onCaptureImage();
+    void onCaptureImage(ImageType type);
 
     void onImdbIdChanged(QString imdbid);
     void onTvdbIdChanged(QString tvdbid);

--- a/travis-ci/package.sh
+++ b/travis-ci/package.sh
@@ -199,7 +199,7 @@ create_macos_dmg() {
 
 	fold_start "ffmpeg"
 	print_info "Downloading and copying ffmpeg into MediaElch.dmg"
-	wget --output-document ffmpeg.7z https://evermeet.cx/ffmpeg/ffmpeg-4.0.7z
+	wget --output-document ffmpeg.7z https://evermeet.cx/ffmpeg/ffmpeg-4.2.2.7z
 	7za e ffmpeg.7z
 	cp ffmpeg MediaElch.app/Contents/MacOS/
 	fold_end


### PR DESCRIPTION
This PR makes it possible to click the "grab a screenshot" button
which generates a random screenshot with the desired poster size in the
aspect ratio of 2:3.

Note that the image is cropped from the screenshot's center. For example, take the following screenshot of the open source movie "Sintel" ( https://durian.blender.org/ ):

<img width="1680" alt="Screen Shot 2020-03-28 at 16 20 00" src="https://user-images.githubusercontent.com/1667306/77826665-0d50c000-7111-11ea-9aa3-aa43c320c9fb.png">

It will be cropped to: 

![Sintel-poster](https://user-images.githubusercontent.com/1667306/77826659-06c24880-7111-11ea-8d79-61b2f7dd47fe.jpg)

Fix  #934