### PR TITLE
[NotificationBox] Hide message and change parent before deleting it

### DIFF
--- a/src/ui/main/Message.cpp
+++ b/src/ui/main/Message.cpp
@@ -117,12 +117,12 @@ void Message::timeout()
     emit sigHideMessage(m_id);
 }
 
-int Message::maxValue()
+int Message::maxValue() const
 {
     return ui->progressBar->maximum();
 }
 
-int Message::value()
+int Message::value() const
 {
     return ui->progressBar->value();
 }

--- a/src/ui/main/Message.h
+++ b/src/ui/main/Message.h
@@ -33,11 +33,12 @@ public:
     void setProgress(int current, int max);
     void setId(int id);
     int id() const;
-    int maxValue();
-    int value();
+    int maxValue() const;
+    int value() const;
 
 signals:
     void sigHideMessage(int);
+
 private slots:
     void timeout();
 

--- a/src/ui/notifications/NotificationBox.cpp
+++ b/src/ui/notifications/NotificationBox.cpp
@@ -7,13 +7,9 @@
 NotificationBox::NotificationBox(QWidget* parent) : QWidget(parent), ui(new Ui::NotificationBox)
 {
     ui->setupUi(this);
-    m_msgCounter = 0;
     hide();
 }
 
-/**
- * \brief NotificationBox::~NotificationBox
- */
 NotificationBox::~NotificationBox()
 {
     delete ui;
@@ -26,10 +22,7 @@ NotificationBox::~NotificationBox()
  */
 NotificationBox* NotificationBox::instance(QWidget* parent)
 {
-    static NotificationBox* m_instance = nullptr;
-    if (m_instance == nullptr) {
-        m_instance = new NotificationBox(parent);
-    }
+    static NotificationBox* m_instance = new NotificationBox(parent);
     return m_instance;
 }
 

--- a/src/ui/notifications/NotificationBox.cpp
+++ b/src/ui/notifications/NotificationBox.cpp
@@ -75,6 +75,15 @@ void NotificationBox::removeMessage(int id)
         auto* msg = m_messages[i];
         if (msg->id() == id) {
             ui->layoutMessages->removeWidget(msg);
+            // Important:
+            // removeWidget() does not change the widget's ownership.
+            // The ownership was transferred to the layout by calling addWidget().
+            // Because we still want to delete the widget, first hide it then
+            // change ownership and only after that delete it.
+            // On systems with Kvantum theme, e.g Manjaro with XFCE, MediaElch
+            // would crash due to SEGFAULT.
+            msg->hide();
+            msg->setParent(this);
             msg->deleteLater();
             m_messages.removeAt(i);
         } else {

--- a/src/ui/notifications/NotificationBox.cpp
+++ b/src/ui/notifications/NotificationBox.cpp
@@ -68,22 +68,20 @@ int NotificationBox::showMessage(QString message, NotificationType type, std::ch
     return m_msgCounter;
 }
 
-/**
- * \brief Removes a message
- * \param id Id of the message to remove
- */
 void NotificationBox::removeMessage(int id)
 {
-    qDebug() << "Entered, id=" << id;
-    for (Message* msg : m_messages) {
+    qDebug() << "[NotificationBox] Removing message with ID:" << id;
+    for (int i = 0; i < m_messages.count();) {
+        auto* msg = m_messages[i];
         if (msg->id() == id) {
             ui->layoutMessages->removeWidget(msg);
             msg->deleteLater();
-            // TODO: If there are multiple messages with this ID, we may run into an issue with the loop.
-            m_messages.removeOne(msg);
-            adjustSize();
+            m_messages.removeAt(i);
+        } else {
+            ++i;
         }
     }
+    adjustSize();
     if (m_messages.isEmpty()) {
         hide();
     }

--- a/src/ui/notifications/NotificationBox.h
+++ b/src/ui/notifications/NotificationBox.h
@@ -59,9 +59,11 @@ public slots:
     virtual void removeMessage(int id);
 
 private:
+    void adjustSize();
+
+private:
     Ui::NotificationBox* ui;
     QSize m_parentSize;
-    int m_msgCounter;
+    int m_msgCounter = 0;
     QVector<Message*> m_messages;
-    void adjustSize();
 };


### PR DESCRIPTION
removeWidget() does not change the widget's ownership.
The ownership was transferred to the layout by calling addWidget().
Because we still want to delete the widget, first hide it then
change ownership and only after that delete it.
On systems with Kvantum theme, e.g Manjaro with XFCE, MediaElch
would crash due to SEGFAULT.

-----


This should:

 - fix #1050
 - fix #1060
 - fix  #976
 - fix #1073