### PR TITLE
[DownloadManager] Run up to 6 downloads in parallel; refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changes
 
- - *tbd*
+ - Image downloads are now run in parallel (up to 6 downloads) (#1077)
 
 ### Added
 

--- a/src/network/NetworkReplyWatcher.cpp
+++ b/src/network/NetworkReplyWatcher.cpp
@@ -2,6 +2,8 @@
 
 #include <QDebug>
 
+constexpr char NetworkReplyWatcher::TIMEOUT_PROP[];
+
 NetworkReplyWatcher::NetworkReplyWatcher(QObject* parent, QNetworkReply* reply) : QObject(parent), m_reply{nullptr}
 {
     connect(&m_timer, &QTimer::timeout, this, &NetworkReplyWatcher::onTimeout);
@@ -23,6 +25,7 @@ void NetworkReplyWatcher::setReply(QNetworkReply* reply)
 void NetworkReplyWatcher::onTimeout()
 {
     if (m_reply != nullptr) {
+        m_reply->setProperty(NetworkReplyWatcher::TIMEOUT_PROP, true);
         m_reply->abort();
     }
 }

--- a/src/network/NetworkReplyWatcher.h
+++ b/src/network/NetworkReplyWatcher.h
@@ -12,6 +12,10 @@
 class NetworkReplyWatcher : public QObject
 {
     Q_OBJECT
+
+public:
+    static constexpr char TIMEOUT_PROP[] = "wasTimeout";
+
 public:
     NetworkReplyWatcher(QObject* parent, QNetworkReply* reply);
     ~NetworkReplyWatcher() override = default;


### PR DESCRIPTION
Currently based on #1076

Previously, only one file was downloaded in parallel. We didn't use the users bandwidth. I refactored the code so that we now download up to 6 elements in parallel. Why 6? Because that's what [qnetworkaccessmanager](https://doc.qt.io/qt-5/qnetworkaccessmanager.html) does per default.

I (with a small 30MBit internet connection) can now load movies way faster.

```
12 years a slave
TMDb
Danish
52 Downloads

__Pre-Change__

Run 1)
Start: 16:02:12
End:   16:02:39
=> 27 seconds

Run 2) 
Start: 16:03:07
End:   16:03:24
=> 27 seconds


__Parallel__

Run 1)
Start: 15:59:27
End:   15:59:34
=> 7 seconds

Run 2)
Start: 16:00:43
End:   16:00:50
=> 7 seconds
```

3-4 times faster :tada:

I have learned from my mistakes in the past and won't merge this for the next MediaElch release. I would only introduce issues that I didn't think of, yet...
