### PR TITLE
[File] Fix stackedBaseName() for names that contain "Captain"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
  - CSV Export: Column names in generated CSV files were renamed
  - TV Show search: If the show's title contains its year, it is remove in the search dialog (#1192)
  - TV Show search: All checkboxes are selected per default on new installations (#1189)
+ - File Searcher: A delimiter is expected if a file is split up into multiple parts (#1194)  
+   If you have media files that are split up into multiple parts (e.g. CDs, DVDs, ...) then MediaElch
+   expects it to be named like `title.part1.mkv` (or `-dvd1`, etc.). `titlepart1.mkv`, i.e. without a
+   delimiter worked before but caused false positives. Delimiters are ` `, `.`, `_` and `-`.
 
 ### Added
 

--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -165,6 +165,7 @@ SOURCES += src/main.cpp \
     src/export/MediaExport.cpp \
     src/export/SimpleEngine.cpp \
     src/file/FileFilter.cpp \
+    src/file/FilenameUtils.cpp \
     src/file/Path.cpp \
     src/globals/Actor.cpp \
     src/globals/ComboDelegate.cpp \
@@ -502,6 +503,7 @@ HEADERS  += Version.h \
     src/export/MediaExport.h \
     src/export/SimpleEngine.h \
     src/file/FileFilter.h \
+    src/file/FilenameUtils.h \
     src/file/Path.h \
     src/globals/Actor.h \
     src/globals/ComboDelegate.h \

--- a/src/file/CMakeLists.txt
+++ b/src/file/CMakeLists.txt
@@ -1,4 +1,7 @@
-add_library(mediaelch_file OBJECT FileFilter.cpp NameFormatter.cpp Path.cpp)
+add_library(
+  mediaelch_file OBJECT FileFilter.cpp NameFormatter.cpp FilenameUtils.cpp
+                        Path.cpp
+)
 
 target_link_libraries(mediaelch_file PRIVATE Qt5::Core)
 mediaelch_post_target_defaults(mediaelch_file)

--- a/src/file/FilenameUtils.cpp
+++ b/src/file/FilenameUtils.cpp
@@ -11,11 +11,15 @@ namespace file {
 
 QString stackedBaseName(const QString& fileName)
 {
+    // TODO: Rework: The variable "volume" is not used. Why was is set in the first place?
+
     QString baseName = fileName;
-    QRegExp rx1a(R"((.*)([ _.-]*(?:cd|dvd|p(?:ar)?t|dis[ck])[ _\.-]*[0-9]+)(.*)(\.[^.]+)$)", Qt::CaseInsensitive);
-    QRegExp rx1b("(.*)([ _\\.-]+)$");
-    QRegExp rx2a(R"((.*)([ _\.-]*(?:cd|dvd|p(?:ar)?t|dis[ck])[ _\.-]*[a-d])(.*)(\.[^.]+)$)", Qt::CaseInsensitive);
-    QRegExp rx2b("(.*)([ _\\.-]+)$");
+    // Assumes that there aren't more parts that 'a' through 'f'.
+    QRegExp rx1a(R"((.*)([ _.-]+(?:cd|dvd|pt|part|dis[ck])[ _.-]*[0-9a-f]+)(.*)(\.[^.]+)$)", Qt::CaseInsensitive);
+    QRegExp rx1b("(.*)([ _.-]+)$");
+    // In case that the first does not match, just remove the extension.
+    QRegExp rx2a(R"((.*)(\.[^.]+)$)", Qt::CaseInsensitive);
+    QRegExp rx2b("(.*)([ _.-]+)$");
 
     QVector<QVector<QRegExp>> regex;
     regex << (QVector<QRegExp>() << rx1a << rx1b);

--- a/src/file/FilenameUtils.cpp
+++ b/src/file/FilenameUtils.cpp
@@ -1,0 +1,44 @@
+#include "file/FilenameUtils.h"
+
+#include "globals/Meta.h"
+
+#include <QRegExp>
+#include <QStringList>
+#include <QVector>
+
+namespace mediaelch {
+namespace file {
+
+QString stackedBaseName(const QString& fileName)
+{
+    QString baseName = fileName;
+    QRegExp rx1a(R"((.*)([ _.-]*(?:cd|dvd|p(?:ar)?t|dis[ck])[ _\.-]*[0-9]+)(.*)(\.[^.]+)$)", Qt::CaseInsensitive);
+    QRegExp rx1b("(.*)([ _\\.-]+)$");
+    QRegExp rx2a(R"((.*)([ _\.-]*(?:cd|dvd|p(?:ar)?t|dis[ck])[ _\.-]*[a-d])(.*)(\.[^.]+)$)", Qt::CaseInsensitive);
+    QRegExp rx2b("(.*)([ _\\.-]+)$");
+
+    QVector<QVector<QRegExp>> regex;
+    regex << (QVector<QRegExp>() << rx1a << rx1b);
+    regex << (QVector<QRegExp>() << rx2a << rx2b);
+
+    for (const QVector<QRegExp>& rx : asConst(regex)) {
+        if (rx.at(0).indexIn(fileName) == -1) {
+            continue;
+        }
+
+        QString title = rx.at(0).cap(1);
+        QString volume = rx.at(0).cap(2);
+        /*QString ignore = rx.at(0).cap(3);
+        QString extension = rx.at(0).cap(4);*/
+        while (rx.at(1).indexIn(title) != -1) {
+            title = rx.at(1).capturedTexts().at(1);
+            volume.prepend(rx.at(1).capturedTexts().at(2));
+        }
+        return title;
+    }
+
+    return baseName;
+}
+
+} // namespace file
+} // namespace mediaelch

--- a/src/file/FilenameUtils.h
+++ b/src/file/FilenameUtils.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <QString>
+
+namespace mediaelch {
+namespace file {
+
+/// \brief   Extracts the basename + path of the media file and removes meta data.
+/// \details Media files can refer to the same file and can have a "-part1" suffix.
+///          This function removes such meta data so that the basename can be compared.
+///          This function does _NOT_ remove the file path, hence the "stacked".
+QString stackedBaseName(const QString& fileName);
+
+} // namespace file
+} // namespace mediaelch

--- a/src/globals/Helper.cpp
+++ b/src/globals/Helper.cpp
@@ -233,35 +233,6 @@ void sanitizeFolderName(QString& fileName)
     return sanitizeFileName(fileName);
 }
 
-QString stackedBaseName(const QString& fileName)
-{
-    QString baseName = fileName;
-    QRegExp rx1a(R"((.*)([ _\.-]*(?:cd|dvd|p(?:ar)?t|dis[ck])[ _\.-]*[0-9]+)(.*)(\.[^.]+)$)", Qt::CaseInsensitive);
-    QRegExp rx1b("(.*)([ _\\.-]+)$");
-    QRegExp rx2a("(.*)([ _\\.-]*(?:cd|dvd|p(?:ar)?t|dis[ck])[ _.-]*[a-d])(.*)(\\.[^.]+)$", Qt::CaseInsensitive);
-    QRegExp rx2b("(.*)([ _\\.-]+)$");
-
-    QVector<QVector<QRegExp>> regex;
-    regex << (QVector<QRegExp>() << rx1a << rx1b);
-    regex << (QVector<QRegExp>() << rx2a << rx2b);
-
-    for (const QVector<QRegExp>& rx : asConst(regex)) {
-        if (rx.at(0).indexIn(fileName) != -1) {
-            QString title = rx.at(0).cap(1);
-            QString volume = rx.at(0).cap(2);
-            /*QString ignore = rx.at(0).cap(3);
-            QString extension = rx.at(0).cap(4);*/
-            while (rx.at(1).indexIn(title) != -1) {
-                title = rx.at(1).capturedTexts().at(1);
-                volume.prepend(rx.at(1).capturedTexts().at(2));
-            }
-            return title;
-        }
-    }
-
-    return baseName;
-}
-
 QString appendArticle(const QString& text)
 {
     if (!Settings::instance()->ignoreArticlesWhenSorting()) {

--- a/src/globals/Helper.h
+++ b/src/globals/Helper.h
@@ -39,7 +39,6 @@ QImage& resizeBackdrop(QImage& image, bool& resized);
 QByteArray& resizeBackdrop(QByteArray& image);
 void sanitizeFileName(QString& fileName);
 void sanitizeFolderName(QString& fileName);
-QString stackedBaseName(const QString& fileName);
 QString appendArticle(const QString& text);
 
 QString mapGenre(const QString& text);

--- a/src/movies/file_searcher/MovieFileSearcher.cpp
+++ b/src/movies/file_searcher/MovieFileSearcher.cpp
@@ -1,5 +1,11 @@
 #include "MovieFileSearcher.h"
 
+#include "data/Subtitle.h"
+#include "file/FilenameUtils.h"
+#include "globals/Helper.h"
+#include "globals/Manager.h"
+#include "globals/MessageIds.h"
+
 #include <QApplication>
 #include <QDebug>
 #include <QDirIterator>
@@ -9,11 +15,6 @@
 #include <QtConcurrent/QtConcurrentFilter>
 #include <QtConcurrent/QtConcurrentMap>
 #include <QtConcurrent/QtConcurrentRun>
-
-#include "data/Subtitle.h"
-#include "globals/Helper.h"
-#include "globals/Manager.h"
-#include "globals/MessageIds.h"
 
 namespace mediaelch {
 
@@ -42,7 +43,7 @@ void MovieFileSearcher::reload(bool force)
 
     emit progress(0, 0, m_progressMessageId);
 
-    for (const auto& movieDir : m_directories) {
+    for (const auto& movieDir : asConst(m_directories)) {
         if (m_aborted) {
             return;
         }
@@ -486,13 +487,13 @@ QVector<Movie*> MovieFileSearcher::loadAndStoreMoviesContents(QVector<MovieFileS
                 while (!files.isEmpty()) {
                     QString file = files.takeLast();
 
-                    QString stackedBase = helper::stackedBaseName(file);
+                    QString stackedBase = mediaelch::file::stackedBaseName(file);
                     stacked.insert(stackedBase, {file});
 
                     for (int fileIndex = 0; fileIndex < files.count();) {
                         const QString& f = files[fileIndex];
 
-                        if (helper::stackedBaseName(f) == stackedBase) {
+                        if (mediaelch::file::stackedBaseName(f) == stackedBase) {
                             stacked[stackedBase].append(f);
                             files.removeAt(fileIndex);
                         } else {

--- a/src/movies/file_searcher/MovieFileSearcher.h
+++ b/src/movies/file_searcher/MovieFileSearcher.h
@@ -37,7 +37,7 @@ public:
     /// \param contents List of contents
     /// \param separateFolders Are concerts in separate folders
     /// \param firstScan When this is true, subfolders are scanned, regardless of separateFolders
-    /// \deprecated
+    /// \deprecated Use reload() instead
     Q_DECL_DEPRECATED void scanDir(QString startPath,
         QString path,
         QVector<QStringList>& contents,

--- a/src/settings/DataFile.cpp
+++ b/src/settings/DataFile.cpp
@@ -5,6 +5,7 @@
 #include <QStringList>
 #include <utility>
 
+#include "file/FilenameUtils.h"
 #include "globals/Globals.h"
 #include "globals/Helper.h"
 
@@ -60,7 +61,7 @@ QString DataFile::saveFileName(const QString& fileName, SeasonNumber season, boo
 
     QString baseName = fi.completeBaseName();
     if (stacked) {
-        baseName = helper::stackedBaseName(fileName);
+        baseName = mediaelch::file::stackedBaseName(fileName);
     }
     newFileName.replace("<baseFileName>", baseName);
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(
     data/testTmdbId.cpp
     data/testCertification.cpp
     file/testNameFormatter.cpp
+    file/testStackedBaseName.cpp
     globals/testVersionInfo.cpp
     globals/testTime.cpp
     movie/testMovieFileSearcher.cpp

--- a/test/unit/file/testStackedBaseName.cpp
+++ b/test/unit/file/testStackedBaseName.cpp
@@ -1,0 +1,17 @@
+#include "test/test_helpers.h"
+
+#include "file/FilenameUtils.h"
+
+TEST_CASE("stackedBasedName", "[filename]")
+{
+    using namespace mediaelch::file;
+    SECTION("Removes default excluded words from name")
+    {
+        // TODO: These tests currently fail
+        // CHECK(stackedBaseName("/my/path/to/movie.mkv/captain.marvel.mk4") == "captain.marvel");
+        // CHECK(stackedBaseName("/my/path/to/movie.mkv/captain.america.mk4") == "captain.america");
+        CHECK(stackedBaseName("/my/path/to/movie.mkv/captain.america.part1.mk4") == "/my/path/to/movie.mkv/captain.america");
+        CHECK(stackedBaseName("/my/path/to/movie.mkv/captain.america.pt1.mk4") == "/my/path/to/movie.mkv/captain.america");
+        CHECK(stackedBaseName("/my/path/to/movie.mkv/captain.america.part-1.mk4") == "/my/path/to/movie.mkv/captain.america");
+    }
+}

--- a/test/unit/file/testStackedBaseName.cpp
+++ b/test/unit/file/testStackedBaseName.cpp
@@ -5,13 +5,25 @@
 TEST_CASE("stackedBasedName", "[filename]")
 {
     using namespace mediaelch::file;
-    SECTION("Removes default excluded words from name")
+
+    // This test case currently only covers the bug reported in
+    // https://github.com/Komet/MediaElch/issues/1194
+
+    SECTION("Removes 'partN' from the filename with *nix filenames")
     {
-        // TODO: These tests currently fail
-        // CHECK(stackedBaseName("/my/path/to/movie.mkv/captain.marvel.mk4") == "captain.marvel");
-        // CHECK(stackedBaseName("/my/path/to/movie.mkv/captain.america.mk4") == "captain.america");
-        CHECK(stackedBaseName("/my/path/to/movie.mkv/captain.america.part1.mk4") == "/my/path/to/movie.mkv/captain.america");
-        CHECK(stackedBaseName("/my/path/to/movie.mkv/captain.america.pt1.mk4") == "/my/path/to/movie.mkv/captain.america");
-        CHECK(stackedBaseName("/my/path/to/movie.mkv/captain.america.part-1.mk4") == "/my/path/to/movie.mkv/captain.america");
+        CHECK(stackedBaseName("/path/to/movie.mkv/captain.marvel.mk4") == "/path/to/movie.mkv/captain.marvel");
+        CHECK(stackedBaseName("/path/to/movie.mkv/captain.america.mk4") == "/path/to/movie.mkv/captain.america");
+        CHECK(stackedBaseName("/path/to/movie.mkv/captain.america.part1.mk4") == "/path/to/movie.mkv/captain.america");
+        CHECK(stackedBaseName("/path/to/movie.mkv/captain.marvel.pt1.ignored.mk4") == "/path/to/movie.mkv/captain.marvel");
+        CHECK(stackedBaseName("/path/to/movie.mkv/captain.america.part-1.mk4") == "/path/to/movie.mkv/captain.america");
+    }
+
+    SECTION("Removes 'partN' from the filename with Windows filenames")
+    {
+        CHECK(stackedBaseName("C:\\path\\to\\movie.mkv\\captain.marvel.mk4") == "C:\\path\\to\\movie.mkv\\captain.marvel");
+        CHECK(stackedBaseName("C:\\path\\to\\movie.mkv\\captain.america.mk4") == "C:\\path\\to\\movie.mkv\\captain.america");
+        CHECK(stackedBaseName("C:\\path\\to\\movie.mkv\\captain.america.part1.mk4") == "C:\\path\\to\\movie.mkv\\captain.america");
+        CHECK(stackedBaseName("C:\\path\\to\\movie.mkv\\captain.marvel.pt1.ignored.mk4") == "C:\\path\\to\\movie.mkv\\captain.marvel");
+        CHECK(stackedBaseName("C:\\path\\to\\movie.mkv\\captain.america.part-1.mk4") == "C:\\path\\to\\movie.mkv\\captain.america");
     }
 }


### PR DESCRIPTION
Fix #1194


------------

It returned the wrong basename for: `Captain.The.Great.mkv`

That was because no delimiter between the title and "ptN"/"dvd-N" was
required and instead of using numbers like `pt1` one could also use
`pta`. And this matches the word `captain`.