### PR TITLE
[TvShow] Don't load shows from database when only count is used

### DIFF
--- a/src/data/Database.cpp
+++ b/src/data/Database.cpp
@@ -691,6 +691,20 @@ void Database::update(TvShowEpisode* episode)
     }
 }
 
+int Database::showCount(QString path)
+{
+    QSqlQuery query(db());
+    query.prepare("SELECT COUNT(*) FROM shows WHERE path=:path");
+    query.bindValue(":path", path.toUtf8());
+    query.exec();
+    if (!query.next()) {
+        return 0;
+    }
+    bool ok = false;
+    int numberOfShows = query.value(0).toInt(&ok);
+    return ok ? numberOfShows : 0;
+}
+
 QVector<TvShow*> Database::shows(QString path)
 {
     QVector<TvShow*> shows;

--- a/src/data/Database.h
+++ b/src/data/Database.h
@@ -41,6 +41,7 @@ public:
     void update(TvShowEpisode* episode);
     void clearTvShows(QString path = "");
     void clearTvShow(QString showDir);
+    int showCount(QString path);
     QVector<TvShow*> shows(QString path);
     QVector<TvShowEpisode*> episodes(int idShow);
     int episodeCount();

--- a/src/tv_shows/TvShowFileSearcher.h
+++ b/src/tv_shows/TvShowFileSearcher.h
@@ -41,6 +41,7 @@ private:
     Database& database();
 
     void clearOldTvShows(bool forceClear);
+    /// \brief Get a map of TV show paths and their respective files in the show folder.
     QMap<QString, QVector<QStringList>> readTvShowContent(bool forceReload);
     QVector<TvShow*> getShowsFromDatabase(bool forceReload);
     void setupShows(QMap<QString, QVector<QStringList>>& contents, int& episodeCounter, int episodeSum);

--- a/src/ui/tv_show/TvShowFilesWidget.cpp
+++ b/src/ui/tv_show/TvShowFilesWidget.cpp
@@ -473,7 +473,7 @@ void TvShowFilesWidget::setFilter(const QVector<Filter*>& filters, QString text)
 /// @brief Renews the model (necessary after searching for TV shows)
 void TvShowFilesWidget::renewModel(bool force)
 {
-    qDebug() << "Renewing model | Forced:" << force;
+    qDebug() << "[TvShowFilesWidget] Renewing model | Forced:" << force;
 
     if (!force) {
         // When not forced, just update the view.


### PR DESCRIPTION
`database().shows(path);` was called which creates new `TvShow*`
instances where only the count was interesting. This commit removes
one such case. This was furthermore a memory leak as the TV shows
were never deleted afterwards.