### PR TITLE
[i18n] Use proper translation loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Note: You may need to set "DVD order" in your settings again as the internal set
  - Movies: Sub-folders are no longer handled as files (#978)
  - Downloads: Fix stylesheet of import dialog window (#984)
  - Fix ADE actor scraping (#1011)
+ - Use user's preferred UI language and not the system language (#1018)
 
 ### Changes
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,19 @@ static void loadStylesheet(QApplication& app)
     }
 }
 
+static void setupTranslation(const QString& filename)
+{
+    QTranslator* qtTranslator = new QTranslator(QCoreApplication::instance());
+    // advanced settings are already loaded in Setting's constructor.
+    QLocale locale = Settings::instance()->advanced()->locale();
+    if (qtTranslator->load(locale, filename, QLatin1String("_"), QLatin1String(":/i18n"), QLatin1String(".qm"))) {
+        QApplication::installTranslator(qtTranslator);
+    } else if (filename != "qt") {
+        // Only warn if "MediaElch" translation could not be loaded.
+        qWarning() << "[i18n] Could not load " << filename << "translation file for" << locale << locale.uiLanguages();
+    }
+}
+
 int main(int argc, char* argv[])
 {
     QApplication app(argc, argv);
@@ -65,23 +78,9 @@ int main(int argc, char* argv[])
     // with translated values to the settings dialog.
     qInstallMessageHandler(mediaelch::messageHandler);
 
-    // Qt localization
-    QTranslator qtTranslator;
-    // advanced settings are already loaded in Setting's constructor.
-    qtTranslator.load(":/i18n/qt_" + Settings::instance()->advanced()->locale().name());
-    QApplication::installTranslator(&qtTranslator);
-
     // MediaElch localization
-    QTranslator editTranslator;
-    const auto localFileName =
-        QStringLiteral("%1%2MediaElch_local.qm").arg(QCoreApplication::applicationDirPath(), QDir::separator());
-    const QFileInfo fi{localFileName};
-    if (fi.isFile()) {
-        editTranslator.load(localFileName);
-    } else {
-        editTranslator.load(Settings::instance()->advanced()->locale(), "MediaElch", "_", ":/i18n/", ".qm");
-    }
-    QApplication::installTranslator(&editTranslator);
+    setupTranslation(QLatin1String("qt"));
+    setupTranslation(QLatin1String("MediaElch"));
 
     // Load the system's settings, e.g. window position, etc.
     Settings::instance()->loadSettings();

--- a/src/settings/AdvancedSettings.cpp
+++ b/src/settings/AdvancedSettings.cpp
@@ -50,21 +50,19 @@ AdvancedSettings::AdvancedSettings()
     m_subtitleFilters = mediaelch::FileFilter({"*.idx", "*.sub", "*.srr", "*.srt", "*.ass", "*.ttml"});
 }
 
-void AdvancedSettings::setLocale(QString locale)
+void AdvancedSettings::setLocale(const QString& locale)
 {
-    locale = locale.trimmed();
-    if (locale.toLower() == "system") {
+    QString localeStr = locale.trimmed();
+    if (localeStr.isEmpty()) {
+        m_locale = QLocale(); // Qt default
+
+    } else if (locale.toLower() == "system" || locale == "C") {
         m_locale = QLocale::system();
 
     } else {
-        m_locale = QLocale(locale);
-        // If "locale" is not a valid locale, Qt uses the C locale.
-        // Because `.name()` also returns "C" instead of the systems locale,
-        // we have to check for it.
-        if (m_locale.name() == "C") {
-            m_locale = QLocale::system();
-        }
+        m_locale = QLocale(localeStr);
     }
+    QLocale::setDefault(m_locale);
 }
 
 bool AdvancedSettings::debugLog() const
@@ -211,7 +209,8 @@ QDebug operator<<(QDebug dbg, const AdvancedSettings& settings)
     };
 
     out << "Advanced settings:" << nl;
-    out << "    locale:                  " << QLocale::languageToString(settings.m_locale.language()) << nl;
+    out << "    locale:                  " << QLocale::languageToString(settings.m_locale.language()) << " ("
+        << QLocale::countryToString(settings.m_locale.country()) << ")" << nl;
     out << "    debugLog:                " << (settings.m_debugLog ? "true" : "false") << nl;
     out << "    logFile:                 " << settings.m_logFile << nl;
     out << "    forceCache:              " << (settings.m_forceCache ? "true" : "false") << nl;

--- a/src/settings/AdvancedSettings.h
+++ b/src/settings/AdvancedSettings.h
@@ -105,7 +105,7 @@ public:
     friend QDebug operator<<(QDebug dbg, const AdvancedSettings& settings);
 
 private:
-    void setLocale(QString locale);
+    void setLocale(const QString& locale);
 
 private:
     bool m_debugLog = false;


### PR DESCRIPTION
The article at [1] describes how to properly load translations.  While
MediaElch did load it partially correct, we had some special coding
that is now removed.

[1]: https://www.kdab.com/fixing-a-common-antipattern-when-loading-translations-in-qt/