### PR TITLE
[Network] Introduce wrapper class "NetworkManager"

### DIFF
--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -107,6 +107,7 @@ SOURCES += src/main.cpp \
     src/concerts/ConcertController.cpp \
     src/data/MediaInfoFile.cpp \
     src/network/NetworkRequest.cpp \
+    src/network/NetworkManager.cpp \
     src/ui/concerts/ConcertFilesWidget.cpp \
     src/ui/concerts/ConcertSearch.cpp \
     src/ui/concerts/ConcertSearchWidget.cpp \
@@ -371,6 +372,7 @@ HEADERS  += Version.h \
     src/concerts/ConcertController.h \
     src/data/MediaInfoFile.h \
     src/network/NetworkRequest.h \
+    src/network/NetworkManager.h \
     src/ui/concerts/ConcertFilesWidget.h \
     src/ui/concerts/ConcertSearch.h \
     src/ui/concerts/ConcertSearchWidget.h \

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ For build instructions, see: https://mediaelch.github.io/mediaelch-doc/contribut
 For building our documentation, see: [`docs/README.md`](docs/README.md).
 
 ### Testing
-See [test/README.md](./test/README.md).
+See [`docs/contributing/testing.md`](./docs/contributing/testing.md).

--- a/src/export/ExportTemplateLoader.cpp
+++ b/src/export/ExportTemplateLoader.cpp
@@ -34,7 +34,7 @@ ExportTemplateLoader* ExportTemplateLoader::instance(QObject* parent)
 
 void ExportTemplateLoader::getRemoteTemplates()
 {
-    QNetworkReply* reply = m_qnam.get(mediaelch::network::requestWithDefaults(QUrl(s_themeListUrl)));
+    QNetworkReply* reply = m_network.get(mediaelch::network::requestWithDefaults(QUrl(s_themeListUrl)));
     connect(reply, &QNetworkReply::finished, this, &ExportTemplateLoader::onLoadRemoteTemplatesFinished);
 }
 
@@ -180,7 +180,7 @@ ExportTemplate* ExportTemplateLoader::parseTemplate(QXmlStreamReader& xml)
 
 void ExportTemplateLoader::installTemplate(ExportTemplate* exportTemplate)
 {
-    QNetworkReply* reply = m_qnam.get(mediaelch::network::requestWithDefaults(QUrl(exportTemplate->remoteFile())));
+    QNetworkReply* reply = m_network.get(mediaelch::network::requestWithDefaults(QUrl(exportTemplate->remoteFile())));
     reply->setProperty("storage", Storage::toVariant(reply, exportTemplate));
     connect(reply, &QNetworkReply::finished, this, &ExportTemplateLoader::onDownloadTemplateFinished);
 }

--- a/src/export/ExportTemplateLoader.h
+++ b/src/export/ExportTemplateLoader.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <QBuffer>
-#include <QNetworkAccessManager>
 #include <QObject>
 #include <QXmlStreamReader>
 
 #include "export/ExportTemplate.h"
 #include "globals/Globals.h"
+#include "network/NetworkManager.h"
 
 /// Load remote and local templates and make them available.
 class ExportTemplateLoader : public QObject
@@ -33,7 +33,7 @@ private slots:
     void onDownloadTemplateFinished();
 
 private:
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     QVector<ExportTemplate*> m_localTemplates;
     QVector<ExportTemplate*> m_remoteTemplates;
 

--- a/src/globals/DownloadManager.h
+++ b/src/globals/DownloadManager.h
@@ -2,9 +2,9 @@
 
 #include "globals/DownloadManagerElement.h"
 #include "globals/Globals.h"
+#include "network/NetworkManager.h"
 
 #include <QMutex>
-#include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QObject>
 #include <QQueue>
@@ -58,7 +58,7 @@ private:
     void checkAllArtistDownloadsFinished();
     void checkAllAlbumDownloadsFinished();
 
-    QNetworkAccessManager* qnam();
+    mediaelch::network::NetworkManager* network();
     bool isLocalFile(const QUrl& url) const;
 
     QNetworkReply* m_currentReply = nullptr;

--- a/src/globals/ImageDialog.cpp
+++ b/src/globals/ImageDialog.cpp
@@ -306,13 +306,9 @@ void ImageDialog::setDownloads(QVector<Poster> downloads, bool initial)
     }
 }
 
-/**
- * \brief Returns an instance of a network access manager
- * \return Instance of a network access manager
- */
-QNetworkAccessManager* ImageDialog::qnam()
+mediaelch::network::NetworkManager* ImageDialog::network()
 {
-    return &m_qnam;
+    return &m_network;
 }
 
 /**
@@ -336,7 +332,7 @@ void ImageDialog::startNextDownload()
         return;
     }
     m_currentDownloadIndex = nextIndex;
-    m_currentDownloadReply = qnam()->get(mediaelch::network::requestWithDefaults(m_elements[nextIndex].thumbUrl));
+    m_currentDownloadReply = network()->get(mediaelch::network::requestWithDefaults(m_elements[nextIndex].thumbUrl));
     connect(m_currentDownloadReply, &QNetworkReply::finished, this, &ImageDialog::downloadFinished);
 }
 
@@ -346,15 +342,6 @@ void ImageDialog::startNextDownload()
  */
 void ImageDialog::downloadFinished()
 {
-    if (m_currentDownloadReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 302
-        || m_currentDownloadReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 301) {
-        m_currentDownloadReply->deleteLater();
-        m_currentDownloadReply = qnam()->get(mediaelch::network::requestWithDefaults(
-            m_currentDownloadReply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl()));
-        connect(m_currentDownloadReply, &QNetworkReply::finished, this, &ImageDialog::downloadFinished);
-        return;
-    }
-
     if (m_currentDownloadReply->error() == QNetworkReply::NoError) {
         m_elements[m_currentDownloadIndex].pixmap.loadFromData(m_currentDownloadReply->readAll());
         helper::setDevicePixelRatio(m_elements[m_currentDownloadIndex].pixmap, helper::devicePixelRatio(this));

--- a/src/globals/ImageDialog.h
+++ b/src/globals/ImageDialog.h
@@ -3,13 +3,13 @@
 #include "globals/Globals.h"
 #include "globals/Poster.h"
 #include "globals/ScraperResult.h"
+#include "network/NetworkManager.h"
 #include "scrapers/image/ImageProviderInterface.h"
 #include "tv_shows/EpisodeNumber.h"
 #include "tv_shows/SeasonNumber.h"
 
 #include <QDialog>
 #include <QLabel>
-#include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QResizeEvent>
 #include <QTableWidgetItem>
@@ -101,7 +101,7 @@ private:
         constexpr static int isDefaultProvider = Qt::UserRole + 1;
     };
 
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     int m_currentDownloadIndex = 0;
     QNetworkReply* m_currentDownloadReply = nullptr;
     ImageType m_imageType = ImageType::None;
@@ -123,7 +123,7 @@ private:
     Artist* m_artist = nullptr;
     Album* m_album = nullptr;
 
-    QNetworkAccessManager* qnam();
+    mediaelch::network::NetworkManager* network();
     void renderTable();
     int calcColumnCount();
     int getColumnWidth();

--- a/src/globals/JsonRequest.cpp
+++ b/src/globals/JsonRequest.cpp
@@ -1,14 +1,13 @@
 #include "globals/JsonRequest.h"
 
+#include "network/NetworkRequest.h"
+
 #include <QEventLoop>
 #include <QJsonDocument>
 #include <QJsonParseError>
 #include <QNetworkRequest>
 #include <QObject>
 #include <QUrl>
-
-#include "network/NetworkReplyWatcher.h"
-#include "network/NetworkRequest.h"
 
 namespace mediaelch {
 
@@ -17,8 +16,7 @@ JsonPostRequest::JsonPostRequest(QUrl url, QJsonObject body, QObject* parent) : 
     QNetworkRequest request = mediaelch::network::requestWithDefaults(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
 
-    QNetworkReply* reply = m_qnam.post(request, QJsonDocument(body).toJson());
-    new NetworkReplyWatcher(this, reply);
+    QNetworkReply* reply = m_network.postWithWatcher(request, QJsonDocument(body).toJson());
 
     QObject::connect(reply, &QNetworkReply::finished, [reply, this]() {
         QJsonDocument parsedJson;

--- a/src/globals/JsonRequest.h
+++ b/src/globals/JsonRequest.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "network/NetworkManager.h"
+
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QNetworkAccessManager>
 #include <QObject>
 #include <QUrl>
 
@@ -25,7 +26,7 @@ signals:
     void sigResponse(QJsonDocument& document);
 
 private:
-    QNetworkAccessManager m_qnam;
+    network::NetworkManager m_network;
 };
 
 } // namespace mediaelch

--- a/src/globals/TrailerDialog.h
+++ b/src/globals/TrailerDialog.h
@@ -3,12 +3,12 @@
 #include "globals/Globals.h"
 #include "globals/ScraperResult.h"
 #include "movies/Movie.h"
+#include "network/NetworkManager.h"
 
 #include <QDialog>
 #include <QElapsedTimer>
 #include <QFile>
 #include <QMediaPlayer>
-#include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QTableWidgetItem>
 #include <QVideoWidget>
@@ -59,7 +59,7 @@ private:
     QString m_providerId;
     Movie* m_currentMovie = nullptr;
     QVector<TrailerResult> m_currentTrailers;
-    QNetworkAccessManager* m_qnam;
+    mediaelch::network::NetworkManager* m_network = nullptr;
     QNetworkReply* m_downloadReply = nullptr;
     QElapsedTimer m_downloadTime;
     QFile m_output;

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(
   mediaelch_network OBJECT NetworkReplyWatcher.cpp NetworkRequest.cpp
-                           WebsiteCache.cpp
+                           NetworkManager.cpp WebsiteCache.cpp
 )
 
 target_link_libraries(

--- a/src/network/NetworkManager.cpp
+++ b/src/network/NetworkManager.cpp
@@ -1,0 +1,33 @@
+#include "network/NetworkManager.h"
+
+#include "network/NetworkReplyWatcher.h"
+
+namespace mediaelch {
+namespace network {
+
+QNetworkReply* NetworkManager::get(const QNetworkRequest& request)
+{
+    return m_qnam.get(request);
+}
+
+QNetworkReply* NetworkManager::getWithWatcher(const QNetworkRequest& request)
+{
+    QNetworkReply* reply = m_qnam.get(request);
+    new NetworkReplyWatcher(this, reply);
+    return reply;
+}
+
+QNetworkReply* NetworkManager::post(const QNetworkRequest& request, const QByteArray& data)
+{
+    return m_qnam.post(request, data);
+}
+
+QNetworkReply* NetworkManager::postWithWatcher(const QNetworkRequest& request, const QByteArray& data)
+{
+    QNetworkReply* reply = m_qnam.post(request, data);
+    new NetworkReplyWatcher(this, reply);
+    return reply;
+}
+
+} // namespace network
+} // namespace mediaelch

--- a/src/network/NetworkManager.h
+++ b/src/network/NetworkManager.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QByteArray>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QObject>
+
+namespace mediaelch {
+namespace network {
+
+/// \brief Wrapper around QNetworkAccessManager that adds timeout mechanisms and logging.
+class NetworkManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit NetworkManager(QObject* parent = nullptr) : QObject(parent) {}
+    ~NetworkManager() override = default;
+
+public:
+    QNetworkReply* get(const QNetworkRequest& request);
+    QNetworkReply* getWithWatcher(const QNetworkRequest& request);
+
+    QNetworkReply* post(const QNetworkRequest& request, const QByteArray& data);
+    QNetworkReply* postWithWatcher(const QNetworkRequest& request, const QByteArray& data);
+
+signals:
+    void authenticationRequired(QNetworkReply* reply, QAuthenticator* authenticator);
+
+private:
+    QNetworkAccessManager m_qnam;
+};
+
+} // namespace network
+} // namespace mediaelch

--- a/src/network/NetworkReplyWatcher.h
+++ b/src/network/NetworkReplyWatcher.h
@@ -13,13 +13,15 @@ class NetworkReplyWatcher : public QObject
 {
     Q_OBJECT
 public:
-    explicit NetworkReplyWatcher(QObject* parent = nullptr, QNetworkReply* reply = nullptr);
+    NetworkReplyWatcher(QObject* parent, QNetworkReply* reply);
     ~NetworkReplyWatcher() override = default;
-    void setReply(QNetworkReply* reply);
 
 public slots:
     void onTimeout();
     void onProgress();
+
+private:
+    void setReply(QNetworkReply* reply);
 
 private:
     QNetworkReply* m_reply;

--- a/src/network/NetworkRequest.cpp
+++ b/src/network/NetworkRequest.cpp
@@ -14,7 +14,8 @@ QNetworkRequest requestWithDefaults(const QUrl& url)
     //  1. http://example.com/tt1234
     //  2. https://example.com/tt1234
     //  3. http://example.com/tt1234/
-    request.setMaximumRedirectsAllowed(3);
+    // A value of 4 should be enough and is enough for all of our scrapers.
+    request.setMaximumRedirectsAllowed(4);
     return request;
 }
 

--- a/src/network/NetworkRequest.h
+++ b/src/network/NetworkRequest.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QNetworkRequest>
+#include <QObject>
 
 namespace mediaelch {
 namespace network {

--- a/src/scrapers/concert/TMDbConcerts.cpp
+++ b/src/scrapers/concert/TMDbConcerts.cpp
@@ -11,7 +11,6 @@
 #include "data/Storage.h"
 #include "globals/Globals.h"
 #include "globals/Helper.h"
-#include "network/NetworkReplyWatcher.h"
 #include "network/NetworkRequest.h"
 #include "ui/main/MainWindow.h"
 
@@ -139,9 +138,9 @@ void TMDbConcerts::saveSettings(ScraperSettings& settings)
  * \brief Just returns a pointer to the scrapers network access manager
  * \return Network Access Manager
  */
-QNetworkAccessManager* TMDbConcerts::qnam()
+mediaelch::network::NetworkManager* TMDbConcerts::network()
 {
-    return &m_qnam;
+    return &m_network;
 }
 
 /**
@@ -161,8 +160,7 @@ void TMDbConcerts::setup()
 {
     QUrl url(QString("https://api.themoviedb.org/3/configuration?api_key=%1").arg(m_apiKey));
     QNetworkRequest request = mediaelch::network::jsonRequestWithDefaults(url);
-    QNetworkReply* reply = qnam()->get(request);
-    new NetworkReplyWatcher(this, reply);
+    QNetworkReply* reply = network()->getWithWatcher(request);
     connect(reply, &QNetworkReply::finished, this, &TMDbConcerts::setupFinished);
 }
 
@@ -241,8 +239,7 @@ void TMDbConcerts::search(QString searchStr)
                        .arg(searchStr));
     }
     QNetworkRequest request = mediaelch::network::jsonRequestWithDefaults(url);
-    QNetworkReply* reply = qnam()->get(request);
-    new NetworkReplyWatcher(this, reply);
+    QNetworkReply* reply = network()->getWithWatcher(request);
     reply->setProperty("searchString", searchStr);
     reply->setProperty("results", Storage::toVariant(reply, QVector<ScraperSearchResult>()));
     connect(reply, &QNetworkReply::finished, this, &TMDbConcerts::searchFinished);
@@ -281,8 +278,7 @@ void TMDbConcerts::searchFinished()
                      .arg(searchString));
         QNetworkRequest request = mediaelch::network::requestWithDefaults(url);
         request.setRawHeader("Accept", "application/json");
-        QNetworkReply* reply = qnam()->get(request);
-        new NetworkReplyWatcher(this, reply);
+        QNetworkReply* reply = network()->getWithWatcher(request);
         reply->setProperty("searchString", searchString);
         reply->setProperty("results", Storage::toVariant(reply, results));
         connect(reply, &QNetworkReply::finished, this, &TMDbConcerts::searchFinished);
@@ -372,8 +368,7 @@ void TMDbConcerts::loadData(TmdbId id, Concert* concert, QSet<ConcertScraperInfo
         url.setUrl(QStringLiteral("https://api.themoviedb.org/3/movie/%1?api_key=%2&language=%3")
                        .arg(id.toString(), m_apiKey, localeForTMDb()));
         request.setUrl(url);
-        QNetworkReply* reply = qnam()->get(request);
-        new NetworkReplyWatcher(this, reply);
+        QNetworkReply* reply = network()->getWithWatcher(request);
         reply->setProperty("storage", Storage::toVariant(reply, concert));
         reply->setProperty("infosToLoad", Storage::toVariant(reply, infos));
         connect(reply, &QNetworkReply::finished, this, &TMDbConcerts::loadFinished);
@@ -384,8 +379,7 @@ void TMDbConcerts::loadData(TmdbId id, Concert* concert, QSet<ConcertScraperInfo
         loadsLeft.append(ScraperData::Trailers);
         url.setUrl(QString("https://api.themoviedb.org/3/movie/%1/trailers?api_key=%2").arg(id.toString(), m_apiKey));
         request.setUrl(url);
-        QNetworkReply* reply = qnam()->get(request);
-        new NetworkReplyWatcher(this, reply);
+        QNetworkReply* reply = network()->getWithWatcher(request);
         reply->setProperty("storage", Storage::toVariant(reply, concert));
         reply->setProperty("infosToLoad", Storage::toVariant(reply, infos));
         connect(reply, &QNetworkReply::finished, this, &TMDbConcerts::loadTrailersFinished);
@@ -396,8 +390,7 @@ void TMDbConcerts::loadData(TmdbId id, Concert* concert, QSet<ConcertScraperInfo
         loadsLeft.append(ScraperData::Images);
         url.setUrl(QString("https://api.themoviedb.org/3/movie/%1/images?api_key=%2").arg(id.toString(), m_apiKey));
         request.setUrl(url);
-        QNetworkReply* reply = qnam()->get(request);
-        new NetworkReplyWatcher(this, reply);
+        QNetworkReply* reply = network()->getWithWatcher(request);
         reply->setProperty("storage", Storage::toVariant(reply, concert));
         reply->setProperty("infosToLoad", Storage::toVariant(reply, infos));
         connect(reply, &QNetworkReply::finished, this, &TMDbConcerts::loadImagesFinished);
@@ -408,8 +401,7 @@ void TMDbConcerts::loadData(TmdbId id, Concert* concert, QSet<ConcertScraperInfo
         loadsLeft.append(ScraperData::Releases);
         url.setUrl(QString("https://api.themoviedb.org/3/movie/%1/releases?api_key=%2").arg(id.toString(), m_apiKey));
         request.setUrl(url);
-        QNetworkReply* reply = qnam()->get(request);
-        new NetworkReplyWatcher(this, reply);
+        QNetworkReply* reply = network()->getWithWatcher(request);
         reply->setProperty("storage", Storage::toVariant(reply, concert));
         reply->setProperty("infosToLoad", Storage::toVariant(reply, infos));
         connect(reply, &QNetworkReply::finished, this, &TMDbConcerts::loadReleasesFinished);

--- a/src/scrapers/concert/TMDbConcerts.h
+++ b/src/scrapers/concert/TMDbConcerts.h
@@ -1,14 +1,14 @@
 #pragma once
 
+#include "network/NetworkManager.h"
 #include "scrapers/concert/ConcertScraperInterface.h"
 #include "settings/ScraperSettings.h"
 
 #include <QComboBox>
 #include <QLocale>
+#include <QNetworkReply>
 #include <QObject>
 #include <QWidget>
-#include <QtNetwork/QNetworkAccessManager>
-#include <QtNetwork/QNetworkReply>
 
 class TMDbConcerts : public ConcertScraperInterface
 {
@@ -38,7 +38,7 @@ private slots:
 
 private:
     QString m_apiKey;
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     QLocale m_locale;
     QString m_language2;
     QString m_baseUrl;
@@ -50,7 +50,7 @@ private:
     QString localeForTMDb() const;
     QString language() const;
     QString country() const;
-    QNetworkAccessManager* qnam();
+    mediaelch::network::NetworkManager* network();
     QVector<ScraperSearchResult> parseSearch(QString json, int& nextPage);
     void parseAndAssignInfos(QString json, Concert* concert, QSet<ConcertScraperInfo> infos);
 };

--- a/src/scrapers/image/FanartTv.cpp
+++ b/src/scrapers/image/FanartTv.cpp
@@ -134,9 +134,9 @@ QVector<ImageType> FanartTv::provides()
  * \brief Just returns a pointer to the scrapers network access manager
  * \return Network Access Manager
  */
-QNetworkAccessManager* FanartTv::qnam()
+mediaelch::network::NetworkManager* FanartTv::network()
 {
-    return &m_qnam;
+    return &m_network;
 }
 
 /**
@@ -296,7 +296,7 @@ void FanartTv::loadMovieData(TmdbId tmdbId, ImageType type)
 
     qDebug() << "[FanartTv] Load movie data:" << url;
 
-    QNetworkReply* reply = qnam()->get(request);
+    QNetworkReply* reply = network()->get(request);
     reply->setProperty("infoToLoad", static_cast<int>(type));
     connect(reply, &QNetworkReply::finished, this, &FanartTv::onLoadMovieDataFinished);
 }
@@ -308,7 +308,7 @@ void FanartTv::loadMovieData(TmdbId tmdbId, QVector<ImageType> types, Movie* mov
 
     qDebug() << "[FanartTv] Load movie data with image types:" << url;
 
-    QNetworkReply* reply = qnam()->get(request);
+    QNetworkReply* reply = network()->get(request);
     reply->setProperty("storage", Storage::toVariant(reply, movie));
     reply->setProperty("infosToLoad", Storage::toVariant(reply, types));
     connect(reply, &QNetworkReply::finished, this, &FanartTv::onLoadAllMovieDataFinished);
@@ -321,7 +321,7 @@ void FanartTv::loadConcertData(TmdbId tmdbId, QVector<ImageType> types, Concert*
 
     qDebug() << "[FanartTv] Load concert data with image types:" << url;
 
-    QNetworkReply* reply = qnam()->get(request);
+    QNetworkReply* reply = network()->get(request);
     reply->setProperty("infosToLoad", Storage::toVariant(reply, types));
     reply->setProperty("storage", Storage::toVariant(reply, concert));
     connect(reply, &QNetworkReply::finished, this, &FanartTv::onLoadAllConcertDataFinished);
@@ -503,7 +503,7 @@ void FanartTv::loadTvShowData(TvDbId tvdbId, ImageType type, SeasonNumber season
     QUrl url = QStringLiteral("https://webservice.fanart.tv/v3/tv/%1?%2").arg(tvdbId.toString(), keyParameter());
     QNetworkRequest request = mediaelch::network::jsonRequestWithDefaults(url);
 
-    QNetworkReply* reply = qnam()->get(request);
+    QNetworkReply* reply = network()->get(request);
     reply->setProperty("infoToLoad", static_cast<int>(type));
     reply->setProperty("season", season.toInt());
     connect(reply, &QNetworkReply::finished, this, &FanartTv::onLoadTvShowDataFinished);
@@ -514,7 +514,7 @@ void FanartTv::loadTvShowData(TvDbId tvdbId, QVector<ImageType> types, TvShow* s
     QUrl url = QStringLiteral("https://webservice.fanart.tv/v3/tv/%1?%2").arg(tvdbId.toString(), keyParameter());
     QNetworkRequest request = mediaelch::network::jsonRequestWithDefaults(url);
 
-    QNetworkReply* reply = qnam()->get(request);
+    QNetworkReply* reply = network()->get(request);
     reply->setProperty("infosToLoad", Storage::toVariant(reply, types));
     reply->setProperty("storage", Storage::toVariant(reply, show));
     connect(reply, &QNetworkReply::finished, this, &FanartTv::onLoadAllTvShowDataFinished);

--- a/src/scrapers/image/FanartTv.h
+++ b/src/scrapers/image/FanartTv.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include "globals/Globals.h"
+#include "network/NetworkManager.h"
 #include "scrapers/image/ImageProviderInterface.h"
 #include "scrapers/movie/MovieScraperInterface.h"
 
 #include <QComboBox>
 #include <QLineEdit>
 #include <QMap>
-#include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QObject>
 #include <QString>
@@ -17,9 +17,6 @@
 class TMDb;
 class TheTvDb;
 
-/**
- * \brief The FanartTv class
- */
 class FanartTv : public ImageProviderInterface
 {
     Q_OBJECT
@@ -92,8 +89,8 @@ private:
     QVector<ImageType> m_provides;
     QString m_apiKey;
     QString m_personalApiKey;
-    QNetworkAccessManager m_qnam;
-    int m_searchResultLimit;
+    mediaelch::network::NetworkManager m_network;
+    int m_searchResultLimit = 0;
     TheTvDb* m_tvdb;
     TMDb* m_tmdb;
     QString m_language;
@@ -105,7 +102,7 @@ private:
     // Multiple languages, but no way to query for it and also no offical list of languages.
     QVector<mediaelch::Locale> m_supportedLanguages = {mediaelch::Locale::English};
 
-    QNetworkAccessManager* qnam();
+    mediaelch::network::NetworkManager* network();
     QVector<Poster> parseMovieData(QString json, ImageType type);
     void loadMovieData(TmdbId tmdbId, ImageType type);
     void loadMovieData(TmdbId tmdbId, QVector<ImageType> types, Movie* movie);

--- a/src/scrapers/image/FanartTvMusic.h
+++ b/src/scrapers/image/FanartTvMusic.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "globals/Globals.h"
+#include "network/NetworkManager.h"
 #include "scrapers/image/ImageProviderInterface.h"
 
-#include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QObject>
 #include <QString>
@@ -79,13 +79,13 @@ private:
     QVector<ImageType> m_provides;
     QString m_apiKey;
     QString m_personalApiKey;
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     int m_searchResultLimit;
     QString m_language;
     // Multiple languages, but no way to query for it and also no offical list of languages.
     QVector<mediaelch::Locale> m_supportedLanguages = {mediaelch::Locale::English};
 
-    QNetworkAccessManager* qnam();
+    mediaelch::network::NetworkManager* network();
     QVector<Poster> parseData(QString json, ImageType type);
     QString keyParameter();
 };

--- a/src/scrapers/image/FanartTvMusicArtists.cpp
+++ b/src/scrapers/image/FanartTvMusicArtists.cpp
@@ -60,13 +60,9 @@ QVector<ImageType> FanartTvMusicArtists::provides()
     return m_provides;
 }
 
-/**
- * \brief Just returns a pointer to the scrapers network access manager
- * \return Network Access Manager
- */
-QNetworkAccessManager* FanartTvMusicArtists::qnam()
+mediaelch::network::NetworkManager* FanartTvMusicArtists::network()
 {
-    return &m_qnam;
+    return &m_network;
 }
 
 /**
@@ -81,7 +77,7 @@ void FanartTvMusicArtists::searchConcert(QString searchStr, int limit)
     QUrl url(QStringLiteral("https://www.musicbrainz.org/ws/2/artist/?query=artist:%1")
                  .arg(QString(QUrl::toPercentEncoding(searchStr))));
     QNetworkRequest request = mediaelch::network::requestWithDefaults(url);
-    QNetworkReply* reply = qnam()->get(request);
+    QNetworkReply* reply = network()->getWithWatcher(request);
     connect(reply, &QNetworkReply::finished, this, &FanartTvMusicArtists::onSearchArtistFinished);
 }
 
@@ -124,7 +120,7 @@ void FanartTvMusicArtists::concertBackdrops(TmdbId tmdbId)
     QUrl url = QStringLiteral("https://webservice.fanart.tv/v3/music/%1?%2").arg(tmdbId.toString(), keyParameter());
     QNetworkRequest request = mediaelch::network::jsonRequestWithDefaults(url);
 
-    QNetworkReply* reply = qnam()->get(request);
+    QNetworkReply* reply = network()->getWithWatcher(request);
     reply->setProperty("infoToLoad", static_cast<int>(ImageType::ConcertBackdrop));
     connect(reply, &QNetworkReply::finished, this, &FanartTvMusicArtists::onLoadConcertFinished);
 }
@@ -134,7 +130,7 @@ void FanartTvMusicArtists::concertLogos(TmdbId tmdbId)
     QUrl url = QStringLiteral("https://webservice.fanart.tv/v3/music/%1?%2").arg(tmdbId.toString(), keyParameter());
     QNetworkRequest request = mediaelch::network::jsonRequestWithDefaults(url);
 
-    QNetworkReply* reply = qnam()->get(request);
+    QNetworkReply* reply = network()->getWithWatcher(request);
     reply->setProperty("infoToLoad", static_cast<int>(ImageType::ConcertLogo));
     connect(reply, &QNetworkReply::finished, this, &FanartTvMusicArtists::onLoadConcertFinished);
 }

--- a/src/scrapers/image/FanartTvMusicArtists.h
+++ b/src/scrapers/image/FanartTvMusicArtists.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "globals/Globals.h"
+#include "network/NetworkManager.h"
 #include "scrapers/image/ImageProviderInterface.h"
 
-#include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QObject>
 
@@ -76,14 +76,14 @@ private:
     QVector<ImageType> m_provides;
     QString m_apiKey;
     QString m_personalApiKey;
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     int m_searchResultLimit;
     QString m_language;
     QString m_preferredDiscType;
     // Multiple languages, but no way to query for it and also no offical list of languages.
     QVector<mediaelch::Locale> m_supportedLanguages = {mediaelch::Locale::English};
 
-    QNetworkAccessManager* qnam();
+    mediaelch::network::NetworkManager* network();
     QVector<Poster> parseData(QString json, ImageType type);
     QString keyParameter();
 };

--- a/src/scrapers/movie/AEBN.cpp
+++ b/src/scrapers/movie/AEBN.cpp
@@ -5,7 +5,6 @@
 #include <QRegExp>
 
 #include "data/Storage.h"
-#include "network/NetworkReplyWatcher.h"
 #include "network/NetworkRequest.h"
 #include "ui/main/MainWindow.h"
 
@@ -123,8 +122,7 @@ void AEBN::search(QString searchStr)
         "Large&theaterId=822&genreId=%3")
                  .arg(m_language.toString(), encodedSearch, m_genreId));
     auto request = mediaelch::network::requestWithDefaults(url);
-    QNetworkReply* reply = m_qnam.get(request);
-    new NetworkReplyWatcher(this, reply);
+    QNetworkReply* reply = m_network.getWithWatcher(request);
     connect(reply, &QNetworkReply::finished, this, &AEBN::onSearchFinished);
 }
 
@@ -179,8 +177,7 @@ void AEBN::loadData(QHash<MovieScraperInterface*, QString> ids, Movie* movie, QS
         "https://straight.theater.aebn.net/dispatcher/movieDetail?movieId=%1&locale=%2&theaterId=822&genreId=%3")
                  .arg(ids.values().first(), m_language.toString(), m_genreId));
     auto request = mediaelch::network::requestWithDefaults(url);
-    QNetworkReply* reply = m_qnam.get(request);
-    new NetworkReplyWatcher(this, reply);
+    QNetworkReply* reply = m_network.getWithWatcher(request);
     reply->setProperty("storage", Storage::toVariant(reply, movie));
     reply->setProperty("infosToLoad", Storage::toVariant(reply, infos));
     connect(reply, &QNetworkReply::finished, this, &AEBN::onLoadFinished);
@@ -352,8 +349,7 @@ void AEBN::downloadActors(Movie* movie, QStringList actorIds)
         "https://straight.theater.aebn.net/dispatcher/starDetail?locale=%2&starId=%1&theaterId=822&genreId=%3")
                  .arg(id, m_language.toString(), m_genreId));
     auto request = mediaelch::network::requestWithDefaults(url);
-    QNetworkReply* reply = m_qnam.get(request);
-    new NetworkReplyWatcher(this, reply);
+    QNetworkReply* reply = m_network.getWithWatcher(request);
     reply->setProperty("storage", Storage::toVariant(reply, movie));
     reply->setProperty("actorIds", actorIds);
     reply->setProperty("actorId", id);

--- a/src/scrapers/movie/AEBN.h
+++ b/src/scrapers/movie/AEBN.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "network/NetworkManager.h"
 #include "scrapers/movie/MovieScraperInterface.h"
 
 #include <QComboBox>
 #include <QMap>
-#include <QNetworkAccessManager>
 #include <QObject>
 #include <QWidget>
 
@@ -36,7 +36,7 @@ private slots:
     void onActorLoadFinished();
 
 private:
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     QSet<MovieScraperInfo> m_scraperSupports;
     mediaelch::Locale m_language;
     QString m_genreId;

--- a/src/scrapers/movie/AdultDvdEmpire.cpp
+++ b/src/scrapers/movie/AdultDvdEmpire.cpp
@@ -5,7 +5,6 @@
 #include <QTextDocument>
 
 #include "data/Storage.h"
-#include "network/NetworkReplyWatcher.h"
 #include "network/NetworkRequest.h"
 #include "settings/Settings.h"
 
@@ -65,9 +64,9 @@ mediaelch::Locale AdultDvdEmpire::defaultLanguage()
     return "en";
 }
 
-QNetworkAccessManager* AdultDvdEmpire::qnam()
+mediaelch::network::NetworkManager* AdultDvdEmpire::network()
 {
-    return &m_qnam;
+    return &m_network;
 }
 
 void AdultDvdEmpire::search(QString searchStr)
@@ -75,8 +74,7 @@ void AdultDvdEmpire::search(QString searchStr)
     QString encodedSearch = QUrl::toPercentEncoding(searchStr);
     QUrl url(QStringLiteral("https://www.adultdvdempire.com/allsearch/search?view=list&q=%1").arg(encodedSearch));
     auto request = mediaelch::network::requestWithDefaults(url);
-    QNetworkReply* reply = qnam()->get(request);
-    new NetworkReplyWatcher(this, reply);
+    QNetworkReply* reply = network()->getWithWatcher(request);
     connect(reply, &QNetworkReply::finished, this, &AdultDvdEmpire::onSearchFinished);
 }
 
@@ -134,8 +132,7 @@ void AdultDvdEmpire::loadData(QHash<MovieScraperInterface*, QString> ids, Movie*
     QUrl url(QStringLiteral("https://www.adultdvdempire.com%1").arg(ids.values().first()));
     auto request = mediaelch::network::requestWithDefaults(url);
     mediaelch::network::useFirefoxUserAgent(request);
-    QNetworkReply* reply = qnam()->get(request);
-    new NetworkReplyWatcher(this, reply);
+    QNetworkReply* reply = network()->getWithWatcher(request);
     reply->setProperty("storage", Storage::toVariant(reply, movie));
     reply->setProperty("infosToLoad", Storage::toVariant(reply, infos));
     reply->setProperty("id", ids.values().first());

--- a/src/scrapers/movie/AdultDvdEmpire.h
+++ b/src/scrapers/movie/AdultDvdEmpire.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "network/NetworkManager.h"
 #include "scrapers/movie/MovieScraperInterface.h"
 
-#include <QNetworkAccessManager>
 #include <QObject>
 #include <QWidget>
 
@@ -33,10 +33,10 @@ private slots:
     void onLoadFinished();
 
 private:
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     QSet<MovieScraperInfo> m_scraperSupports;
 
-    QNetworkAccessManager* qnam();
+    mediaelch::network::NetworkManager* network();
     QVector<ScraperSearchResult> parseSearch(QString html);
     void parseAndAssignInfos(QString html, Movie* movie, QSet<MovieScraperInfo> infos);
 };

--- a/src/scrapers/movie/CustomMovieScraper.cpp
+++ b/src/scrapers/movie/CustomMovieScraper.cpp
@@ -6,7 +6,6 @@
 
 #include "data/Storage.h"
 #include "globals/ScraperManager.h"
-#include "network/NetworkReplyWatcher.h"
 #include "scrapers/movie/IMDB.h"
 #include "scrapers/movie/TMDb.h"
 #include "settings/Settings.h"
@@ -20,9 +19,9 @@ CustomMovieScraper::CustomMovieScraper(QObject* parent)
     }
 }
 
-QNetworkAccessManager* CustomMovieScraper::qnam()
+mediaelch::network::NetworkManager* CustomMovieScraper::network()
 {
-    return &m_qnam;
+    return &m_network;
 }
 
 CustomMovieScraper* CustomMovieScraper::instance(QObject* parent)
@@ -191,8 +190,7 @@ void CustomMovieScraper::loadData(QHash<MovieScraperInterface*, QString> ids,
         request.setRawHeader("Accept", "application/json");
         QUrl url(QString("https://api.themoviedb.org/3/movie/%1?api_key=%2").arg(tmdbId).arg(TMDb::apiKey()));
         request.setUrl(url);
-        QNetworkReply* reply = qnam()->get(request);
-        new NetworkReplyWatcher(this, reply);
+        QNetworkReply* reply = network()->getWithWatcher(request);
         reply->setProperty("movie", Storage::toVariant(reply, movie));
         reply->setProperty("infosToLoad", Storage::toVariant(reply, infos));
         reply->setProperty("ids", Storage::toVariant(reply, ids));

--- a/src/scrapers/movie/CustomMovieScraper.h
+++ b/src/scrapers/movie/CustomMovieScraper.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "network/NetworkManager.h"
 #include "scrapers/image/ImageProviderInterface.h"
 #include "scrapers/movie/MovieScraperInterface.h"
 
-#include <QNetworkAccessManager>
 #include <QObject>
 
 class CustomMovieScraper : public MovieScraperInterface
@@ -39,7 +39,7 @@ private slots:
 
 private:
     QVector<MovieScraperInterface*> m_scrapers;
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
 
     QVector<MovieScraperInterface*> scrapersForInfos(QSet<MovieScraperInfo> infos);
     ImageProviderInterface* imageProviderForInfo(int info);
@@ -51,5 +51,5 @@ private:
         QSet<MovieScraperInfo> infos,
         QString tmdbId,
         QString imdbId);
-    QNetworkAccessManager* qnam();
+    mediaelch::network::NetworkManager* network();
 };

--- a/src/scrapers/movie/HotMovies.cpp
+++ b/src/scrapers/movie/HotMovies.cpp
@@ -2,7 +2,6 @@
 
 #include "data/Storage.h"
 #include "globals/Helper.h"
-#include "network/NetworkReplyWatcher.h"
 #include "network/NetworkRequest.h"
 #include "ui/main/MainWindow.h"
 
@@ -68,9 +67,9 @@ mediaelch::Locale HotMovies::defaultLanguage()
     return "en";
 }
 
-QNetworkAccessManager* HotMovies::qnam()
+mediaelch::network::NetworkManager* HotMovies::network()
 {
-    return &m_qnam;
+    return &m_network;
 }
 
 void HotMovies::search(QString searchStr)
@@ -79,8 +78,7 @@ void HotMovies::search(QString searchStr)
     QUrl url(QString("https://www.hotmovies.com/search.php?words=%1&search_in=video_title&num_per_page=30")
                  .arg(encodedSearch));
     auto request = mediaelch::network::requestWithDefaults(url);
-    QNetworkReply* reply = qnam()->get(request);
-    new NetworkReplyWatcher(this, reply);
+    QNetworkReply* reply = network()->getWithWatcher(request);
     connect(reply, &QNetworkReply::finished, this, &HotMovies::onSearchFinished);
 }
 
@@ -128,8 +126,7 @@ void HotMovies::loadData(QHash<MovieScraperInterface*, QString> ids, Movie* movi
 
     QUrl url(ids.values().first());
     auto request = mediaelch::network::requestWithDefaults(url);
-    QNetworkReply* reply = qnam()->get(request);
-    new NetworkReplyWatcher(this, reply);
+    QNetworkReply* reply = network()->getWithWatcher(request);
     reply->setProperty("storage", Storage::toVariant(reply, movie));
     reply->setProperty("infosToLoad", Storage::toVariant(reply, infos));
     connect(reply, &QNetworkReply::finished, this, &HotMovies::onLoadFinished);

--- a/src/scrapers/movie/HotMovies.h
+++ b/src/scrapers/movie/HotMovies.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "network/NetworkManager.h"
 #include "scrapers/movie/MovieScraperInterface.h"
 
 #include <QComboBox>
-#include <QNetworkAccessManager>
 #include <QObject>
 #include <QWidget>
 
@@ -34,10 +34,10 @@ private slots:
     void onLoadFinished();
 
 private:
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     QSet<MovieScraperInfo> m_scraperSupports;
 
-    QNetworkAccessManager* qnam();
+    mediaelch::network::NetworkManager* network();
     QVector<ScraperSearchResult> parseSearch(QString html);
     void parseAndAssignInfos(QString html, Movie* movie, QSet<MovieScraperInfo> infos);
 };

--- a/src/scrapers/movie/IMDB.cpp
+++ b/src/scrapers/movie/IMDB.cpp
@@ -6,7 +6,6 @@
 
 #include "data/Storage.h"
 #include "globals/Helper.h"
-#include "network/NetworkReplyWatcher.h"
 #include "network/NetworkRequest.h"
 #include "scrapers/movie/imdb/ImdbMovieScraper.h"
 #include "settings/Settings.h"
@@ -111,8 +110,7 @@ void IMDB::search(QString searchStr)
         QUrl url = QUrl(QStringLiteral("https://www.imdb.com/title/%1/").arg(searchStr).toUtf8());
         QNetworkRequest request(url);
         request.setRawHeader("Accept-Language", "en"); // todo: add language dropdown in settings
-        QNetworkReply* reply = m_qnam.get(request);
-        new NetworkReplyWatcher(this, reply);
+        QNetworkReply* reply = m_network.getWithWatcher(request);
         connect(reply, &QNetworkReply::finished, this, &IMDB::onSearchIdFinished);
 
     } else {
@@ -130,8 +128,7 @@ void IMDB::search(QString searchStr)
 
         QNetworkRequest request(url);
         request.setRawHeader("Accept-Language", "en");
-        QNetworkReply* reply = m_qnam.get(request);
-        new NetworkReplyWatcher(this, reply);
+        QNetworkReply* reply = m_network.getWithWatcher(request);
         connect(reply, &QNetworkReply::finished, this, &IMDB::onSearchFinished);
     }
 }

--- a/src/scrapers/movie/IMDB.h
+++ b/src/scrapers/movie/IMDB.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "movies/Movie.h"
+#include "network/NetworkManager.h"
 #include "scrapers/movie/MovieScraperInterface.h"
 
 #include <QMutexLocker>
-#include <QNetworkAccessManager>
 #include <QNetworkReply>
 
 class QCheckBox;
@@ -49,7 +49,7 @@ private:
     QCheckBox* m_loadAllTagsWidget;
 
     bool m_loadAllTags = false;
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     QSet<MovieScraperInfo> m_scraperSupports;
 
     QVector<ScraperSearchResult> parseSearch(const QString& html);

--- a/src/scrapers/movie/OFDb.h
+++ b/src/scrapers/movie/OFDb.h
@@ -1,14 +1,11 @@
 #pragma once
 
+#include "network/NetworkManager.h"
 #include "scrapers/movie/MovieScraperInterface.h"
 
+#include <QNetworkReply>
 #include <QObject>
-#include <QtNetwork/QNetworkAccessManager>
-#include <QtNetwork/QNetworkReply>
 
-/**
- * \brief The OFDb class
- */
 class OFDb : public MovieScraperInterface
 {
     Q_OBJECT
@@ -36,10 +33,10 @@ private slots:
     void loadFinished();
 
 private:
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     QSet<MovieScraperInfo> m_scraperSupports;
 
-    QNetworkAccessManager* qnam();
+    mediaelch::network::NetworkManager* network();
     QVector<ScraperSearchResult> parseSearch(QString xml, QString searchStr);
     void parseAndAssignInfos(QString data, Movie* movie, QSet<MovieScraperInfo> infos);
 };

--- a/src/scrapers/movie/TMDb.h
+++ b/src/scrapers/movie/TMDb.h
@@ -1,16 +1,16 @@
 #pragma once
 
 #include "data/TmdbId.h"
+#include "network/NetworkManager.h"
 #include "scrapers/movie/MovieScraperInterface.h"
 
 #include <QComboBox>
 #include <QLocale>
 #include <QMap>
 #include <QMutex>
+#include <QNetworkReply>
 #include <QObject>
 #include <QPointer>
-#include <QtNetwork/QNetworkAccessManager>
-#include <QtNetwork/QNetworkReply>
 
 /**
  * \brief The TMDb class
@@ -51,7 +51,7 @@ private slots:
     void setupFinished();
 
 private:
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     mediaelch::Locale m_locale = mediaelch::Locale::English;
     QString m_baseUrl;
     QMutex m_mutex;

--- a/src/scrapers/movie/VideoBuster.cpp
+++ b/src/scrapers/movie/VideoBuster.cpp
@@ -5,7 +5,6 @@
 #include "data/Storage.h"
 #include "globals/Globals.h"
 #include "globals/Helper.h"
-#include "network/NetworkReplyWatcher.h"
 #include "network/NetworkRequest.h"
 #include "settings/Settings.h"
 
@@ -29,13 +28,9 @@ VideoBuster::VideoBuster(QObject* parent) :
     setParent(parent);
 }
 
-/**
- * \brief Just returns a pointer to the scrapers network access manager
- * \return Network Access Manager
- */
-QNetworkAccessManager* VideoBuster::qnam()
+mediaelch::network::NetworkManager* VideoBuster::network()
 {
-    return &m_qnam;
+    return &m_network;
 }
 
 /**
@@ -99,8 +94,7 @@ void VideoBuster::search(QString searchStr)
                      "titlesearch.php?tab_search_content=movies&view=title_list_view_option_list&search_title=%1")
                  .arg(encodedSearch)
                  .toUtf8());
-    QNetworkReply* reply = qnam()->get(mediaelch::network::requestWithDefaults(url));
-    new NetworkReplyWatcher(this, reply);
+    QNetworkReply* reply = network()->getWithWatcher(mediaelch::network::requestWithDefaults(url));
     connect(reply, &QNetworkReply::finished, this, &VideoBuster::searchFinished);
 }
 
@@ -163,8 +157,7 @@ void VideoBuster::loadData(QHash<MovieScraperInterface*, QString> ids, Movie* mo
     movie->clear(infos);
 
     QUrl url(QString("https://www.videobuster.de%1").arg(ids.values().first()));
-    QNetworkReply* reply = this->qnam()->get(mediaelch::network::requestWithDefaults(url));
-    new NetworkReplyWatcher(this, reply);
+    QNetworkReply* reply = network()->getWithWatcher(mediaelch::network::requestWithDefaults(url));
     reply->setProperty("storage", Storage::toVariant(reply, movie));
     reply->setProperty("infosToLoad", Storage::toVariant(reply, infos));
     connect(reply, &QNetworkReply::finished, this, &VideoBuster::loadFinished);

--- a/src/scrapers/movie/VideoBuster.h
+++ b/src/scrapers/movie/VideoBuster.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include "network/NetworkManager.h"
 #include "scrapers/movie/MovieScraperInterface.h"
 
+#include <QNetworkReply>
 #include <QObject>
 #include <QWidget>
-#include <QtNetwork/QNetworkAccessManager>
-#include <QtNetwork/QNetworkReply>
 
 /**
  * \brief The VideoBuster class
@@ -37,10 +37,10 @@ private slots:
     void loadFinished();
 
 private:
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     QSet<MovieScraperInfo> m_scraperSupports;
 
-    QNetworkAccessManager* qnam();
+    mediaelch::network::NetworkManager* network();
     QVector<ScraperSearchResult> parseSearch(QString html);
     void parseAndAssignInfos(QString html, Movie* movie, QSet<MovieScraperInfo> infos);
     QString replaceEntities(const QString msg);

--- a/src/scrapers/movie/imdb/ImdbMovieScraper.cpp
+++ b/src/scrapers/movie/imdb/ImdbMovieScraper.cpp
@@ -12,8 +12,7 @@ void ImdbMovieLoader::load()
     QUrl url = QUrl(QString("https://www.imdb.com/title/%1/").arg(m_imdbId).toUtf8());
     QNetworkRequest request = mediaelch::network::requestWithDefaults(url);
     request.setRawHeader("Accept-Language", "en");
-    QNetworkReply* reply = m_qnam.get(request);
-    new NetworkReplyWatcher(this, reply);
+    QNetworkReply* reply = m_network.getWithWatcher(request);
     connect(reply, &QNetworkReply::finished, this, &ImdbMovieLoader::onLoadFinished);
 }
 
@@ -81,8 +80,7 @@ void ImdbMovieLoader::loadPoster(const QUrl& posterViewerUrl)
 {
     qDebug() << "[ImdbMovieLoader] Loading movie poster detail view";
     auto request = mediaelch::network::requestWithDefaults(posterViewerUrl);
-    QNetworkReply* posterReply = m_qnam.get(request);
-    new NetworkReplyWatcher(this, posterReply);
+    QNetworkReply* posterReply = m_network.getWithWatcher(request);
     connect(posterReply, &QNetworkReply::finished, this, &ImdbMovieLoader::onPosterLoadFinished);
 }
 
@@ -90,8 +88,7 @@ void ImdbMovieLoader::loadTags()
 {
     QUrl tagsUrl(QStringLiteral("https://www.imdb.com/title/%1/keywords").arg(m_movie.imdbId().toString()));
     auto request = mediaelch::network::requestWithDefaults(tagsUrl);
-    QNetworkReply* tagsReply = m_qnam.get(request);
-    new NetworkReplyWatcher(this, tagsReply);
+    QNetworkReply* tagsReply = m_network.getWithWatcher(request);
     connect(tagsReply, &QNetworkReply::finished, this, &ImdbMovieLoader::onTagsFinished);
 }
 
@@ -102,8 +99,7 @@ void ImdbMovieLoader::loadActorImageUrls()
         // The actor's image should be the same for all languages. So we can
         // just load the English version of the page.
         request.setRawHeader("Accept-Language", "en");
-        QNetworkReply* reply = m_qnam.get(request);
-        new NetworkReplyWatcher(this, reply);
+        QNetworkReply* reply = m_network.getWithWatcher(request);
         reply->setProperty("actorIndex", QVariant(index));
         connect(reply, &QNetworkReply::finished, this, &ImdbMovieLoader::onActorImageUrlLoadDone);
     }

--- a/src/scrapers/movie/imdb/ImdbMovieScraper.h
+++ b/src/scrapers/movie/imdb/ImdbMovieScraper.h
@@ -3,9 +3,8 @@
 #include "data/Storage.h"
 #include "globals/ScraperInfos.h"
 #include "movies/Movie.h"
-#include "network/NetworkReplyWatcher.h"
+#include "network/NetworkManager.h"
 
-#include <QNetworkAccessManager>
 #include <QObject>
 #include <QString>
 
@@ -65,7 +64,7 @@ private:
     QString m_imdbId;
     Movie& m_movie;
     QSet<MovieScraperInfo> m_infos;
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     bool m_loadAllTags = false;
 
     QVector<QPair<Actor, QUrl>> m_actorUrls;

--- a/src/scrapers/music/TvTunes.cpp
+++ b/src/scrapers/music/TvTunes.cpp
@@ -5,7 +5,6 @@
 #include <QRegExp>
 
 #include "globals/Helper.h"
-#include "network/NetworkReplyWatcher.h"
 #include "network/NetworkRequest.h"
 
 TvTunes::TvTunes(QObject* parent) : QObject(parent)
@@ -25,8 +24,7 @@ void TvTunes::search(QString searchStr)
 
     QUrl url(QStringLiteral("https://www.televisiontunes.com/search.php?q=%1").arg(searchStr));
     QNetworkRequest request = mediaelch::network::requestWithDefaults(url);
-    QNetworkReply* reply = m_qnam.get(request);
-    new NetworkReplyWatcher(this, reply);
+    QNetworkReply* reply = m_network.getWithWatcher(request);
     reply->setProperty("searchStr", searchStr);
     connect(reply, &QNetworkReply::finished, this, &TvTunes::onSearchFinished);
 }
@@ -81,8 +79,7 @@ void TvTunes::getNextDownloadUrl(QString searchStr)
     }
 
     ScraperSearchResult res = m_queue.dequeue();
-    QNetworkReply* reply = m_qnam.get(mediaelch::network::requestWithDefaults(QUrl(res.id)));
-    new NetworkReplyWatcher(this, reply);
+    QNetworkReply* reply = m_network.getWithWatcher(mediaelch::network::requestWithDefaults(QUrl(res.id)));
     reply->setProperty("searchStr", searchStr);
     reply->setProperty("name", res.name);
     connect(reply, &QNetworkReply::finished, this, &TvTunes::onDownloadUrlFinished);

--- a/src/scrapers/music/TvTunes.h
+++ b/src/scrapers/music/TvTunes.h
@@ -2,8 +2,8 @@
 
 #include "globals/Globals.h"
 #include "globals/ScraperResult.h"
+#include "network/NetworkManager.h"
 
-#include <QNetworkAccessManager>
 #include <QObject>
 #include <QQueue>
 
@@ -22,7 +22,7 @@ private slots:
     void onDownloadUrlFinished();
 
 private:
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     QVector<ScraperSearchResult> m_results;
     QQueue<ScraperSearchResult> m_queue;
     QString m_searchStr;

--- a/src/scrapers/music/UniversalMusicScraper.h
+++ b/src/scrapers/music/UniversalMusicScraper.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "globals/ScraperInfos.h"
+#include "network/NetworkManager.h"
 #include "scrapers/music/MusicScraperInterface.h"
 
 #include <QComboBox>
 #include <QMutex>
-#include <QNetworkAccessManager>
 #include <QObject>
 #include <QWidget>
 
@@ -47,7 +47,7 @@ private:
     };
 
     QString m_tadbApiKey;
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     QString m_language;
     QString m_prefer;
     QWidget* m_widget;
@@ -58,7 +58,7 @@ private:
     QMutex m_artistMutex;
     QMutex m_albumMutex;
 
-    QNetworkAccessManager* qnam();
+    mediaelch::network::NetworkManager* network();
     QString trim(QString text);
     bool shouldLoad(MusicScraperInfo info, QSet<MusicScraperInfo> infos, Artist* artist);
     bool shouldLoad(MusicScraperInfo info, QSet<MusicScraperInfo> infos, Album* album);

--- a/src/scrapers/trailer/HdTrailers.cpp
+++ b/src/scrapers/trailer/HdTrailers.cpp
@@ -7,7 +7,7 @@
 #include "network/NetworkRequest.h"
 
 HdTrailers::HdTrailers(QObject* parent) :
-    m_qnam{new QNetworkAccessManager(this)}, m_searchReply{nullptr}, m_loadReply{nullptr}
+    m_network{new mediaelch::network::NetworkManager(this)}, m_searchReply{nullptr}, m_loadReply{nullptr}
 {
     setParent(parent);
     m_libraryPages.enqueue('0');
@@ -50,7 +50,7 @@ void HdTrailers::searchMovie(QString searchStr)
 
     if (!m_libraryPages.isEmpty()) {
         QNetworkRequest request = mediaelch::network::requestWithDefaults(getLibraryUrl(m_libraryPages.dequeue()));
-        m_searchReply = m_qnam->get(request);
+        m_searchReply = m_network->get(request);
         connect(m_searchReply, &QNetworkReply::finished, this, &HdTrailers::onSearchFinished);
 
     } else {
@@ -88,7 +88,7 @@ void HdTrailers::onSearchFinished()
 
 void HdTrailers::loadMovieTrailers(QString id)
 {
-    m_loadReply = m_qnam->get(mediaelch::network::requestWithDefaults(QUrl("https://www.hd-trailers.net" + id)));
+    m_loadReply = m_network->get(mediaelch::network::requestWithDefaults(QUrl("https://www.hd-trailers.net" + id)));
     connect(m_loadReply, &QNetworkReply::finished, this, &HdTrailers::onLoadFinished);
 }
 

--- a/src/scrapers/trailer/HdTrailers.h
+++ b/src/scrapers/trailer/HdTrailers.h
@@ -1,13 +1,13 @@
 #pragma once
 
+#include "network/NetworkManager.h"
+#include "scrapers/trailer/TrailerProvider.h"
+
 #include <QMultiMap>
-#include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QObject>
 #include <QQueue>
 #include <QStringList>
-
-#include "scrapers/trailer/TrailerProvider.h"
 
 class HdTrailers : public TrailerProvider
 {
@@ -25,7 +25,7 @@ private slots:
     void onLoadFinished();
 
 private:
-    QNetworkAccessManager* m_qnam;
+    mediaelch::network::NetworkManager* m_network;
     QNetworkReply* m_searchReply;
     QNetworkReply* m_loadReply;
     QString m_currentSearch;

--- a/src/tv_shows/TvShowUpdater.cpp
+++ b/src/tv_shows/TvShowUpdater.cpp
@@ -1,9 +1,5 @@
 #include "TvShowUpdater.h"
 
-#include <QBuffer>
-#include <QDebug>
-#include <QNetworkReply>
-
 #include "data/Storage.h"
 #include "globals/Globals.h"
 #include "globals/Manager.h"

--- a/src/tv_shows/TvShowUpdater.h
+++ b/src/tv_shows/TvShowUpdater.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <QNetworkAccessManager>
 #include <QObject>
+#include <QVector>
 
 class TvShow;
 class TheTvDb;

--- a/src/ui/main/Update.cpp
+++ b/src/ui/main/Update.cpp
@@ -34,7 +34,7 @@ void Update::checkForUpdate()
     // all meta data about MediaElch, e.g. the latest version.
     const QUrl url("https://raw.githubusercontent.com/mediaelch/mediaelch-meta/master/version.xml");
     auto request = mediaelch::network::requestWithDefaults(url);
-    QNetworkReply* reply = m_qnam.get(request);
+    QNetworkReply* reply = m_network.getWithWatcher(request);
     connect(reply, &QNetworkReply::finished, this, &Update::onCheckFinished);
 }
 

--- a/src/ui/main/Update.h
+++ b/src/ui/main/Update.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <QNetworkAccessManager>
+#include "network/NetworkManager.h"
+
 #include <QObject>
 
 class Update : public QObject
@@ -17,6 +18,6 @@ private slots:
     void onCheckFinished();
 
 private:
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     bool checkIfNewVersion(QString xmlString, QString& version, QString& downloadUrl);
 };

--- a/src/ui/media_centers/KodiSync.cpp
+++ b/src/ui/media_centers/KodiSync.cpp
@@ -28,7 +28,7 @@ KodiSync::KodiSync(KodiSettings& settings, QWidget* parent) :
 {
     ui->setupUi(this);
 
-    connect(&m_qnam, &QNetworkAccessManager::authenticationRequired, this, &KodiSync::onAuthRequired);
+    connect(&m_network, &mediaelch::network::NetworkManager::authenticationRequired, this, &KodiSync::onAuthRequired);
 
     // clang-format off
     connect(ui->buttonSync,          &QAbstractButton::clicked, this, &KodiSync::startSync);
@@ -182,7 +182,7 @@ void KodiSync::startSync()
         QNetworkRequest request(xbmcUrl());
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("Accept", "application/json");
-        QNetworkReply* reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
+        QNetworkReply* reply = m_network.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
         connect(reply, &QNetworkReply::finished, this, &KodiSync::onMovieListFinished);
     }
 
@@ -193,7 +193,7 @@ void KodiSync::startSync()
         QNetworkRequest request(xbmcUrl());
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("Accept", "application/json");
-        QNetworkReply* reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
+        QNetworkReply* reply = m_network.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
         connect(reply, &QNetworkReply::finished, this, &KodiSync::onConcertListFinished);
     }
 
@@ -204,7 +204,7 @@ void KodiSync::startSync()
         QNetworkRequest request(xbmcUrl());
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("Accept", "application/json");
-        QNetworkReply* reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
+        QNetworkReply* reply = m_network.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
         connect(reply, &QNetworkReply::finished, this, &KodiSync::onTvShowListFinished);
     }
 
@@ -215,7 +215,7 @@ void KodiSync::startSync()
         QNetworkRequest request(xbmcUrl());
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("Accept", "application/json");
-        QNetworkReply* reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
+        QNetworkReply* reply = m_network.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
         connect(reply, &QNetworkReply::finished, this, &KodiSync::onEpisodeListFinished);
     }
 
@@ -434,7 +434,7 @@ void KodiSync::removeItems()
         QNetworkRequest request(xbmcUrl());
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("Accept", "application/json");
-        QNetworkReply* reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
+        QNetworkReply* reply = m_network.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
         connect(reply, &QNetworkReply::finished, this, &KodiSync::onRemoveFinished);
         return;
     }
@@ -449,7 +449,7 @@ void KodiSync::removeItems()
         QNetworkRequest request(xbmcUrl());
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("Accept", "application/json");
-        QNetworkReply* reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
+        QNetworkReply* reply = m_network.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
         connect(reply, &QNetworkReply::finished, this, &KodiSync::onRemoveFinished);
         return;
     }
@@ -464,7 +464,7 @@ void KodiSync::removeItems()
         QNetworkRequest request(xbmcUrl());
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("Accept", "application/json");
-        QNetworkReply* reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
+        QNetworkReply* reply = m_network.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
         connect(reply, &QNetworkReply::finished, this, &KodiSync::onRemoveFinished);
         return;
     }
@@ -480,7 +480,7 @@ void KodiSync::removeItems()
         QNetworkRequest request(xbmcUrl());
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("Accept", "application/json");
-        QNetworkReply* reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
+        QNetworkReply* reply = m_network.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
         connect(reply, &QNetworkReply::finished, this, &KodiSync::onRemoveFinished);
         return;
     }
@@ -520,7 +520,7 @@ void KodiSync::triggerReload()
     QNetworkRequest request(xbmcUrl());
     request.setRawHeader("Content-Type", "application/json");
     request.setRawHeader("Accept", "application/json");
-    QNetworkReply* reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
+    QNetworkReply* reply = m_network.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
     connect(reply, &QNetworkReply::finished, this, &KodiSync::onScanFinished);
 }
 
@@ -540,7 +540,7 @@ void KodiSync::triggerClean()
     QNetworkRequest request(xbmcUrl());
     request.setRawHeader("Content-Type", "application/json");
     request.setRawHeader("Accept", "application/json");
-    QNetworkReply* reply = m_qnam.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
+    QNetworkReply* reply = m_network.post(request, QJsonDocument(o).toJson(QJsonDocument::Compact));
     connect(reply, &QNetworkReply::finished, this, &KodiSync::onCleanFinished);
 }
 

--- a/src/ui/media_centers/KodiSync.h
+++ b/src/ui/media_centers/KodiSync.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "movies/Movie.h"
+#include "network/NetworkManager.h"
 #include "settings/KodiSettings.h"
 
 #include <QAuthenticator>
 #include <QDialog>
 #include <QMutex>
-#include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QTcpSocket>
 #include <QTimer>
@@ -74,7 +74,7 @@ private:
     Ui::KodiSync* ui;
     KodiSettings& m_settings;
 
-    QNetworkAccessManager m_qnam;
+    mediaelch::network::NetworkManager m_network;
     QVector<Movie*> m_moviesToSync;
     QVector<Concert*> m_concertsToSync;
     QVector<TvShow*> m_tvShowsToSync;

--- a/src/ui/tv_show/TvTunesDialog.cpp
+++ b/src/ui/tv_show/TvTunesDialog.cpp
@@ -28,7 +28,7 @@ TvTunesDialog::TvTunesDialog(TvShow& show, QWidget* parent) :
 #endif
 
     m_tvTunes = new TvTunes(this);
-    m_qnam = new QNetworkAccessManager(this);
+    m_network = new mediaelch::network::NetworkManager(this);
 
     connect(ui->btnClose, &QAbstractButton::clicked, this, &TvTunesDialog::onClose);
     connect(ui->searchString, &QLineEdit::returnPressed, this, &TvTunesDialog::onSearch);
@@ -170,7 +170,7 @@ void TvTunesDialog::startDownload()
 
     m_downloadInProgress = true;
     // No NetworkReplyWatcher to avoid timeout.
-    m_downloadReply = m_qnam->get(mediaelch::network::requestWithDefaults(m_themeUrl));
+    m_downloadReply = m_network->get(mediaelch::network::requestWithDefaults(m_themeUrl));
     connect(m_downloadReply, &QNetworkReply::finished, this, &TvTunesDialog::downloadFinished);
     connect(m_downloadReply, &QNetworkReply::downloadProgress, this, &TvTunesDialog::downloadProgress);
     connect(m_downloadReply, &QIODevice::readyRead, this, &TvTunesDialog::downloadReadyRead);
@@ -219,7 +219,7 @@ void TvTunesDialog::downloadFinished()
         || m_downloadReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 301) {
         const QUrl url = m_downloadReply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
         qDebug() << "[TvTunesDialog] Got redirect" << url;
-        m_downloadReply = m_qnam->get(mediaelch::network::requestWithDefaults(url));
+        m_downloadReply = m_network->get(mediaelch::network::requestWithDefaults(url));
         connect(m_downloadReply, &QNetworkReply::finished, this, &TvTunesDialog::downloadFinished);
         connect(m_downloadReply, &QNetworkReply::downloadProgress, this, &TvTunesDialog::downloadProgress);
         connect(m_downloadReply, &QIODevice::readyRead, this, &TvTunesDialog::downloadReadyRead);

--- a/src/ui/tv_show/TvTunesDialog.h
+++ b/src/ui/tv_show/TvTunesDialog.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include "globals/ScraperResult.h"
+#include "network/NetworkManager.h"
 #include "tv_shows/TvShow.h"
 
 #include <QDialog>
 #include <QElapsedTimer>
 #include <QFile>
 #include <QMediaPlayer>
-#include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QTableWidgetItem>
 
@@ -49,7 +49,7 @@ private:
     TvShow& m_show;
     qint64 m_totalTime = 0;
     QMediaPlayer* m_mediaPlayer = nullptr;
-    QNetworkAccessManager* m_qnam = nullptr;
+    mediaelch::network::NetworkManager* m_network = nullptr;
     QNetworkReply* m_downloadReply = nullptr;
     QElapsedTimer m_downloadTime;
     QFile m_output;


### PR DESCRIPTION
This class can be used for future logging of network requests.

As we will rely on Qt >= 5.6, auto-redirect is supported so we can remove code that checks for a 301/302 code.
This change will also make it possible to have a central URL logging instance.