### PR TITLE
[Episode] Write empty streamdetails if they were loaded once

### DIFF
--- a/src/media_centers/KodiXml.cpp
+++ b/src/media_centers/KodiXml.cpp
@@ -438,10 +438,18 @@ void KodiXml::loadStreamDetails(StreamDetails* streamDetails, QDomElement elem)
 /// \brief Writes streamdetails to xml stream
 /// \param xml XML Stream
 /// \param streamDetails Stream Details object
-void KodiXml::writeStreamDetails(QXmlStreamWriter& xml, StreamDetails* streamDetails)
+void KodiXml::writeStreamDetails(QXmlStreamWriter& xml, StreamDetails* streamDetails, bool hasStreamDetails)
 {
     if (streamDetails->videoDetails().isEmpty() && streamDetails->audioDetails().isEmpty()
         && streamDetails->subtitleDetails().isEmpty()) {
+        // We still write <fileinfo> and <streamdetails> because otherwise MediaElch
+        // will always mark the media item as changed.
+        if (hasStreamDetails) {
+            xml.writeStartElement("fileinfo");
+            xml.writeStartElement("streamdetails");
+            xml.writeEndElement();
+            xml.writeEndElement();
+        }
         return;
     }
 

--- a/src/media_centers/KodiXml.h
+++ b/src/media_centers/KodiXml.h
@@ -98,7 +98,7 @@ public:
     QString nfoFilePath(Artist* artist) override;
     QString nfoFilePath(Album* album) override;
 
-    static void writeStreamDetails(QXmlStreamWriter& xml, StreamDetails* streamDetails);
+    static void writeStreamDetails(QXmlStreamWriter& xml, StreamDetails* streamDetails, bool hasStreamDetails);
     static void writeStreamDetails(QDomDocument& doc,
         const StreamDetails* streamDetails,
         QVector<Subtitle*> subtitles = QVector<Subtitle*>());

--- a/src/media_centers/kodi/v17/EpisodeXmlWriterV17.cpp
+++ b/src/media_centers/kodi/v17/EpisodeXmlWriterV17.cpp
@@ -134,7 +134,7 @@ void EpisodeXmlWriterV17::writeSingleEpisodeDetails(QXmlStreamWriter& xml, TvSho
         xml.writeTextElement("tag", tag);
     }
 
-    KodiXml::writeStreamDetails(xml, episode->streamDetails());
+    KodiXml::writeStreamDetails(xml, episode->streamDetails(), episode->streamDetailsLoaded());
 
     if (!testMode) {
         addMediaelchGeneratorTag(xml, KodiVersion::v17);


### PR DESCRIPTION
Avoid the "changed" state when reloading.