### PR TITLE
[Export] Fix replacing TV show images in tvshows.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
  - Concert Export: `{{ CONCERT.FILENAME }}` and `{{ CONCERT.DIR }}` are now supported in themes (#962)
 
 ### Improvements
- - *tbd*
+
+ - Export: `{{ IMAGE.XYZ }}` are now only replaced if the image type is actually used (#961)
 
 ### Internal Improvements and Changes
  - *tbd*

--- a/src/export/SimpleEngine.cpp
+++ b/src/export/SimpleEngine.cpp
@@ -556,11 +556,11 @@ void SimpleEngine::replaceImages(QString& m,
         bool isPlaceholderUsed = true;
         QString typeName;
         if (movie != nullptr) {
-            imageSaved = saveImageForType(type, size, destFile, movie);
+            imageSaved = saveImageForType(type, size, destFile, movie, &isPlaceholderUsed);
             typeName = "movie";
 
         } else if (concert != nullptr) {
-            imageSaved = saveImageForType(type, size, destFile, concert);
+            imageSaved = saveImageForType(type, size, destFile, concert, &isPlaceholderUsed);
             typeName = "concert";
 
         } else if (tvShow != nullptr) {
@@ -586,7 +586,11 @@ void SimpleEngine::replaceImages(QString& m,
     }
 }
 
-bool SimpleEngine::saveImageForType(const QString& type, const QSize& size, QString& destFile, const Movie* movie)
+bool SimpleEngine::saveImageForType(const QString& type,
+    const QSize& size,
+    QString& destFile,
+    const Movie* movie,
+    bool* isPlaceHolderUsed)
 {
     std::string imageFormat = "png";
     ImageType imageType;
@@ -604,8 +608,11 @@ bool SimpleEngine::saveImageForType(const QString& type, const QSize& size, QStr
     } else if (type == "disc") {
         imageType = ImageType::MovieCdArt;
     } else {
+        *isPlaceHolderUsed = false;
         return false;
     }
+
+    *isPlaceHolderUsed = true;
 
     QString file_ending = QString::fromStdString(imageFormat);
     destFile = "movie_images/"
@@ -627,7 +634,11 @@ bool SimpleEngine::saveImageForType(const QString& type, const QSize& size, QStr
     return true;
 }
 
-bool SimpleEngine::saveImageForType(const QString& type, const QSize& size, QString& destFile, const Concert* concert)
+bool SimpleEngine::saveImageForType(const QString& type,
+    const QSize& size,
+    QString& destFile,
+    const Concert* concert,
+    bool* isPlaceHolderUsed)
 {
     std::string imageFormat = "png";
     ImageType imageType;
@@ -644,10 +655,12 @@ bool SimpleEngine::saveImageForType(const QString& type, const QSize& size, QStr
         imageType = ImageType::ConcertClearArt;
     } else if (type == "disc") {
         imageType = ImageType::ConcertCdArt;
-
     } else {
+        *isPlaceHolderUsed = false;
         return false;
     }
+
+    *isPlaceHolderUsed = true;
 
     QString file_ending = QString::fromStdString(imageFormat);
     destFile = "movie_images/"

--- a/src/export/SimpleEngine.cpp
+++ b/src/export/SimpleEngine.cpp
@@ -162,7 +162,7 @@ void SimpleEngine::replaceVars(QString& m, Movie* movie, bool subDir)
     replaceMultiBlock(m, "ACTORS", {"ACTOR.NAME", "ACTOR.ROLE"}, QVector<QStringList>() << actorNames << actorRoles);
 
     replaceStreamDetailsVars(m, movie->streamDetails());
-    replaceImages(m, subDir, movie);
+    replaceImages(m, subDir, movie, nullptr, nullptr, nullptr);
 }
 
 void SimpleEngine::exportConcerts(QVector<Concert*> concerts)
@@ -255,7 +255,7 @@ void SimpleEngine::replaceVars(QString& m, const Concert* concert, bool subDir)
     replaceStreamDetailsVars(m, concert->streamDetails());
     replaceSingleBlock(m, "TAGS", "TAG.NAME", concert->tags());
     replaceSingleBlock(m, "GENRES", "GENRE.NAME", concert->genres());
-    replaceImages(m, subDir, nullptr, concert);
+    replaceImages(m, subDir, nullptr, concert, nullptr, nullptr);
 }
 
 void SimpleEngine::exportTvShows(QVector<TvShow*> shows)
@@ -289,22 +289,28 @@ void SimpleEngine::exportTvShows(QVector<TvShow*> shows)
             return;
         }
 
-        QString showTemplate = itemContent;
-        replaceVars(showTemplate, show, true);
+        // tvshow.html - Single TV show
         {
+            QString showTemplate = itemContent;
+            replaceVars(showTemplate, show, true);
             QFile file(m_dir.path() + QString("/tvshows/%1.html").arg(show->showId()));
             if (file.open(QFile::WriteOnly | QFile::Text)) {
                 file.write(showTemplate.toUtf8());
                 file.close();
             }
+            QApplication::processEvents();
         }
 
-        QString s = listTvShowItem;
-        replaceVars(s, show);
-        tvShowList << s;
-        emit sigItemExported();
-        QApplication::processEvents();
+        // tvshows.html - All TV shows listed
+        {
+            QString showBlock = listTvShowItem;
+            replaceVars(showBlock, show, false);
+            tvShowList << showBlock;
+            emit sigItemExported();
+            QApplication::processEvents();
+        }
 
+        // episode.html - Single episode
         for (TvShowEpisode* episode : show->episodes()) {
             if (episode->isDummy()) {
                 continue;
@@ -362,11 +368,7 @@ void SimpleEngine::replaceVars(QString& m, const TvShow* show, bool subDir)
         actorNames << actor->name;
         actorRoles << actor->role;
     }
-    replaceMultiBlock(m,
-        "ACTORS",
-        QStringList() << "ACTOR.NAME"
-                      << "ACTOR.ROLE",
-        QVector<QStringList>() << actorNames << actorRoles);
+    replaceMultiBlock(m, "ACTORS", {"ACTOR.NAME", "ACTOR.ROLE"}, {actorNames, actorRoles});
     replaceSingleBlock(m, "TAGS", "TAG.NAME", show->tags());
     replaceSingleBlock(m, "GENRES", "GENRE.NAME", show->genres());
 
@@ -385,6 +387,7 @@ void SimpleEngine::replaceVars(QString& m, const TvShow* show, bool subDir)
     }
 
     if (listSeasonBlock.isEmpty() || listSeasonItem.isEmpty()) {
+        replaceImages(m, subDir, nullptr, nullptr, show, nullptr);
         return;
     }
 
@@ -408,20 +411,22 @@ void SimpleEngine::replaceVars(QString& m, const TvShow* show, bool subDir)
             listEpisodeItem = rx.cap(1).trimmed();
         }
 
-        for (TvShowEpisode* episode : episodes) {
-            QString e = listEpisodeItem;
-            replaceVars(e, episode, true);
-            episodeList << e;
+        if (!listEpisodeItem.isEmpty()) {
+            for (TvShowEpisode* episode : episodes) {
+                QString e = listEpisodeItem;
+                replaceVars(e, episode, subDir);
+                episodeList << e;
+            }
         }
         s.replace(listEpisodeBlock, episodeList.join("\n"));
         seasonList << s;
     }
 
     m.replace(listSeasonBlock, seasonList.join("\n"));
-    replaceImages(m, subDir, nullptr, nullptr, show);
+    replaceImages(m, subDir, nullptr, nullptr, show, nullptr);
 }
 
-void SimpleEngine::replaceVars(QString& m, TvShowEpisode* episode, bool subDir)
+void SimpleEngine::replaceVars(QString& m, const TvShowEpisode* episode, bool subDir)
 {
     m.replace("{{ SHOW.TITLE }}", episode->tvShow()->name().toHtmlEscaped());
     m.replace("{{ SHOW.LINK }}", QString("../tvshows/%1.html").arg(episode->tvShow()->showId()));

--- a/src/export/SimpleEngine.h
+++ b/src/export/SimpleEngine.h
@@ -43,8 +43,16 @@ private:
         const Concert* concert = nullptr,
         const TvShow* tvShow = nullptr,
         const TvShowEpisode* episode = nullptr);
-    bool saveImageForType(const QString& type, const QSize& size, QString& destFile, const Movie* movie);
-    bool saveImageForType(const QString& type, const QSize& size, QString& destFile, const Concert* concert);
+    bool saveImageForType(const QString& type,
+        const QSize& size,
+        QString& destFile,
+        const Movie* movie,
+        bool* isPlaceHolderUsed);
+    bool saveImageForType(const QString& type,
+        const QSize& size,
+        QString& destFile,
+        const Concert* concert,
+        bool* isPlaceHolderUsed);
     bool saveImageForType(const QString& type,
         const QSize& size,
         QString& destFile,

--- a/src/export/SimpleEngine.h
+++ b/src/export/SimpleEngine.h
@@ -39,10 +39,10 @@ private:
     void saveImage(QSize size, QString imageFile, QString destinationFile, const char* format, int quality);
     void replaceImages(QString& m,
         const bool& subDir,
-        const Movie* movie = nullptr,
-        const Concert* concert = nullptr,
-        const TvShow* tvShow = nullptr,
-        const TvShowEpisode* episode = nullptr);
+        const Movie* movie,
+        const Concert* concert,
+        const TvShow* tvShow,
+        const TvShowEpisode* episode);
     bool saveImageForType(const QString& type,
         const QSize& size,
         QString& destFile,
@@ -66,7 +66,7 @@ private:
     void replaceVars(QString& m, Movie* movie, bool subDir = false);
     void replaceVars(QString& m, const Concert* concert, bool subDir = false);
     void replaceVars(QString& m, const TvShow* show, bool subDir = false);
-    void replaceVars(QString& m, TvShowEpisode* episode, bool subDir = false);
+    void replaceVars(QString& m, const TvShowEpisode* episode, bool subDir = false);
     void replaceSingleBlock(QString& m, QString blockName, QString itemName, QStringList replaces);
     void replaceMultiBlock(QString& m, QString blockName, QStringList itemNames, QVector<QStringList> replaces);
     void replaceStreamDetailsVars(QString& m, const StreamDetails* details);

--- a/src/tv_shows/TvShowEpisode.cpp
+++ b/src/tv_shows/TvShowEpisode.cpp
@@ -545,6 +545,11 @@ StreamDetails* TvShowEpisode::streamDetails()
     return m_streamDetails;
 }
 
+const StreamDetails* TvShowEpisode::streamDetails() const
+{
+    return m_streamDetails;
+}
+
 QString TvShowEpisode::nfoContent() const
 {
     return m_nfoContent;

--- a/src/tv_shows/TvShowEpisode.h
+++ b/src/tv_shows/TvShowEpisode.h
@@ -69,6 +69,7 @@ public:
     bool infoLoaded() const;
     int episodeId() const;
     StreamDetails* streamDetails();
+    const StreamDetails* streamDetails() const;
     bool streamDetailsLoaded() const;
     QString nfoContent() const;
     int databaseId() const;


### PR DESCRIPTION
In a previous commit, images were replaced last for TV shows so that the
inner most block is used for images. This lead to a stupid bug because
the "replaceImages" call was not called unless a `SEASON` block existed.
If it didn't, an early return was triggered.

This commit also introduces some minor changes to image-replacement for
concerts and movies. Image tags are only replaced if the tag is actually
used.

Furthermore, some minor refactoring was done.

Fix #961 