### PR TITLE
 [Export] Allow using episode images in TV show overview 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## 2.6.8 - *tbd*
 
 ### Bugfixes
- - *tbd*
+
+ - Exporter: Fix episode thumbnails in TV show view (#961)
 
 ### Changes
+
  - Concert Export: `{{ CONCERT.FILENAME }}` and `{{ CONCERT.DIR }}` are now supported in themes (#962)
 
 ### Improvements

--- a/src/export/SimpleEngine.cpp
+++ b/src/export/SimpleEngine.cpp
@@ -369,7 +369,6 @@ void SimpleEngine::replaceVars(QString& m, const TvShow* show, bool subDir)
         QVector<QStringList>() << actorNames << actorRoles);
     replaceSingleBlock(m, "TAGS", "TAG.NAME", show->tags());
     replaceSingleBlock(m, "GENRES", "GENRE.NAME", show->genres());
-    replaceImages(m, subDir, nullptr, nullptr, show);
 
     QString listSeasonItem;
     QString listSeasonBlock;
@@ -419,6 +418,7 @@ void SimpleEngine::replaceVars(QString& m, const TvShow* show, bool subDir)
     }
 
     m.replace(listSeasonBlock, seasonList.join("\n"));
+    replaceImages(m, subDir, nullptr, nullptr, show);
 }
 
 void SimpleEngine::replaceVars(QString& m, TvShowEpisode* episode, bool subDir)


### PR DESCRIPTION
Fix #961

![Screenshot_20200422_191032](https://user-images.githubusercontent.com/1667306/80012216-417b8e80-84cd-11ea-8d7b-99addb59469c.png)
