### PR TITLE
[TvShowSearch] Fix load/store of episode/show details and language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - TV search on TMDb: It is now possible to search for a show by its TMDb and IMDb ID,
    e.g. "tt0096697" or "456" for "The Simpsons"
  - Fix the immediate "network error"-message in the TV show image dialog (#1124)
+ - TV search: Episode and show details are stored per scraper (#801)
 
 ### Changes
 

--- a/src/settings/Settings.h
+++ b/src/settings/Settings.h
@@ -98,6 +98,9 @@ public:
     template<typename T>
     QSet<T> scraperInfos(QString scraperId); // TODO
 
+    QSet<ShowScraperInfo> scraperInfosShow(const QString& scraperId);
+    QSet<EpisodeScraperInfo> scraperInfosEpisode(const QString& scraperId);
+
     bool autoLoadStreamDetails() const;
 
     void setMainWindowSize(QSize mainWindowSize);
@@ -122,8 +125,8 @@ public:
     void setUsePlotForOutline(bool use);
     void setIgnoreDuplicateOriginalTitle(bool ignoreDuplicateOriginalTitle);
     void setScraperInfos(const QString& scraperNo, const QSet<MovieScraperInfo>& items);
-    void setScraperShowInfos(const QString& scraperNo, const QSet<ShowScraperInfo>& items);
-    void setScraperEpisodeInfos(const QString& scraperNo, const QSet<EpisodeScraperInfo>& items);
+    void setScraperInfosShow(const QString& scraperId, const QSet<ShowScraperInfo>& items);
+    void setScraperInfosEpisode(const QString& scraperId, const QSet<EpisodeScraperInfo>& items);
     void setScraperInfos(const QString& scraperNo, const QSet<ConcertScraperInfo>& items);
     void setScraperInfos(const QString& scraperNo, const QSet<MusicScraperInfo>& items);
     void setRenamePatterns(Renamer::RenameType renameType,

--- a/src/ui/tv_show/TvShowCommonWidgets.cpp
+++ b/src/ui/tv_show/TvShowCommonWidgets.cpp
@@ -16,30 +16,34 @@ void TvShowCommonWidgets::toggleInfoBoxesForScraper(const mediaelch::scraper::Tv
     showInfosGroupBox->setEnabled(enableShow);
 
     const auto& meta = scraper.meta();
-    const auto showInfos = Settings::instance()->scraperInfos<ShowScraperInfo>(meta.identifier);
-    const auto episodeInfos = Settings::instance()->scraperInfos<EpisodeScraperInfo>(meta.identifier);
+    const auto showInfos = Settings::instance()->scraperInfosShow(meta.identifier);
+    const auto episodeInfos = Settings::instance()->scraperInfosEpisode(meta.identifier);
+
+    const bool showBlocked = showInfosGroupBox->blockSignals(true);
+    const bool episodeBlocked = episodeInfosGroupBox->blockSignals(true);
 
     for (auto* box : showInfosGroupBox->findChildren<MyCheckBox*>()) {
         const auto detail = ShowScraperInfo(box->myData().toInt());
-        const bool enabled = enableShow && meta.supportedShowDetails.contains(detail);
-        const bool checked = enabled && (showInfos.isEmpty() || showInfos.contains(detail));
-        box->setChecked(checked);
-        box->setEnabled(enabled);
+        const bool supported = meta.supportedShowDetails.contains(detail);
+        box->setChecked(showInfos.contains(detail) && supported);
+        box->setEnabled(enableShow && supported);
     }
     for (auto* box : episodeInfosGroupBox->findChildren<MyCheckBox*>()) {
         const auto detail = EpisodeScraperInfo(box->myData().toInt());
-        const bool enabled = enableEpisode && meta.supportedEpisodeDetails.contains(detail);
-        const bool checked = enabled && (showInfos.isEmpty() || episodeInfos.contains(detail));
-        box->setChecked(checked);
-        box->setEnabled(enabled);
+        const bool supported = meta.supportedEpisodeDetails.contains(detail);
+        box->setChecked(episodeInfos.contains(detail) && supported);
+        box->setEnabled(enableEpisode && supported);
     }
+
+    showInfosGroupBox->blockSignals(showBlocked);
+    episodeInfosGroupBox->blockSignals(episodeBlocked);
 }
 
 SeasonOrder TvShowCommonWidgets::setupSeasonOrderComboBox(const mediaelch::scraper::TvScraper& scraper,
     SeasonOrder defaultSeasonOrder,
     QComboBox* comboSeasonOrder)
 {
-    comboSeasonOrder->blockSignals(true);
+    const bool blocked = comboSeasonOrder->blockSignals(true);
 
     const auto& supported = scraper.meta().supportedSeasonOrders;
 
@@ -59,6 +63,6 @@ SeasonOrder TvShowCommonWidgets::setupSeasonOrderComboBox(const mediaelch::scrap
         qCritical() << "[TvShowSearch] Couldn't find season order element in combo box";
     }
 
-    comboSeasonOrder->blockSignals(true);
+    comboSeasonOrder->blockSignals(blocked);
     return defaultSeasonOrder;
 }

--- a/src/ui/tv_show/TvShowCommonWidgets.h
+++ b/src/ui/tv_show/TvShowCommonWidgets.h
@@ -10,7 +10,8 @@
 class TvShowCommonWidgets
 {
 public:
-    /// \brief Enables/disables the episode/show info boxes to reflect what the given scraper supports.
+    /// \brief Enables/disables the episode/show info boxes
+    /// \details Does so to reflect what the given scraper supports and what the user saved.
     static void toggleInfoBoxesForScraper(const mediaelch::scraper::TvScraper& scraper,
         TvShowUpdateType type,
         QGroupBox* showInfosGroupBox,

--- a/src/ui/tv_show/TvShowMultiScrapeDialog.h
+++ b/src/ui/tv_show/TvShowMultiScrapeDialog.h
@@ -45,7 +45,6 @@ private slots:
     void onEpisodeLoadDone();
     void onLoadDone(TvShow* show, QMap<ImageType, QVector<Poster>> posters);
     void onDownloadFinished(DownloadManagerElement elem);
-    void onDownloadsFinished();
 
     void onScraperChanged(int index);
     void onLanguageChanged(int index);
@@ -60,20 +59,21 @@ private:
     QSet<EpisodeScraperInfo> m_episodeDetailsToLoad;
     QQueue<TvShow*> m_showQueue;
     QQueue<TvShowEpisode*> m_episodeQueue;
-    QPointer<TvShow> m_currentShow;
-    QPointer<TvShowEpisode> m_currentEpisode;
-    mediaelch::scraper::TvScraper* m_currentScraper;
+    QPointer<TvShow> m_currentShow = nullptr;
+    QPointer<TvShowEpisode> m_currentEpisode = nullptr;
+    mediaelch::scraper::TvScraper* m_currentScraper = nullptr;
     mediaelch::Locale m_locale = mediaelch::Locale::English;
     DownloadManager* m_downloadManager;
     QMap<QString, mediaelch::scraper::ShowIdentifier> m_showIds;
 
 private:
-    void setCheckBoxesEnabled();
     void setupLanguageDropdown();
     void setupScraperDropdown();
     void setupSeasonOrderComboBox();
     void updateCheckBoxes();
     void saveCurrentItem();
+
+    TvShowUpdateType updateType() const;
 
     void logToUser(const QString& msg);
 

--- a/src/ui/tv_show/TvShowSearchWidget.h
+++ b/src/ui/tv_show/TvShowSearchWidget.h
@@ -22,14 +22,16 @@ public:
     explicit TvShowSearchWidget(QWidget* parent = nullptr);
     ~TvShowSearchWidget() override;
 
-    QString showIdentifier();
+    void setSearchType(TvShowType type);
+
+    QString showIdentifier() const;
     mediaelch::scraper::TvScraper* scraper();
+
     const mediaelch::Locale& locale() const;
     SeasonOrder seasonOrder() const;
     const QSet<ShowScraperInfo>& showDetailsToLoad() const;
     const QSet<EpisodeScraperInfo>& episodeDetailsToLoad() const;
-    void setSearchType(TvShowType type);
-    TvShowUpdateType updateType();
+    TvShowUpdateType updateType() const;
 
 public slots:
     void search(QString searchString);
@@ -66,11 +68,12 @@ private:
 
 private:
     Ui::TvShowSearchWidget* ui = nullptr;
+    TvShowType m_searchType = TvShowType::None;
+
     QString m_showIdentifier;
     QSet<ShowScraperInfo> m_showDetailsToLoad;
     QSet<EpisodeScraperInfo> m_episodeDetailsToLoad;
     SeasonOrder m_seasonOrder = SeasonOrder::Aired;
-    TvShowType m_searchType = TvShowType::None;
     TvShowUpdateType m_updateType = TvShowUpdateType::Show;
 
     mediaelch::scraper::TvScraper* m_currentScraper = nullptr;


### PR DESCRIPTION
Episode and show details were not correctly stored.  MediaElch now uses
the scraper's id to store the selected episode and show details.

The same applies to the selected language.

---------

Fix #801