### PR TITLE
[AdvancedSettings] Add possibility to use custom CSS file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Note: You may need to set "DVD order" in your settings again as the internal set
  - Movie: Add TMDb ID field to UI (#1022)
  - Movie: Add buttons that take you to the movie's IMDb/TMDb page (#684)
  - Movie Filter: Add "Has TMDb ID"/"No TMDb ID" filters (#684)
+ - Advanced Settings: You can now specify a custom stylesheet for MediaElch theme development (#1040)
 
 ### Internal Improvements and Changes
 

--- a/docs/advancedsettings.xml
+++ b/docs/advancedsettings.xml
@@ -36,6 +36,11 @@
     -->
     <gui>
         <forceCache>false</forceCache>
+        <!--
+            If set, MediaElch will load this stylesheet instead of the bundled `default.css`.
+            Only use this tag if you want to develop a custom MediaElch theme for the main window.
+        -->
+        <!--<stylesheet>./path/relative/to/Mediaelch.css</stylesheet>-->
     </gui>
 
     <!--

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,18 +29,25 @@ static void initLogFile()
         QObject::tr("The logfile %1 could not be openend for writing.").arg(logFile));
 }
 
-static void loadStylesheet(QApplication& app)
+static void loadStylesheet(QApplication& app, const QString& customStylesheet)
 {
-    QFile file(":/src/ui/default.css");
+    QString filename = customStylesheet.isEmpty() ? ":/src/ui/default.css" : customStylesheet;
+    QFile file(filename);
     if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        if (!customStylesheet.isEmpty()) {
+            qInfo() << "Using custom stylesheet from:" << customStylesheet;
+        }
         app.setStyleSheet(file.readAll());
         file.close();
 
     } else {
-        qCritical() << "The default stylesheet could not be openend for reading.";
-        QMessageBox::critical(nullptr,
-            QObject::tr("Stylesheet could not be opened!"),
-            QObject::tr("The default stylesheet could not be openend for reading."));
+        qCritical() << "The stylesheet could not be openend for reading:" << filename;
+        const QString heading = QObject::tr("Stylesheet could not be opened!");
+        const QString body = customStylesheet.isEmpty()
+                                 ? QObject::tr("The default stylesheet could not be openend for reading.")
+                                 : QObject::tr("The custom stylesheet could not be openend for reading. Using: %1")
+                                       .arg(customStylesheet);
+        QMessageBox::critical(nullptr, heading, body);
     }
 }
 
@@ -86,7 +93,7 @@ int main(int argc, char* argv[])
     Settings::instance()->loadSettings();
 
     initLogFile();
-    loadStylesheet(app);
+    loadStylesheet(app, Settings::instance()->advanced()->customStylesheet());
 
     MainWindow window;
     window.show();

--- a/src/settings/AdvancedSettings.cpp
+++ b/src/settings/AdvancedSettings.cpp
@@ -85,6 +85,11 @@ QStringList AdvancedSettings::sortTokens() const
     return m_sortTokens;
 }
 
+QString AdvancedSettings::customStylesheet() const
+{
+    return m_customStylesheet;
+}
+
 QHash<QString, QString> AdvancedSettings::genreMappings() const
 {
     return m_genreMappings;
@@ -214,6 +219,8 @@ QDebug operator<<(QDebug dbg, const AdvancedSettings& settings)
     out << "    debugLog:                " << (settings.m_debugLog ? "true" : "false") << nl;
     out << "    logFile:                 " << settings.m_logFile << nl;
     out << "    forceCache:              " << (settings.m_forceCache ? "true" : "false") << nl;
+    out << "    stylesheet:              "
+        << (settings.m_customStylesheet.isEmpty() ? "<bundled>" : settings.m_customStylesheet) << nl;
     out << "    sortTokens:              " << settings.m_sortTokens.join(", ") << nl;
     out << "    movieFilters:            " << settings.m_movieFilters.filters().join(", ") << nl;
     out << "    concertFilters:          " << settings.m_concertFilters.filters().join(", ") << nl;

--- a/src/settings/AdvancedSettings.h
+++ b/src/settings/AdvancedSettings.h
@@ -78,6 +78,7 @@ public:
     QString logFile() const;
     QLocale locale() const;
     QStringList sortTokens() const;
+    QString customStylesheet() const;
     QHash<QString, QString> genreMappings() const;
 
     const mediaelch::FileFilter& movieFilters() const;
@@ -112,6 +113,7 @@ private:
     QString m_logFile;
     QLocale m_locale;
     QStringList m_sortTokens;
+    QString m_customStylesheet;
     QHash<QString, QString> m_genreMappings;
     mediaelch::FileFilter m_movieFilters;
     mediaelch::FileFilter m_concertFilters;

--- a/src/settings/AdvancedSettingsXmlReader.cpp
+++ b/src/settings/AdvancedSettingsXmlReader.cpp
@@ -174,6 +174,8 @@ void AdvancedSettingsXmlReader::loadGui()
     while (m_xml.readNextStartElement()) {
         if (m_xml.name() == "forceCache") {
             expectBool(m_settings.m_forceCache);
+        } else if (m_xml.name() == "stylesheet") {
+            m_settings.m_customStylesheet = m_xml.readElementText().trimmed();
         } else {
             skipUnsupportedTag();
         }


### PR DESCRIPTION
This commit introduced the option `<stylesheet>` which allows users to
use a custom CSS file.  This is intended for developing MediaElch themes
(for the main window).

-------

Haven't tested this PR, yet. Just coded this off the top of my head.