### PR TITLE
[scripts] Update clang-format and other dependencies

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -36,9 +36,10 @@ Cpp11BracedListStyle: true
 FixNamespaceComments: true
 ForEachMacros: ['foreach']
 IndentCaseLabels: false
-# Will be supported in clang-format 6
+# Maybe enable if groups aren't changed but only reordered
+# and we use IncludeCategories
 # IncludeBlocks: Regroup
-# IndentPPDirectives: AfterHash
+IndentPPDirectives: AfterHash
 IndentWidth: 4
 IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,15 +42,15 @@ jobs:
       - git diff --diff-filter=M --quiet || (echo "Found unformatted CMakeLists.txt! Use cmake-format!"; exit 1)
 
   - name: "clang-format check"
-    dist: bionic
-    addons: { apt: { packages: ['clang-format-9'] } }
+    dist: focal
+    addons: { apt: { packages: ['clang-format-10'] } }
     script:
       - ./scripts/run_clang_format.sh
       - git diff --diff-filter=M --color | cat
       - git diff --diff-filter=M --quiet || (echo "Found unformatted C++ files! Use clang-format!"; exit 1)
 
   - name: "cppcheck linting"
-    dist: bionic
+    dist: focal
     addons: { apt: { packages: ['cppcheck'] } }
     before_script:
       - cppcheck --version

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -16,20 +16,20 @@ RUN apt-get update && \
     add-apt-repository ppa:ubuntu-toolchain-r/test
 
 RUN apt-get update && \
-    apt-get install -y zlib1g zlib1g-dev g++-9 gcc-9 git wget curl \
-        libclang-9-dev clang-tidy-9 clang-tools-9 clang-format-9 clang-9 \
-        llvm-9-dev git-core xvfb \
+    apt-get install -y zlib1g zlib1g-dev g++-10 gcc-10 git wget curl \
+        libclang-10-dev clang-tidy-10 clang-tools-10 clang-format-10 clang-10 \
+        llvm-10-dev git-core xvfb \
         python3 python3-yaml python3-pip libjson-perl \
         libncurses5-dev libncurses5 ninja-build doxygen && \
-    update-alternatives --install /usr/bin/gcc           gcc          /usr/bin/gcc-9          10 && \
-    update-alternatives --install /usr/bin/gcov          gcov         /usr/bin/gcov-9         10 && \
-    update-alternatives --install /usr/bin/g++           g++          /usr/bin/g++-9          10 && \
-    update-alternatives --install /usr/bin/clang++       clang++      /usr/bin/clang++-9      10 && \
-    update-alternatives --install /usr/bin/clang         clang        /usr/bin/clang-9        10 && \
-    update-alternatives --install /usr/bin/clang-format  clang-format /usr/bin/clang-format-9 10 && \
-    update-alternatives --install /usr/bin/clang-tidy    clang-tidy   /usr/bin/clang-tidy-9   10 && \
-    update-alternatives --install /usr/bin/llvm-config   llvm-config  /usr/bin/llvm-config-9  10 && \
-    update-alternatives --install /usr/bin/llvm-cov      llvm-cov     /usr/bin/llvm-cov-9     10
+    update-alternatives --install /usr/bin/gcc           gcc          /usr/bin/gcc-10          10 && \
+    update-alternatives --install /usr/bin/gcov          gcov         /usr/bin/gcov-10         10 && \
+    update-alternatives --install /usr/bin/g++           g++          /usr/bin/g++-10          10 && \
+    update-alternatives --install /usr/bin/clang++       clang++      /usr/bin/clang++-10      10 && \
+    update-alternatives --install /usr/bin/clang         clang        /usr/bin/clang-10        10 && \
+    update-alternatives --install /usr/bin/clang-format  clang-format /usr/bin/clang-format-10 10 && \
+    update-alternatives --install /usr/bin/clang-tidy    clang-tidy   /usr/bin/clang-tidy-10   10 && \
+    update-alternatives --install /usr/bin/llvm-config   llvm-config  /usr/bin/llvm-config-10  10 && \
+    update-alternatives --install /usr/bin/llvm-cov      llvm-cov     /usr/bin/llvm-cov-10     10
 
 # Latest versions that aren't available through apt or pip
 COPY install_cmake.sh    /opt/install_cmake.sh

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -6,6 +6,7 @@ development. It has recent versions of compilers, Qt, CMake and so on.
 ## Build Docker Image
 
 ```sh
+cd scripts/docker
 docker build -t "mediaelch-build:dev" .
 ```
 

--- a/scripts/docker/install_cmake.sh
+++ b/scripts/docker/install_cmake.sh
@@ -4,9 +4,9 @@ set -e
 
 cd ~
 mkdir temp && cd $_
-wget https://cmake.org/files/v3.16/cmake-3.16.1-Linux-x86_64.sh
+wget https://cmake.org/files/v3.18/cmake-3.18.3-Linux-x86_64.sh
 mkdir /opt/cmake
-sh cmake-3.16.1-Linux-x86_64.sh --prefix=/opt/cmake --skip-license
+sh cmake-3.18.3-Linux-x86_64.sh --prefix=/opt/cmake --skip-license
 ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
 cd ..
 rm -rf temp

--- a/scripts/docker/install_iwyu.sh
+++ b/scripts/docker/install_iwyu.sh
@@ -5,9 +5,9 @@ set -e
 cd ~
 git clone https://github.com/include-what-you-use/include-what-you-use.git
 cd include-what-you-use
-git checkout clang_9.0
+git checkout clang_10
 cd ..
 mkdir build && cd $_
-cmake -G "Unix Makefiles" -DIWYU_LLVM_ROOT_PATH=/usr/lib/llvm-9.0 ../include-what-you-use
+cmake -G "Unix Makefiles" -DIWYU_LLVM_ROOT_PATH=/usr/lib/llvm-10 ../include-what-you-use
 make -j4
 make install

--- a/scripts/run_clang_format.sh
+++ b/scripts/run_clang_format.sh
@@ -6,11 +6,14 @@ IFS=$'\n\t'
 cd "$(dirname "$0")/.."
 source scripts/utils.sh
 
-if [[ -x "$(command -v clang-format-9)" ]]; then
-	CF=clang-format-9
+if [[ -x "$(command -v clang-format-10)" ]]; then
+	CF=clang-format-10
+elif [[ -x "$(command -v clang-format-mp-10)" ]]; then
+	# MacPorts version
+	CF=clang-format-mp-10
 else
 	CF=clang-format
-	clang-format --version | grep " 9." > /dev/null || ( print_warning "WARNING: MediaElch requires clang-format version 9")
+	clang-format --version | grep " 10." > /dev/null || ( print_warning "WARNING: MediaElch requires clang-format version 10")
 fi
 
 print_important "Format all source files using ${CF}"

--- a/src/data/MediaInfoFile.cpp
+++ b/src/data/MediaInfoFile.cpp
@@ -12,11 +12,11 @@
 #include <QStringList>
 
 #ifdef Q_OS_WIN
-#define QString2MI(_DATA) QString(_DATA).toStdWString()
-#define MI2QString(_DATA) QString::fromStdWString(_DATA)
+#    define QString2MI(_DATA) QString(_DATA).toStdWString()
+#    define MI2QString(_DATA) QString::fromStdWString(_DATA)
 #else
-#define QString2MI(_DATA) QString{_DATA}.toUtf8().data()
-#define MI2QString(_DATA) QString((_DATA).c_str())
+#    define QString2MI(_DATA) QString{_DATA}.toUtf8().data()
+#    define MI2QString(_DATA) QString((_DATA).c_str())
 #endif
 
 MediaInfoFile::MediaInfoFile(const QString& filepath) : m_mediaInfo{std::make_unique<MediaInfoDLL::MediaInfo>()}

--- a/src/export/ExportTemplateLoader.cpp
+++ b/src/export/ExportTemplateLoader.cpp
@@ -7,11 +7,11 @@
 #include <QXmlStreamReader>
 
 #ifndef EXTERN_QUAZIP
-#include "quazip/quazip/quazip.h"
-#include "quazip/quazip/quazipfile.h"
+#    include "quazip/quazip/quazip.h"
+#    include "quazip/quazip/quazipfile.h"
 #else
-#include "quazip5/quazip.h"
-#include "quazip5/quazipfile.h"
+#    include "quazip5/quazip.h"
+#    include "quazip5/quazipfile.h"
 #endif
 
 #include "data/Storage.h"

--- a/src/globals/Helper.cpp
+++ b/src/globals/Helper.cpp
@@ -392,9 +392,9 @@ void applyStyle(QWidget* widget, bool removeFocus, bool /*isTable*/)
                              << "    color: #666666;"
 #ifndef Q_OS_WIN
                              << "    font-family: \"Helvetica Neue\";"
-#ifndef Q_OS_MACX
+#    ifndef Q_OS_MACX
                              << "    font-size: 12px;"
-#endif
+#    endif
 #endif
                              << "}"
 

--- a/src/log/Log.cpp
+++ b/src/log/Log.cpp
@@ -7,7 +7,7 @@
 static QFile data;
 
 #if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
-#include <unistd.h>
+#    include <unistd.h>
 #endif
 
 // Some colors

--- a/src/tv_shows/TvShowUpdater.cpp
+++ b/src/tv_shows/TvShowUpdater.cpp
@@ -6,11 +6,11 @@
 #include "globals/MessageIds.h"
 
 #ifndef EXTERN_QUAZIP
-#include "quazip/quazip/quazip.h"
-#include "quazip/quazip/quazipfile.h"
+#    include "quazip/quazip/quazip.h"
+#    include "quazip/quazip/quazipfile.h"
 #else
-#include "quazip5/quazip.h"
-#include "quazip5/quazipfile.h"
+#    include "quazip5/quazip.h"
+#    include "quazip5/quazipfile.h"
 #endif
 
 #include "scrapers/tv_show/TheTvDb.h"

--- a/src/ui/main/MainWindow.cpp
+++ b/src/ui/main/MainWindow.cpp
@@ -10,7 +10,7 @@
 #include <QToolBar>
 
 #ifdef Q_OS_MAC
-#include <QMenuBar>
+#    include <QMenuBar>
 #endif
 
 #include "data/Storage.h"

--- a/src/ui/music/MusicWidgetAlbum.cpp
+++ b/src/ui/music/MusicWidgetAlbum.cpp
@@ -10,7 +10,7 @@
 #include "ui/notifications/NotificationBox.h"
 
 #ifdef Q_OS_WIN
-#include <QGLFormat>
+#    include <QGLFormat>
 #endif
 #include <QPainter>
 

--- a/src/ui/notifications/Notificator.cpp
+++ b/src/ui/notifications/Notificator.cpp
@@ -2,8 +2,8 @@
 
 #include <QMessageBox>
 #ifdef Q_OS_MAC
-#include "ui/notifications/MacNotificationHandler.h"
-#include <ApplicationServices/ApplicationServices.h>
+#    include "ui/notifications/MacNotificationHandler.h"
+#    include <ApplicationServices/ApplicationServices.h>
 #endif
 
 Notificator::Notificator(QSystemTrayIcon* trayIcon, QWidget* parent) :


### PR DESCRIPTION
We now format our code base using clang-format-10 and no longer with
clang-format-9.  Also update clang and gcc dependencies to clang-10 and
gcc10 as well as CMake.

This requires us to use Ubuntu Focal Fossa in TravisCI.

For easier use on macOS, the `run_clang_format.sh` script now also
checks for the MacPorts version of clang-format.