### PR TITLE
[MovieFileSearcher] Only add directory to movie files if it's a DVD/BR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugfixes
 
  - Exporter: Fix episode thumbnails in TV show view (#961)
+ - Movies: Sub-folders are no longer handled as files (#978)
 
 ### Changes
 

--- a/src/movies/file_searcher/MovieFileSearcher.h
+++ b/src/movies/file_searcher/MovieFileSearcher.h
@@ -38,7 +38,7 @@ public:
     /// \param separateFolders Are concerts in separate folders
     /// \param firstScan When this is true, subfolders are scanned, regardless of separateFolders
     /// \deprecated
-    void scanDir(QString startPath,
+    Q_DECL_DEPRECATED void scanDir(QString startPath,
         QString path,
         QVector<QStringList>& contents,
         bool separateFolders = false,


### PR DESCRIPTION
Previously, folder's like `something.mkv` inside an actual movie folder
were added to the movie's file list. Now only files are added or folders
that have a special structure like DVD or BluRay folders.

Fix  #977