### PR TITLE
[Dialogs] Fix downloading trailers for many movies and tv tunes for shows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Release (*tbd*)
 
+*Note:* This release has changed its internal file and directory handling to
+fix Windows-related bugs (#732).  Please report any issues with network drives
+or other non-local drives.
+
 ### Bugfixes
 
  - Fix AEBN crash when scraping a movie (#910)
@@ -21,6 +25,10 @@
    light background is not readable. The text is now always set to black.
  - HotMovies: Fix rating scraping  
    Due to a change on their website, the vote count scraping did not work anymore.
+ - Trailer Download: Fix downloading trailers for many movies (#940)  
+   If the trailer dialog window was closed using the window frame's close
+   button ("x") instead of the button labeled "Close", the dialog was destroyed
+   and reopening it resulted in an empty dialog window.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ or other non-local drives.
    If the trailer dialog window was closed using the window frame's close
    button ("x") instead of the button labeled "Close", the dialog was destroyed
    and reopening it resulted in an empty dialog window.
+ - TV Tunes Download: Fix crash when aborting download and restarting it (#940)  
+   If the TV tune dialog is closed before it has finished loading its search
+   results and is reopened for another show, MediaElch crashed due to a
+   race condition.
 
 ### Changes
 

--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -157,6 +157,7 @@ SOURCES += src/main.cpp \
     src/globals/JsonRequest.cpp \
     src/globals/Manager.cpp \
     src/globals/MessageIds.cpp \
+    src/globals/Meta.cpp \
     src/globals/NameFormatter.cpp \
     src/network/NetworkReplyWatcher.cpp \
     src/network/Request.cpp \
@@ -420,6 +421,7 @@ HEADERS  += Version.h \
     src/globals/LocaleStringCompare.h \
     src/globals/Manager.h \
     src/globals/MessageIds.h \
+    src/globals/Meta.h \
     src/globals/NameFormatter.h \
     src/network/NetworkReplyWatcher.h \
     src/network/Request.h \

--- a/src/globals/CMakeLists.txt
+++ b/src/globals/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(
   JsonRequest.cpp
   Manager.cpp
   MessageIds.cpp
+  Meta.cpp
   NameFormatter.cpp
   Poster.cpp
   ScraperInfos.cpp

--- a/src/globals/Manager.cpp
+++ b/src/globals/Manager.cpp
@@ -55,8 +55,6 @@ Manager::Manager(QObject* parent) : QObject(parent)
 
     m_trailerProviders.append(new HdTrailers(this));
 
-    m_tvTunes = new TvTunes(this);
-
     m_iconFont = new MyIconFont(this);
     m_iconFont->initFontAwesome();
 
@@ -278,11 +276,6 @@ void Manager::setFileScannerDialog(FileScannerDialog* dialog)
 QVector<TrailerProvider*> Manager::trailerProviders()
 {
     return m_trailerProviders;
-}
-
-TvTunes* Manager::tvTunes()
-{
-    return m_tvTunes;
 }
 
 QVector<MovieScraperInterface*> Manager::constructNativeScrapers(QObject* scraperParent)

--- a/src/globals/Manager.h
+++ b/src/globals/Manager.h
@@ -13,7 +13,6 @@
 #include "scrapers/image/ImageProviderInterface.h"
 #include "scrapers/movie/MovieScraperInterface.h"
 #include "scrapers/music/MusicScraperInterface.h"
-#include "scrapers/music/TvTunes.h"
 #include "scrapers/trailer/TrailerProvider.h"
 #include "scrapers/tv_show/TvScraperInterface.h"
 #include "settings/Settings.h"
@@ -67,7 +66,6 @@ public:
     FanartTv* fanartTv();
     TvShowFilesWidget* tvShowFilesWidget();
     MusicFilesWidget* musicFilesWidget();
-    TvTunes* tvTunes();
     MyIconFont* iconFont();
     void setTvShowFilesWidget(TvShowFilesWidget* widget);
     void setMusicFilesWidget(MusicFilesWidget* widget);
@@ -97,7 +95,6 @@ private:
     TvShowFilesWidget* m_tvShowFilesWidget = nullptr;
     MusicFilesWidget* m_musicFilesWidget = nullptr;
     FileScannerDialog* m_fileScannerDialog = nullptr;
-    TvTunes* m_tvTunes = nullptr;
     MusicFileSearcher* m_musicFileSearcher = nullptr;
     MyIconFont* m_iconFont = nullptr;
 };

--- a/src/globals/Meta.cpp
+++ b/src/globals/Meta.cpp
@@ -1,0 +1,3 @@
+#include "globals/Meta.h"
+
+// Empty

--- a/src/globals/Meta.h
+++ b/src/globals/Meta.h
@@ -1,0 +1,65 @@
+#pragma once
+
+
+// Partially copied from Qt: qtbase/src/corelib/global/qglobal.h
+// Qt 5.5 does not support Overload so we have to provide it ourselves.
+// This code can be removed when Qt 5.6 is required.
+//
+// Copyright (C) 2019 The Qt Company Ltd.
+// Modified to avoid name clashes.
+
+template<typename... Args>
+struct NonConstOverload
+{
+    template<typename R, typename T>
+    constexpr auto operator()(R (T::*ptr)(Args...)) const noexcept -> decltype(ptr)
+    {
+        return ptr;
+    }
+    template<typename R, typename T>
+    static constexpr auto of(R (T::*ptr)(Args...)) noexcept -> decltype(ptr)
+    {
+        return ptr;
+    }
+};
+
+template<typename... Args>
+struct ConstOverload
+{
+    template<typename R, typename T>
+    constexpr auto operator()(R (T::*ptr)(Args...) const) const noexcept -> decltype(ptr)
+    {
+        return ptr;
+    }
+    template<typename R, typename T>
+    static constexpr auto of(R (T::*ptr)(Args...) const) noexcept -> decltype(ptr)
+    {
+        return ptr;
+    }
+};
+
+template<typename... Args>
+struct Overload : ConstOverload<Args...>, NonConstOverload<Args...>
+{
+    using ConstOverload<Args...>::of;
+    using ConstOverload<Args...>::operator();
+    using NonConstOverload<Args...>::of;
+    using NonConstOverload<Args...>::operator();
+    template<typename R>
+    constexpr auto operator()(R (*ptr)(Args...)) const noexcept -> decltype(ptr)
+    {
+        return ptr;
+    }
+    template<typename R>
+    static constexpr auto of(R (*ptr)(Args...)) noexcept -> decltype(ptr)
+    {
+        return ptr;
+    }
+};
+
+template<typename... Args>
+constexpr Overload<Args...> elchOverload = {};
+template<typename... Args>
+constexpr ConstOverload<Args...> elchConstOverload = {};
+template<typename... Args>
+constexpr NonConstOverload<Args...> elchNonConstOverload = {};

--- a/src/globals/TrailerDialog.h
+++ b/src/globals/TrailerDialog.h
@@ -24,7 +24,6 @@ class TrailerDialog : public QDialog
 public:
     explicit TrailerDialog(QWidget* parent = nullptr);
     ~TrailerDialog() override;
-    static TrailerDialog* instance(QWidget* parent = nullptr);
 
 public slots:
     int exec() override;
@@ -33,6 +32,8 @@ public slots:
 
 private slots:
     void search();
+    void searchIndex(int comboIndex);
+
     void showResults(QVector<ScraperSearchResult> results);
     void showTrailers(QVector<TrailerResult> trailers);
     void resultClicked(QTableWidgetItem* item);

--- a/src/scrapers/music/TvTunes.h
+++ b/src/scrapers/music/TvTunes.h
@@ -26,6 +26,9 @@ private:
     QVector<ScraperSearchResult> m_results;
     QQueue<ScraperSearchResult> m_queue;
     QString m_searchStr;
+
+private:
+    /// \brief Parse the given HTML for TV tunes. Limits results to 50.
     QVector<ScraperSearchResult> parseSearch(QString html);
     void getNextDownloadUrl(QString searchStr = "");
 };

--- a/src/scrapers/trailer/HdTrailers.cpp
+++ b/src/scrapers/trailer/HdTrailers.cpp
@@ -73,7 +73,6 @@ void HdTrailers::onSearchFinished()
 {
     if (m_searchReply->error() == QNetworkReply::NoError) {
         QString msg = m_searchReply->readAll();
-
         int pos = 0;
         QRegExp rx("<td class=\"trailer\"><a href=\"([^\"]*)\">([^<]*)</a>");
         rx.setMinimal(true);

--- a/src/scrapers/tv_show/TheTvDb.cpp
+++ b/src/scrapers/tv_show/TheTvDb.cpp
@@ -90,7 +90,7 @@ void TheTvDb::loadTvShowData(TvDbId tvDbId,
 
     // todo: use reference for show
     if (show == nullptr) {
-        qWarning() << "[TheTvDb] Tried to load nullptr TvShow!";
+        qCritical() << "[TheTvDb] Tried to load nullptr TvShow!";
         return;
     }
 

--- a/src/ui/main/MainWindow.cpp
+++ b/src/ui/main/MainWindow.cpp
@@ -36,7 +36,6 @@
 #include "ui/notifications/Notificator.h"
 #include "ui/tv_show/TvShowMultiScrapeDialog.h"
 #include "ui/tv_show/TvShowSearch.h"
-#include "ui/tv_show/TvTunesDialog.h"
 
 MainWindow* MainWindow::m_instance = nullptr;
 
@@ -210,7 +209,6 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
     MovieListDialog::instance(this);
     ImagePreviewDialog::instance(this);
     ConcertSearch::instance(this);
-    TvTunesDialog::instance(this);
     NameFormatter::instance(this);
     MovieMultiScrapeDialog::instance(this);
     MusicMultiScrapeDialog::instance(this);

--- a/src/ui/main/MainWindow.cpp
+++ b/src/ui/main/MainWindow.cpp
@@ -20,7 +20,6 @@
 #include "globals/ImagePreviewDialog.h"
 #include "globals/Manager.h"
 #include "globals/NameFormatter.h"
-#include "globals/TrailerDialog.h"
 #include "media_centers/MediaCenterInterface.h"
 #include "scrapers/movie/MovieScraperInterface.h"
 #include "settings/Settings.h"
@@ -211,7 +210,6 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
     MovieListDialog::instance(this);
     ImagePreviewDialog::instance(this);
     ConcertSearch::instance(this);
-    TrailerDialog::instance(this);
     TvTunesDialog::instance(this);
     NameFormatter::instance(this);
     MovieMultiScrapeDialog::instance(this);

--- a/src/ui/movies/MovieWidget.cpp
+++ b/src/ui/movies/MovieWidget.cpp
@@ -858,7 +858,10 @@ void MovieWidget::onDownloadTrailer()
     if (m_movie == nullptr) {
         return;
     }
-    TrailerDialog::instance()->exec(m_movie);
+    auto* dialog = new TrailerDialog(this);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->exec(m_movie);
+
     ui->localTrailer->setVisible(m_movie->hasLocalTrailer());
 }
 

--- a/src/ui/tv_show/TvShowWidgetTvShow.cpp
+++ b/src/ui/tv_show/TvShowWidgetTvShow.cpp
@@ -1134,8 +1134,13 @@ void TvShowWidgetTvShow::onExtraFanartDropped(QUrl imageUrl)
 
 void TvShowWidgetTvShow::onDownloadTune()
 {
-    TvTunesDialog::instance()->setTvShow(m_show);
-    int result = TvTunesDialog::instance()->exec();
+    if (m_show == nullptr) {
+        qCritical() << "[TvShowWidgetTvShow] Show is undefined, cannot download TV tunes!";
+        return;
+    }
+    auto* tvTunesDialog = new TvTunesDialog(*m_show, this);
+    tvTunesDialog->setAttribute(Qt::WA_DeleteOnClose);
+    const int result = tvTunesDialog->exec();
     if (result == QDialog::Accepted) {
         ui->badgeTuneExisting->setVisible(true);
         ui->badgeTuneMissing->setVisible(false);

--- a/src/ui/tv_show/TvTunesDialog.h
+++ b/src/ui/tv_show/TvTunesDialog.h
@@ -15,15 +15,15 @@ namespace Ui {
 class TvTunesDialog;
 }
 
+class TvTunes;
+
 class TvTunesDialog : public QDialog
 {
     Q_OBJECT
 
 public:
-    explicit TvTunesDialog(QWidget* parent = nullptr);
+    TvTunesDialog(TvShow& show, QWidget* parent = nullptr);
     ~TvTunesDialog() override;
-    static TvTunesDialog* instance(QWidget* parent = nullptr);
-    void setTvShow(TvShow* show);
 
 public slots:
     int exec() override;
@@ -45,7 +45,8 @@ private slots:
 
 private:
     Ui::TvTunesDialog* ui = nullptr;
-    TvShow* m_show = nullptr;
+    TvTunes* m_tvTunes;
+    TvShow& m_show;
     qint64 m_totalTime = 0;
     QMediaPlayer* m_mediaPlayer = nullptr;
     QNetworkAccessManager* m_qnam = nullptr;


### PR DESCRIPTION
Fix #940

**[TrailerDialog] Fix downloading trailers for many movies**  
If the trailer dialog window was closed using the window frame's close
button ("x") instead of the button labeled "Close", the dialog was
destroyed and reopening it resulted in an empty dialog window.

There is no need to use a singleton for the TrailerDialog so it was


**[TvTunes] Fix crash when dialog is closed and re-opened for other show**  
If the TvTunes dialog is opened the first time for a show, it downloads
some resources. This download does not stop when the dialog is closed.
If the dialog is now reopened (e.g. for another show) we get a race
condition because two threads try to dequeue a list with only one item.
Because an empty list cannot be dequeued, `abort()` is called by Qt.

The fix is simple: Use one TvTunes instance for each show download.  We
can achieve that by simply creating a new TV Tunes dialog for each show.

