### PR TITLE
[CSV Export] Add first basic TV show/episode export

### DIFF
--- a/src/export/CsvExport.cpp
+++ b/src/export/CsvExport.cpp
@@ -1,122 +1,10 @@
 #include "export/CsvExport.h"
 
 #include "movies/Movie.h"
+#include "tv_shows/TvShow.h"
+#include "tv_shows/TvShowEpisode.h"
 
-namespace mediaelch {
-
-
-CsvMovieExport::CsvMovieExport(QVector<CsvMovieExport::MovieField> fields, QObject* parent) :
-    QObject(parent), m_fields{fields}
-{
-}
-
-QString CsvMovieExport::exportMovies(const QVector<Movie*>& movies, std::function<void()> callback)
-{
-    CsvExport csv;
-    csv.setFieldsInOrder(fieldsToStrings());
-    csv.setSeparator(m_separator);
-    csv.setReplacement(m_replacement);
-
-    csv.addRow({
-        {"imdbid", "IMDb ID"}, //
-        {"tmdbid", "TMDb ID"}, //
-        {"title", "Title"},    //
-        {"originalTitle", "Original Title"},
-        {"sortTitle", "Sort Title"},
-        {"overview", "Overview"},
-        {"outline", "Outline"},
-        {"rating", "Rating"},
-        {"userRating", "User Rating"},
-        {"top250", "Top 250"},
-        {"releaseDate", "Release Date"},
-        {"tagline", "Tagline"},
-        {"runtime", "Runtime"},
-        {"certification", "Certfication"},
-        {"writers", "Writers"},
-        {"directors", "Directors"},
-        {"genres", "Genres"},
-        {"countries", "Countries"},
-        {"studios", "Studios"},
-        {"tags", "Tags"},
-        {"trailers", "Trailers"},
-        {"actors", "Actors"},
-        {"playcount", "Playcount"},
-        {"lastPlayed", "Last Played"},
-        {"movieSet", "MovieSet"} //
-    });
-
-    for (Movie* movie : asConst(movies)) {
-        csv.addRow({
-            {"imdbid", movie->imdbId().toString()},
-            {"tmdbid", movie->tmdbId().toString()},
-            {"title", movie->name()},
-            {"originalTitle", movie->originalName()},
-            {"sortTitle", movie->sortTitle()},
-            {"overview", movie->overview()},
-            {"outline", movie->outline()},
-            {"rating", ratingsToString(movie->ratings())},
-            {"userRating", QString::number(movie->userRating())},
-            {"top250", QString::number(movie->top250())},
-            {"releaseDate", movie->released().isValid() ? movie->released().toString(Qt::ISODate) : ""},
-            {"tagline", movie->tagline()},
-            {"runtime", QString::number(movie->runtime().count())},
-            {"certification", movie->certification().toString()},
-            {"writers", movie->writer()},
-            {"directors", movie->director()},
-            {"genres", movie->genres().join(", ")},
-            {"countries", movie->countries().join(", ")},
-            {"studios", movie->studios().join(", ")},
-            {"tags", movie->tags().join(", ")},
-            {"trailers", movie->trailer().toString()},
-            {"actors", actorsToString(movie->actors())},
-            {"playcount", QString::number(movie->playcount())},
-            {"lastPlayed", movie->lastPlayed().toString(Qt::ISODate)},
-            {"movieSet", movie->set().name} //
-        });
-        callback();
-    }
-
-    return csv.csv();
-}
-
-QVector<QString> CsvMovieExport::fieldsToStrings() const
-{
-    const static QMap<MovieField, QString> fieldToString = {
-        {MovieField::Imdbid, "imdbid"},
-        {MovieField::Tmdbid, "tmdbid"},
-        {MovieField::Title, "title"},
-        {MovieField::OriginalTitle, "originalTitle"},
-        {MovieField::SortTitle, "sortTitle"},
-        {MovieField::Overview, "overview"},
-        {MovieField::Outline, "outline"},
-        {MovieField::Ratings, "rating"},
-        {MovieField::UserRating, "userRating"},
-        {MovieField::IsImdbTop250, "top250"},
-        {MovieField::ReleaseDate, "releaseDate"},
-        {MovieField::Tagline, "tagline"},
-        {MovieField::Runtime, "runtime"},
-        {MovieField::Certification, "certification"},
-        {MovieField::Writers, "writers"},
-        {MovieField::Directors, "directors"},
-        {MovieField::Genres, "genres"},
-        {MovieField::Countries, "countries"},
-        {MovieField::Studios, "studios"},
-        {MovieField::Tags, "tags"},
-        {MovieField::Trailer, "trailers"},
-        {MovieField::Actors, "actors"},
-        {MovieField::PlayCount, "playcount"},
-        {MovieField::LastPlayed, "lastPlayed"},
-        {MovieField::MovieSet, "movieSet"} //
-    };
-
-    QVector<QString> out;
-    for (const MovieField field : asConst(m_fields)) {
-        out << fieldToString.value(field);
-    }
-    return out;
-}
-
-QString CsvMovieExport::ratingsToString(const QVector<Rating>& ratings) const
+static QString ratingsToString(const QVector<Rating>& ratings)
 {
     QStringList out;
     for (const Rating& rating : ratings) {
@@ -133,7 +21,7 @@ QString CsvMovieExport::ratingsToString(const QVector<Rating>& ratings) const
     return out.join(", ");
 }
 
-QString CsvMovieExport::actorsToString(const QVector<Actor*>& actors) const
+static QString actorsToString(const QVector<Actor*>& actors)
 {
     QStringList out;
     for (const Actor* actor : actors) {
@@ -146,9 +34,205 @@ QString CsvMovieExport::actorsToString(const QVector<Actor*>& actors) const
     return out.join(", ");
 }
 
+namespace mediaelch {
+
+CsvMovieExport::CsvMovieExport(QVector<CsvMovieExport::MovieField> fields, QObject* parent) :
+    QObject(parent), m_fields{fields}
+{
+}
+
+QString CsvMovieExport::exportMovies(const QVector<Movie*>& movies, std::function<void()> callback)
+{
+    CsvExport csv;
+    csv.setFieldsInOrder(fieldsToStrings());
+    csv.setSeparator(m_separator);
+    csv.setReplacement(m_replacement);
+
+    const auto s = [this](MovieField field) { return fieldToString(field); };
+
+    csv.writeHeader();
+
+    for (Movie* movie : asConst(movies)) {
+        csv.addRow({
+            {s(MovieField::Imdbid), movie->imdbId().toString()},
+            {s(MovieField::Tmdbid), movie->tmdbId().toString()},
+            {s(MovieField::Title), movie->name()},
+            {s(MovieField::OriginalTitle), movie->originalName()},
+            {s(MovieField::SortTitle), movie->sortTitle()},
+            {s(MovieField::Overview), movie->overview()},
+            {s(MovieField::Outline), movie->outline()},
+            {s(MovieField::Ratings), ratingsToString(movie->ratings())},
+            {s(MovieField::UserRating), QString::number(movie->userRating())},
+            {s(MovieField::IsImdbTop250), QString::number(movie->top250())},
+            {s(MovieField::ReleaseDate), movie->released().isValid() ? movie->released().toString(Qt::ISODate) : ""},
+            {s(MovieField::Tagline), movie->tagline()},
+            {s(MovieField::Runtime), QString::number(movie->runtime().count())},
+            {s(MovieField::Certification), movie->certification().toString()},
+            {s(MovieField::Writers), movie->writer()},
+            {s(MovieField::Directors), movie->director()},
+            {s(MovieField::Genres), movie->genres().join(", ")},
+            {s(MovieField::Countries), movie->countries().join(", ")},
+            {s(MovieField::Studios), movie->studios().join(", ")},
+            {s(MovieField::Tags), movie->tags().join(", ")},
+            {s(MovieField::Trailer), movie->trailer().toString()},
+            {s(MovieField::Actors), actorsToString(movie->actors())},
+            {s(MovieField::PlayCount), QString::number(movie->playcount())},
+            {s(MovieField::LastPlayed), movie->lastPlayed().toString(Qt::ISODate)},
+            {s(MovieField::MovieSet), movie->set().name} //
+        });
+        callback();
+    }
+
+    return csv.csv();
+}
+
+QVector<QString> CsvMovieExport::fieldsToStrings() const
+{
+    QVector<QString> out;
+    for (const MovieField field : asConst(m_fields)) {
+        out << fieldToString(field);
+    }
+    return out;
+}
+
+QString CsvMovieExport::fieldToString(MovieField field) const
+{
+    switch (field) {
+    case MovieField::Imdbid: return "imdb_id";
+    case MovieField::Tmdbid: return "tmdb_id";
+    case MovieField::Title: return "title";
+    case MovieField::OriginalTitle: return "original_title";
+    case MovieField::SortTitle: return "sort_title";
+    case MovieField::Overview: return "overview";
+    case MovieField::Outline: return "outline";
+    case MovieField::Ratings: return "ratings";
+    case MovieField::UserRating: return "user_rating";
+    case MovieField::IsImdbTop250: return "top250";
+    case MovieField::ReleaseDate: return "release_date";
+    case MovieField::Tagline: return "tagline";
+    case MovieField::Runtime: return "runtime";
+    case MovieField::Certification: return "certification";
+    case MovieField::Writers: return "writers";
+    case MovieField::Directors: return "directors";
+    case MovieField::Genres: return "genres";
+    case MovieField::Countries: return "countries";
+    case MovieField::Studios: return "studios";
+    case MovieField::Tags: return "tags";
+    case MovieField::Trailer: return "trailers";
+    case MovieField::Actors: return "actors";
+    case MovieField::PlayCount: return "playcount";
+    case MovieField::LastPlayed: return "last_played";
+    case MovieField::MovieSet: return "movie_set";
+    };
+    return "unknown";
+}
+
+CsvTvExport::CsvTvExport(QVector<CsvTvExport::TvField> fields, QObject* parent) : QObject(parent), m_fields{fields}
+{
+}
+
+QString CsvTvExport::exportTvShows(const QVector<TvShow*>& movies, std::function<void()> callback)
+{
+    CsvExport csv;
+    csv.setFieldsInOrder(fieldsToStrings());
+    csv.setSeparator(m_separator);
+    csv.setReplacement(m_replacement);
+
+    const auto s = [this](TvField field) { return fieldToString(field); };
+
+    csv.writeHeader();
+
+    for (TvShow* show : asConst(movies)) {
+        for (TvShowEpisode* episode : asConst(show->episodes())) {
+            csv.addRow({
+                {s(TvField::ShowTmdbId), show->tmdbId().toString()},
+                {s(TvField::ShowImdbId), show->imdbId().toString()},
+                {s(TvField::ShowTvDbId), show->tvdbId().toString()},
+                {s(TvField::ShowTvMazeId), show->tvmazeId().toString()},
+                {s(TvField::ShowTitle), show->title()},
+                {s(TvField::ShowFirstAired), show->firstAired().toString(Qt::ISODate)},
+                {s(TvField::ShowNetwork), show->network()},
+                {s(TvField::ShowGenres), show->genres().join(", ")},
+                {s(TvField::ShowRuntime), QString::number(show->runtime().count())},
+                {s(TvField::ShowRatings), ratingsToString(show->ratings())},
+                {s(TvField::ShowUserRating), QString::number(show->userRating())},
+                {s(TvField::EpisodeSeason), episode->seasonNumber().toString()},
+                {s(TvField::EpisodeNumber), episode->episodeNumber().toString()},
+                {s(TvField::EpisodeTmdbId), episode->tmdbId().toString()},
+                {s(TvField::EpisodeImdbId), episode->imdbId().toString()},
+                {s(TvField::EpisodeTvDbId), episode->tvdbId().toString()},
+                {s(TvField::EpisodeTvMazeId), episode->tvmazeId().toString()},
+                {s(TvField::EpisodeFirstAired), episode->firstAired().toString(Qt::ISODate)},
+                {s(TvField::EpisodeTitle), episode->title()},
+                {s(TvField::EpisodeOverview), episode->overview()},
+                {s(TvField::EpisodeTitle), episode->title()},
+                {s(TvField::EpisodeUserRating), QString::number(episode->userRating())},
+                {s(TvField::EpisodeActors), actorsToString(episode->actors())} //
+            });
+        }
+        callback();
+    }
+
+    return csv.csv();
+}
+
+QVector<QString> CsvTvExport::fieldsToStrings() const
+{
+    QVector<QString> out;
+    for (const TvField field : asConst(m_fields)) {
+        out << fieldToString(field);
+    }
+    return out;
+}
+
+QString CsvTvExport::fieldToString(CsvTvExport::TvField field) const
+{
+    switch (field) {
+    case TvField::ShowImdbId: return "show_imdb_id";
+    case TvField::ShowTmdbId: return "show_tmdb_id";
+    case TvField::ShowTvMazeId: return "show_tvmaze_id";
+    case TvField::ShowTvDbId: return "show_tvdb_id";
+    case TvField::ShowFirstAired: return "show_first_aired";
+    case TvField::ShowTitle: return "show_title";
+    case TvField::ShowNetwork: return "show_network";
+    case TvField::ShowGenres: return "show_genres";
+    case TvField::ShowRuntime: return "show_runtime";
+    case TvField::ShowRatings: return "show_ratings";
+    case TvField::ShowUserRating: return "show_user_rating";
+    case TvField::EpisodeSeason: return "episode_season";
+    case TvField::EpisodeNumber: return "episode_number";
+    case TvField::EpisodeImdbId: return "episode_imdb_id";
+    case TvField::EpisodeTmdbId: return "episode_tmdb_id";
+    case TvField::EpisodeTvDbId: return "episode_tvdb_id";
+    case TvField::EpisodeTvMazeId: return "episode_tvmaze_id";
+    case TvField::EpisodeFirstAired: return "episode_actors";
+    case TvField::EpisodeTitle: return "episode_title";
+    case TvField::EpisodeOverview: return "episode_overview";
+    case TvField::EpisodeUserRating: return "episode_user_rating";
+    case TvField::EpisodeDirectors: return "episode_directors";
+    case TvField::EpisodeWriters: return "episode_writers";
+    case TvField::EpisodeActors: return "episode_actors";
+    }
+    return "unknown";
+}
+
+
 const QString& CsvExport::csv() const
 {
     return m_csv;
+}
+
+void CsvExport::writeHeader()
+{
+    QVector<QString>::const_iterator i = m_fieldsInOrder.cbegin();
+    writeEscaped(*i);
+    ++i;
+
+    for (; i != m_fieldsInOrder.cend(); ++i) {
+        m_csv.append(m_separator);
+        writeEscaped(*i);
+    }
+    m_csv.append('\n');
 }
 
 void CsvExport::addRow(const QMap<QString, QString>& values)
@@ -175,7 +259,11 @@ void CsvExport::writeEscaped(const QString& text)
         return;
     }
 
-    m_csv.append(QString(text).replace(m_separator, m_replacement).replace("\n", "\\n"));
+    m_csv.append(QString(text)
+                     .replace(m_separator, m_replacement)
+                     .replace("\r\n", "\\n")
+                     .replace("\n", "\\n")
+                     .replace("\r", "\\n"));
 }
 
 } // namespace mediaelch

--- a/src/export/CsvExport.h
+++ b/src/export/CsvExport.h
@@ -12,6 +12,7 @@
 
 struct Actor;
 class Movie;
+class TvShow;
 
 namespace mediaelch {
 
@@ -51,6 +52,7 @@ public:
 
 public:
     explicit CsvMovieExport(QVector<MovieField> fields, QObject* parent = nullptr);
+    ~CsvMovieExport() override = default;
 
     void setSeparator(QString separator) { m_separator = std::move(separator); }
     void setReplacement(QString replacement) { m_replacement = std::move(replacement); }
@@ -61,11 +63,66 @@ public:
 
 private:
     QVector<QString> fieldsToStrings() const;
-    QString ratingsToString(const QVector<Rating>& ratings) const;
-    QString actorsToString(const QVector<Actor*>& actors) const;
+    QString fieldToString(MovieField field) const;
 
 private:
     QVector<MovieField> m_fields;
+    QString m_separator = "\t";
+    QString m_replacement = " ";
+};
+
+
+class CsvTvExport : public QObject
+{
+    Q_OBJECT
+
+public:
+    enum class TvField
+    {
+        ShowImdbId = 1,
+        ShowTmdbId,
+        ShowTvDbId,
+        ShowTvMazeId,
+        ShowTitle,
+        ShowFirstAired,
+        ShowNetwork,
+        ShowGenres,
+        ShowRuntime,
+        ShowRatings,
+        ShowUserRating,
+        EpisodeSeason,
+        EpisodeNumber,
+        EpisodeImdbId,
+        EpisodeTmdbId,
+        EpisodeTvDbId,
+        EpisodeTvMazeId,
+        EpisodeFirstAired,
+        EpisodeTitle,
+        EpisodeOverview,
+        EpisodeUserRating,
+        EpisodeWriters,
+        EpisodeDirectors,
+        EpisodeActors
+    };
+
+public:
+    explicit CsvTvExport(QVector<TvField> fields, QObject* parent = nullptr);
+    ~CsvTvExport() override = default;
+
+    void setSeparator(QString separator) { m_separator = std::move(separator); }
+    void setReplacement(QString replacement) { m_replacement = std::move(replacement); }
+
+public:
+    /// \brief Exports the given TV shows and their episodes
+    /// \param callback Called after each TV show
+    ELCH_NODISCARD QString exportTvShows(const QVector<TvShow*>& movies, std::function<void()> callback);
+
+private:
+    QVector<QString> fieldsToStrings() const;
+    QString fieldToString(TvField field) const;
+
+private:
+    QVector<TvField> m_fields;
     QString m_separator = "\t";
     QString m_replacement = " ";
 };
@@ -84,6 +141,8 @@ public:
 
     const QString& csv() const;
 
+    /// \brief Writes a CSV header using the given fieldsInOrder
+    void writeHeader();
     void addRow(const QMap<QString, QString>& values);
 
 private:

--- a/src/ui/export/CsvExportDialog.h
+++ b/src/ui/export/CsvExportDialog.h
@@ -3,6 +3,8 @@
 #include "export/CsvExport.h"
 
 #include <QDialog>
+#include <QDir>
+#include <QListWidget>
 
 namespace Ui {
 class CsvExportDialog;
@@ -24,8 +26,30 @@ private slots:
 
 private:
     void initializeItems();
-    QVector<mediaelch::CsvMovieExport::MovieField> getMovieFields() const;
-    QString defaultCsvFileName() const;
+
+    template<typename T>
+    QVector<T> getFields(QListWidget* widget) const
+    {
+        QVector<T> fields;
+
+        for (int i = 0; i < widget->count(); ++i) {
+            const QListWidgetItem* item = widget->item(i);
+            if (item->checkState() == Qt::Unchecked) {
+                continue;
+            }
+
+            bool ok = false;
+            const int value = item->data(Qt::UserRole).toInt(&ok);
+            if (ok) {
+                fields.push_back(static_cast<T>(value));
+            }
+        }
+        return fields;
+    }
+
+    bool saveCsvToFile(const QString& type, QDir exportDir, const QString& csv);
+
+    QString defaultCsvFileName(const QString& type) const;
 
 private:
     Ui::CsvExportDialog* ui;

--- a/src/ui/export/CsvExportDialog.ui
+++ b/src/ui/export/CsvExportDialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="lblIntro">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Export your movies into a CSV file.&lt;br/&gt;This feature is &lt;span style=&quot; font-weight:600;&quot;&gt;experimental&lt;/span&gt; and only supports movies at the moment!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Export your movies into a CSV file.&lt;br/&gt;This feature is &lt;span style=&quot; font-weight:600;&quot;&gt;experimental&lt;/span&gt; and only supports moviesand TV shows at the moment!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="textFormat">
       <enum>Qt::RichText</enum>
@@ -40,45 +40,78 @@
    <item>
     <layout class="QHBoxLayout" name="layoutSettings" stretch="3,4">
      <item>
-      <widget class="QListWidget" name="detailsToExport">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>90</height>
-        </size>
+      <widget class="QTabWidget" name="tabDetailsWidget">
+       <property name="currentIndex">
+        <number>0</number>
        </property>
-       <property name="dragDropMode">
-        <enum>QAbstractItemView::InternalMove</enum>
-       </property>
-       <property name="alternatingRowColors">
-        <bool>true</bool>
-       </property>
-       <property name="selectionBehavior">
-        <enum>QAbstractItemView::SelectRows</enum>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <item>
-        <property name="text">
-         <string>Test</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>New Item1</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>New Item2</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>New Item3</string>
-        </property>
-       </item>
+       <widget class="QWidget" name="tabMovieDetails">
+        <attribute name="title">
+         <string>Movie</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="QListWidget" name="movieDetailsToExport">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>90</height>
+            </size>
+           </property>
+           <property name="dragDropMode">
+            <enum>QAbstractItemView::InternalMove</enum>
+           </property>
+           <property name="alternatingRowColors">
+            <bool>true</bool>
+           </property>
+           <property name="selectionBehavior">
+            <enum>QAbstractItemView::SelectRows</enum>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <item>
+            <property name="text">
+             <string notr="true">Placeholder</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="tabTvShowDetails">
+        <attribute name="title">
+         <string>TV Show</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="QListWidget" name="tvShowDetailsToExport">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>90</height>
+            </size>
+           </property>
+           <property name="dragDropMode">
+            <enum>QAbstractItemView::InternalMove</enum>
+           </property>
+           <property name="alternatingRowColors">
+            <bool>true</bool>
+           </property>
+           <property name="selectionBehavior">
+            <enum>QAbstractItemView::SelectRows</enum>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <item>
+            <property name="text">
+             <string notr="true">Placeholder</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </item>
      <item>
@@ -96,7 +129,7 @@
           <widget class="QComboBox" name="separator">
            <property name="minimumSize">
             <size>
-             <width>20</width>
+             <width>40</width>
              <height>0</height>
             </size>
            </property>
@@ -113,7 +146,7 @@
           <widget class="QComboBox" name="replacement">
            <property name="minimumSize">
             <size>
-             <width>20</width>
+             <width>40</width>
              <height>0</height>
             </size>
            </property>


### PR DESCRIPTION
Part of #585

Currently only some fields are supported:

```
TvField::ShowTitle
TvField::ShowImdbid
TvField::ShowTmdbid
TvField::EpisodeSeason
TvField::EpisodeNumber
TvField::EpisodeTitle
TvField::EpisodeOverview
```

Just quickly added some fields. @GarfieldS  What fields would like to have? I'm unsure about adding e.g. the show's overview because having that for each episode (i.e. for each row) is _a lot_ of extra text.