### PR TITLE
[Log] Respect QT_MESSAGE_PATTERN and use better defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@
  - Updater: Use new MediaElch meta repository for version checks (#896)
  - Download Section: Refactor the file searcher to make it non-blocking and
    improve the overall performance (#830)
+ - Logging: Respect `QT_MESSAGE_PATTERN` and use better defaults  
+   Previously, MediaElch did not respect Qt's environment variable
+   `QT_MESSAGE_PATTERN`.  That environment variable can be used to format logging messages.
+   In debug mode the default pattern uses colors if the console supports it.
 
 
 ## 2.6.4 - Ferenginar (2020-02-08)

--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -139,6 +139,7 @@ SOURCES += src/main.cpp \
     src/imports/Extractor.cpp \
     src/imports/FileWorker.cpp \
     src/imports/DownloadFileSearcher.cpp \
+    src/log/Log.cpp \
     src/export/ExportTemplate.cpp \
     src/export/ExportTemplateLoader.cpp \
     src/export/MediaExport.cpp \
@@ -390,17 +391,18 @@ HEADERS  += Version.h \
     src/tv_shows/TvShow.h \
     src/tv_shows/TvShowEpisode.h \
     src/tv_shows/TvShowFileSearcher.h \
-    src/ui/imports/DownloadsWidget.h \
+    src/imports/DownloadFileSearcher.h \
     src/imports/Extractor.h \
     src/imports/FileWorker.h \
+    src/imports/MakeMkvCon.h \
+    src/imports/MyFile.h \
+    src/log/Log.h \
+    src/ui/export/ExportDialog.h \
+    src/ui/imports/DownloadsWidget.h \
     src/ui/imports/ImportActions.h \
     src/ui/imports/ImportDialog.h \
-    src/imports/MakeMkvCon.h \
-    src/imports/DownloadFileSearcher.h \
     src/ui/imports/MakeMkvDialog.h \
-    src/imports/MyFile.h \
     src/ui/imports/UnpackButtons.h \
-    src/ui/export/ExportDialog.h \
     src/export/ExportTemplate.h \
     src/export/ExportTemplateLoader.h \
     src/export/MediaExport.h \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory(file)
 add_subdirectory(globals)
 add_subdirectory(image)
 add_subdirectory(imports)
+add_subdirectory(log)
 add_subdirectory(media_centers)
 add_subdirectory(movies)
 add_subdirectory(network)
@@ -45,6 +46,7 @@ target_link_libraries(
     mediaelch_globals
     mediaelch_image
     mediaelch_image_providers
+    mediaelch_log
     mediaelch_mediacenter
     mediaelch_movies
     mediaelch_music

--- a/src/log/CMakeLists.txt
+++ b/src/log/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(mediaelch_log OBJECT Log.cpp)
+
+# GUI is required due to Globals.h
+target_link_libraries(mediaelch_log PRIVATE Qt5::Core Qt5::Widgets)
+mediaelch_post_target_defaults(mediaelch_log)

--- a/src/log/Log.cpp
+++ b/src/log/Log.cpp
@@ -1,0 +1,116 @@
+#include "log/Log.h"
+
+#include "settings/Settings.h"
+
+#include <QMessageBox>
+
+static QFile data;
+
+#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+#include <unistd.h>
+#endif
+
+// Some colors
+#define MEDIAELCH_FONT_RESET "\033[00m"
+#define MEDIAELCH_COLOR_RED "\x1B[31m"
+#define MEDIAELCH_COLOR_GREEN "\x1B[32m"
+#define MEDIAELCH_COLOR_YELLOW "\x1B[33m"
+#define MEDIAELCH_COLOR_BLUE "\x1B[34m"
+#define MEDIAELCH_COLOR_MAGENTA "\x1B[35m"
+#define MEDIAELCH_COLOR_WHITE "\x1B[37m"
+
+#define MEDIAELCH_FONT_ITALIC "\033[3m"
+#define MEDIAELCH_FONT_BOLD "\033[1m"
+
+static bool is_stderr_tty()
+{
+    if (stderr == nullptr) {
+        // Can't detect whether TTY or not
+        return false;
+    }
+
+#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+    return isatty(fileno(stderr));
+#else
+    // No colors for Windows, yet
+    return false;
+#endif
+}
+
+
+namespace mediaelch {
+
+void initLoggingPattern()
+{
+#ifdef QT_DEBUG
+    QString pattern;
+    if (is_stderr_tty()) {
+        pattern = "%{time yyyy-MM-dd h:mm:ss.zzz} "
+                  "%{if-debug}" MEDIAELCH_COLOR_WHITE "DEBUG" MEDIAELCH_FONT_RESET "%{endif}"
+                  "%{if-info}" MEDIAELCH_COLOR_BLUE " INFO" MEDIAELCH_FONT_RESET "%{endif}"
+                  "%{if-warning}" MEDIAELCH_COLOR_YELLOW " WARN" MEDIAELCH_FONT_RESET "%{endif}"
+                  "%{if-critical}" MEDIAELCH_COLOR_RED " CRIT" MEDIAELCH_FONT_RESET "%{endif}"
+                  "%{if-fatal}" MEDIAELCH_COLOR_MAGENTA "FATAL" MEDIAELCH_FONT_RESET "%{endif}"
+                  " [%{file}:%{line}] " MEDIAELCH_COLOR_BLUE "|" MEDIAELCH_FONT_RESET " %{message}";
+
+    } else {
+        pattern = "%{time yyyy-MM-dd h:mm:ss.zzz} "
+                  "%{if-debug}DEBUG%{endif}"
+                  "%{if-info} INFO%{endif}"
+                  "%{if-warning} WARN%{endif}"
+                  "%{if-critical} CRIT%{endif}"
+                  "%{if-fatal}FATAL%{endif}"
+                  " [%{file}:%{line}] | %{message}";
+    }
+#else
+    QString pattern = "MediaElch %{time yyyy-MM-dd h:mm:ss.zzz} "
+                      "%{if-debug}DEBUG %{endif}"
+                      "%{if-info}INFO  %{endif}"
+                      "%{if-warning}WARN  %{endif}"
+                      "%{if-critical}CRIT  %{endif}"
+                      "%{if-fatal}FATAL  %{endif}"
+                      ": %{message}";
+
+#endif
+    qSetMessagePattern(pattern);
+}
+
+void messageHandler(QtMsgType type, const QMessageLogContext& context, const QString& msg)
+{
+#ifdef Q_OS_WIN
+    const QString newLine = "\r\n";
+#else
+    const QString newLine = "\n";
+#endif
+
+    QTextStream out(stderr);
+    if (data.isOpen()) {
+        out.setDevice(&data);
+    }
+
+    out << qFormatLogMessage(type, context, msg) << newLine;
+
+    if (type == QtFatalMsg) {
+        abort();
+    }
+}
+
+bool openLogFile(const QString& filePath)
+{
+    if (filePath.isEmpty()) {
+        return true;
+    }
+
+    data.setFileName(filePath);
+
+    return data.open(QFile::WriteOnly | QFile::Truncate);
+}
+
+void closeLogFile()
+{
+    if (data.isOpen()) {
+        data.close();
+    }
+}
+
+} // namespace mediaelch

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <QDebug>
+
+namespace mediaelch {
+
+/// \brief Sets the default message pattern of Qt's logging framework.
+///
+/// As per Qt documentation, the pattern can be overwritten using the
+/// environment variable "QT_MESSAGE_PATTERN".  For more information see
+/// https://doc.qt.io/qt-5/qtglobal.html#qSetMessagePattern
+void initLoggingPattern();
+
+/// \brief MediaElch's default message handler with optional log file.
+///
+/// If a debug log file is set in MediaElch's advanced settings then all debug
+/// messages are redirected to that.  Otherwise stderr is used.
+/// Repects QT_MESSAGE_PATTERN.
+///
+/// \see initLoggingPattern()
+void messageHandler(QtMsgType type, const QMessageLogContext& context, const QString& msg);
+
+/// \brief Opens the given log file for logging.
+/// \returns True if the file was opened for writing successfuly.
+bool openLogFile(const QString& filePath);
+
+/// \brief Closes the currently used log file if it is opened.
+void closeLogFile();
+
+} // namespace mediaelch

--- a/src/ui/main/AboutDialog.cpp
+++ b/src/ui/main/AboutDialog.cpp
@@ -82,7 +82,8 @@ void AboutDialog::setDeveloperInformation()
                << QStringLiteral("System: %1 (%2)<br><br>").arg(QSysInfo::prettyProductName(), QSysInfo::buildAbi())
                << "Application dir: " << QDir::toNativeSeparators(Settings::applicationDir()) << "<br>"
                << "Settings file: " << Settings::instance()->settings()->fileName() << "<br>"
-               << "Data dir: " << QStandardPaths::writableLocation(QStandardPaths::DataLocation) << "<br>"
+               << "Data dir: "
+               << QDir::toNativeSeparators(QStandardPaths::writableLocation(QStandardPaths::DataLocation)) << "<br>"
                << "MediaInfo Version: ";
 
 #ifdef Q_OS_WIN


### PR DESCRIPTION
**[Log] Respect `QT_MESSAGE_PATTERN` and use better defaults** 
Previously, MediaElch did not respect Qt's environment variable
`QT_MESSAGE_PATTERN`.  That environment variable can be used to format
logging messages.  MediaElch now uses that environment variable and
changes its default logging pattern.  In debug mode the default pattern
uses colors if the console supports it.  It may be expanded to release
mode as well.

