### PR TITLE
[macOS] Set NSSupportsAutomaticGraphicsSwitching to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
    Windows disallows the following characters in filenames: `<`, `>`, `:`, `"`, `/`, `\`, `|`, `?`, `*`.
    MediaElch now does a bit of filename sanitization more, even if not a lot.  Previously unchecked was `|`.
    Furthermore, leading dots are removed because they indicate hidden files on Unix systems.
+ - On macOS the discrete GPU is no longer required (#702)
 
 ### Added
 

--- a/MediaElch.plist
+++ b/MediaElch.plist
@@ -1,36 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
-<plist version="0.9">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
 <dict>
-    <key>CFBundleIconFile</key>
-    <string>MediaElch.icns</string>
-    <key>CFBundlePackageType</key>
-    <string>APPL</string>
-    <key>CFBundleGetInfoString</key>
-    <string>2.8.3</string>
-    <key>CFBundleVersion</key>
-    <string>2.8.3</string>
-    <key>CFBundleShortVersionString</key>
-    <string>2.8.3</string>
-    <key>CFBundleExecutable</key>
-    <string>MediaElch</string>
-    <key>CFBundleHelpBookFolder</key>
-    <string>MediaElch.help</string>
-    <key>CFBundleHelpBookName</key>
-    <string>com.kvibes.MediaElch.help</string>
-    <key>CFBundleIdentifier</key>
-    <string>com.kvibes.MediaElch</string>
-    <key>NSHumanReadableCopyright</key>
-    <string>2019 Daniel Kabel</string>
-    <key>LSMinimumSystemVersion</key>
-    <string>10.6.8</string>
-    <key>LSApplicationCategoryType</key>
-    <string>public.app-category.utilities</string>
-    <key>ForAppStore</key>
-    <string>yes</string>
-    <key>NSPrincipalClass</key>
-    <string>NSApplication</string>
-    <key>NSRequiresAquaSystemAppearance</key>
+	<key>CFBundleIconFile</key>
+	<string>MediaElch.icns</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleGetInfoString</key>
+	<string>2.8.3</string>
+	<key>CFBundleVersion</key>
+	<string>2.8.3</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.8.3</string>
+	<key>CFBundleExecutable</key>
+	<string>MediaElch</string>
+	<key>CFBundleHelpBookFolder</key>
+	<string>MediaElch.help</string>
+	<key>CFBundleHelpBookName</key>
+	<string>com.kvibes.MediaElch.help</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kvibes.MediaElch</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>2021 Daniel Kabel</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.14.0</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.utilities</string>
+	<key>ForAppStore</key>
+	<string>yes</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSRequiresAquaSystemAppearance</key>
 	<string>True</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Make it possible to use the builtin graphics card instead of the
discrete one.

Fix #702

Before
<img width="410" alt="Screen Shot 2021-01-02 at 19 36 37" src="https://user-images.githubusercontent.com/1667306/103464210-318d9d00-4d32-11eb-9a65-bd429729b9e7.png">


After

<img width="410" alt="Screen Shot 2021-01-02 at 19 38 20" src="https://user-images.githubusercontent.com/1667306/103464211-35212400-4d32-11eb-91bd-0993eb405d73.png">


Tested on macOS 11.1