### PR TITLE
[TvShow] Also load TV show posters when searching for new season posters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ or other non-local drives.
    random screenshot from the movie file. Movies must have a format that is readable
    by ffmpeg. The resolution is hard coded to 720x1080px which has a typical poster
    aspect ratio of 2:3.
+ - TV show: Also load TV show posters when searching for new season posters (#600)
+   TheTvDb may not return posters for a certain seasons. However it may still be
+   useful to select TV show posters for a season.
 
 ### Internal Improvements and Changes
 

--- a/src/ui/tv_show/TvShowWidgetSeason.cpp
+++ b/src/ui/tv_show/TvShowWidgetSeason.cpp
@@ -225,18 +225,28 @@ void TvShowWidgetSeason::onChooseImage()
     ImageDialog::instance()->clear();
     ImageDialog::instance()->setTvShow(m_show);
     ImageDialog::instance()->setSeason(m_season);
+
     if (image->imageType() == ImageType::TvShowSeasonPoster) {
-        ImageDialog::instance()->setDownloads(m_show->seasonPosters(m_season));
+        // Merge with TV show posters. This is useful if there are
+        // only a few or none season posters.
+        QVector<Poster> posters;
+        posters << m_show->seasonPosters(m_season);
+        posters << m_show->posters();
+        ImageDialog::instance()->setDownloads(posters);
+
     } else if (image->imageType() == ImageType::TvShowSeasonBackdrop) {
         ImageDialog::instance()->setDownloads(m_show->seasonBackdrops(m_season));
+
     } else if (image->imageType() == ImageType::TvShowSeasonBanner) {
         QVector<Poster> banners;
         banners << m_show->seasonBanners(m_season, true);
         banners << m_show->banners();
         ImageDialog::instance()->setDownloads(banners);
+
     } else {
         ImageDialog::instance()->setDownloads(QVector<Poster>());
     }
+
     ImageDialog::instance()->exec(image->imageType());
 
     if (ImageDialog::instance()->result() == QDialog::Accepted) {


### PR DESCRIPTION
TheTvDb may not return posters for a certain seasons. However users may
want to select TvShow posters for a season.

Fix #600