### PR TITLE
[TvShowEpisode] Disable thumbnail download if not wanted 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ create-dmg/
 
 # IDEs
 .vscode
+.idea
+cmake-build-debug
 
 # Fake data
 scripts/generated_media

--- a/src/scrapers/movie/imdb/CMakeLists.txt
+++ b/src/scrapers/movie/imdb/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(mediaelch_scraper_movie_imdb OBJECT IMDb.cpp ImdbMovieScraper.cpp)
+add_library(mediaelch_scraper_movie_imdb OBJECT IMDB.cpp ImdbMovieScraper.cpp)
 
 target_link_libraries(
   mediaelch_scraper_movie_imdb PRIVATE Qt5::Sql Qt5::Widgets Qt5::Multimedia

--- a/src/scrapers/tv_show/ShowMerger.cpp
+++ b/src/scrapers/tv_show/ShowMerger.cpp
@@ -224,7 +224,9 @@ void copyDetailsToShow(TvShow& target, TvShow& source, const QSet<ShowScraperInf
 
 void copyDetailsToEpisode(TvShowEpisode& target, const TvShowEpisode& source, const QSet<EpisodeScraperInfo>& details)
 {
-    target.setWantThumbnailDownload(details.contains(EpisodeScraperInfo::Thumbnail));
+    if (details.contains(EpisodeScraperInfo::Thumbnail)){
+        target.setWantThumbnailDownload(true);
+    }
     for (EpisodeScraperInfo detail : details) {
         copyDetailToEpisode(target, source, detail);
     }

--- a/src/scrapers/tv_show/ShowMerger.cpp
+++ b/src/scrapers/tv_show/ShowMerger.cpp
@@ -224,13 +224,10 @@ void copyDetailsToShow(TvShow& target, TvShow& source, const QSet<ShowScraperInf
 
 void copyDetailsToEpisode(TvShowEpisode& target, const TvShowEpisode& source, const QSet<EpisodeScraperInfo>& details)
 {
-    bool hasThumbnail = false;
+    target.setWantThumbnailDownload(details.contains(EpisodeScraperInfo::Thumbnail));
     for (EpisodeScraperInfo detail : details) {
-        if (detail == EpisodeScraperInfo::Thumbnail)
-            hasThumbnail = true;
         copyDetailToEpisode(target, source, detail);
     }
-  target.setWantThumbnailDownload(hasThumbnail);
 }
 
 void copyDetailsToShowEpisodes(TvShow& target,

--- a/src/scrapers/tv_show/ShowMerger.cpp
+++ b/src/scrapers/tv_show/ShowMerger.cpp
@@ -224,9 +224,13 @@ void copyDetailsToShow(TvShow& target, TvShow& source, const QSet<ShowScraperInf
 
 void copyDetailsToEpisode(TvShowEpisode& target, const TvShowEpisode& source, const QSet<EpisodeScraperInfo>& details)
 {
+    bool hasThumbnail = false;
     for (EpisodeScraperInfo detail : details) {
+        if (detail == EpisodeScraperInfo::Thumbnail)
+            hasThumbnail = true;
         copyDetailToEpisode(target, source, detail);
     }
+  target.setWantThumbnailDownload(hasThumbnail);
 }
 
 void copyDetailsToShowEpisodes(TvShow& target,

--- a/src/tv_shows/TvShowEpisode.cpp
+++ b/src/tv_shows/TvShowEpisode.cpp
@@ -893,6 +893,16 @@ bool TvShowEpisode::isDummy() const
     return m_isDummy;
 }
 
+void TvShowEpisode::setWantThumbnailDownload(bool wantThumbnail)
+{
+    m_want_thumbnail_download = wantThumbnail;
+}
+
+bool TvShowEpisode::wantThumbnailDownload() const
+{
+  return m_want_thumbnail_download;
+}
+
 QVector<const Actor*> TvShowEpisode::actors() const
 {
     QVector<const Actor*> actorPtrs;

--- a/src/tv_shows/TvShowEpisode.cpp
+++ b/src/tv_shows/TvShowEpisode.cpp
@@ -900,7 +900,7 @@ void TvShowEpisode::setWantThumbnailDownload(bool wantThumbnail)
 
 bool TvShowEpisode::wantThumbnailDownload() const
 {
-  return m_wantThumbnailDownload;
+    return m_wantThumbnailDownload;
 }
 
 QVector<const Actor*> TvShowEpisode::actors() const

--- a/src/tv_shows/TvShowEpisode.cpp
+++ b/src/tv_shows/TvShowEpisode.cpp
@@ -895,12 +895,12 @@ bool TvShowEpisode::isDummy() const
 
 void TvShowEpisode::setWantThumbnailDownload(bool wantThumbnail)
 {
-    m_want_thumbnail_download = wantThumbnail;
+    m_wantThumbnailDownload = wantThumbnail;
 }
 
 bool TvShowEpisode::wantThumbnailDownload() const
 {
-  return m_want_thumbnail_download;
+  return m_wantThumbnailDownload;
 }
 
 QVector<const Actor*> TvShowEpisode::actors() const

--- a/src/tv_shows/TvShowEpisode.h
+++ b/src/tv_shows/TvShowEpisode.h
@@ -125,7 +125,7 @@ public:
     void setDatabaseId(int id);
     void setSyncNeeded(bool syncNeeded);
     void setIsDummy(bool dummy);
-  void setWantThumbnailDownload(bool);
+    void setWantThumbnailDownload(bool wantThumbnail);
 
     void removeWriter(QString* writer);
     void removeDirector(QString* director);

--- a/src/tv_shows/TvShowEpisode.h
+++ b/src/tv_shows/TvShowEpisode.h
@@ -92,6 +92,7 @@ public:
     int databaseId() const;
     bool syncNeeded() const;
     bool isDummy() const;
+    bool wantThumbnailDownload() const;
 
     void setShow(TvShow* show);
     void setTitle(QString title);
@@ -124,6 +125,7 @@ public:
     void setDatabaseId(int id);
     void setSyncNeeded(bool syncNeeded);
     void setIsDummy(bool dummy);
+  void setWantThumbnailDownload(bool);
 
     void removeWriter(QString* writer);
     void removeDirector(QString* director);
@@ -209,6 +211,7 @@ private:
     QVector<ImageType> m_imagesToRemove;
     bool m_isDummy = false;
     std::vector<std::unique_ptr<Actor>> m_actors;
+    bool m_want_thumbnail_download = false;
 };
 
 QDebug operator<<(QDebug dbg, const TvShowEpisode& episode);

--- a/src/tv_shows/TvShowEpisode.h
+++ b/src/tv_shows/TvShowEpisode.h
@@ -211,7 +211,7 @@ private:
     QVector<ImageType> m_imagesToRemove;
     bool m_isDummy = false;
     std::vector<std::unique_ptr<Actor>> m_actors;
-    bool m_want_thumbnail_download = false;
+    bool m_wantThumbnailDownload = false;
 };
 
 QDebug operator<<(QDebug dbg, const TvShowEpisode& episode);

--- a/src/ui/tv_show/TvShowWidgetEpisode.cpp
+++ b/src/ui/tv_show/TvShowWidgetEpisode.cpp
@@ -701,7 +701,7 @@ void TvShowWidgetEpisode::onLoadDone()
     updateEpisodeInfo();
     onSetEnabled(true);
 
-    if (!m_episode->thumbnail().isEmpty()) {
+    if (!m_episode->thumbnail().isEmpty() && m_episode->wantThumbnailDownload()) {
         DownloadManagerElement d;
         d.imageType = ImageType::TvShowEpisodeThumb;
         d.url = m_episode->thumbnail();


### PR DESCRIPTION
* Add field, getter and setter for wanting to download thumbnail (`m_want_thumbnail_download`)
 * Add detection of `EpisodeScraperInfo::Thumbnail` in `copyDetailsToEpisode` to check if thumbnail was selected in episode scraper settings
 * Fix IMDB scraper's CMakeLists.txt (for case-sensitive filesystem)
 * Add CLion-specific folders in .gitignore