### PR TITLE
[TVShowSearch] Select all episode/show details if non were selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
  - CSV Export: Column names in generated CSV files were renamed
  - TV Show search: If the show's title contains its year, it is remove in the search dialog (#1192)
+ - TV Show search: All checkboxes are selected per default on new installations (#1189)
 
 ### Added
 

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -940,8 +940,11 @@ QSet<ShowScraperInfo> Settings::scraperInfosShow(const QString& scraperId)
             infos << ShowScraperInfo(val);
         }
     }
-    if (infos.contains(ShowScraperInfo::Invalid)) {
-        infos.clear();
+    // Return ALL available details if non were found.
+    // Reason: Users very likely DID NOT un-select all details and then scrape a show.
+    // Also if there aren't any details stored yet, the user has to select all details.
+    if (infos.isEmpty() || infos.contains(ShowScraperInfo::Invalid)) {
+        return mediaelch::allShowScraperInfos();
     }
     return infos;
 }
@@ -957,8 +960,12 @@ QSet<EpisodeScraperInfo> Settings::scraperInfosEpisode(const QString& scraperId)
             infos << EpisodeScraperInfo(val);
         }
     }
-    if (infos.contains(EpisodeScraperInfo::Invalid)) {
-        infos.clear();
+    // Return ALL available details if non were found.
+    // Reason: Users very likely DID NOT un-select all details and then scrape an episode.
+    // Also if there aren't any details stored yet, the user has to select all details.
+    // And the episode-tab may be "hidden" (the user has to select it).
+    if (infos.isEmpty() || infos.contains(EpisodeScraperInfo::Invalid)) {
+        return mediaelch::allEpisodeScraperInfos();
     }
     return infos;
 }

--- a/src/ui/tv_show/TvShowCommonWidgets.cpp
+++ b/src/ui/tv_show/TvShowCommonWidgets.cpp
@@ -22,17 +22,23 @@ void TvShowCommonWidgets::toggleInfoBoxesForScraper(const mediaelch::scraper::Tv
     const bool showBlocked = showInfosGroupBox->blockSignals(true);
     const bool episodeBlocked = episodeInfosGroupBox->blockSignals(true);
 
-    for (auto* box : showInfosGroupBox->findChildren<MyCheckBox*>()) {
-        const auto detail = ShowScraperInfo(box->myData().toInt());
-        const bool supported = meta.supportedShowDetails.contains(detail);
-        box->setChecked(showInfos.contains(detail) && supported);
-        box->setEnabled(enableShow && supported);
+    {
+        const auto& showCheckBoxes = showInfosGroupBox->findChildren<MyCheckBox*>();
+        for (auto* box : showCheckBoxes) {
+            const auto detail = ShowScraperInfo(box->myData().toInt());
+            const bool supported = meta.supportedShowDetails.contains(detail);
+            box->setChecked(showInfos.contains(detail) && supported);
+            box->setEnabled(enableShow && supported);
+        }
     }
-    for (auto* box : episodeInfosGroupBox->findChildren<MyCheckBox*>()) {
-        const auto detail = EpisodeScraperInfo(box->myData().toInt());
-        const bool supported = meta.supportedEpisodeDetails.contains(detail);
-        box->setChecked(episodeInfos.contains(detail) && supported);
-        box->setEnabled(enableEpisode && supported);
+    {
+        const auto& episodeCheckBoxes = episodeInfosGroupBox->findChildren<MyCheckBox*>();
+        for (auto* box : episodeCheckBoxes) {
+            const auto detail = EpisodeScraperInfo(box->myData().toInt());
+            const bool supported = meta.supportedEpisodeDetails.contains(detail);
+            box->setChecked(episodeInfos.contains(detail) && supported);
+            box->setEnabled(enableEpisode && supported);
+        }
     }
 
     showInfosGroupBox->blockSignals(showBlocked);


### PR DESCRIPTION
On fresh installations, `scraperInfosShow()` will return no details at
all.  To avoid that the user accidentally misses to enable checkboxes
on the episodes tab, enable all details per default.

--------

Fix #1189