### PR TITLE
[Menu] Add help menu for macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Note: You may need to set "DVD order" in your settings again as the internal set
  - Movies: Sub-folders are no longer handled as files (#978)
  - Downloads: Fix stylesheet of import dialog window (#984)
  - Fix ADE actor scraping (#1011)
- - Use user's preferred UI language and not the system language (#1018)
+ - Use user's preferred UI language and not the system language (#1002)
 
 ### Changes
 
@@ -29,6 +29,7 @@ Note: You may need to set "DVD order" in your settings again as the internal set
    In v2.6.4 MediaElch started to ignore the original title (i.e. did not save it) if it was the same
    as the "normal" title.  We now added an option to reverse this behavior.
  - TV shows and episodes now support TMDb IDs (#1010)
+ - macOS: A simple help menu with useful URLs is added (#1020)
 
 ### Internal Improvements and Changes
 

--- a/src/ui/main/MainWindow.cpp
+++ b/src/ui/main/MainWindow.cpp
@@ -1,18 +1,6 @@
 #include "MainWindow.h"
 #include "ui_MainWindow.h"
 
-#include <QCheckBox>
-#include <QDebug>
-#include <QDir>
-#include <QMessageBox>
-#include <QPainter>
-#include <QTimer>
-#include <QToolBar>
-
-#ifdef Q_OS_MAC
-#    include <QMenuBar>
-#endif
-
 #include "data/Storage.h"
 #include "globals/Globals.h"
 #include "globals/Helper.h"
@@ -37,6 +25,19 @@
 #include "ui/tv_show/TvShowMultiScrapeDialog.h"
 #include "ui/tv_show/TvShowSearch.h"
 
+#include <QCheckBox>
+#include <QDebug>
+#include <QDesktopServices>
+#include <QDir>
+#include <QMessageBox>
+#include <QPainter>
+#include <QTimer>
+#include <QToolBar>
+
+#ifdef Q_OS_MAC
+#    include <QMenuBar>
+#endif
+
 MainWindow* MainWindow::m_instance = nullptr;
 
 MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWindow)
@@ -48,6 +49,23 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
     mAbout->setMenuRole(QAction::AboutRole);
     auto* aboutDialog = new AboutDialog(this);
     connect(mAbout, &QAction::triggered, aboutDialog, &AboutDialog::exec);
+
+    QMenu* help = macMenuBar->addMenu("Help");
+    const auto addHelpUrl = [help](const QString& str, const QString& url) {
+        auto* action = help->addAction(str);
+        connect(action, &QAction::triggered, [url]() { QDesktopServices::openUrl(QUrl(url, QUrl::StrictMode)); });
+    };
+
+    addHelpUrl("FAQ", "https://mediaelch.github.io/mediaelch-doc/faq.html");
+    addHelpUrl("Troubleshooting", "https://mediaelch.github.io/mediaelch-doc/troubleshooting.html");
+    addHelpUrl("Report Issue", "https://mediaelch.github.io/mediaelch-doc/contributing/bug-reports.html");
+    help->addSeparator();
+    addHelpUrl("Release Notes", "https://mediaelch.github.io/mediaelch-doc/release-notes.html");
+    addHelpUrl("Documentation", "https://mediaelch.github.io/mediaelch-doc/");
+    addHelpUrl("Blog", "https://mediaelch.github.io/mediaelch-blog/posts/");
+    addHelpUrl("Official Kodi Forum", "https://forum.kodi.tv/");
+    help->addSeparator();
+    addHelpUrl("View License", "https://mediaelch.github.io/mediaelch-doc/license.html");
 #endif
 
     ui->setupUi(this);


### PR DESCRIPTION
A simple help menu for macOS which contains some useful URLs.

<img width="609" alt="Screen Shot 2020-09-27 at 11 56 23" src="https://user-images.githubusercontent.com/1667306/94361992-84631300-00b8-11eb-8e63-b7d880ac9264.png">
