### PR TITLE
[Renamer] Remove leading dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@
 
  - NFO files now contain a `<generator>` tag which holds meta information about MediaElch.  
    This may be helpful when users complain about Kodi not displaying certain details on the Kodi forum.
- - Renamer: Special characters that are not allowed in filenames are now replaced by a space.  
+ - Renamer: More special characters that are not allowed in filenames are now replaced by a space.  
    Windows disallows the following characters in filenames: `<`, `>`, `:`, `"`, `/`, `\`, `|`, `?`, `*`.
-   MediaElch now does a bit of filename sanitization, even if not a lot.
+   MediaElch now does a bit of filename sanitization more, even if not a lot.  Previously unchecked was `|`.
+   Furthermore, leading dots are removed because they indicate hidden files on Unix systems.
 
 ### Added
 

--- a/src/globals/Helper.cpp
+++ b/src/globals/Helper.cpp
@@ -201,19 +201,34 @@ QByteArray& resizeBackdrop(QByteArray& image)
     return image;
 }
 
-QString& sanitizeFileName(QString& fileName)
+void sanitizeFileName(QString& fileName)
 {
+    // Just a few changes to avoid invalid filenames.
+    // See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+    fileName.replace("<", " ");
+    fileName.replace(">", " ");
+    fileName.replace(":", " ");
+    fileName.replace("\"", " ");
     fileName.replace("/", " ");
     fileName.replace("\\", " ");
-    fileName.replace("$", "");
-    fileName.replace("<", "");
-    fileName.replace(">", "");
-    fileName.replace(":", "");
-    fileName.replace("\"", "");
+    fileName.replace("|", " ");
     fileName.replace("?", "");
     fileName.replace("*", "");
+
+    // Not part of the list above but may cause issues for Shell-Scripts.
+    fileName.replace("$", "");
+
+    // If the filename starts with a dot then it is hidden on *nix systems.
+    fileName.remove(QRegularExpression("^[.]+"));
+    // Replace consecutive spaces
+    fileName.replace(QRegularExpression(R"(\s\s+)"), " ");
+
     fileName = fileName.trimmed();
-    return fileName;
+}
+
+void sanitizeFolderName(QString& fileName)
+{
+    return sanitizeFileName(fileName);
 }
 
 QString stackedBaseName(const QString& fileName)

--- a/src/globals/Helper.h
+++ b/src/globals/Helper.h
@@ -37,7 +37,8 @@ bool isBluRay(QString path);
 
 QImage& resizeBackdrop(QImage& image, bool& resized);
 QByteArray& resizeBackdrop(QByteArray& image);
-QString& sanitizeFileName(QString& fileName);
+void sanitizeFileName(QString& fileName);
+void sanitizeFolderName(QString& fileName);
 QString stackedBaseName(const QString& fileName);
 QString appendArticle(const QString& text);
 QString mapGenre(const QString& text);

--- a/src/renamer/ConcertRenamer.cpp
+++ b/src/renamer/ConcertRenamer.cpp
@@ -164,7 +164,7 @@ ConcertRenamer::RenameError ConcertRenamer::renameConcert(Concert& concert)
             helper::matchResolution(videoDetails.value(StreamDetails::VideoDetails::Width).toInt(),
                 videoDetails.value(StreamDetails::VideoDetails::Height).toInt(),
                 videoDetails.value(StreamDetails::VideoDetails::ScanType)));
-        helper::sanitizeFileName(newFolderName);
+        helper::sanitizeFolderName(newFolderName);
         if (dir.dirName() != newFolderName) {
             renameRow = m_dialog->addResultToTable(dir.dirName(), newFolderName, Renamer::RenameOperation::Rename);
         }

--- a/src/renamer/EpisodeRenamer.cpp
+++ b/src/renamer/EpisodeRenamer.cpp
@@ -178,7 +178,7 @@ EpisodeRenamer::RenameError EpisodeRenamer::renameEpisode(TvShowEpisode& episode
         QString seasonDirName = seasonPattern;
         Renamer::replace(seasonDirName, "season", episode.seasonString());
         Renamer::replace(seasonDirName, "showTitle", episode.showTitle());
-        helper::sanitizeFileName(seasonDirName);
+        helper::sanitizeFolderName(seasonDirName);
         QDir seasonDir(showDir.path() + "/" + seasonDirName);
         if (!seasonDir.exists()) {
             int row = m_dialog->addResultToTable(seasonDirName, "", Renamer::RenameOperation::CreateDir);

--- a/src/renamer/MovieRenamer.cpp
+++ b/src/renamer/MovieRenamer.cpp
@@ -254,7 +254,7 @@ MovieRenamer::RenameError MovieRenamer::renameMovie(Movie& movie)
             newFolderName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
         Renamer::replaceCondition(newFolderName, "movieset", movie.set().name);
         Renamer::replaceCondition(newFolderName, "imdbId", movie.imdbId().toString());
-        helper::sanitizeFileName(newFolderName);
+        helper::sanitizeFolderName(newFolderName);
         if (dir.dirName() != newFolderName) {
             renameRow = m_dialog->addResultToTable(dir.dirName(), newFolderName, RenameOperation::Rename);
         }
@@ -283,7 +283,7 @@ MovieRenamer::RenameError MovieRenamer::renameMovie(Movie& movie)
             newFolderName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
         Renamer::replaceCondition(newFolderName, "movieset", movie.set().name);
         Renamer::replaceCondition(newFolderName, "imdbId", movie.imdbId().toString());
-        helper::sanitizeFileName(newFolderName);
+        helper::sanitizeFolderName(newFolderName);
 
         if (dir.dirName() != newFolderName) { // check if movie is not already on good folder
             int i = 0;

--- a/src/renamer/Renamer.cpp
+++ b/src/renamer/Renamer.cpp
@@ -38,18 +38,6 @@ QString Renamer::typeToString(Renamer::RenameType type)
 
 QString Renamer::replace(QString& text, const QString& search, QString replacement)
 {
-    // Just a few changes to avoid invalid filenames.
-    // See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
-    replacement.replace("<", " ");
-    replacement.replace(">", " ");
-    replacement.replace(":", " ");
-    replacement.replace("\"", " ");
-    replacement.replace("/", " ");
-    replacement.replace("\\", " ");
-    replacement.replace("|", " ");
-    replacement.replace("?", " ");
-    replacement.replace("*", " ");
-
     text.replace("<" + search + ">", replacement.trimmed());
     return text;
 }

--- a/src/renamer/RenamerDialog.cpp
+++ b/src/renamer/RenamerDialog.cpp
@@ -292,7 +292,7 @@ void RenamerDialog::renameShows(QVector<TvShow*> shows,
         Renamer::replace(newFolderName, "title", show->title());
         Renamer::replace(newFolderName, "showTitle", show->title());
         Renamer::replace(newFolderName, "year", show->firstAired().toString("yyyy"));
-        helper::sanitizeFileName(newFolderName);
+        helper::sanitizeFolderName(newFolderName);
         if (newFolderName != dir.dirName()) {
             const int row = addResultToTable(dir.dirName(), newFolderName, Renamer::RenameOperation::Rename);
             QDir parentDir(dir.path());

--- a/src/settings/DataFile.cpp
+++ b/src/settings/DataFile.cpp
@@ -50,7 +50,9 @@ QString DataFile::saveFileName(const QString& fileName, SeasonNumber season, boo
 {
     if (type() == DataFileType::MovieSetBackdrop || type() == DataFileType::MovieSetPoster) {
         QString newFileName = m_fileName;
-        return helper::sanitizeFileName(newFileName.replace("<setName>", fileName));
+        newFileName.replace("<setName>", fileName);
+        helper::sanitizeFileName(newFileName);
+        return newFileName;
     }
 
     QFileInfo fi(fileName);

--- a/src/ui/imports/ImportDialog.cpp
+++ b/src/ui/imports/ImportDialog.cpp
@@ -477,7 +477,7 @@ void ImportDialog::onImport()
             Renamer::replaceCondition(
                 newFolderName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
             Renamer::replaceCondition(newFolderName, "movieset", m_movie->set().name);
-            helper::sanitizeFileName(newFolderName);
+            helper::sanitizeFolderName(newFolderName);
             /// \todo Should also check whether the directory exists.
             if (!dir.mkdir(newFolderName)) {
                 QMessageBox::warning(this,
@@ -519,7 +519,7 @@ void ImportDialog::onImport()
         if (ui->chkSeasonDirectories->isChecked()) {
             QString newFolderName = ui->seasonNaming->text();
             Renamer::replace(newFolderName, "season", m_episode->seasonString());
-            helper::sanitizeFileName(newFolderName);
+            helper::sanitizeFolderName(newFolderName);
             dir.mkdir(newFolderName);
             dir.cd(newFolderName);
         }
@@ -570,7 +570,7 @@ void ImportDialog::onImport()
             Renamer::replaceCondition(newFolderName, "dvd", m_concert->discType() == DiscType::Dvd);
             Renamer::replaceCondition(
                 newFolderName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
-            helper::sanitizeFileName(newFolderName);
+            helper::sanitizeFolderName(newFolderName);
             /// \todo Should also check whether the directory exists.
             if (!dir.mkdir(newFolderName)) {
                 QMessageBox::warning(this,

--- a/src/ui/imports/MakeMkvDialog.cpp
+++ b/src/ui/imports/MakeMkvDialog.cpp
@@ -293,7 +293,7 @@ void MakeMkvDialog::onImport()
         newFolderName.replace("<title>", m_movie->name());
         newFolderName.replace("<originalTitle>", m_movie->originalName());
         newFolderName.replace("<year>", m_movie->released().toString("yyyy"));
-        helper::sanitizeFileName(newFolderName);
+        helper::sanitizeFolderName(newFolderName);
         if (!dir.mkdir(newFolderName)) {
             QMessageBox::warning(this,
                 tr("Creating destination directory failed"),


### PR DESCRIPTION
Leading dots indicate hidden files on Unix systems.

Fix #1150

Tested with `.....Movie Name          Part 2`. Seems to work just fine. :-)