### PR TITLE
[Downloads] Use a queued connection for the download manager everywhere

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -4,6 +4,7 @@
 #include "cli/list.h"
 #include "cli/reload.h"
 #include "cli/show.h"
+#include "globals/Meta.h"
 #include "settings/Settings.h"
 
 #include <QApplication>
@@ -150,6 +151,7 @@ static int parseArguments(QApplication& app)
 int main(int argc, char** argv)
 {
     QApplication app(argc, argv);
+    registerAllMetaTypes();
 
     QCoreApplication::setOrganizationName(mediaelch::constants::OrganizationName);
     QCoreApplication::setApplicationName(mediaelch::constants::AppName);

--- a/src/concerts/ConcertController.cpp
+++ b/src/concerts/ConcertController.cpp
@@ -17,12 +17,16 @@
 ConcertController::ConcertController(Concert* parent) :
     QObject(parent), m_concert{parent}, m_downloadManager{new DownloadManager(this)}
 {
-    connect(m_downloadManager, &DownloadManager::sigDownloadFinished, this, &ConcertController::onDownloadFinished);
+    connect(m_downloadManager,
+        &DownloadManager::sigDownloadFinished,
+        this,
+        &ConcertController::onDownloadFinished,
+        static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
     connect(m_downloadManager,
         &DownloadManager::allConcertDownloadsFinished,
         this,
         &ConcertController::onAllDownloadsFinished,
-        Qt::UniqueConnection);
+        static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
 }
 
 Concert* ConcertController::concert()

--- a/src/data/ImageCache.cpp
+++ b/src/data/ImageCache.cpp
@@ -26,7 +26,7 @@ ImageCache::ImageCache(QObject* parent) : QObject(parent)
     if (exists) {
         m_cacheDir = location;
     }
-    qDebug() << "Cache dir" << m_cacheDir;
+    qDebug() << "[ImageCache] Using cache dir:" << m_cacheDir;
 
     m_forceCache = Settings::instance()->advanced()->forceCache();
 }

--- a/src/globals/DownloadManagerElement.h
+++ b/src/globals/DownloadManagerElement.h
@@ -37,3 +37,6 @@ public:
     template<class T>
     T* getElement();
 };
+
+// required for QVariant
+Q_DECLARE_METATYPE(DownloadManagerElement)

--- a/src/globals/Meta.cpp
+++ b/src/globals/Meta.cpp
@@ -1,3 +1,8 @@
 #include "globals/Meta.h"
 
-// Empty
+#include "globals/DownloadManagerElement.h"
+
+void registerAllMetaTypes()
+{
+    qRegisterMetaType<DownloadManagerElement>();
+}

--- a/src/globals/Meta.h
+++ b/src/globals/Meta.h
@@ -5,6 +5,13 @@
 #define ELCH_NODISCARD Q_REQUIRED_RESULT
 #define ELCH_DEPRECATED Q_DECL_DEPRECATED
 
+/// \brief Registers some common types using qRegisterMetaType
+/// \details Qt's queued connections require that types are registered using
+///          qRegisterMetaType.  Q_DECLARE_METATYPE is not enough.
+///          To avoid registering these types multiple times, this function is
+///          called once on startup.
+void registerAllMetaTypes();
+
 // Partially copied from Qt: qtbase/src/corelib/global/qglobal.h
 // Qt 5.5 does not support Overload so we have to provide it ourselves.
 // This code can be removed when Qt 5.6 is required.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,6 +67,7 @@ static void setupTranslation(const QString& filename)
 int main(int argc, char* argv[])
 {
     QApplication app(argc, argv);
+    registerAllMetaTypes();
 
     QCoreApplication::setOrganizationName(mediaelch::constants::OrganizationName);
     QCoreApplication::setApplicationName(mediaelch::constants::AppName);

--- a/src/movies/MovieController.cpp
+++ b/src/movies/MovieController.cpp
@@ -29,12 +29,16 @@ MovieController::MovieController(Movie* parent) :
     m_forceFanartCdArt{false},
     m_forceFanartLogo{false}
 {
-    connect(m_downloadManager, &DownloadManager::sigDownloadFinished, this, &MovieController::onDownloadFinished);
+    connect(m_downloadManager,
+        &DownloadManager::sigDownloadFinished,
+        this,
+        &MovieController::onDownloadFinished,
+        static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
     connect(m_downloadManager,
         &DownloadManager::allMovieDownloadsFinished,
         this,
         &MovieController::onAllDownloadsFinished,
-        Qt::UniqueConnection);
+        static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
 }
 
 bool MovieController::saveData(MediaCenterInterface* mediaCenterInterface)

--- a/src/music/AlbumController.cpp
+++ b/src/music/AlbumController.cpp
@@ -16,12 +16,16 @@ AlbumController::AlbumController(Album* parent) :
     m_infoFromNfoLoaded{false},
     m_downloadManager{new DownloadManager(this)}
 {
-    connect(m_downloadManager, &DownloadManager::sigDownloadFinished, this, &AlbumController::onDownloadFinished);
+    connect(m_downloadManager,
+        &DownloadManager::sigDownloadFinished,
+        this,
+        &AlbumController::onDownloadFinished,
+        static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
     connect(m_downloadManager,
         &DownloadManager::allAlbumDownloadsFinished,
         this,
         &AlbumController::onAllDownloadsFinished,
-        Qt::UniqueConnection);
+        static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
 }
 
 AlbumController::~AlbumController() = default;

--- a/src/music/ArtistController.cpp
+++ b/src/music/ArtistController.cpp
@@ -18,12 +18,16 @@ ArtistController::ArtistController(Artist* parent) :
     m_infoFromNfoLoaded{false},
     m_downloadManager{new DownloadManager(this)}
 {
-    connect(m_downloadManager, &DownloadManager::sigDownloadFinished, this, &ArtistController::onDownloadFinished);
+    connect(m_downloadManager,
+        &DownloadManager::sigDownloadFinished,
+        this,
+        &ArtistController::onDownloadFinished,
+        static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
     connect(m_downloadManager,
         &DownloadManager::allDownloadsFinished,
         this,
         &ArtistController::onAllDownloadsFinished,
-        Qt::UniqueConnection);
+        static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
 }
 
 bool ArtistController::loadData(MediaCenterInterface* mediaCenterInterface, bool force, bool reloadFromNfo)

--- a/src/network/NetworkManager.cpp
+++ b/src/network/NetworkManager.cpp
@@ -5,6 +5,15 @@
 namespace mediaelch {
 namespace network {
 
+NetworkManager::NetworkManager(QObject* parent) : QObject(parent)
+{
+    // Mapping of important signals
+    // clang-format off
+    connect(&m_qnam, &QNetworkAccessManager::authenticationRequired, this, &NetworkManager::authenticationRequired, Qt::UniqueConnection);
+    connect(&m_qnam, &QNetworkAccessManager::finished,               this, &NetworkManager::finished,               Qt::UniqueConnection);
+    // clang-format on
+}
+
 QNetworkReply* NetworkManager::get(const QNetworkRequest& request)
 {
     return m_qnam.get(request);

--- a/src/network/NetworkManager.h
+++ b/src/network/NetworkManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QAuthenticator>
 #include <QByteArray>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
@@ -14,7 +15,7 @@ class NetworkManager : public QObject
 {
     Q_OBJECT
 public:
-    explicit NetworkManager(QObject* parent = nullptr) : QObject(parent) {}
+    explicit NetworkManager(QObject* parent = nullptr);
     ~NetworkManager() override = default;
 
 public:
@@ -26,6 +27,7 @@ public:
 
 signals:
     void authenticationRequired(QNetworkReply* reply, QAuthenticator* authenticator);
+    void finished(QNetworkReply* reply);
 
 private:
     QNetworkAccessManager m_qnam;

--- a/src/scrapers/image/FanartTv.cpp
+++ b/src/scrapers/image/FanartTv.cpp
@@ -306,7 +306,8 @@ void FanartTv::loadMovieData(TmdbId tmdbId, QVector<ImageType> types, Movie* mov
     QUrl url = QStringLiteral("https://webservice.fanart.tv/v3/movies/%1?%2").arg(tmdbId.toString(), keyParameter());
     QNetworkRequest request = mediaelch::network::jsonRequestWithDefaults(url);
 
-    qDebug() << "[FanartTv] Load movie data with image types:" << url;
+    qDebug() << "[FanartTv] Load movie data with image types:"
+             << url.toString(QUrl::RemoveQuery); // query not relevant as it only contains the API key
 
     QNetworkReply* reply = network()->get(request);
     reply->setProperty("storage", Storage::toVariant(reply, movie));

--- a/src/ui/imports/ImportDialog.cpp
+++ b/src/ui/imports/ImportDialog.cpp
@@ -33,8 +33,11 @@ ImportDialog::ImportDialog(QWidget* parent) : QDialog(parent), ui(new Ui::Import
     m_timer.setInterval(500);
 
     m_posterDownloadManager = new DownloadManager(this);
-    connect(
-        m_posterDownloadManager, &DownloadManager::sigDownloadFinished, this, &ImportDialog::onEpisodeDownloadFinished);
+    connect(m_posterDownloadManager,
+        &DownloadManager::sigDownloadFinished,
+        this,
+        &ImportDialog::onEpisodeDownloadFinished,
+        static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
 
     connect(ui->movieSearchWidget, &MovieSearchWidget::sigResultClicked, this, &ImportDialog::onMovieChosen);
     connect(ui->concertSearchWidget, &ConcertSearchWidget::sigResultClicked, this, &ImportDialog::onConcertChosen);

--- a/src/ui/main/MainWindow.cpp
+++ b/src/ui/main/MainWindow.cpp
@@ -362,7 +362,6 @@ void MainWindow::progressProgress(int current, int max, int id)
  */
 void MainWindow::progressFinished(int id)
 {
-    qDebug() << "Entered, id=" << id;
     NotificationBox::instance()->hideProgressBar(id);
 }
 

--- a/src/ui/movie_sets/SetsWidget.cpp
+++ b/src/ui/movie_sets/SetsWidget.cpp
@@ -54,7 +54,7 @@ SetsWidget::SetsWidget(QWidget* parent) : QWidget(parent), ui(new Ui::SetsWidget
     connect(ui->backdrop,              &MyLabel::clicked,                     this, &SetsWidget::chooseSetBackdrop);
     connect(ui->buttonPreviewPoster,   &QAbstractButton::clicked,             this, &SetsWidget::onPreviewPoster);
     connect(ui->buttonPreviewBackdrop, &QAbstractButton::clicked,             this, &SetsWidget::onPreviewBackdrop);
-    connect(m_downloadManager,         &DownloadManager::sigDownloadFinished, this, &SetsWidget::onDownloadFinished);
+    connect(m_downloadManager,         &DownloadManager::sigDownloadFinished, this, &SetsWidget::onDownloadFinished, static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
     // clang-format on
 
     ui->sets->setContextMenuPolicy(Qt::CustomContextMenu);

--- a/src/ui/tv_show/TvShowMultiScrapeDialog.cpp
+++ b/src/ui/tv_show/TvShowMultiScrapeDialog.cpp
@@ -141,9 +141,16 @@ TvShowMultiScrapeDialog::TvShowMultiScrapeDialog(QVector<TvShow*> shows,
     m_currentScraper = Manager::instance()->scrapers().tvScrapers().at(0);
 
     m_downloadManager = new DownloadManager(this);
-    connect(m_downloadManager, &DownloadManager::sigElemDownloaded, this, &TvShowMultiScrapeDialog::onDownloadFinished);
-    connect(
-        m_downloadManager, &DownloadManager::allDownloadsFinished, this, &TvShowMultiScrapeDialog::onDownloadsFinished);
+    connect(m_downloadManager,
+        &DownloadManager::sigElemDownloaded,
+        this,
+        &TvShowMultiScrapeDialog::onDownloadFinished,
+        static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
+    connect(m_downloadManager,
+        &DownloadManager::allDownloadsFinished,
+        this,
+        &TvShowMultiScrapeDialog::onDownloadsFinished,
+        static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
 }
 
 TvShowMultiScrapeDialog::~TvShowMultiScrapeDialog()

--- a/src/ui/tv_show/TvShowWidgetEpisode.cpp
+++ b/src/ui/tv_show/TvShowWidgetEpisode.cpp
@@ -68,7 +68,8 @@ TvShowWidgetEpisode::TvShowWidgetEpisode(QWidget* parent) :
     connect(m_posterDownloadManager,
         &DownloadManager::sigDownloadFinished,
         this,
-        &TvShowWidgetEpisode::onPosterDownloadFinished);
+        &TvShowWidgetEpisode::onPosterDownloadFinished,
+        static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
     connect(ui->buttonRevert, &QAbstractButton::clicked, this, &TvShowWidgetEpisode::onRevertChanges);
     connect(
         ui->buttonReloadStreamDetails, &QAbstractButton::clicked, this, &TvShowWidgetEpisode::onReloadStreamDetails);

--- a/src/ui/tv_show/TvShowWidgetSeason.cpp
+++ b/src/ui/tv_show/TvShowWidgetSeason.cpp
@@ -72,7 +72,11 @@ TvShowWidgetSeason::TvShowWidgetSeason(QWidget* parent) :
     }
 
     connect(ui->buttonRevert, &QAbstractButton::clicked, this, &TvShowWidgetSeason::onRevertChanges);
-    connect(m_downloadManager, &DownloadManager::sigDownloadFinished, this, &TvShowWidgetSeason::onDownloadFinished);
+    connect(m_downloadManager,
+        &DownloadManager::sigDownloadFinished,
+        this,
+        &TvShowWidgetSeason::onDownloadFinished,
+        static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
 
     ui->missingLabel->setVisible(false);
 

--- a/src/ui/tv_show/TvShowWidgetTvShow.cpp
+++ b/src/ui/tv_show/TvShowWidgetTvShow.cpp
@@ -119,7 +119,8 @@ TvShowWidgetTvShow::TvShowWidgetTvShow(QWidget* parent) :
     connect(m_posterDownloadManager,
         &DownloadManager::sigDownloadFinished,
         this,
-        &TvShowWidgetTvShow::onPosterDownloadFinished);
+        &TvShowWidgetTvShow::onPosterDownloadFinished,
+        static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
     connect(m_posterDownloadManager, &DownloadManager::showDownloadsLeft, this, &TvShowWidgetTvShow::onDownloadsLeft);
     connect(ui->actors, &QTableWidget::itemSelectionChanged, this, &TvShowWidgetTvShow::onActorChanged);
     connect(ui->actor, &MyLabel::clicked, this, &TvShowWidgetTvShow::onChangeActorImage);
@@ -720,7 +721,7 @@ void TvShowWidgetTvShow::onLoadDone(TvShow* show, QMap<ImageType, QVector<Poster
             &DownloadManager::allTvShowDownloadsFinished,
             this,
             &TvShowWidgetTvShow::onDownloadsFinished,
-            Qt::UniqueConnection);
+            static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
     } else if (show == m_show) {
         onSetEnabled(true);
         emit sigSetActionSearchEnabled(true, MainWidgets::TvShows);

--- a/test/integration/main.cpp
+++ b/test/integration/main.cpp
@@ -1,6 +1,7 @@
 #define CATCH_CONFIG_RUNNER
 #include "third_party/catch2/catch.hpp"
 
+#include "globals/Meta.h"
 #include "test/integration/resource_dir.h"
 
 #include <QApplication>
@@ -16,6 +17,7 @@ int main(int argc, char** argv)
     qSetGlobalQHashSeed(0);
 
     QApplication app(argc, argv);
+    registerAllMetaTypes();
     Catch::Session session; // NOLINT(clang-analyzer-core.uninitialized.UndefReturn)
 
     std::string resourceDirString;

--- a/test/scrapers/main.cpp
+++ b/test/scrapers/main.cpp
@@ -1,11 +1,14 @@
 #define CATCH_CONFIG_RUNNER
 #include "third_party/catch2/catch.hpp"
 
+#include "globals/Meta.h"
+
 #include <QApplication>
 
 int main(int argc, char** argv)
 {
     QApplication app(argc, argv);
+    registerAllMetaTypes();
     Catch::Session session; // NOLINT(clang-analyzer-core.uninitialized.UndefReturn)
     const int res = session.run(argc, argv);
     return res;

--- a/test/unit/main.cpp
+++ b/test/unit/main.cpp
@@ -1,11 +1,14 @@
 #define CATCH_CONFIG_RUNNER
 #include "third_party/catch2/catch.hpp"
 
+#include "globals/Meta.h"
+
 #include <QApplication>
 
 int main(int argc, char** argv)
 {
     QApplication app(argc, argv);
+    registerAllMetaTypes();
     Catch::Session session; // NOLINT(clang-analyzer-core.uninitialized.UndefReturn)
     const int res = session.run(argc, argv);
     return res;


### PR DESCRIPTION
Fix  #1073

-------

I previously assumed that we had a threading issue.  But this is not
the case because connect() calls methods of DownloadManager only in one
thread, DownloadManager's thread.
But I forgot that signals (e.g. "emit sigFinished") call their slots
_immediately_ by default. This means we could end up in inconsistent
states because member variables are changed while we are still inside a
method that depends on them or has a previous state.  For example:

```
 addDownload()
   startNextDownload();
    on finished: downloadFinished()
      emit sigDownloadFinished(elem);
        some slot calls addDownload, m_currentDownloadElement changes
      emit sigElemDownloaded(elem);
        may emit wrong element
```

To avoid this, I've adapted all places where a connect() to this
download manager is used.  Those places now all used a queued
connection.

But to be more robust, we should refactor this class and get rid of
all member variables that may change state.
Also, this would allow parallel downloads.