### PR TITLE
[NameFormatter] If exclude-words contain special characters, replace it

### DIFF
--- a/src/file/NameFormatter.cpp
+++ b/src/file/NameFormatter.cpp
@@ -21,12 +21,13 @@ QString NameFormatter::excludeWords(QString name)
             name.replace(word, "");
             continue;
         }
-        // ...or ignore words with special characters... (TODO: may not be safe)
+        // ...or just replace words with special characters...
         rx.setPattern("[$&+,:;=?@#|'<>.^*()%!-]");
         if (rx.match(word).hasMatch()) {
+            name.replace(word, "");
             continue;
         }
-        // ...otherwise who knows how this regex would look like
+        // ...otherwise who knows how this regex would look like (TODO: may not be safe)
         rx.setPattern(R"((^|[-_(\s.[,]+))" + word + R"(([-_\s.)\],]+|$))");
         if (!rx.isValid()) {
             continue;

--- a/test/unit/file/testNameFormatter.cpp
+++ b/test/unit/file/testNameFormatter.cpp
@@ -27,12 +27,13 @@ TEST_CASE("NameFormatter formats names", "[rename]")
             CHECK(nf.excludeWords("my[480i]movie") == "my movie");
         }
 
-        SECTION("Only match basic words and not special characters")
+        SECTION("Only match basic words and not regex special characters")
         {
             NameFormatter nf({".?", "(480i)", ".+"});
             CHECK(nf.excludeWords("my.movie.480i") == "my.movie.480i");
-            CHECK(nf.excludeWords("my(480i)movie") == "my(480i)movie");
-            CHECK(nf.excludeWords("480i-.+my-movie") == "480i-.+my-movie");
+            CHECK(nf.excludeWords("my.movie.?.?.?480i") == "my.movie480i");
+            CHECK(nf.excludeWords("my(480i)movie") == "mymovie");
+            CHECK(nf.excludeWords("480i-..+my-movie") == "480i-.my-movie");
         }
 
         SECTION("Match braces")


### PR DESCRIPTION
Just replacing it is better than ignoring the word.

Fix #1131