### PR TITLE
[Docker] Add missing libssl-dev dependency for mxe-cmake

### DIFF
--- a/travis-ci/docker/Dockerfile.build-windows
+++ b/travis-ci/docker/Dockerfile.build-windows
@@ -7,7 +7,7 @@ RUN apt-get install -y --no-install-recommends \
     cmake debhelper devscripts fakeroot flex gcc \
     git gperf intltool inetutils-ping jq libgdk-pixbuf2.0-dev \
     libffi-dev libgmp-dev libmpc-dev libmpfr-dev \
-    libtool libtool-bin libz-dev openssl \
+    libtool libtool-bin libz-dev libssl-dev openssl \
     patch pkg-config p7zip-full ruby scons \
     subversion texinfo unzip zip wget
 


### PR DESCRIPTION
The update to CMake 3.17 in mxe produced this issue. We were simply missing some headers.