### PR TITLE
[Locale] Add missing default constructor

### DIFF
--- a/src/data/Locale.cpp
+++ b/src/data/Locale.cpp
@@ -6,6 +6,10 @@ namespace mediaelch {
 
 Locale Locale::English = Locale("en-US");
 
+Locale::Locale() : m_lang("en"), m_country("US")
+{
+}
+
 Locale::Locale(const QString& locale)
 {
     QStringList split = locale.split('-');

--- a/src/data/Locale.h
+++ b/src/data/Locale.h
@@ -18,6 +18,9 @@ public:
     static Locale English;
 
 public:
+    /// \brief Default constructor required for Qt containers like QVector.
+    ///        Defaults to en-US.
+    Locale();
     /*implicit*/ Locale(const char* locale) : Locale(QString(locale)) {}
     /*implicit*/ Locale(const QString& locale);
 

--- a/src/scrapers/movie/TMDb.cpp
+++ b/src/scrapers/movie/TMDb.cpp
@@ -1036,10 +1036,10 @@ void TMDb::parseAndAssignInfos(QString json, Movie* movie, QSet<MovieScraperInfo
             }
         }
 
-        if (m_locale.country() == QLocale::UnitedStates && us.isValid()) {
+        if (m_locale.country() == "US" && us.isValid()) {
             movie->setCertification(helper::mapCertification(us));
 
-        } else if (m_locale.language() == QLocale::English && gb.isValid()) {
+        } else if (m_locale.language() == "en" && gb.isValid()) {
             movie->setCertification(helper::mapCertification(gb));
 
         } else if (locale.isValid()) {


### PR DESCRIPTION
The default constructor is required for some Qt containers like QVector
on certain platforms (Linux).

Fix #999 