### PR TITLE
[ImageProviders] Add supportedLanguages() method

### DIFF
--- a/src/data/Locale.cpp
+++ b/src/data/Locale.cpp
@@ -130,6 +130,15 @@ QDebug operator<<(QDebug debug, const Locale& id)
     return debug;
 }
 
+bool operator==(const Locale& lhs, const Locale& rhs)
+{
+    return lhs.toString() == rhs.toString();
+}
+
+bool operator!=(const Locale& lhs, const Locale& rhs)
+{
+    return !(lhs == rhs);
+}
 
 // no-op
 } // namespace mediaelch

--- a/src/data/Locale.h
+++ b/src/data/Locale.h
@@ -47,6 +47,9 @@ private:
     QString m_country;
 };
 
+bool operator==(const Locale& lhs, const Locale& rhs);
+bool operator!=(const Locale& lhs, const Locale& rhs);
+
 std::ostream& operator<<(std::ostream& os, const Locale& id);
 QDebug operator<<(QDebug debug, const Locale& id);
 

--- a/src/scrapers/image/FanartTv.cpp
+++ b/src/scrapers/image/FanartTv.cpp
@@ -111,6 +111,11 @@ QString FanartTv::identifier() const
     return QStringLiteral("images.fanarttv");
 }
 
+const QVector<mediaelch::Locale>& FanartTv::supportedLanguages()
+{
+    return m_supportedLanguages;
+}
+
 /**
  * \brief Returns a list of supported image types
  * \return List of supported image types

--- a/src/scrapers/image/FanartTv.cpp
+++ b/src/scrapers/image/FanartTv.cpp
@@ -111,6 +111,11 @@ QString FanartTv::identifier() const
     return QStringLiteral("images.fanarttv");
 }
 
+mediaelch::Locale FanartTv::defaultLanguage()
+{
+    return mediaelch::Locale::English;
+}
+
 const QVector<mediaelch::Locale>& FanartTv::supportedLanguages()
 {
     return m_supportedLanguages;

--- a/src/scrapers/image/FanartTv.h
+++ b/src/scrapers/image/FanartTv.h
@@ -28,6 +28,7 @@ public:
     QString name() const override;
     QUrl siteUrl() const override;
     QString identifier() const override;
+    mediaelch::Locale defaultLanguage() override;
     const QVector<mediaelch::Locale>& supportedLanguages() override;
     void movieImages(Movie* movie, TmdbId tmdbId, QVector<ImageType> types) override;
     void moviePosters(TmdbId tmdbId) override;

--- a/src/scrapers/image/FanartTv.h
+++ b/src/scrapers/image/FanartTv.h
@@ -28,6 +28,7 @@ public:
     QString name() const override;
     QUrl siteUrl() const override;
     QString identifier() const override;
+    const QVector<mediaelch::Locale>& supportedLanguages() override;
     void movieImages(Movie* movie, TmdbId tmdbId, QVector<ImageType> types) override;
     void moviePosters(TmdbId tmdbId) override;
     void movieBackdrops(TmdbId tmdbId) override;
@@ -100,6 +101,8 @@ private:
     QComboBox* m_box;
     QComboBox* m_discBox;
     QLineEdit* m_personalApiKeyEdit;
+    // Multiple languages, but no way to query for it and also no offical list of languages.
+    QVector<mediaelch::Locale> m_supportedLanguages = {mediaelch::Locale::English};
 
     QNetworkAccessManager* qnam();
     QVector<Poster> parseMovieData(QString json, ImageType type);

--- a/src/scrapers/image/FanartTvMusic.cpp
+++ b/src/scrapers/image/FanartTvMusic.cpp
@@ -42,6 +42,11 @@ QString FanartTvMusic::identifier() const
     return QString("images.fanarttv-music_lib");
 }
 
+const QVector<mediaelch::Locale>& FanartTvMusic::supportedLanguages()
+{
+    return m_supportedLanguages;
+}
+
 QVector<ImageType> FanartTvMusic::provides()
 {
     return m_provides;

--- a/src/scrapers/image/FanartTvMusic.cpp
+++ b/src/scrapers/image/FanartTvMusic.cpp
@@ -42,6 +42,11 @@ QString FanartTvMusic::identifier() const
     return QString("images.fanarttv-music_lib");
 }
 
+mediaelch::Locale FanartTvMusic::defaultLanguage()
+{
+    return mediaelch::Locale::English;
+}
+
 const QVector<mediaelch::Locale>& FanartTvMusic::supportedLanguages()
 {
     return m_supportedLanguages;

--- a/src/scrapers/image/FanartTvMusic.h
+++ b/src/scrapers/image/FanartTvMusic.h
@@ -17,6 +17,7 @@ public:
     QString name() const override;
     QUrl siteUrl() const override;
     QString identifier() const override;
+    mediaelch::Locale defaultLanguage() override;
     const QVector<mediaelch::Locale>& supportedLanguages() override;
     void movieImages(Movie* movie, TmdbId tmdbId, QVector<ImageType> types) override;
     void moviePosters(TmdbId tmdbId) override;

--- a/src/scrapers/image/FanartTvMusic.h
+++ b/src/scrapers/image/FanartTvMusic.h
@@ -17,6 +17,7 @@ public:
     QString name() const override;
     QUrl siteUrl() const override;
     QString identifier() const override;
+    const QVector<mediaelch::Locale>& supportedLanguages() override;
     void movieImages(Movie* movie, TmdbId tmdbId, QVector<ImageType> types) override;
     void moviePosters(TmdbId tmdbId) override;
     void movieBackdrops(TmdbId tmdbId) override;
@@ -80,6 +81,8 @@ private:
     QNetworkAccessManager m_qnam;
     int m_searchResultLimit;
     QString m_language;
+    // Multiple languages, but no way to query for it and also no offical list of languages.
+    QVector<mediaelch::Locale> m_supportedLanguages = {mediaelch::Locale::English};
 
     QNetworkAccessManager* qnam();
     QVector<Poster> parseData(QString json, ImageType type);

--- a/src/scrapers/image/FanartTvMusicArtists.cpp
+++ b/src/scrapers/image/FanartTvMusicArtists.cpp
@@ -41,6 +41,11 @@ QString FanartTvMusicArtists::identifier() const
     return QString("images.fanarttv-music");
 }
 
+const QVector<mediaelch::Locale>& FanartTvMusicArtists::supportedLanguages()
+{
+    return m_supportedLanguages;
+}
+
 /**
  * \brief Returns a list of supported image types
  * \return List of supported image types

--- a/src/scrapers/image/FanartTvMusicArtists.cpp
+++ b/src/scrapers/image/FanartTvMusicArtists.cpp
@@ -41,6 +41,11 @@ QString FanartTvMusicArtists::identifier() const
     return QString("images.fanarttv-music");
 }
 
+mediaelch::Locale FanartTvMusicArtists::defaultLanguage()
+{
+    return mediaelch::Locale::English;
+}
+
 const QVector<mediaelch::Locale>& FanartTvMusicArtists::supportedLanguages()
 {
     return m_supportedLanguages;

--- a/src/scrapers/image/FanartTvMusicArtists.h
+++ b/src/scrapers/image/FanartTvMusicArtists.h
@@ -18,6 +18,7 @@ public:
     QString name() const override;
     QUrl siteUrl() const override;
     QString identifier() const override;
+    mediaelch::Locale defaultLanguage() override;
     const QVector<mediaelch::Locale>& supportedLanguages() override;
     void movieImages(Movie* movie, TmdbId tmdbId, QVector<ImageType> types) override;
     void moviePosters(TmdbId tmdbId) override;

--- a/src/scrapers/image/FanartTvMusicArtists.h
+++ b/src/scrapers/image/FanartTvMusicArtists.h
@@ -18,6 +18,7 @@ public:
     QString name() const override;
     QUrl siteUrl() const override;
     QString identifier() const override;
+    const QVector<mediaelch::Locale>& supportedLanguages() override;
     void movieImages(Movie* movie, TmdbId tmdbId, QVector<ImageType> types) override;
     void moviePosters(TmdbId tmdbId) override;
     void movieBackdrops(TmdbId tmdbId) override;
@@ -78,6 +79,8 @@ private:
     int m_searchResultLimit;
     QString m_language;
     QString m_preferredDiscType;
+    // Multiple languages, but no way to query for it and also no offical list of languages.
+    QVector<mediaelch::Locale> m_supportedLanguages = {mediaelch::Locale::English};
 
     QNetworkAccessManager* qnam();
     QVector<Poster> parseData(QString json, ImageType type);

--- a/src/scrapers/image/ImageProviderInterface.h
+++ b/src/scrapers/image/ImageProviderInterface.h
@@ -58,6 +58,7 @@ public:
     virtual void artistImages(Artist* artist, QString mbId, QVector<ImageType> types) = 0;
     virtual void albumImages(Album* album, QString mbId, QVector<ImageType> types) = 0;
     virtual QVector<ImageType> provides() = 0;
+    virtual const QVector<mediaelch::Locale>& supportedLanguages() = 0;
     bool hasSettings() const override = 0;
     void loadSettings(ScraperSettings& settings) override = 0;
     void saveSettings(ScraperSettings& settings) override = 0;

--- a/src/scrapers/image/ImageProviderInterface.h
+++ b/src/scrapers/image/ImageProviderInterface.h
@@ -22,6 +22,8 @@ public:
     QString name() const override = 0;
     QString identifier() const override = 0;
     virtual QUrl siteUrl() const = 0;
+    virtual mediaelch::Locale defaultLanguage() = 0;
+    virtual const QVector<mediaelch::Locale>& supportedLanguages() = 0;
     virtual void movieImages(Movie* movie, TmdbId tmdbId, QVector<ImageType> types) = 0;
     virtual void moviePosters(TmdbId tmdbId) = 0;
     virtual void movieBackdrops(TmdbId tmdbId) = 0;
@@ -58,7 +60,6 @@ public:
     virtual void artistImages(Artist* artist, QString mbId, QVector<ImageType> types) = 0;
     virtual void albumImages(Album* album, QString mbId, QVector<ImageType> types) = 0;
     virtual QVector<ImageType> provides() = 0;
-    virtual const QVector<mediaelch::Locale>& supportedLanguages() = 0;
     bool hasSettings() const override = 0;
     void loadSettings(ScraperSettings& settings) override = 0;
     void saveSettings(ScraperSettings& settings) override = 0;

--- a/src/scrapers/image/TMDbImages.cpp
+++ b/src/scrapers/image/TMDbImages.cpp
@@ -12,15 +12,82 @@ TMDbImages::TMDbImages(QObject* parent)
         ImageType::ConcertPoster};
     m_searchResultLimit = 0;
     m_tmdb = new TMDb(this);
-    m_dummyMovie = new Movie(QStringList(), this);
+    m_dummyMovie = new Movie({}, this);
+
+    m_supportedLanguages = {"ar-AE",
+        "ar-SA",
+        "be-BY",
+        "bg-BG",
+        "bn-BD",
+        "ca-ES",
+        "ch-GU",
+        "cn-CN",
+        "cs-CZ",
+        "da-DK",
+        "de-DE",
+        "de-AT",
+        "de-CH",
+        "el-GR",
+        "en-AU",
+        "en-CA",
+        "en-GB",
+        "en-NZ",
+        "en-US",
+        "eo-EO",
+        "es-ES",
+        "es-MX",
+        "et-EE",
+        "eu-ES",
+        "fa-IR",
+        "fi-FI",
+        "fr-CA",
+        "fr-FR",
+        "gl-ES",
+        "he-IL",
+        "hi-IN",
+        "hu-HU",
+        "id-ID",
+        "it-IT",
+        "ja-JP",
+        "ka-GE",
+        "kk-KZ",
+        "kn-IN",
+        "ko-KR",
+        "lt-LT",
+        "lv-LV",
+        "ml-IN",
+        "ms-MY",
+        "ms-SG",
+        "nb-NO",
+        "nl-NL",
+        "no-NO",
+        "pl-PL",
+        "pt-BR",
+        "pt-PT",
+        "ro-RO",
+        "ru-RU",
+        "si-LK",
+        "sk-SK",
+        "sl-SI",
+        "sq-AL",
+        "sr-RS",
+        "sv-SE",
+        "ta-IN",
+        "te-IN",
+        "th-TH",
+        "tl-PH",
+        "tr-TR",
+        "uk-UA",
+        "vi-VN",
+        "zh-CN",
+        "zh-HK",
+        "zh-TW",
+        "zu-ZA"};
+
     connect(m_dummyMovie->controller(), &MovieController::sigInfoLoadDone, this, &TMDbImages::onLoadImagesFinished);
     connect(m_tmdb, &TMDb::searchDone, this, &TMDbImages::onSearchMovieFinished);
 }
 
-/**
- * \brief Returns the name of this image provider
- * \return Name of this image provider
- */
 QString TMDbImages::name() const
 {
     return QString("The Movie DB");
@@ -34,6 +101,11 @@ QUrl TMDbImages::siteUrl() const
 QString TMDbImages::identifier() const
 {
     return QString("images.tmdb");
+}
+
+const QVector<mediaelch::Locale>& TMDbImages::supportedLanguages()
+{
+    return m_supportedLanguages;
 }
 
 /**

--- a/src/scrapers/image/TMDbImages.cpp
+++ b/src/scrapers/image/TMDbImages.cpp
@@ -103,6 +103,11 @@ QString TMDbImages::identifier() const
     return QString("images.tmdb");
 }
 
+mediaelch::Locale TMDbImages::defaultLanguage()
+{
+    return mediaelch::Locale::English;
+}
+
 const QVector<mediaelch::Locale>& TMDbImages::supportedLanguages()
 {
     return m_supportedLanguages;

--- a/src/scrapers/image/TMDbImages.h
+++ b/src/scrapers/image/TMDbImages.h
@@ -15,6 +15,7 @@ public:
     QString name() const override;
     QUrl siteUrl() const override;
     QString identifier() const override;
+    mediaelch::Locale defaultLanguage() override;
     const QVector<mediaelch::Locale>& supportedLanguages() override;
     void movieImages(Movie* movie, TmdbId tmdbId, QVector<ImageType> types) override;
     void moviePosters(TmdbId tmdbId) override;

--- a/src/scrapers/image/TMDbImages.h
+++ b/src/scrapers/image/TMDbImages.h
@@ -15,6 +15,7 @@ public:
     QString name() const override;
     QUrl siteUrl() const override;
     QString identifier() const override;
+    const QVector<mediaelch::Locale>& supportedLanguages() override;
     void movieImages(Movie* movie, TmdbId tmdbId, QVector<ImageType> types) override;
     void moviePosters(TmdbId tmdbId) override;
     void movieBackdrops(TmdbId tmdbId) override;
@@ -73,4 +74,5 @@ private:
     TMDb* m_tmdb = nullptr;
     Movie* m_dummyMovie = nullptr;
     ImageType m_imageType = ImageType::None;
+    QVector<mediaelch::Locale> m_supportedLanguages = {mediaelch::Locale::English};
 };

--- a/src/scrapers/image/TheTvDbImages.cpp
+++ b/src/scrapers/image/TheTvDbImages.cpp
@@ -19,6 +19,31 @@ TheTvDbImages::TheTvDbImages(QObject* parent)
     m_dummyEpisode = new TvShowEpisode(QStringList(), m_dummyShow);
     m_tvdb = new TheTvDb(this);
     m_searchResultLimit = 0;
+    m_supportedLanguages = {"bg",
+        "zh",
+        "hr",
+        "cs",
+        "da",
+        "nl",
+        "en",
+        "fi",
+        "fr",
+        "de",
+        "el",
+        "he",
+        "hu",
+        "it",
+        "ja",
+        "ko",
+        "no",
+        "pl",
+        "pt",
+        "ru",
+        "sl",
+        "es",
+        "sv",
+        "tr"};
+
     connect(m_tvdb, &TheTvDb::sigSearchDone, this, &TheTvDbImages::onSearchTvShowFinished);
     connect(m_dummyShow, &TvShow::sigLoaded, this, &TheTvDbImages::onLoadTvShowDataFinished);
     connect(m_dummyEpisode, &TvShowEpisode::sigLoaded, this, &TheTvDbImages::onLoadTvShowDataFinished);
@@ -41,6 +66,11 @@ QUrl TheTvDbImages::siteUrl() const
 QString TheTvDbImages::identifier() const
 {
     return QString("images.thetvdb");
+}
+
+const QVector<mediaelch::Locale>& TheTvDbImages::supportedLanguages()
+{
+    return m_supportedLanguages;
 }
 
 /**

--- a/src/scrapers/image/TheTvDbImages.cpp
+++ b/src/scrapers/image/TheTvDbImages.cpp
@@ -68,6 +68,11 @@ QString TheTvDbImages::identifier() const
     return QString("images.thetvdb");
 }
 
+mediaelch::Locale TheTvDbImages::defaultLanguage()
+{
+    return "en";
+}
+
 const QVector<mediaelch::Locale>& TheTvDbImages::supportedLanguages()
 {
     return m_supportedLanguages;

--- a/src/scrapers/image/TheTvDbImages.h
+++ b/src/scrapers/image/TheTvDbImages.h
@@ -23,6 +23,7 @@ public:
     QString name() const override;
     QUrl siteUrl() const override;
     QString identifier() const override;
+    const QVector<mediaelch::Locale>& supportedLanguages() override;
     void movieImages(Movie* movie, TmdbId tmdbId, QVector<ImageType> types) override;
     void moviePosters(TmdbId tmdbId) override;
     void movieBackdrops(TmdbId tmdbId) override;
@@ -83,6 +84,7 @@ private:
     TvShow* m_dummyShow = nullptr;
     TvShowEpisode* m_dummyEpisode = nullptr;
     SeasonNumber m_season;
+    QVector<mediaelch::Locale> m_supportedLanguages;
 
     void loadTvShowData(TvDbId tvdbId, ImageType type);
 };

--- a/src/scrapers/image/TheTvDbImages.h
+++ b/src/scrapers/image/TheTvDbImages.h
@@ -23,6 +23,7 @@ public:
     QString name() const override;
     QUrl siteUrl() const override;
     QString identifier() const override;
+    mediaelch::Locale defaultLanguage() override;
     const QVector<mediaelch::Locale>& supportedLanguages() override;
     void movieImages(Movie* movie, TmdbId tmdbId, QVector<ImageType> types) override;
     void moviePosters(TmdbId tmdbId) override;


### PR DESCRIPTION
These methods are not yet used, but required for the TV scraper refactoring. The languages are only used for searching for TV shows by title.