### PR TITLE
[Movie] Don't save runtime from file if it cannot be detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ or other non-local drives.
    If the TV tune dialog is closed before it has finished loading its search
    results and is reopened for another show, MediaElch crashed due to a
    race condition.
+ - Movie: Don't save runtime from file if it cannot be detected (#604)  
+   If the user changes the movie's runtime and saves it, it may be reset to
+   0 if "Automatically load and save stream details from file" is enabled in MediaElch's
+   settings. MediaElch now first checks if the detected runtime is greater than 0.
 
 ### Changes
 

--- a/scripts/create_fakes.sh
+++ b/scripts/create_fakes.sh
@@ -132,3 +132,23 @@ do
 done
 
 printf "[Done]\n"
+
+
+###########################################################
+# Downloads
+###########################################################
+
+downloadInput="${root}/library/downloads.txt"
+downloadOutDir="${outDir}/downloads"
+
+mkdir -p "${downloadOutDir}"
+
+printf "Creating fake downloads...    "
+while IFS= read -r line
+do
+	if [ "$line" != "" ]; then
+		cp "${root}/library/Demo.mov" "${downloadOutDir}/${line}"
+	fi
+done < "$downloadInput"
+
+printf "  [Done]\n"

--- a/scripts/library/downloads.txt
+++ b/scripts/library/downloads.txt
@@ -1,0 +1,6 @@
+Oldboy.r1
+Oldboy.r2
+Oldboy.r3
+Oldboy.r4
+Sintel_2010.mov
+Big_Buck_Bunny.mov

--- a/src/movies/MovieController.cpp
+++ b/src/movies/MovieController.cpp
@@ -149,10 +149,13 @@ void MovieController::loadData(QHash<MovieScraperInterface*, QString> ids,
 void MovieController::loadStreamDetailsFromFile()
 {
     using namespace std::chrono;
+    using namespace std::chrono_literals;
     m_movie->streamDetails()->loadStreamDetails();
     seconds runtime =
         seconds(m_movie->streamDetails()->videoDetails().value(StreamDetails::VideoDetails::DurationInSeconds).toInt());
-    m_movie->setRuntime(duration_cast<minutes>(runtime));
+    if (runtime > 0s) {
+        m_movie->setRuntime(duration_cast<minutes>(runtime));
+    }
     m_movie->setStreamDetailsLoaded(true);
     m_movie->setChanged(true);
 }

--- a/src/ui/movies/MovieWidget.cpp
+++ b/src/ui/movies/MovieWidget.cpp
@@ -768,8 +768,11 @@ void MovieWidget::updateStreamDetails(bool reloadFromFile)
     time = time.addSecs(videoDetails.value(StreamDetails::VideoDetails::DurationInSeconds).toInt());
     ui->videoDuration->setTime(time);
     if (reloadFromFile) {
-        ui->runtime->setValue(
-            qFloor(streamDetails->videoDetails().value(StreamDetails::VideoDetails::DurationInSeconds).toInt() / 60.0));
+        const int duration =
+            qFloor(streamDetails->videoDetails().value(StreamDetails::VideoDetails::DurationInSeconds).toInt() / 60.0);
+        if (duration > 0) {
+            ui->runtime->setValue(duration);
+        }
     }
 
     for (QWidget* widget : m_streamDetailsWidgets) {
@@ -881,12 +884,9 @@ void MovieWidget::onPlayLocalTrailer()
     QDesktopServices::openUrl(QUrl::fromLocalFile(m_movie->localTrailerFileName()));
 }
 
-/**
- * @brief Saves movie information
- */
 void MovieWidget::saveInformation()
 {
-    qDebug() << "Entered";
+    qDebug() << "[Movie] Save movie";
     setDisabledTrue();
 
     QVector<Movie*> movies = MovieFilesWidget::instance()->selectedMovies();
@@ -895,16 +895,16 @@ void MovieWidget::saveInformation()
     }
 
     m_savingWidget->show();
-    if (movies.count() > 0) {
+    if (movies.count() > 1) {
         int counter = 0;
-        int moviesToSave = movies.count();
+        const int moviesToSave = movies.count();
 
         NotificationBox::instance()->showProgressBar(tr("Saving movies..."), Constants::MovieWidgetProgressMessageId);
         NotificationBox::instance()->progressBarProgress(0, moviesToSave, Constants::MovieWidgetProgressMessageId);
         QApplication::processEvents();
         for (Movie* movie : movies) {
-            counter++;
             if (movie->hasChanged()) {
+                counter++;
                 NotificationBox::instance()->progressBarProgress(
                     counter, moviesToSave, Constants::MovieWidgetProgressMessageId);
                 QApplication::processEvents();
@@ -918,7 +918,7 @@ void MovieWidget::saveInformation()
         NotificationBox::instance()->hideProgressBar(Constants::MovieWidgetProgressMessageId);
         NotificationBox::instance()->showSuccess(tr("Movies Saved"));
     } else {
-        int id = NotificationBox::instance()->showMessage(tr("Saving movie..."));
+        const int id = NotificationBox::instance()->showMessage(tr("Saving movie..."));
         m_movie->controller()->saveData(Manager::instance()->mediaCenterInterface());
         m_movie->controller()->loadData(Manager::instance()->mediaCenterInterface(), true);
         updateMovieInfo();
@@ -935,7 +935,7 @@ void MovieWidget::saveInformation()
  */
 void MovieWidget::saveAll()
 {
-    qDebug() << "Entered";
+    qDebug() << "[Movies] Save all movies";
     setDisabledTrue();
     m_savingWidget->show();
 
@@ -952,8 +952,9 @@ void MovieWidget::saveAll()
     QApplication::processEvents();
     for (Movie* movie : Manager::instance()->movieModel()->movies()) {
         if (movie->hasChanged()) {
+            counter++;
             NotificationBox::instance()->progressBarProgress(
-                counter++, moviesToSave, Constants::MovieWidgetProgressMessageId);
+                counter, moviesToSave, Constants::MovieWidgetProgressMessageId);
             QApplication::processEvents();
             movie->controller()->saveData(Manager::instance()->mediaCenterInterface());
             movie->controller()->loadData(Manager::instance()->mediaCenterInterface(), true);


### PR DESCRIPTION
If the user changes the movie's runtime and saves it, it may be set to
0 if "Automatically load and save stream details from file" is enabled.
This commit first checks if the detected runtime is greater than 0.

Fix #604