### PR TITLE
[Settings] Refactor TV scraper settings into custom widget class

### DIFF
--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -297,6 +297,7 @@ SOURCES += src/main.cpp \
     src/ui/settings/MusicSettingsWidget.cpp \
     src/ui/settings/NetworkSettingsWidget.cpp \
     src/ui/settings/ScraperSettingsWidget.cpp \
+    src/ui/settings/TvScraperSettingsWidget.cpp \
     src/ui/settings/TvShowSettingsWidget.cpp \
     src/ui/small_widgets/AlphabeticalList.cpp \
     src/ui/small_widgets/Badge.cpp \
@@ -562,6 +563,7 @@ HEADERS  += Version.h \
     src/ui/settings/MusicSettingsWidget.h \
     src/ui/settings/NetworkSettingsWidget.h \
     src/ui/settings/ScraperSettingsWidget.h \
+    src/ui/settings/TvScraperSettingsWidget.h \
     src/ui/settings/TvShowSettingsWidget.h \
     src/ui/small_widgets/AlphabeticalList.h \
     src/ui/small_widgets/Badge.h \
@@ -672,6 +674,7 @@ FORMS    += src/ui/main/MainWindow.ui \
     src/ui/settings/MusicSettingsWidget.ui \
     src/ui/settings/NetworkSettingsWidget.ui \
     src/ui/settings/ScraperSettingsWidget.ui \
+    src/ui/settings/TvScraperSettingsWidget.ui \
     src/ui/settings/TvShowSettingsWidget.ui \
     src/ui/small_widgets/FilterWidget.ui \
     src/ui/small_widgets/ImageLabel.ui \

--- a/src/ui/settings/CMakeLists.txt
+++ b/src/ui/settings/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(
   ScraperSettingsWidget.cpp
   SettingsWindow.cpp
   TvShowSettingsWidget.cpp
+  TvScraperSettingsWidget.cpp
 )
 
 target_link_libraries(

--- a/src/ui/settings/ScraperSettingsWidget.cpp
+++ b/src/ui/settings/ScraperSettingsWidget.cpp
@@ -15,18 +15,14 @@ ScraperSettingsWidget::ScraperSettingsWidget(QWidget* parent) : QWidget(parent),
     ui->setupUi(this);
 
 #ifdef Q_OS_MAC
-    QFont smallFont = ui->label_18->font();
+    QFont smallFont = ui->lblCustomMovieScraperHelp->font();
     smallFont.setPointSize(smallFont.pointSize() - 1);
-    ui->label_18->setFont(smallFont);
+    ui->lblCustomMovieScraperHelp->setFont(smallFont);
 #endif
 
     ui->customScraperTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
     ui->customScraperTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
     ui->customScraperTable->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
-
-    ui->tvScraperTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
-    ui->tvScraperTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
-    ui->tvScraperTable->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
 
     int scraperCounter = 0;
     for (auto* scraper : Manager::instance()->movieScrapers()) {
@@ -95,6 +91,7 @@ ScraperSettingsWidget::~ScraperSettingsWidget()
 void ScraperSettingsWidget::setSettings(Settings& settings)
 {
     m_settings = &settings;
+    ui->tvScraperSettings->setSettings(settings);
 }
 
 void ScraperSettingsWidget::loadSettings()
@@ -134,27 +131,7 @@ void ScraperSettingsWidget::loadSettings()
         ui->customScraperTable->setCellWidget(row, 1, comboForMovieScraperInfo(info));
     }
 
-    QSet<ShowScraperInfos> tvInfos = {ShowScraperInfos::Title,
-        ShowScraperInfos::Rating,
-        ShowScraperInfos::FirstAired,
-        ShowScraperInfos::Runtime,
-        ShowScraperInfos::Director,
-        ShowScraperInfos::Writer,
-        ShowScraperInfos::Certification,
-        ShowScraperInfos::Overview,
-        ShowScraperInfos::Genres,
-        ShowScraperInfos::Tags,
-        ShowScraperInfos::Actors};
-
-    ui->tvScraperTable->clearContents();
-    ui->tvScraperTable->setRowCount(0);
-
-    for (const auto info : tvInfos) {
-        int row = ui->tvScraperTable->rowCount();
-        ui->tvScraperTable->insertRow(row);
-        ui->tvScraperTable->setItem(row, 0, new QTableWidgetItem(titleForTvScraperInfo(info)));
-        ui->tvScraperTable->setCellWidget(row, 1, comboForTvScraperInfo(info));
-    }
+    ui->tvScraperSettings->loadSettings();
 
     onShowAdultScrapers();
 }
@@ -173,15 +150,7 @@ void ScraperSettingsWidget::saveSettings()
     }
     m_settings->setCustomMovieScraper(customMovieScraper);
 
-    // tv scraper
-    QMap<ShowScraperInfos, QString> tvScraper;
-    for (int row = 0, n = ui->tvScraperTable->rowCount(); row < n; ++row) {
-        auto box = dynamic_cast<QComboBox*>(ui->tvScraperTable->cellWidget(row, 1));
-        ShowScraperInfos info = ShowScraperInfos(box->itemData(0, Qt::UserRole + 1).toInt());
-        QString scraper = box->itemData(box->currentIndex()).toString();
-        tvScraper.insert(info, scraper);
-    }
-    m_settings->setCustomTvScraper(tvScraper);
+    ui->tvScraperSettings->saveSettings();
 }
 
 void ScraperSettingsWidget::onShowAdultScrapers()
@@ -271,42 +240,6 @@ QString ScraperSettingsWidget::titleForMovieScraperInfo(MovieScraperInfos info)
     case MovieScraperInfos::ClearArt: return tr("Clear Art");
     case MovieScraperInfos::Banner: return tr("Banner");
     case MovieScraperInfos::Thumb: return tr("Thumb");
-    default: return tr("Unsupported");
-    }
-}
-
-QComboBox* ScraperSettingsWidget::comboForTvScraperInfo(const ShowScraperInfos info)
-{
-    QString currentScraper = m_settings->customTvScraper().value(info, "notset");
-
-    auto box = new QComboBox();
-    box->addItem("The TV DB", TheTvDb::scraperIdentifier);
-    box->setItemData(0, static_cast<int>(info), Qt::UserRole + 1);
-
-    box->addItem("IMDB", IMDB::scraperIdentifier);
-    box->setItemData(1, static_cast<int>(info), Qt::UserRole + 1);
-
-    if (currentScraper == IMDB::scraperIdentifier) {
-        box->setCurrentIndex(1);
-    }
-
-    return box;
-}
-
-QString ScraperSettingsWidget::titleForTvScraperInfo(const ShowScraperInfos info)
-{
-    switch (info) {
-    case ShowScraperInfos::Title: return tr("Title");
-    case ShowScraperInfos::Rating: return tr("Rating");
-    case ShowScraperInfos::FirstAired: return tr("First Aired");
-    case ShowScraperInfos::Runtime: return tr("Runtime");
-    case ShowScraperInfos::Director: return tr("Director");
-    case ShowScraperInfos::Writer: return tr("Writer");
-    case ShowScraperInfos::Certification: return tr("Certification");
-    case ShowScraperInfos::Overview: return tr("Plot");
-    case ShowScraperInfos::Genres: return tr("Genres");
-    case ShowScraperInfos::Tags: return tr("Tags");
-    case ShowScraperInfos::Actors: return tr("Actors");
     default: return tr("Unsupported");
     }
 }

--- a/src/ui/settings/ScraperSettingsWidget.h
+++ b/src/ui/settings/ScraperSettingsWidget.h
@@ -34,6 +34,4 @@ private:
 
     QComboBox* comboForMovieScraperInfo(MovieScraperInfos info);
     QString titleForMovieScraperInfo(MovieScraperInfos info);
-    QComboBox* comboForTvScraperInfo(ShowScraperInfos info);
-    QString titleForTvScraperInfo(ShowScraperInfos info);
 };

--- a/src/ui/settings/ScraperSettingsWidget.ui
+++ b/src/ui/settings/ScraperSettingsWidget.ui
@@ -11,181 +11,168 @@
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
-    <item>
-     <widget class="QTabWidget" name="tabWidget">
-      <property name="currentIndex">
-       <number>0</number>
-      </property>
-      <widget class="QWidget" name="tab">
-       <attribute name="title">
-        <string>Scraper</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_10">
-        <item>
-         <widget class="QCheckBox" name="chkEnableAdultScrapers">
-          <property name="text">
-           <string>Enable adult movie scrapers</string>
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="tabGeneralScraper">
+      <attribute name="title">
+       <string>Scraper</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_10">
+       <item>
+        <widget class="QCheckBox" name="chkEnableAdultScrapers">
+         <property name="text">
+          <string>Enable adult movie scrapers</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="Line" name="line">
+         <property name="frameShadow">
+          <enum>QFrame::Plain</enum>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QScrollArea" name="scrapersScrollArea">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrapersScrollContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>930</width>
+            <height>522</height>
+           </rect>
           </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Line" name="line">
-          <property name="frameShadow">
-           <enum>QFrame::Plain</enum>
-          </property>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QScrollArea" name="scrapersScrollArea">
-          <property name="frameShape">
-           <enum>QFrame::NoFrame</enum>
-          </property>
-          <property name="widgetResizable">
-           <bool>true</bool>
-          </property>
-          <widget class="QWidget" name="scrapersScrollContents">
-           <property name="geometry">
-            <rect>
-             <x>0</x>
-             <y>0</y>
-             <width>883</width>
-             <height>418</height>
-            </rect>
+          <layout class="QVBoxLayout" name="verticalLayout_12">
+           <property name="leftMargin">
+            <number>0</number>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_12">
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <layout class="QGridLayout" name="gridLayoutScrapers"/>
-            </item>
-            <item>
-             <spacer name="verticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>529</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </widget>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="tab_2">
-       <attribute name="title">
-        <string>Custom Movie Scraper</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_11">
-        <item>
-         <widget class="QLabel" name="label_18">
-          <property name="text">
-           <string>Combine multiple scrapers to your custom scraper. If you select other scrapers than IMDB, The Movie DB and Fanart.tv multiple searches may be necessary as only these three share an id.</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QTableWidget" name="customScraperTable">
-          <property name="editTriggers">
-           <set>QAbstractItemView::NoEditTriggers</set>
-          </property>
-          <property name="alternatingRowColors">
-           <bool>true</bool>
-          </property>
-          <property name="selectionMode">
-           <enum>QAbstractItemView::NoSelection</enum>
-          </property>
-          <property name="showGrid">
-           <bool>false</bool>
-          </property>
-          <attribute name="verticalHeaderVisible">
-           <bool>false</bool>
-          </attribute>
-          <column>
-           <property name="text">
-            <string>Item</string>
+           <property name="topMargin">
+            <number>0</number>
            </property>
-          </column>
-          <column>
-           <property name="text">
-            <string>Scraper</string>
+           <property name="rightMargin">
+            <number>0</number>
            </property>
-          </column>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="tab_3">
-       <attribute name="title">
-        <string>TV Scraper</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_18">
-        <item>
-         <widget class="QLabel" name="label_69">
-          <property name="text">
-           <string>Select which site you prefer for each element of a TV show and episode.</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QTableWidget" name="tvScraperTable">
-          <property name="editTriggers">
-           <set>QAbstractItemView::NoEditTriggers</set>
-          </property>
-          <property name="alternatingRowColors">
-           <bool>true</bool>
-          </property>
-          <property name="selectionMode">
-           <enum>QAbstractItemView::NoSelection</enum>
-          </property>
-          <property name="showGrid">
-           <bool>false</bool>
-          </property>
-          <attribute name="verticalHeaderVisible">
-           <bool>false</bool>
-          </attribute>
-          <column>
-           <property name="text">
-            <string>Item</string>
+           <property name="bottomMargin">
+            <number>0</number>
            </property>
-          </column>
-          <column>
-           <property name="text">
-            <string>Site</string>
-           </property>
-          </column>
+           <item>
+            <layout class="QGridLayout" name="gridLayoutScrapers"/>
+           </item>
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>529</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
          </widget>
-        </item>
-       </layout>
-      </widget>
+        </widget>
+       </item>
+      </layout>
      </widget>
-    </item>
-   </layout>
+     <widget class="QWidget" name="tabCustomMovieScraper">
+      <attribute name="title">
+       <string>Custom Movie Scraper</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_11">
+       <item>
+        <widget class="QLabel" name="lblCustomMovieScraperHelp">
+         <property name="text">
+          <string>Combine multiple scrapers to your custom scraper. If you select other scrapers than IMDB, The Movie DB and Fanart.tv multiple searches may be necessary as only these three share an id.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTableWidget" name="customScraperTable">
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::NoSelection</enum>
+         </property>
+         <property name="showGrid">
+          <bool>false</bool>
+         </property>
+         <attribute name="verticalHeaderVisible">
+          <bool>false</bool>
+         </attribute>
+         <column>
+          <property name="text">
+           <string>Item</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Scraper</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabTvScraper">
+      <attribute name="title">
+       <string>TV Scraper</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_22">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="TvScraperSettingsWidget" name="tvScraperSettings" native="true"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TvScraperSettingsWidget</class>
+   <extends>QWidget</extends>
+   <header>ui/settings/TvScraperSettingsWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/settings/SettingsWindow.ui
+++ b/src/ui/settings/SettingsWindow.ui
@@ -13,7 +13,7 @@
   <property name="minimumSize">
    <size>
     <width>600</width>
-    <height>0</height>
+    <height>200</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/src/ui/settings/TvScraperSettingsWidget.cpp
+++ b/src/ui/settings/TvScraperSettingsWidget.cpp
@@ -1,0 +1,103 @@
+#include "ui/settings/TvScraperSettingsWidget.h"
+#include "ui_TvScraperSettingsWidget.h"
+
+#include "globals/Manager.h"
+#include "scrapers/concert/ConcertScraperInterface.h"
+#include "scrapers/movie/CustomMovieScraper.h"
+#include "scrapers/movie/IMDB.h"
+#include "scrapers/movie/MovieScraperInterface.h"
+#include "scrapers/tv_show/TheTvDb.h"
+#include "scrapers/tv_show/TvScraperInterface.h"
+#include "settings/Settings.h"
+
+TvScraperSettingsWidget::TvScraperSettingsWidget(QWidget* parent) : QWidget(parent), ui(new Ui::TvScraperSettingsWidget)
+{
+    ui->setupUi(this);
+
+    ui->tvScraperTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    ui->tvScraperTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    ui->tvScraperTable->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+}
+
+TvScraperSettingsWidget::~TvScraperSettingsWidget()
+{
+    delete ui;
+}
+
+void TvScraperSettingsWidget::setSettings(Settings& settings)
+{
+    m_settings = &settings;
+}
+
+void TvScraperSettingsWidget::loadSettings()
+{
+    QSet<ShowScraperInfos> tvInfos = {ShowScraperInfos::Title,
+        ShowScraperInfos::Rating,
+        ShowScraperInfos::FirstAired,
+        ShowScraperInfos::Runtime,
+        ShowScraperInfos::Director,
+        ShowScraperInfos::Writer,
+        ShowScraperInfos::Certification,
+        ShowScraperInfos::Overview,
+        ShowScraperInfos::Genres,
+        ShowScraperInfos::Tags,
+        ShowScraperInfos::Actors};
+
+    ui->tvScraperTable->clearContents();
+    ui->tvScraperTable->setRowCount(0);
+
+    for (const auto info : tvInfos) {
+        int row = ui->tvScraperTable->rowCount();
+        ui->tvScraperTable->insertRow(row);
+        ui->tvScraperTable->setItem(row, 0, new QTableWidgetItem(titleForTvScraperInfo(info)));
+        ui->tvScraperTable->setCellWidget(row, 1, comboForTvScraperInfo(info));
+    }
+}
+
+void TvScraperSettingsWidget::saveSettings()
+{
+    QMap<ShowScraperInfos, QString> tvScraper;
+    for (int row = 0, n = ui->tvScraperTable->rowCount(); row < n; ++row) {
+        auto box = dynamic_cast<QComboBox*>(ui->tvScraperTable->cellWidget(row, 1));
+        ShowScraperInfos info = ShowScraperInfos(box->itemData(0, Qt::UserRole + 1).toInt());
+        QString scraper = box->itemData(box->currentIndex()).toString();
+        tvScraper.insert(info, scraper);
+    }
+    m_settings->setCustomTvScraper(tvScraper);
+}
+
+QComboBox* TvScraperSettingsWidget::comboForTvScraperInfo(const ShowScraperInfos info)
+{
+    QString currentScraper = m_settings->customTvScraper().value(info, "notset");
+
+    auto box = new QComboBox();
+    box->addItem("The TV DB", TheTvDb::scraperIdentifier);
+    box->setItemData(0, static_cast<int>(info), Qt::UserRole + 1);
+
+    box->addItem("IMDB", IMDB::scraperIdentifier);
+    box->setItemData(1, static_cast<int>(info), Qt::UserRole + 1);
+
+    if (currentScraper == IMDB::scraperIdentifier) {
+        box->setCurrentIndex(1);
+    }
+
+    return box;
+}
+
+QString TvScraperSettingsWidget::titleForTvScraperInfo(const ShowScraperInfos info)
+{
+    switch (info) {
+    case ShowScraperInfos::Title: return tr("Title");
+    case ShowScraperInfos::Rating: return tr("Rating");
+    case ShowScraperInfos::FirstAired: return tr("First Aired");
+    case ShowScraperInfos::Runtime: return tr("Runtime");
+    case ShowScraperInfos::Director: return tr("Director");
+    case ShowScraperInfos::Writer: return tr("Writer");
+    case ShowScraperInfos::Certification: return tr("Certification");
+    case ShowScraperInfos::Overview: return tr("Plot");
+    case ShowScraperInfos::Genres: return tr("Genres");
+    case ShowScraperInfos::Tags: return tr("Tags");
+    case ShowScraperInfos::Actors: return tr("Actors");
+    default: return tr("Unsupported");
+    }
+}

--- a/src/ui/settings/TvScraperSettingsWidget.h
+++ b/src/ui/settings/TvScraperSettingsWidget.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "globals/ScraperInfos.h"
+
+#include <QComboBox>
+#include <QWidget>
+
+namespace Ui {
+class TvScraperSettingsWidget;
+}
+
+class Settings;
+
+class TvScraperSettingsWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit TvScraperSettingsWidget(QWidget* parent = nullptr);
+    ~TvScraperSettingsWidget() override;
+
+    void setSettings(Settings& settings);
+    void loadSettings();
+    void saveSettings();
+
+private:
+    Ui::TvScraperSettingsWidget* ui = nullptr;
+    Settings* m_settings = nullptr;
+
+    QComboBox* comboForTvScraperInfo(ShowScraperInfos info);
+    QString titleForTvScraperInfo(ShowScraperInfos info);
+};

--- a/src/ui/settings/TvScraperSettingsWidget.ui
+++ b/src/ui/settings/TvScraperSettingsWidget.ui
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TvScraperSettingsWidget</class>
+ <widget class="QWidget" name="TvScraperSettingsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,1">
+   <item>
+    <widget class="QLabel" name="lblTvScraperSettingsHelp">
+     <property name="text">
+      <string>Select which site you prefer for each element of a TV show and episode.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="tvScraperTable">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
+     </property>
+     <property name="showGrid">
+      <bool>false</bool>
+     </property>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Item</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Site</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Move the UI part of the TV scraper settings into a custom widget class.
This makes it easier to refactor it for future scraper changes.

Needed for #972