### PR TITLE
[Release] Prepare release of v2.6.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,14 +24,14 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **MediaElch Version:**
- - [ ] 2.6.5-dev (nightly)
- - [ ] 2.6.4 stable
+ - [ ] 2.6.7-dev (nightly)
+ - [ ] 2.6.6 stable
 <!-- older stable versions are not supported; please update -->
 
 **Operating System:**
  - [ ] Windows
  - [ ] macOS
- - [ ] Linux (distribution: ___)
+ - [ ] Linux (distribution: _._)
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/scraper-does-not-work.md
+++ b/.github/ISSUE_TEMPLATE/scraper-does-not-work.md
@@ -24,8 +24,8 @@ assignees: ''
 Add a list of information that is not loaded correctly.
 
 **MediaElch Version:**
- - [ ] 2.6.5-dev (nightly)
- - [ ] 2.6.4 stable
+ - [ ] 2.6.7-dev (nightly)
+ - [ ] 2.6.6 stable
 
 **Operating System:**
  - [ ] Windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Next Release (*tbd*)
+## 2.6.6 - Ferenginar (2020-04-18)
 
 *Note:* This release has changed its internal file and directory handling to
 fix Windows-related bugs (#732).  Please report any issues with network drives

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.13.0 FATAL_ERROR)
 
 project(
   mediaelch
-  VERSION 2.6.5
+  VERSION 2.6.6
   DESCRIPTION "Media Manager for Kodi"
   HOMEPAGE_URL "https://mediaelch.github.io/"
 )

--- a/MediaElch.plist
+++ b/MediaElch.plist
@@ -7,11 +7,11 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleGetInfoString</key>
-    <string>2.6.5</string>
+    <string>2.6.6</string>
     <key>CFBundleVersion</key>
-    <string>2.6.5</string>
+    <string>2.6.6</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.6.5</string>
+    <string>2.6.6</string>
     <key>CFBundleExecutable</key>
     <string>MediaElch</string>
     <key>CFBundleHelpBookFolder</key>

--- a/Version.h
+++ b/Version.h
@@ -9,8 +9,8 @@ namespace mediaelch {
 namespace constants {
 
 constexpr char AppName[] = "MediaElch";
-constexpr char AppVersionStr[] = "2.6.5";         // major.minor.patch
-constexpr char AppVersionFullStr[] = "2.6.5-dev"; // major.minor.patch-identifier
+constexpr char AppVersionStr[] = "2.6.6";         // major.minor.patch
+constexpr char AppVersionFullStr[] = "2.6.6";     // major.minor.patch-identifier
 constexpr char VersionName[] = "Ferenginar";
 constexpr char OrganizationName[] = "kvibes";
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,40 @@
-mediaelch (2.6.4-1) vivid; urgency=low
+mediaelch (2.6.6-1) vivid; urgency=low
+
+  * Fix AEBN crash when scraping a movie (#910)
+  * Select correct language for TMDb in the movie search dialog (#916)
+  * Windows: Fix scanning of concerts (#814)
+  * Downloads Section: Fix crash when importing items (#828)
+  * Downloads Section: Fix invalid file sizes (#829)
+  * TV episodes: Manually edited writers and directors were not saved (#933)
+  * TV shows: Fix TV shows always being reloaded from disk (#732)
+  * UI: Fix text color in messages boxes (#942)
+  * HotMovies: Fix rating scraping
+  * Trailer Download: Fix downloading trailers for many movies (#940)
+  * TV Tunes Download: Fix crash when aborting download and restarting it (#940)
+  * Movie: Don't save runtime from file if it cannot be detected (#604)
+  * TV show file searcher now allows spaces between episode and season (#513)
+  * Image Preview: Fix centering of image dialog (#863)
+  * Export: The generated folder name now also contains seconds (#935)
+  * Always write the episode guide URL to TV show NFOs using TheTvDb format (#652)
+  * Fanart.tv: Print better error messages for shows and movies that cannot be found (#900)
+  * TMDb: Update available languages to support official translations (#901)
+  * Movies: If movies are sorted by "name", the movie's sort title is used if
+    set and the name otherwise (#919)
+  * IMDb: Use higher image resolution for actors (#920)
+  * Movie Poster: Make it possible to set a random screenshot as the movie's poster (#934)
+  * TV show: Also load TV show posters when searching for new season posters (#600)
+  * TV show: Remove suffix (e.g. `.mkv`) from default episode names (#513)
+  * Set MediaElch specific HTTP User-Agent header for most HTTP requests (#912)
+  * Updater: Use new MediaElch meta repository for version checks (#896)
+  * Download Section: Refactor the file searcher to make it non-blocking and
+    improve the overall performance (#830)
+  * Logging: Respect `QT_MESSAGE_PATTERN` and use better defaults
+  * Replace all old-style `SIGNAL`/`SLOT` connections with new-style ones.
+
+ -- Andre Meyering <info@andremeyering.de>  Sat, 18 Apr 2020 12:00:00 +0200
+
+
+ mediaelch (2.6.4-1) vivid; urgency=low
 
   * Fix TV shows sorting and possible crashes if "Show missing episodes" is enabled (#789, #883)
   * Fix hanging window if the custom movie scraper is selected but no valid scraper is found.

--- a/docs/admin/release.md
+++ b/docs/admin/release.md
@@ -47,10 +47,10 @@ they should have been added right with the corresponding commits.
 But better check all commit messages since the last version tag:
 
 ```sh
-# Print all commits between the git tag v2.6.4 and the current master branch
-git log --oneline v2.6.4..master
+# Print all commits between the git tag v2.6.6 and the current master branch
+git log --oneline v2.6.6..master
 # Count the number of commits since the last version
-git log --oneline v2.6.4..master | wc -l
+git log --oneline v2.6.6..master | wc -l
 ```
 
 
@@ -87,7 +87,7 @@ add a Git tag (see next section), it includes the latest documentation state.
  1. Commit your changes (MediaElch version and changelogs).
  2. Add a version tag and push your changes
  
-  - `git tag -a v2.6.3 -m "MediaElch Version 2.6.3"`
+  - `git tag -a v2.6.6 -m "MediaElch Version 2.6.6"`
   - `git push origin master`
   - `git push --tags`
 

--- a/obs/MediaElch.changes
+++ b/obs/MediaElch.changes
@@ -1,5 +1,10 @@
 -------------------------------------------------------------------
-Sat Feb  8 12:44:59 UTC 2020 - info@andremeyering.de
+Sat Feb 18 12:00:00 UTC 2020 - info@andremeyering.de
+
+ - Updated MediaElch to v2.6.6
+
+-------------------------------------------------------------------
+Sat Feb 08 12:44:59 UTC 2020 - info@andremeyering.de
 
  - Updated MediaElch to v2.6.4
 

--- a/obs/MediaElch.spec
+++ b/obs/MediaElch.spec
@@ -3,7 +3,7 @@
 #
 
 Name:           MediaElch
-Version:        2.6.5
+Version:        2.6.6
 Release:        1%{?dist}
 License:        LGPL-2.1+
 Summary:        A Media Manager for Kodi

--- a/obs/README.md
+++ b/obs/README.md
@@ -60,7 +60,7 @@ osc commit
 ## Compress MediaElch (`.tar.gz`)
 
 ```sh
-export ME_VERSION=2.6.5
+export ME_VERSION=2.6.6
 # Clone latest version.
 git clone https://github.com/Komet/MediaElch.git MediaElch
 cd MediaElch


### PR DESCRIPTION
This PR prepares the release of MediaElch v2.6.6. Please note that I plan to release the next version on 2020-04-19 but if I for some reason cannot hold that deadline, it will be released a week later. :-)

Todo:
- [x] Change version strings
- [x] Update documentation
- [x] Prepare Blog Post (see [here](https://github.com/mediaelch/mediaelch-blog/pull/2))
- [x] Prepare Forum Post (German / English)

After merging this PR:
- [ ] Release Windows Version (upload to GitHub Releases)
- [ ] Release macOS Version (upload to GitHub Releases)
- [ ] Release Linux AppImage Version (upload to GitHub Releases)
- [ ] Release openSUSE version (repository)
- [ ] Release Ubuntu version (repository)


Ping @sumo300 (windows), @Komet (owner), @scottfurry (other linux repo)

To all packagers: There are two useful compile flags:
 - `USE_EXTERN_QUAZIP` (see #756)
 - `DISABLE_UPDATER`(see #763)