### PR TITLE
[NameFormatter] Re-use regular expression object for better performance

### DIFF
--- a/src/movies/Movie.cpp
+++ b/src/movies/Movie.cpp
@@ -1,5 +1,4 @@
 #include "Movie.h"
-#include "file/NameFormatter.h"
 
 #include <QApplication>
 #include <QDebug>

--- a/src/movies/file_searcher/MovieFileSearcher.h
+++ b/src/movies/file_searcher/MovieFileSearcher.h
@@ -38,6 +38,7 @@ public:
     /// \param separateFolders Are concerts in separate folders
     /// \param firstScan When this is true, subfolders are scanned, regardless of separateFolders
     /// \deprecated Use reload() instead
+    /// \note Only used in MovieFilesOrganizer
     Q_DECL_DEPRECATED void scanDir(QString startPath,
         QString path,
         QVector<QStringList>& contents,
@@ -62,11 +63,11 @@ private:
         QMap<QString, QStringList> contents;
     };
 
-    static Movie* loadMovieData(Movie* movie);
+    static void loadMovieData(Movie* movie);
 
     QStringList getFiles(QString path);
 
-    int loadMoviesFromDirectory(const SettingsDir& movieDir,
+    int loadMoviesContentFromDirectory(const SettingsDir& movieDir,
         bool force,
         QVector<MovieContents>& moviesContent,
         QVector<Movie*>& dbMovies,


### PR DESCRIPTION
The Nameformatter is a hot path in MediaElch. And as it turns out, the call to `QRegularExpression::optimize` takes about 50% of the time loading new movies.

Before
```
[MovieFileSearcher] Reloading took 5276 ms
```

After
```
[MovieFileSearcher] Reloading took 3859 ms
```

We may cache Regular expression in the future. 