### PR TITLE
[MediaInfoFile] Fix audio-channel detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugfixes
 
- - *tbd*
+ - Audio-channel detection was broken since the previous version (#1172)
 
 ### Changes
 

--- a/src/data/MediaInfoFile.cpp
+++ b/src/data/MediaInfoFile.cpp
@@ -269,7 +269,7 @@ QString MediaInfoFile::audioChannels(int streamIndex) const
     if (!channelsOriginal.isEmpty()) {
         channels = channelsOriginal;
     }
-    QRegularExpression rx(R"(^\D*(\d*?)\D*)");
+    QRegularExpression rx(R"(^\D*(\d*)\D*)");
     QRegularExpressionMatch match = rx.match(channels);
     channels = match.hasMatch() ? match.captured(1) : "";
     return channels;


### PR DESCRIPTION
Due to an incorrect regular expression, audio channels were no longer
detected.  The issue was that `*?` means "zero-or-more" in a non-greedy
way.  Because it is non greedy and everything after `\d` is optional as
well, it always matched _nothing_.