### PR TITLE
[Renamer] Use scroll view to avoid dialogs that are too large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugfixes
 
- - *tbd*
+ - Renamer: On macOS, the renamer was sometimes so large that buttons were not visible (#1227)
 
 ### Changes
 

--- a/src/renamer/RenamerDialog.cpp
+++ b/src/renamer/RenamerDialog.cpp
@@ -37,7 +37,7 @@ RenamerDialog::RenamerDialog(QWidget* parent) : QDialog(parent), ui(new Ui::Rena
     ui->helpLabel->setText(tr("Please see %1 for help and examples on how to use the renamer.")
                                .arg("<a "
                                     "href=\"https://mediaelch.github.io/mediaelch-doc/renaming.html\">"
-                                    "RenamingFiles.md</a>"));
+                                    "Renaming Files</a>"));
 }
 
 RenamerDialog::~RenamerDialog()

--- a/src/renamer/RenamerDialog.ui
+++ b/src/renamer/RenamerDialog.ui
@@ -239,7 +239,7 @@
          <property name="maximumSize">
           <size>
            <width>16777215</width>
-           <height>100</height>
+           <height>110</height>
           </size>
          </property>
          <property name="frameShape">

--- a/src/renamer/RenamerPlaceholders.cpp
+++ b/src/renamer/RenamerPlaceholders.cpp
@@ -6,6 +6,7 @@
 RenamerPlaceholders::RenamerPlaceholders(QWidget* parent) : QWidget(parent), ui(new Ui::RenamerPlaceholders)
 {
     ui->setupUi(this);
+    setType(Renamer::RenameType::Movies);
 }
 
 RenamerPlaceholders::~RenamerPlaceholders()
@@ -26,4 +27,5 @@ void RenamerPlaceholders::setType(Renamer::RenameType renameType)
                           || (renameType == Type::TvShows && itemTypes.contains("tvshow"))
                           || (renameType == Type::Concerts && itemTypes.contains("concert")));
     }
+    adjustSize();
 }

--- a/src/renamer/RenamerPlaceholders.ui
+++ b/src/renamer/RenamerPlaceholders.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>642</width>
-    <height>547</height>
+    <width>650</width>
+    <height>300</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -29,669 +29,693 @@
       <string>Placeholders</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
       <property name="topMargin">
        <number>0</number>
       </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
-       <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
-        <item row="19" column="1">
-         <widget class="QLabel" name="descDvd">
-          <property name="text">
-           <string>File/directory is DVD</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="17" column="1">
-         <widget class="QLabel" name="descAudioChannels">
-          <property name="text">
-           <string>Number of audio channels</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="labelOriginalTitle">
-          <property name="text">
-           <string notr="true">&lt;originalTitle&gt;</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="15" column="1">
-         <widget class="QLabel" name="descVideoCodec">
-          <property name="text">
-           <string>Video Codec</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="12" column="1">
-         <widget class="QLabel" name="descArtist">
-          <property name="text">
-           <string>Artist</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="labelExtension">
-          <property name="text">
-           <string notr="true">&lt;extension&gt;</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="17" column="0">
-         <widget class="QLabel" name="labelChannels">
-          <property name="text">
-           <string notr="true">&lt;channels&gt;</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="19" column="0">
-         <widget class="QLabel" name="labelDvd">
-          <property name="text">
-           <string notr="true">{dvd}...{/dvd}</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="labelSortTitle">
-          <property name="text">
-           <string notr="true">&lt;sortTitle&gt;</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="QLabel" name="descSortTitle">
-          <property name="text">
-           <string>Sort Title</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="labelPartNo">
-          <property name="text">
-           <string notr="true">&lt;partNo&gt;</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="1">
-         <widget class="QLabel" name="descSeason">
-          <property name="text">
-           <string>Season Number</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>tvshow</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="labelTitle">
-          <property name="text">
-           <string notr="true">&lt;title&gt;</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="1">
-         <widget class="QLabel" name="descShowTitle">
-          <property name="text">
-           <string>Title of the show</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>tvshow</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="QLabel" name="descYear">
-          <property name="text">
-           <string>Year</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="21" column="1">
-         <widget class="QLabel" name="descMovieSet">
-          <property name="text">
-           <string>Movie set name</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="lblPlaceholder">
-          <property name="font">
-           <font>
-            <weight>75</weight>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Placeholder</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-          </property>
-         </widget>
-        </item>
-        <item row="15" column="0">
-         <widget class="QLabel" name="labelVideoCodec">
-          <property name="text">
-           <string notr="true">&lt;videoCodec&gt;</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QLabel" name="descTitle">
-          <property name="text">
-           <string>Title</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="12" column="0">
-         <widget class="QLabel" name="labelArtist">
-          <property name="text">
-           <string notr="true">&lt;artist&gt;</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="20" column="0">
-         <widget class="QLabel" name="label3d">
-          <property name="text">
-           <string notr="true">{3D}...{/3D}</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="0">
-         <widget class="QLabel" name="labelSeason">
-          <property name="text">
-           <string notr="true">&lt;season&gt;</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>tvshow</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="labelYear">
-          <property name="text">
-           <string notr="true">&lt;year&gt;</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="14" column="0">
-         <widget class="QLabel" name="labelResolution">
-          <property name="text">
-           <string notr="true">&lt;resolution&gt;</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="22" column="1">
-         <widget class="QLabel" name="descImdbId">
-          <property name="text">
-           <string>IMDb ID</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="0">
-         <widget class="QLabel" name="labelDirector">
-          <property name="text">
-           <string notr="true">&lt;director&gt;</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QLabel" name="descPartNo">
-          <property name="text">
-           <string>Part number of the current file</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="21" column="0">
-         <widget class="QLabel" name="labelMovieSet">
-          <property name="text">
-           <string notr="true">{movieset}...&lt;movieset&gt;...{/movieset}</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLabel" name="lblDescription">
-          <property name="font">
-           <font>
-            <weight>75</weight>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Description</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-          </property>
-         </widget>
-        </item>
-        <item row="13" column="1">
-         <widget class="QLabel" name="descAlbum">
-          <property name="text">
-           <string>Album</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="1">
-         <widget class="QLabel" name="descEpisode">
-          <property name="text">
-           <string>Episode Number</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>tvshow</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="1">
-         <widget class="QLabel" name="descDirector">
-          <property name="text">
-           <string>Director(s)</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="16" column="0">
-         <widget class="QLabel" name="labelAudioCodec">
-          <property name="text">
-           <string notr="true">&lt;audioCodec&gt;</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="0">
-         <widget class="QLabel" name="labelShowTitle">
-          <property name="text">
-           <string notr="true">&lt;showTitle&gt;</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>tvshow</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="labelEpisode">
-          <property name="text">
-           <string notr="true">&lt;episode&gt;</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>tvshow</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="16" column="1">
-         <widget class="QLabel" name="descAudioCodec">
-          <property name="text">
-           <string>Audio Codec</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="22" column="0">
-         <widget class="QLabel" name="labelImdbId">
-          <property name="text">
-           <string notr="true">{imdbId}...&lt;imdbId&gt;...{/imdbId}</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="18" column="0">
-         <widget class="QLabel" name="labelBluray">
-          <property name="text">
-           <string notr="true">{bluray}...{/bluray}</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="14" column="1">
-         <widget class="QLabel" name="descResolution">
-          <property name="text">
-           <string>Resolution (1080p, 720p, ...)</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QLabel" name="descOriginalTitle">
-          <property name="text">
-           <string>Original Title</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="13" column="0">
-         <widget class="QLabel" name="labelAlbum">
-          <property name="text">
-           <string notr="true">&lt;album&gt;</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::PlainText</enum>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="18" column="1">
-         <widget class="QLabel" name="descBluray">
-          <property name="text">
-           <string>File/directory is BluRay</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="20" column="1">
-         <widget class="QLabel" name="desc3d">
-          <property name="text">
-           <string>File is 3D</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QLabel" name="descExtension">
-          <property name="text">
-           <string>File extension</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-            <string>tvshow</string>
-            <string>concert</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="11" column="0">
-         <widget class="QLabel" name="labelStudio">
-          <property name="text">
-           <string notr="true">&lt;studio&gt;</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item row="11" column="1">
-         <widget class="QLabel" name="descStudio">
-          <property name="text">
-           <string>Studio(s) (separated by a comma)</string>
-          </property>
-          <property name="itemTypes" stdset="0">
-           <stringlist notr="true">
-            <string>movie</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <widget class="QScrollArea" name="scrollArea">
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <widget class="QWidget" name="placeholderItems">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>628</width>
+           <height>518</height>
+          </rect>
+         </property>
+         <layout class="QGridLayout" name="placeholderLayout" columnstretch="0,1">
+          <item row="19" column="1">
+           <widget class="QLabel" name="descDvd">
+            <property name="text">
+             <string>File/directory is DVD</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="17" column="1">
+           <widget class="QLabel" name="descAudioChannels">
+            <property name="text">
+             <string>Number of audio channels</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelOriginalTitle">
+            <property name="text">
+             <string notr="true">&lt;originalTitle&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="15" column="1">
+           <widget class="QLabel" name="descVideoCodec">
+            <property name="text">
+             <string>Video Codec</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="1">
+           <widget class="QLabel" name="descArtist">
+            <property name="text">
+             <string>Artist</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelExtension">
+            <property name="text">
+             <string notr="true">&lt;extension&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="17" column="0">
+           <widget class="QLabel" name="labelChannels">
+            <property name="text">
+             <string notr="true">&lt;channels&gt;</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="19" column="0">
+           <widget class="QLabel" name="labelDvd">
+            <property name="text">
+             <string notr="true">{dvd}...{/dvd}</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="labelSortTitle">
+            <property name="text">
+             <string notr="true">&lt;sortTitle&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLabel" name="descSortTitle">
+            <property name="text">
+             <string>Sort Title</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelPartNo">
+            <property name="text">
+             <string notr="true">&lt;partNo&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="QLabel" name="descSeason">
+            <property name="text">
+             <string>Season Number</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>tvshow</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelTitle">
+            <property name="text">
+             <string notr="true">&lt;title&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1">
+           <widget class="QLabel" name="descShowTitle">
+            <property name="text">
+             <string>Title of the show</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>tvshow</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QLabel" name="descYear">
+            <property name="text">
+             <string>Year</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="21" column="1">
+           <widget class="QLabel" name="descMovieSet">
+            <property name="text">
+             <string>Movie set name</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="lblPlaceholder">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Placeholder</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+            </property>
+           </widget>
+          </item>
+          <item row="15" column="0">
+           <widget class="QLabel" name="labelVideoCodec">
+            <property name="text">
+             <string notr="true">&lt;videoCodec&gt;</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLabel" name="descTitle">
+            <property name="text">
+             <string>Title</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="0">
+           <widget class="QLabel" name="labelArtist">
+            <property name="text">
+             <string notr="true">&lt;artist&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="20" column="0">
+           <widget class="QLabel" name="label3d">
+            <property name="text">
+             <string notr="true">{3D}...{/3D}</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="labelSeason">
+            <property name="text">
+             <string notr="true">&lt;season&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>tvshow</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="labelYear">
+            <property name="text">
+             <string notr="true">&lt;year&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="14" column="0">
+           <widget class="QLabel" name="labelResolution">
+            <property name="text">
+             <string notr="true">&lt;resolution&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="22" column="1">
+           <widget class="QLabel" name="descImdbId">
+            <property name="text">
+             <string>IMDb ID</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="0">
+           <widget class="QLabel" name="labelDirector">
+            <property name="text">
+             <string notr="true">&lt;director&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLabel" name="descPartNo">
+            <property name="text">
+             <string>Part number of the current file</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="21" column="0">
+           <widget class="QLabel" name="labelMovieSet">
+            <property name="text">
+             <string notr="true">{movieset}...&lt;movieset&gt;...{/movieset}</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="lblDescription">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Description</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+            </property>
+           </widget>
+          </item>
+          <item row="13" column="1">
+           <widget class="QLabel" name="descAlbum">
+            <property name="text">
+             <string>Album</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QLabel" name="descEpisode">
+            <property name="text">
+             <string>Episode Number</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>tvshow</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="1">
+           <widget class="QLabel" name="descDirector">
+            <property name="text">
+             <string>Director(s)</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="16" column="0">
+           <widget class="QLabel" name="labelAudioCodec">
+            <property name="text">
+             <string notr="true">&lt;audioCodec&gt;</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
+           <widget class="QLabel" name="labelShowTitle">
+            <property name="text">
+             <string notr="true">&lt;showTitle&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>tvshow</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="labelEpisode">
+            <property name="text">
+             <string notr="true">&lt;episode&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>tvshow</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="16" column="1">
+           <widget class="QLabel" name="descAudioCodec">
+            <property name="text">
+             <string>Audio Codec</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="22" column="0">
+           <widget class="QLabel" name="labelImdbId">
+            <property name="text">
+             <string notr="true">{imdbId}...&lt;imdbId&gt;...{/imdbId}</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="18" column="0">
+           <widget class="QLabel" name="labelBluray">
+            <property name="text">
+             <string notr="true">{bluray}...{/bluray}</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="14" column="1">
+           <widget class="QLabel" name="descResolution">
+            <property name="text">
+             <string>Resolution (1080p, 720p, ...)</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLabel" name="descOriginalTitle">
+            <property name="text">
+             <string>Original Title</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="13" column="0">
+           <widget class="QLabel" name="labelAlbum">
+            <property name="text">
+             <string notr="true">&lt;album&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="18" column="1">
+           <widget class="QLabel" name="descBluray">
+            <property name="text">
+             <string>File/directory is BluRay</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="20" column="1">
+           <widget class="QLabel" name="desc3d">
+            <property name="text">
+             <string>File is 3D</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="descExtension">
+            <property name="text">
+             <string>File extension</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="0">
+           <widget class="QLabel" name="labelStudio">
+            <property name="text">
+             <string notr="true">&lt;studio&gt;</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="1">
+           <widget class="QLabel" name="descStudio">
+            <property name="text">
+             <string>Studio(s) (separated by a comma)</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/ui/main/MainWindow.cpp
+++ b/src/ui/main/MainWindow.cpp
@@ -42,13 +42,13 @@ MainWindow* MainWindow::m_instance = nullptr;
 
 MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWindow)
 {
+    m_aboutDialog = new AboutDialog(this);
 #ifdef Q_OS_MACOS
     auto* macMenuBar = new QMenuBar();
     QMenu* menu = macMenuBar->addMenu("File");
     QAction* mAbout = menu->addAction("About");
     mAbout->setMenuRole(QAction::AboutRole);
-    auto* aboutDialog = new AboutDialog(this);
-    connect(mAbout, &QAction::triggered, aboutDialog, &AboutDialog::exec);
+    connect(mAbout, &QAction::triggered, m_aboutDialog, &AboutDialog::exec);
 
     QMenu* help = macMenuBar->addMenu("Help");
     const auto addHelpUrl = [help](const QString& str, const QString& url) {
@@ -101,7 +101,6 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
     m_actions[MainWidgets::Music][MainActions::FilterWidget] = true;
 
     m_settings = Settings::instance(this);
-    m_aboutDialog = new AboutDialog(this);
     m_supportDialog = new SupportDialog(this);
     m_settingsWindow = new SettingsWindow(this);
     m_fileScannerDialog = new FileScannerDialog(this);


### PR DESCRIPTION
Fix #1227

<img width="743" alt="Screen Shot 2021-02-16 at 20 03 24" src="https://user-images.githubusercontent.com/1667306/108109514-45971f00-7092-11eb-9e6d-71adb17d25f6.png">
