### PR TITLE
[Kodi] Add "generator" tag to NFO files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 
 ### Changes
 
- - *tbd*
+ - NFO files now contain a `<generator>` tag which holds meta information about MediaElch.  
+   This may be helpful when users complain about Kodi not displaying certain details on the Kodi forum.
 
 ### Added
 

--- a/src/media_centers/kodi/AlbumXmlWriter.h
+++ b/src/media_centers/kodi/AlbumXmlWriter.h
@@ -9,7 +9,7 @@ class AlbumXmlWriter
 {
 public:
     virtual ~AlbumXmlWriter() = default;
-    virtual QByteArray getAlbumXml() = 0;
+    virtual QByteArray getAlbumXml(bool testMode = false) = 0;
 };
 
 } // namespace kodi

--- a/src/media_centers/kodi/ArtistXmlWriter.h
+++ b/src/media_centers/kodi/ArtistXmlWriter.h
@@ -11,7 +11,7 @@ class ArtistXmlWriter
 {
 public:
     virtual ~ArtistXmlWriter() = default;
-    virtual QByteArray getArtistXml() = 0;
+    virtual QByteArray getArtistXml(bool testMode = false) = 0;
 };
 
 } // namespace kodi

--- a/src/media_centers/kodi/ConcertXmlWriter.h
+++ b/src/media_centers/kodi/ConcertXmlWriter.h
@@ -11,7 +11,7 @@ class ConcertXmlWriter
 {
 public:
     virtual ~ConcertXmlWriter() = default;
-    virtual QByteArray getConcertXml() = 0;
+    virtual QByteArray getConcertXml(bool testMode = false) = 0;
 };
 
 } // namespace kodi

--- a/src/media_centers/kodi/EpisodeXmlWriter.cpp
+++ b/src/media_centers/kodi/EpisodeXmlWriter.cpp
@@ -7,9 +7,9 @@
 namespace mediaelch {
 namespace kodi {
 
-QString EpisodeXmlWriter::getEpisodeXmlWithSingleRoot()
+QString EpisodeXmlWriter::getEpisodeXmlWithSingleRoot(bool testMode)
 {
-    return EpisodeXmlReader::makeValidEpisodeXml(getEpisodeXml());
+    return EpisodeXmlReader::makeValidEpisodeXml(getEpisodeXml(testMode));
 }
 
 } // namespace kodi

--- a/src/media_centers/kodi/EpisodeXmlWriter.h
+++ b/src/media_centers/kodi/EpisodeXmlWriter.h
@@ -11,10 +11,10 @@ class EpisodeXmlWriter
 {
 public:
     virtual ~EpisodeXmlWriter() = default;
-    virtual QByteArray getEpisodeXml() = 0;
+    virtual QByteArray getEpisodeXml(bool testMode = false) = 0;
     /// Get the episode's XML content with an extra root element: <episodes>
     /// Used for testing to allow multi-episodes in one DOM.
-    virtual QString getEpisodeXmlWithSingleRoot();
+    virtual QString getEpisodeXmlWithSingleRoot(bool testMode);
 };
 
 } // namespace kodi

--- a/src/media_centers/kodi/KodiNfoMeta.cpp
+++ b/src/media_centers/kodi/KodiNfoMeta.cpp
@@ -7,11 +7,72 @@
 namespace mediaelch {
 namespace kodi {
 
-QString getKodiNfoComment()
+void addMediaelchGeneratorTag(QDomDocument& doc, KodiVersion::Version kodiVersion)
 {
-    return QString("created on %1 - by MediaElch version %2")
-        .arg(QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm:ss"), //
-            mediaelch::constants::AppVersionFullStr);
+    QDomNode rootNode = doc.firstChild();
+    while ((rootNode.nodeName() == "xml" || rootNode.isComment()) && !rootNode.isNull()) {
+        rootNode = rootNode.nextSibling();
+    }
+
+    // Remove existing "generator" tags
+    QDomNodeList childNodes = rootNode.childNodes();
+    QVector<QDomNode> nodesToRemove;
+    for (int i = 0, n = childNodes.count(); i < n; ++i) {
+        if (childNodes.at(i).nodeName() == "generator") {
+            nodesToRemove.append(childNodes.at(i));
+        }
+    }
+    for (const QDomNode& node : nodesToRemove) {
+        rootNode.removeChild(node);
+    }
+
+    // Proposed here:
+    // https://forum.kodi.tv/showthread.php?tid=347109
+    //
+    // <generator>
+    //     <appname>MediaElch</appname>              <!-- can be any string -->
+    //     <appversion>2.6.1-dev</appversion>        <!-- can be any string -->
+    //     <appdata>meta data or similar</appdata>   <!-- can be any data, e.g. multiline string, more tags, etc. -->
+    //     <kodiversion>18.4</kodiversion>           <!-- numerical representation of the target kodi version -->
+    //     <datetime>2019-09-09 11:04:10</datetime>  <!-- generation time -->
+    // </generator>
+
+    QDomElement generator = doc.createElement("generator");
+
+    QDomElement appName = doc.createElement("appname");
+    appName.appendChild(doc.createTextNode(mediaelch::constants::AppName));
+
+    QDomElement appVersion = doc.createElement("appversion");
+    appVersion.appendChild(doc.createTextNode(mediaelch::constants::AppVersionFullStr));
+
+    // TODO: Enable when the NFO writers are restructured. Currently there is a lot of
+    // duplicated code and v18 is just an alias for the v17 writer.
+    Q_UNUSED(kodiVersion)
+    // QDomElement kodiTarget = doc.createElement("kodiversion");
+    // kodiTarget.appendChild(doc.createTextNode(KodiVersion(kodiVersion).toString()));
+
+    QDomElement dateTime = doc.createElement("datetime");
+    dateTime.appendChild(doc.createTextNode(QDateTime::currentDateTimeUtc().toString(Qt::ISODate)));
+
+    generator.appendChild(appName);
+    generator.appendChild(appVersion);
+    // generator.appendChild(kodiTarget);
+    generator.appendChild(dateTime);
+
+    rootNode.appendChild(generator);
+}
+
+void addMediaelchGeneratorTag(QXmlStreamWriter& xml, KodiVersion::Version kodiVersion)
+{
+    xml.writeStartElement("generator");
+    xml.writeTextElement("appname", mediaelch::constants::AppName);
+    xml.writeTextElement("appversion", mediaelch::constants::AppVersionFullStr);
+    // TODO: Enable when the NFO writers are restructured. Currently there is a lot of
+    // duplicated code and v18 is just an alias for the v17 writer.
+    Q_UNUSED(kodiVersion)
+    // xml.writeTextElement("kodiversion", KodiVersion(kodiVersion).toString());
+    xml.writeTextElement("datetime", QDateTime::currentDateTimeUtc().toString(Qt::ISODate));
+    xml.writeEndElement();
 }
 
 } // namespace kodi

--- a/src/media_centers/kodi/KodiNfoMeta.h
+++ b/src/media_centers/kodi/KodiNfoMeta.h
@@ -1,13 +1,23 @@
 #pragma once
 
+#include "media_centers/KodiVersion.h"
+
+#include <QDomDocument>
 #include <QString>
+#include <QXmlStreamWriter>
 
 namespace mediaelch {
 namespace kodi {
 
-/// Returns a string containing basic meta information about the
-/// media manager used to create the NFO file (MediaElch)
-QString getKodiNfoComment();
+/// \brief Adds a xml <generator> tag to the given document.
+/// \details The <generator> tag contains MediaElch specific values and can be
+///          used for debugging purposes.
+void addMediaelchGeneratorTag(QDomDocument& doc, KodiVersion::Version kodiVersion);
+
+/// \brief Writes a xml <generator> tag to the given document.
+/// \details The <generator> tag contains MediaElch specific values and can be
+///          used for debugging purposes.
+void addMediaelchGeneratorTag(QXmlStreamWriter& xml, KodiVersion::Version kodiVersion);
 
 } // namespace kodi
 } // namespace mediaelch

--- a/src/media_centers/kodi/MovieXmlWriter.h
+++ b/src/media_centers/kodi/MovieXmlWriter.h
@@ -11,7 +11,7 @@ class MovieXmlWriter
 {
 public:
     virtual ~MovieXmlWriter() = default;
-    virtual QByteArray getMovieXml() = 0;
+    virtual QByteArray getMovieXml(bool testMode = false) = 0;
 };
 
 } // namespace kodi

--- a/src/media_centers/kodi/TvShowXmlWriter.h
+++ b/src/media_centers/kodi/TvShowXmlWriter.h
@@ -9,7 +9,7 @@ class TvShowXmlWriter
 {
 public:
     virtual ~TvShowXmlWriter() = default;
-    virtual QByteArray getTvShowXml() = 0;
+    virtual QByteArray getTvShowXml(bool testMode = false) = 0;
 };
 
 } // namespace kodi

--- a/src/media_centers/kodi/v16/AlbumXmlWriterV16.cpp
+++ b/src/media_centers/kodi/v16/AlbumXmlWriterV16.cpp
@@ -2,6 +2,7 @@
 
 #include "globals/Helper.h"
 #include "media_centers/KodiXml.h"
+#include "media_centers/kodi/KodiNfoMeta.h"
 #include "music/Album.h"
 #include "settings/Settings.h"
 
@@ -14,7 +15,7 @@ AlbumXmlWriterV16::AlbumXmlWriterV16(Album& album) : m_album{album}
 {
 }
 
-QByteArray AlbumXmlWriterV16::getAlbumXml()
+QByteArray AlbumXmlWriterV16::getAlbumXml(bool testMode)
 {
     QDomDocument doc;
     doc.setContent(m_album.nfoContent());
@@ -69,6 +70,10 @@ QByteArray AlbumXmlWriterV16::getAlbumXml()
             elem.appendChild(doc.createTextNode(poster.originalUrl.toString()));
             KodiXml::appendXmlNode(doc, elem);
         }
+    }
+
+    if (!testMode) {
+        addMediaelchGeneratorTag(doc, KodiVersion::v16);
     }
 
     return doc.toByteArray(4);

--- a/src/media_centers/kodi/v16/AlbumXmlWriterV16.h
+++ b/src/media_centers/kodi/v16/AlbumXmlWriterV16.h
@@ -13,7 +13,7 @@ class AlbumXmlWriterV16 : public AlbumXmlWriter
 {
 public:
     explicit AlbumXmlWriterV16(Album& album);
-    QByteArray getAlbumXml() override;
+    QByteArray getAlbumXml(bool testMode = false) override;
 
 private:
     Album& m_album;

--- a/src/media_centers/kodi/v16/ArtistXmlWriterV16.cpp
+++ b/src/media_centers/kodi/v16/ArtistXmlWriterV16.cpp
@@ -2,6 +2,7 @@
 
 #include "globals/Helper.h"
 #include "media_centers/KodiXml.h"
+#include "media_centers/kodi/KodiNfoMeta.h"
 #include "music/Artist.h"
 #include "settings/Settings.h"
 
@@ -14,7 +15,7 @@ ArtistXmlWriterV16::ArtistXmlWriterV16(Artist& artist) : m_artist{artist}
 {
 }
 
-QByteArray ArtistXmlWriterV16::getArtistXml()
+QByteArray ArtistXmlWriterV16::getArtistXml(bool testMode)
 {
     QDomDocument doc;
     doc.setContent(m_artist.nfoContent());
@@ -113,6 +114,10 @@ QByteArray ArtistXmlWriterV16::getArtistXml()
     }
     for (const QDomNode& node : albumNodes) {
         artistElem.removeChild(node);
+    }
+
+    if (!testMode) {
+        addMediaelchGeneratorTag(doc, KodiVersion::v16);
     }
 
     return doc.toByteArray(4);

--- a/src/media_centers/kodi/v16/ArtistXmlWriterV16.h
+++ b/src/media_centers/kodi/v16/ArtistXmlWriterV16.h
@@ -15,7 +15,7 @@ class ArtistXmlWriterV16 : public ArtistXmlWriter
 {
 public:
     explicit ArtistXmlWriterV16(Artist& artist);
-    QByteArray getArtistXml() override;
+    QByteArray getArtistXml(bool testMode = false) override;
 
 private:
     Artist& m_artist;

--- a/src/media_centers/kodi/v16/ConcertXmlWriterV16.cpp
+++ b/src/media_centers/kodi/v16/ConcertXmlWriterV16.cpp
@@ -3,6 +3,7 @@
 #include "concerts/Concert.h"
 #include "globals/Helper.h"
 #include "media_centers/KodiXml.h"
+#include "media_centers/kodi/KodiNfoMeta.h"
 #include "settings/Settings.h"
 
 #include <QDomDocument>
@@ -14,7 +15,7 @@ ConcertXmlWriterV16::ConcertXmlWriterV16(Concert& concert) : m_concert{concert}
 {
 }
 
-QByteArray ConcertXmlWriterV16::getConcertXml()
+QByteArray ConcertXmlWriterV16::getConcertXml(bool testMode)
 {
     using namespace std::chrono_literals;
 
@@ -75,6 +76,10 @@ QByteArray ConcertXmlWriterV16::getConcertXml()
     }
 
     KodiXml::writeStreamDetails(doc, m_concert.streamDetails());
+
+    if (!testMode) {
+        addMediaelchGeneratorTag(doc, KodiVersion::v16);
+    }
 
     return doc.toByteArray(4);
 }

--- a/src/media_centers/kodi/v16/ConcertXmlWriterV16.h
+++ b/src/media_centers/kodi/v16/ConcertXmlWriterV16.h
@@ -13,7 +13,7 @@ class ConcertXmlWriterV16 : public ConcertXmlWriter
 {
 public:
     ConcertXmlWriterV16(Concert& concert);
-    QByteArray getConcertXml() override;
+    QByteArray getConcertXml(bool testMode = false) override;
 
 private:
     Concert& m_concert;

--- a/src/media_centers/kodi/v16/EpisodeXmlWriterV16.cpp
+++ b/src/media_centers/kodi/v16/EpisodeXmlWriterV16.cpp
@@ -2,6 +2,7 @@
 
 #include "globals/Helper.h"
 #include "media_centers/KodiXml.h"
+#include "media_centers/kodi/KodiNfoMeta.h"
 #include "settings/Settings.h"
 #include "tv_shows/TvShowEpisode.h"
 
@@ -14,7 +15,7 @@ EpisodeXmlWriterV16::EpisodeXmlWriterV16(QVector<TvShowEpisode*> episodes) : m_e
 {
 }
 
-QByteArray EpisodeXmlWriterV16::getEpisodeXml()
+QByteArray EpisodeXmlWriterV16::getEpisodeXml(bool testMode)
 {
     QByteArray xmlContent;
     QXmlStreamWriter xml(&xmlContent);
@@ -22,7 +23,7 @@ QByteArray EpisodeXmlWriterV16::getEpisodeXml()
     xml.writeStartDocument("1.0", true);
 
     for (TvShowEpisode* subEpisode : m_episodes) {
-        writeSingleEpisodeDetails(xml, subEpisode);
+        writeSingleEpisodeDetails(xml, subEpisode, testMode);
     }
 
     xml.writeEndDocument();
@@ -33,7 +34,7 @@ QByteArray EpisodeXmlWriterV16::getEpisodeXml()
 /// \brief Writes TV show episode elements to an xml stream
 /// \param xml XML stream
 /// \param episode Episode to save
-void EpisodeXmlWriterV16::writeSingleEpisodeDetails(QXmlStreamWriter& xml, TvShowEpisode* episode)
+void EpisodeXmlWriterV16::writeSingleEpisodeDetails(QXmlStreamWriter& xml, TvShowEpisode* episode, bool testMode)
 {
     xml.writeStartElement("episodedetails");
     xml.writeTextElement("imdbid", episode->imdbId().toString());
@@ -90,6 +91,10 @@ void EpisodeXmlWriterV16::writeSingleEpisodeDetails(QXmlStreamWriter& xml, TvSho
     }
 
     KodiXml::writeStreamDetails(xml, episode->streamDetails());
+
+    if (!testMode) {
+        addMediaelchGeneratorTag(xml, KodiVersion::v16);
+    }
 
     xml.writeEndElement();
 }

--- a/src/media_centers/kodi/v16/EpisodeXmlWriterV16.h
+++ b/src/media_centers/kodi/v16/EpisodeXmlWriterV16.h
@@ -15,10 +15,10 @@ class EpisodeXmlWriterV16 : public EpisodeXmlWriter
 {
 public:
     EpisodeXmlWriterV16(QVector<TvShowEpisode*> episodes);
-    QByteArray getEpisodeXml() override;
+    QByteArray getEpisodeXml(bool testMode = false) override;
 
 private:
-    void writeSingleEpisodeDetails(QXmlStreamWriter& xml, TvShowEpisode* episode);
+    void writeSingleEpisodeDetails(QXmlStreamWriter& xml, TvShowEpisode* episode, bool testMode);
 
     const QVector<TvShowEpisode*> m_episodes;
 };

--- a/src/media_centers/kodi/v16/MovieXmlWriterV16.cpp
+++ b/src/media_centers/kodi/v16/MovieXmlWriterV16.cpp
@@ -17,7 +17,7 @@ MovieXmlWriterV16::MovieXmlWriterV16(Movie& movie) : m_movie{movie}
 {
 }
 
-QByteArray MovieXmlWriterV16::getMovieXml()
+QByteArray MovieXmlWriterV16::getMovieXml(bool testMode)
 {
     using namespace std::chrono_literals;
 
@@ -27,12 +27,7 @@ QByteArray MovieXmlWriterV16::getMovieXml()
         QDomNode node = doc.createProcessingInstruction("xml", R"(version="1.0" encoding="UTF-8" standalone="yes" )");
         doc.insertBefore(node, doc.firstChild());
         doc.appendChild(doc.createElement("movie"));
-        QDomComment meta;
-        meta.setData(getKodiNfoComment());
-        doc.appendChild(meta);
     }
-
-    QDomElement movieElem = doc.elementsByTagName("movie").at(0).toElement();
 
     KodiXml::setTextValue(doc, "title", m_movie.name());
     KodiXml::setTextValue(doc, "originaltitle", m_movie.originalName());
@@ -147,6 +142,10 @@ QByteArray MovieXmlWriterV16::getMovieXml()
     }
 
     KodiXml::writeStreamDetails(doc, m_movie.streamDetails(), m_movie.subtitles());
+
+    if (!testMode) {
+        addMediaelchGeneratorTag(doc, KodiVersion::v16);
+    }
 
     return doc.toByteArray(4);
 }

--- a/src/media_centers/kodi/v16/MovieXmlWriterV16.h
+++ b/src/media_centers/kodi/v16/MovieXmlWriterV16.h
@@ -13,7 +13,7 @@ class MovieXmlWriterV16 : public MovieXmlWriter
 {
 public:
     MovieXmlWriterV16(Movie& movie);
-    QByteArray getMovieXml() override;
+    QByteArray getMovieXml(bool testMode = false) override;
 
 private:
     Movie& m_movie;

--- a/src/media_centers/kodi/v16/TvShowXmlWriterV16.cpp
+++ b/src/media_centers/kodi/v16/TvShowXmlWriterV16.cpp
@@ -2,6 +2,7 @@
 
 #include "globals/Helper.h"
 #include "media_centers/KodiXml.h"
+#include "media_centers/kodi/KodiNfoMeta.h"
 #include "settings/Settings.h"
 #include "tv_shows/TvShow.h"
 
@@ -14,7 +15,7 @@ TvShowXmlWriterV16::TvShowXmlWriterV16(TvShow& tvShow) : m_show{tvShow}
 {
 }
 
-QByteArray TvShowXmlWriterV16::getTvShowXml()
+QByteArray TvShowXmlWriterV16::getTvShowXml(bool testMode)
 {
     using namespace std::chrono_literals;
 
@@ -143,6 +144,10 @@ QByteArray TvShowXmlWriterV16::getTvShowXml()
                 KodiXml::appendXmlNode(doc, elemSeason);
             }
         }
+    }
+
+    if (!testMode) {
+        addMediaelchGeneratorTag(doc, KodiVersion::v16);
     }
 
     return doc.toByteArray(4);

--- a/src/media_centers/kodi/v16/TvShowXmlWriterV16.h
+++ b/src/media_centers/kodi/v16/TvShowXmlWriterV16.h
@@ -15,7 +15,7 @@ class TvShowXmlWriterV16 : public TvShowXmlWriter
 {
 public:
     TvShowXmlWriterV16(TvShow& tvShow);
-    QByteArray getTvShowXml() override;
+    QByteArray getTvShowXml(bool testMode = false) override;
 
 private:
     TvShow& m_show;

--- a/src/media_centers/kodi/v17/AlbumXmlWriterV17.cpp
+++ b/src/media_centers/kodi/v17/AlbumXmlWriterV17.cpp
@@ -2,6 +2,7 @@
 
 #include "globals/Helper.h"
 #include "media_centers/KodiXml.h"
+#include "media_centers/kodi/KodiNfoMeta.h"
 #include "music/Album.h"
 #include "settings/Settings.h"
 
@@ -14,7 +15,7 @@ AlbumXmlWriterV17::AlbumXmlWriterV17(Album& album) : m_album{album}
 {
 }
 
-QByteArray AlbumXmlWriterV17::getAlbumXml()
+QByteArray AlbumXmlWriterV17::getAlbumXml(bool testMode)
 {
     QDomDocument doc;
     doc.setContent(m_album.nfoContent());
@@ -81,6 +82,10 @@ QByteArray AlbumXmlWriterV17::getAlbumXml()
     }
 
     writeArtistCredits(doc);
+
+    if (!testMode) {
+        addMediaelchGeneratorTag(doc, KodiVersion::v17);
+    }
 
     return doc.toByteArray(4);
 }

--- a/src/media_centers/kodi/v17/AlbumXmlWriterV17.h
+++ b/src/media_centers/kodi/v17/AlbumXmlWriterV17.h
@@ -14,7 +14,7 @@ class AlbumXmlWriterV17 : public AlbumXmlWriter
 {
 public:
     explicit AlbumXmlWriterV17(Album& album);
-    QByteArray getAlbumXml() override;
+    QByteArray getAlbumXml(bool testMode = false) override;
 
 private:
     Album& m_album;

--- a/src/media_centers/kodi/v17/ArtistXmlWriterV17.cpp
+++ b/src/media_centers/kodi/v17/ArtistXmlWriterV17.cpp
@@ -2,6 +2,7 @@
 
 #include "globals/Helper.h"
 #include "media_centers/KodiXml.h"
+#include "media_centers/kodi/KodiNfoMeta.h"
 #include "music/Artist.h"
 #include "settings/Settings.h"
 
@@ -14,7 +15,7 @@ ArtistXmlWriterV17::ArtistXmlWriterV17(Artist& artist) : m_artist{artist}
 {
 }
 
-QByteArray ArtistXmlWriterV17::getArtistXml()
+QByteArray ArtistXmlWriterV17::getArtistXml(bool testMode)
 {
     QDomDocument doc;
     doc.setContent(m_artist.nfoContent());
@@ -117,6 +118,10 @@ QByteArray ArtistXmlWriterV17::getArtistXml()
     }
     for (const QDomNode& node : albumNodes) {
         artistElem.removeChild(node);
+    }
+
+    if (!testMode) {
+        addMediaelchGeneratorTag(doc, KodiVersion::v17);
     }
 
     return doc.toByteArray(4);

--- a/src/media_centers/kodi/v17/ArtistXmlWriterV17.h
+++ b/src/media_centers/kodi/v17/ArtistXmlWriterV17.h
@@ -15,7 +15,7 @@ class ArtistXmlWriterV17 : public ArtistXmlWriter
 {
 public:
     explicit ArtistXmlWriterV17(Artist& artist);
-    QByteArray getArtistXml() override;
+    QByteArray getArtistXml(bool testMode = false) override;
 
 private:
     Artist& m_artist;

--- a/src/media_centers/kodi/v17/ConcertXmlWriterV17.cpp
+++ b/src/media_centers/kodi/v17/ConcertXmlWriterV17.cpp
@@ -3,6 +3,7 @@
 #include "concerts/Concert.h"
 #include "globals/Helper.h"
 #include "media_centers/KodiXml.h"
+#include "media_centers/kodi/KodiNfoMeta.h"
 #include "settings/Settings.h"
 
 #include <QDomDocument>
@@ -14,7 +15,7 @@ ConcertXmlWriterV17::ConcertXmlWriterV17(Concert& concert) : m_concert{concert}
 {
 }
 
-QByteArray ConcertXmlWriterV17::getConcertXml()
+QByteArray ConcertXmlWriterV17::getConcertXml(bool testMode)
 {
     using namespace std::chrono_literals;
 
@@ -118,6 +119,10 @@ QByteArray ConcertXmlWriterV17::getConcertXml()
     }
 
     KodiXml::writeStreamDetails(doc, m_concert.streamDetails());
+
+    if (!testMode) {
+        addMediaelchGeneratorTag(doc, KodiVersion::v17);
+    }
 
     return doc.toByteArray(4);
 }

--- a/src/media_centers/kodi/v17/ConcertXmlWriterV17.h
+++ b/src/media_centers/kodi/v17/ConcertXmlWriterV17.h
@@ -13,7 +13,7 @@ class ConcertXmlWriterV17 : public ConcertXmlWriter
 {
 public:
     ConcertXmlWriterV17(Concert& concert);
-    QByteArray getConcertXml() override;
+    QByteArray getConcertXml(bool testMode = false) override;
 
 private:
     Concert& m_concert;

--- a/src/media_centers/kodi/v17/EpisodeXmlWriterV17.cpp
+++ b/src/media_centers/kodi/v17/EpisodeXmlWriterV17.cpp
@@ -36,7 +36,6 @@ QByteArray EpisodeXmlWriterV17::getEpisodeXml()
 void EpisodeXmlWriterV17::writeSingleEpisodeDetails(QXmlStreamWriter& xml, TvShowEpisode* episode)
 {
     xml.writeStartElement("episodedetails");
-    xml.writeTextElement("id", episode->tvdbId().toString());
     xml.writeTextElement("title", episode->title());
     xml.writeTextElement("showtitle", episode->showTitle());
 

--- a/src/media_centers/kodi/v17/EpisodeXmlWriterV17.cpp
+++ b/src/media_centers/kodi/v17/EpisodeXmlWriterV17.cpp
@@ -2,6 +2,7 @@
 
 #include "globals/Helper.h"
 #include "media_centers/KodiXml.h"
+#include "media_centers/kodi/KodiNfoMeta.h"
 #include "settings/Settings.h"
 #include "tv_shows/TvShowEpisode.h"
 
@@ -14,7 +15,7 @@ EpisodeXmlWriterV17::EpisodeXmlWriterV17(QVector<TvShowEpisode*> episodes) : m_e
 {
 }
 
-QByteArray EpisodeXmlWriterV17::getEpisodeXml()
+QByteArray EpisodeXmlWriterV17::getEpisodeXml(bool testMode)
 {
     QByteArray xmlContent;
     QXmlStreamWriter xml(&xmlContent);
@@ -22,7 +23,7 @@ QByteArray EpisodeXmlWriterV17::getEpisodeXml()
     xml.writeStartDocument("1.0", true);
 
     for (TvShowEpisode* subEpisode : m_episodes) {
-        writeSingleEpisodeDetails(xml, subEpisode);
+        writeSingleEpisodeDetails(xml, subEpisode, testMode);
     }
 
     xml.writeEndDocument();
@@ -33,7 +34,7 @@ QByteArray EpisodeXmlWriterV17::getEpisodeXml()
 /// \brief Writes TV show episode elements to an xml stream
 /// \param xml XML stream
 /// \param episode Episode to save
-void EpisodeXmlWriterV17::writeSingleEpisodeDetails(QXmlStreamWriter& xml, TvShowEpisode* episode)
+void EpisodeXmlWriterV17::writeSingleEpisodeDetails(QXmlStreamWriter& xml, TvShowEpisode* episode, bool testMode)
 {
     xml.writeStartElement("episodedetails");
     xml.writeTextElement("title", episode->title());
@@ -134,6 +135,10 @@ void EpisodeXmlWriterV17::writeSingleEpisodeDetails(QXmlStreamWriter& xml, TvSho
     }
 
     KodiXml::writeStreamDetails(xml, episode->streamDetails());
+
+    if (!testMode) {
+        addMediaelchGeneratorTag(xml, KodiVersion::v17);
+    }
 
     xml.writeEndElement();
 }

--- a/src/media_centers/kodi/v17/EpisodeXmlWriterV17.h
+++ b/src/media_centers/kodi/v17/EpisodeXmlWriterV17.h
@@ -15,10 +15,10 @@ class EpisodeXmlWriterV17 : public EpisodeXmlWriter
 {
 public:
     EpisodeXmlWriterV17(QVector<TvShowEpisode*> episodes);
-    QByteArray getEpisodeXml() override;
+    QByteArray getEpisodeXml(bool testMode = false) override;
 
 private:
-    void writeSingleEpisodeDetails(QXmlStreamWriter& xml, TvShowEpisode* episode);
+    void writeSingleEpisodeDetails(QXmlStreamWriter& xml, TvShowEpisode* episode, bool testMode);
 
     const QVector<TvShowEpisode*> m_episodes;
 };

--- a/src/media_centers/kodi/v17/MovieXmlWriterV17.cpp
+++ b/src/media_centers/kodi/v17/MovieXmlWriterV17.cpp
@@ -18,7 +18,7 @@ MovieXmlWriterV17::MovieXmlWriterV17(Movie& movie) : m_movie{movie}
 {
 }
 
-QByteArray MovieXmlWriterV17::getMovieXml()
+QByteArray MovieXmlWriterV17::getMovieXml(bool testMode)
 {
     using namespace std::chrono_literals;
 
@@ -28,12 +28,7 @@ QByteArray MovieXmlWriterV17::getMovieXml()
         QDomNode node = doc.createProcessingInstruction("xml", R"(version="1.0" encoding="UTF-8" standalone="yes" )");
         doc.insertBefore(node, doc.firstChild());
         doc.appendChild(doc.createElement("movie"));
-        QDomComment meta;
-        meta.setData(getKodiNfoComment());
-        doc.appendChild(meta);
     }
-
-    QDomElement movieElem = doc.elementsByTagName("movie").at(0).toElement();
 
     // remove old v16 tags if they exist
     KodiXml::removeChildNodes(doc, "tmdbid");
@@ -214,6 +209,10 @@ QByteArray MovieXmlWriterV17::getMovieXml()
         KodiXml::removeChildNodes(doc, "dateadded");
     }
     KodiXml::setListValue(doc, "tag", m_movie.tags());
+
+    if (!testMode) {
+        addMediaelchGeneratorTag(doc, KodiVersion::v17);
+    }
 
     return doc.toByteArray(4);
 }

--- a/src/media_centers/kodi/v17/MovieXmlWriterV17.h
+++ b/src/media_centers/kodi/v17/MovieXmlWriterV17.h
@@ -13,7 +13,7 @@ class MovieXmlWriterV17 : public MovieXmlWriter
 {
 public:
     MovieXmlWriterV17(Movie& movie);
-    QByteArray getMovieXml() override;
+    QByteArray getMovieXml(bool testMode = false) override;
 
 private:
     Movie& m_movie;

--- a/src/media_centers/kodi/v17/TvShowXmlWriterV17.cpp
+++ b/src/media_centers/kodi/v17/TvShowXmlWriterV17.cpp
@@ -2,6 +2,7 @@
 
 #include "globals/Helper.h"
 #include "media_centers/KodiXml.h"
+#include "media_centers/kodi/KodiNfoMeta.h"
 #include "settings/Settings.h"
 #include "tv_shows/TvShow.h"
 
@@ -14,7 +15,7 @@ TvShowXmlWriterV17::TvShowXmlWriterV17(TvShow& tvShow) : m_show{tvShow}
 {
 }
 
-QByteArray TvShowXmlWriterV17::getTvShowXml()
+QByteArray TvShowXmlWriterV17::getTvShowXml(bool testMode)
 {
     using namespace std::chrono_literals;
 
@@ -267,6 +268,10 @@ QByteArray TvShowXmlWriterV17::getTvShowXml()
             elem.appendChild(elemThumb);
         }
         KodiXml::appendXmlNode(doc, elem);
+    }
+
+    if (!testMode) {
+        addMediaelchGeneratorTag(doc, KodiVersion::v17);
     }
 
     return doc.toByteArray(4);

--- a/src/media_centers/kodi/v17/TvShowXmlWriterV17.h
+++ b/src/media_centers/kodi/v17/TvShowXmlWriterV17.h
@@ -15,7 +15,7 @@ class TvShowXmlWriterV17 : public TvShowXmlWriter
 {
 public:
     TvShowXmlWriterV17(TvShow& tvShow);
-    QByteArray getTvShowXml() override;
+    QByteArray getTvShowXml(bool testMode = false) override;
 
 private:
     TvShow& m_show;

--- a/test/integration/media_centers/testKodi_v16_episode.cpp
+++ b/test/integration/media_centers/testKodi_v16_episode.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Episode XML writer for Kodi v16", "[data][tvshow][kodi][nfo]")
         CAPTURE(filename);
 
         mediaelch::kodi::EpisodeXmlWriterV16 writer({&episode});
-        QString actual = writer.getEpisodeXmlWithSingleRoot().trimmed();
+        QString actual = writer.getEpisodeXmlWithSingleRoot(true).trimmed();
         writeTempFile(filename, actual);
         checkSameXml(getFileContent(filename), actual);
     }
@@ -33,7 +33,7 @@ TEST_CASE("Episode XML writer for Kodi v16", "[data][tvshow][kodi][nfo]")
         CAPTURE(filename);
 
         mediaelch::kodi::EpisodeXmlWriterV16 writer({&episode1, &episode2});
-        QString actual = writer.getEpisodeXmlWithSingleRoot().trimmed();
+        QString actual = writer.getEpisodeXmlWithSingleRoot(true).trimmed();
         writeTempFile(filename, actual);
         checkSameXml(getFileContent(filename), actual);
     }
@@ -54,7 +54,7 @@ TEST_CASE("Episode XML writer for Kodi v16", "[data][tvshow][kodi][nfo]")
         reader.parseNfoDom(doc.elementsByTagName("episodedetails").at(0).toElement());
 
         mediaelch::kodi::EpisodeXmlWriterV16 writer({&episode});
-        QString actual = writer.getEpisodeXmlWithSingleRoot().trimmed();
+        QString actual = writer.getEpisodeXmlWithSingleRoot(true).trimmed();
         writeTempFile(filename, actual);
         checkSameXml(episodeContent, actual);
     }

--- a/test/integration/media_centers/testKodi_v16_movie.cpp
+++ b/test/integration/media_centers/testKodi_v16_movie.cpp
@@ -29,7 +29,7 @@ static void createAndCompareMovie(const QString& filename, Callback callback)
     callback(movie);
 
     mediaelch::kodi::MovieXmlWriterV16 writer(movie);
-    QString actual = writer.getMovieXml().trimmed();
+    QString actual = writer.getMovieXml(true).trimmed();
     writeTempFile(filename, actual);
     checkSameXml(movieContent, actual);
 }
@@ -44,7 +44,7 @@ TEST_CASE("Movie XML writer for Kodi v16", "[data][movie][kodi][nfo]")
         CAPTURE(filename);
 
         mediaelch::kodi::MovieXmlWriterV16 writer(movie);
-        QString actual = writer.getMovieXml().trimmed();
+        QString actual = writer.getMovieXml(true).trimmed();
 
         writeTempFile(filename, actual);
         checkSameXml(expected, actual);
@@ -146,7 +146,7 @@ TEST_CASE("Movie XML writer for Kodi v16", "[data][movie][kodi][nfo]")
 
         mediaelch::kodi::MovieXmlWriterV16 writer(movie);
 
-        QString actual = writer.getMovieXml().trimmed();
+        QString actual = writer.getMovieXml(true).trimmed();
         writeTempFile("movie/kodi_v16_movie_all.nfo", actual);
         checkSameXml(getFileContent("movie/kodi_v16_movie_all.nfo"), actual);
     }

--- a/test/integration/media_centers/testKodi_v16_show.cpp
+++ b/test/integration/media_centers/testKodi_v16_show.cpp
@@ -20,7 +20,7 @@ TEST_CASE("TV show XML writer for Kodi v16", "[data][tvshow][kodi][nfo]")
         CAPTURE(filename);
 
         mediaelch::kodi::TvShowXmlWriterV16 writer(tvShow);
-        QString actual = writer.getTvShowXml().trimmed();
+        QString actual = writer.getTvShowXml(true).trimmed();
         writeTempFile(filename, actual);
         checkSameXml(getFileContent(filename), actual);
     }
@@ -39,7 +39,7 @@ TEST_CASE("TV show XML writer for Kodi v16", "[data][tvshow][kodi][nfo]")
         reader.parseNfoDom(doc);
 
         mediaelch::kodi::TvShowXmlWriterV16 writer(tvShow);
-        QString actual = writer.getTvShowXml().trimmed();
+        QString actual = writer.getTvShowXml(true).trimmed();
         writeTempFile(filename, actual);
         checkSameXml(showContent, actual);
     }

--- a/test/integration/media_centers/testKodi_v18_concert.cpp
+++ b/test/integration/media_centers/testKodi_v18_concert.cpp
@@ -30,7 +30,7 @@ static void createAndCompareConcert(const QString& filename, Callback callback)
     callback(concert);
 
     mediaelch::kodi::ConcertXmlWriterV18 writer(concert);
-    QString actual = writer.getConcertXml().trimmed();
+    QString actual = writer.getConcertXml(true).trimmed();
     writeTempFile(filename, actual);
     checkSameXml(concertContent, actual);
 }
@@ -44,7 +44,7 @@ TEST_CASE("Concert XML writer for Kodi v18", "[data][concert][kodi][nfo]")
         CAPTURE(filename);
 
         mediaelch::kodi::ConcertXmlWriterV18 writer(concert);
-        QString actual = writer.getConcertXml().trimmed();
+        QString actual = writer.getConcertXml(true).trimmed();
         writeTempFile(filename, actual);
         checkSameXml(getFileContent(filename), actual);
     }

--- a/test/integration/media_centers/testKodi_v18_episode.cpp
+++ b/test/integration/media_centers/testKodi_v18_episode.cpp
@@ -33,7 +33,7 @@ static void createAndCompareSingleEpisode(const QString& filename, Callback call
     callback(episode);
 
     mediaelch::kodi::EpisodeXmlWriterV18 writer({&episode});
-    QString actual = writer.getEpisodeXmlWithSingleRoot().trimmed();
+    QString actual = writer.getEpisodeXmlWithSingleRoot(true).trimmed();
     writeTempFile(filename, actual);
     checkSameXml(episodeContent, actual);
 }
@@ -62,7 +62,7 @@ static void createAndCompareMultiEpisode(const QString& filename, Callback callb
     callback(episodesPointer);
 
     mediaelch::kodi::EpisodeXmlWriterV18 writer(episodesPointer);
-    QString actual = writer.getEpisodeXmlWithSingleRoot().trimmed();
+    QString actual = writer.getEpisodeXmlWithSingleRoot(true).trimmed();
     writeTempFile(filename, actual);
     checkSameXml(episodeContent, actual);
 }
@@ -80,7 +80,7 @@ TEST_CASE("Episode XML writer for Kodi v18", "[data][tvshow][kodi][nfo]")
         CAPTURE(filename);
 
         mediaelch::kodi::EpisodeXmlWriterV18 writer({&episode});
-        QString actual = writer.getEpisodeXmlWithSingleRoot().trimmed();
+        QString actual = writer.getEpisodeXmlWithSingleRoot(true).trimmed();
         writeTempFile(filename, actual);
         checkSameXml(getFileContent(filename), actual);
     }
@@ -93,7 +93,7 @@ TEST_CASE("Episode XML writer for Kodi v18", "[data][tvshow][kodi][nfo]")
         CAPTURE(filename);
 
         mediaelch::kodi::EpisodeXmlWriterV18 writer({&episode1, &episode2});
-        QString actual = writer.getEpisodeXmlWithSingleRoot().trimmed();
+        QString actual = writer.getEpisodeXmlWithSingleRoot(true).trimmed();
         writeTempFile(filename, actual);
         checkSameXml(getFileContent(filename), actual);
     }
@@ -114,7 +114,7 @@ TEST_CASE("Episode XML writer for Kodi v18", "[data][tvshow][kodi][nfo]")
         reader.parseNfoDom(doc.elementsByTagName("episodedetails").at(0).toElement());
 
         mediaelch::kodi::EpisodeXmlWriterV18 writer({&episode});
-        QString actual = writer.getEpisodeXmlWithSingleRoot().trimmed();
+        QString actual = writer.getEpisodeXmlWithSingleRoot(true).trimmed();
         writeTempFile(filename, actual);
         checkSameXml(episodeContent, actual);
     }

--- a/test/integration/media_centers/testKodi_v18_movie.cpp
+++ b/test/integration/media_centers/testKodi_v18_movie.cpp
@@ -30,7 +30,7 @@ static void createAndCompareMovie(const QString& filename, Callback callback)
     callback(movie);
 
     mediaelch::kodi::MovieXmlWriterV18 writer(movie);
-    QString actual = writer.getMovieXml().trimmed();
+    QString actual = writer.getMovieXml(true).trimmed();
     writeTempFile(filename, actual);
     checkSameXml(movieContent, actual);
 }
@@ -44,7 +44,7 @@ TEST_CASE("Movie XML writer for Kodi v18", "[data][movie][kodi][nfo]")
         CAPTURE(filename);
 
         mediaelch::kodi::MovieXmlWriterV18 writer(movie);
-        QString actual = writer.getMovieXml().trimmed();
+        QString actual = writer.getMovieXml(true).trimmed();
         writeTempFile(filename, actual);
         checkSameXml(getFileContent(filename), actual);
     }
@@ -193,7 +193,7 @@ TEST_CASE("Movie XML writer for Kodi v18", "[data][movie][kodi][nfo]")
 
         mediaelch::kodi::MovieXmlWriterV18 writer(movie);
 
-        QString actual = writer.getMovieXml().trimmed();
+        QString actual = writer.getMovieXml(true).trimmed();
         QString filename = "movie/kodi_v18_movie_all.nfo";
         CAPTURE(filename);
         writeTempFile(filename, actual);

--- a/test/integration/media_centers/testKodi_v18_music_album.cpp
+++ b/test/integration/media_centers/testKodi_v18_music_album.cpp
@@ -30,7 +30,7 @@ static void createAndCompareAlbum(const QString& filename, Callback callback)
     callback(album);
 
     mediaelch::kodi::AlbumXmlWriterV18 writer(album);
-    QString actual = writer.getAlbumXml().trimmed();
+    QString actual = writer.getAlbumXml(true).trimmed();
     writeTempFile(filename, actual);
     checkSameXml(albumContent, actual);
 }
@@ -44,7 +44,7 @@ TEST_CASE("Music Album XML writer for Kodi v18", "[data][music][album][kodi][nfo
         CAPTURE(filename);
 
         mediaelch::kodi::AlbumXmlWriterV18 writer(album);
-        QString actual = writer.getAlbumXml().trimmed();
+        QString actual = writer.getAlbumXml(true).trimmed();
         writeTempFile(filename, actual);
         checkSameXml(getFileContent(filename), actual);
     }

--- a/test/integration/media_centers/testKodi_v18_music_artist.cpp
+++ b/test/integration/media_centers/testKodi_v18_music_artist.cpp
@@ -30,7 +30,7 @@ static void createAndCompareArtist(const QString& filename, Callback callback)
     callback(artist);
 
     mediaelch::kodi::ArtistXmlWriterV18 writer(artist);
-    QString actual = writer.getArtistXml().trimmed();
+    QString actual = writer.getArtistXml(true).trimmed();
     writeTempFile(filename, actual);
     checkSameXml(artistContent, actual);
 }
@@ -44,7 +44,7 @@ TEST_CASE("Music Artist XML writer for Kodi v18", "[data][music][artist][kodi][n
         CAPTURE(filename);
 
         mediaelch::kodi::ArtistXmlWriterV18 writer(artist);
-        QString actual = writer.getArtistXml().trimmed();
+        QString actual = writer.getArtistXml(true).trimmed();
         writeTempFile(filename, actual);
         checkSameXml(getFileContent(filename), actual);
     }

--- a/test/integration/media_centers/testKodi_v18_show.cpp
+++ b/test/integration/media_centers/testKodi_v18_show.cpp
@@ -30,7 +30,7 @@ static void createAndCompareTvShow(const QString& filename, Callback callback)
     callback(show);
 
     mediaelch::kodi::TvShowXmlWriterV18 writer(show);
-    QString actual = writer.getTvShowXml().trimmed();
+    QString actual = writer.getTvShowXml(true).trimmed();
     writeTempFile(filename, actual);
     checkSameXml(showContent, actual);
 }
@@ -44,7 +44,7 @@ TEST_CASE("TV show XML writer for Kodi v18", "[data][tvshow][kodi][nfo]")
         CAPTURE(filename);
 
         mediaelch::kodi::TvShowXmlWriterV18 writer(tvShow);
-        QString actual = writer.getTvShowXml().trimmed();
+        QString actual = writer.getTvShowXml(true).trimmed();
         writeTempFile(filename, actual);
         checkSameXml(getFileContent(filename), actual);
     }
@@ -133,7 +133,7 @@ TEST_CASE("TV show XML writer for Kodi v18", "[data][tvshow][kodi][nfo]")
 
         mediaelch::kodi::TvShowXmlWriterV18 writer(show);
 
-        QString actual = writer.getTvShowXml().trimmed();
+        QString actual = writer.getTvShowXml(true).trimmed();
         QString filename = "show/kodi_v18_show_all.nfo";
         CAPTURE(filename);
         writeTempFile(filename, actual);

--- a/test/resources/show/kodi_v18_episode_American_Dad_S02E01.nfo
+++ b/test/resources/show/kodi_v18_episode_American_Dad_S02E01.nfo
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <episodes>
   <episodedetails>
-    <id>306168</id>
     <title>Camp Refoogee</title>
     <showtitle>American Dad!</showtitle>
     <uniqueid type="tvdb" default="true">306168</uniqueid>

--- a/test/resources/show/kodi_v18_episode_American_Dad_S02E03-S02E04.nfo
+++ b/test/resources/show/kodi_v18_episode_American_Dad_S02E03-S02E04.nfo
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <episodes>
   <episodedetails>
-    <id>306170</id>
     <title>Con Heir</title>
     <showtitle>American Dad!</showtitle>
     <uniqueid type="tvdb" default="true">306170</uniqueid>
@@ -90,7 +89,6 @@
     </actor>
   </episodedetails>
   <episodedetails>
-    <id>306167</id>
     <title>All About Steve</title>
     <showtitle>American Dad!</showtitle>
     <uniqueid type="tvdb" default="true">306167</uniqueid>

--- a/test/resources/show/kodi_v18_episode_empty.nfo
+++ b/test/resources/show/kodi_v18_episode_empty.nfo
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <episodes>
   <episodedetails>
-    <id></id>
     <title></title>
     <showtitle></showtitle>
     <uniqueid type="tvdb" default="true"></uniqueid>

--- a/test/resources/show/kodi_v18_episode_multi_empty.nfo
+++ b/test/resources/show/kodi_v18_episode_multi_empty.nfo
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <episodes>
   <episodedetails>
-    <id></id>
     <title></title>
     <showtitle></showtitle>
     <uniqueid type="tvdb" default="true"></uniqueid>
@@ -18,7 +17,6 @@
     <studio></studio>
 </episodedetails>
 <episodedetails>
-    <id></id>
     <title></title>
     <showtitle></showtitle>
     <uniqueid type="tvdb" default="true"></uniqueid>

--- a/test/scrapers/thetvdb/testTheTvDbShowLoader.cpp
+++ b/test/scrapers/thetvdb/testTheTvDbShowLoader.cpp
@@ -85,45 +85,45 @@ TEST_CASE("TheTvDb scrapes show details", "[show][TheTvDb][load_data]")
         // CHECK(show.seasonBanners(SeasonNumber(1)).size() > 1);
         // CHECK(show.banners().size() > 11);
     }
-/* TheTvDb (again) has issues with other languages...
-    SECTION("Loads all details for Scrubs in another Language")
-    {
-        TheTvDb tvdb;
-        ShowScrapeJob::Config config{ShowIdentifier("76156"), Locale("de-DE"), tvdb.meta().supportedShowDetails};
+    /* TheTvDb (again) has issues with other languages...
+        SECTION("Loads all details for Scrubs in another Language")
+        {
+            TheTvDb tvdb;
+            ShowScrapeJob::Config config{ShowIdentifier("76156"), Locale("de-DE"), tvdb.meta().supportedShowDetails};
 
-        auto scrapeJob = std::make_unique<TheTvDbShowScrapeJob>(getTheTvDbApi(), config);
-        scrapeTvScraperSync(scrapeJob.get());
-        auto& show = scrapeJob->tvShow();
+            auto scrapeJob = std::make_unique<TheTvDbShowScrapeJob>(getTheTvDbApi(), config);
+            scrapeTvScraperSync(scrapeJob.get());
+            auto& show = scrapeJob->tvShow();
 
-        REQUIRE(show.tvdbId() == TvDbId("76156"));
+            REQUIRE(show.tvdbId() == TvDbId("76156"));
 
-        CHECK(show.title() == "Scrubs");
-        CHECK(show.certification() == Certification("TV-PG"));
-        CHECK(show.firstAired() == QDate(2001, 10, 2));
-        CHECK(show.network() == "NBC");
-        CHECK_THAT(show.overview(),
-            StartsWith("Mittelpunkt und Ich-Erzähler der Serie ist der junge Mediziner John Michael Dorian"));
+            CHECK(show.title() == "Scrubs");
+            CHECK(show.certification() == Certification("TV-PG"));
+            CHECK(show.firstAired() == QDate(2001, 10, 2));
+            CHECK(show.network() == "NBC");
+            CHECK_THAT(show.overview(),
+                StartsWith("Mittelpunkt und Ich-Erzähler der Serie ist der junge Mediziner John Michael Dorian"));
 
-        REQUIRE_FALSE(show.ratings().isEmpty());
-        CHECK(show.ratings().first().rating == Approx(9).margin(0.5));
-        CHECK(show.ratings().first().voteCount > 290);
+            REQUIRE_FALSE(show.ratings().isEmpty());
+            CHECK(show.ratings().first().rating == Approx(9).margin(0.5));
+            CHECK(show.ratings().first().voteCount > 290);
 
-        CHECK(show.runtime() == 25min);
-        CHECK(show.status() == "Ended");
+            CHECK(show.runtime() == 25min);
+            CHECK(show.status() == "Ended");
 
-        // const auto& actors = show.actors();
-        // REQUIRE(actors.size() > 15);
-        // CHECK(actors[0]->name == "Aloma Wright");
+            // const auto& actors = show.actors();
+            // REQUIRE(actors.size() > 15);
+            // CHECK(actors[0]->name == "Aloma Wright");
 
-        const auto& genres = show.genres();
-        REQUIRE(!genres.empty());
-        CHECK_THAT(genres[0], Contains("Comedy"));
+            const auto& genres = show.genres();
+            REQUIRE(!genres.empty());
+            CHECK_THAT(genres[0], Contains("Comedy"));
 
-        // CHECK(show.backdrops().size() > 25);
-        // CHECK(show.posters().size() > 15);
-        // TODO: CHECK(show.seasonPosters(SeasonNumber(1)).size() > 4);
-        // CHECK(show.seasonBanners(SeasonNumber(1)).size() > 1);
-        // CHECK(show.banners().size() > 11);
-    }
-*/
+            // CHECK(show.backdrops().size() > 25);
+            // CHECK(show.posters().size() > 15);
+            // TODO: CHECK(show.seasonPosters(SeasonNumber(1)).size() > 4);
+            // CHECK(show.seasonBanners(SeasonNumber(1)).size() > 1);
+            // CHECK(show.banners().size() > 11);
+        }
+    */
 }


### PR DESCRIPTION
A `<generator>` tag contains meta details about the tools used to
generate the NFO file.  It is an unofficial tag for Kodi that may be
useful for debugging purposes.

XML looks like:

```xml
    <generator>
        <appname>MediaElch</appname>
        <appversion>2.8.3-dev</appversion>
        <datetime>2020-12-30T13:32:36Z</datetime>
    </generator>
```

`<kodiversion>` is not yet included but may come at a later point.