### PR TITLE
[MovieFileSearcher] Do search in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
    as well.  `QXmlStreamWriter` is faster and the code becomes more maintainable.
  - MediaElch no longer has `*.qm` files in its source tree.  QMake (and CMake) need
    to be able to run `lrelease` to generated translation files.
+ - MediaElch now searches for movies in parallel (#1230)  
+   Improvements can vary. During tests on different hard drives with
+   1000 movie directories, the time improvements were:
+   - 3.8s -> 1.3s (SSD)
+   - 4.1s -> 1.4s (HDD)
 
 
 ## 2.8.6 - Coridian (2021-01-22)

--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -136,6 +136,7 @@ SOURCES += src/main.cpp \
     src/data/ResumeTime.cpp \
     src/movies/Movie.cpp \
     src/movies/file_searcher/MovieFileSearcher.cpp \
+    src/movies/file_searcher/MovieDirectorySearcher.cpp \
     src/movies/MovieFilesOrganizer.cpp \
     src/movies/MovieImages.cpp \
     src/movies/MovieModel.cpp \
@@ -456,6 +457,7 @@ HEADERS  += Version.h \
     src/media_centers/MediaCenterInterface.h \
     src/movies/Movie.h \
     src/movies/file_searcher/MovieFileSearcher.h \
+    src/movies/file_searcher/MovieDirectorySearcher.h \
     src/movies/MovieFilesOrganizer.h \
     src/movies/MovieImages.h \
     src/movies/MovieModel.h \

--- a/src/data/Database.h
+++ b/src/data/Database.h
@@ -5,6 +5,7 @@
 #include "tv_shows/TvDbId.h"
 
 #include <QDateTime>
+#include <QMutex>
 #include <QSqlDatabase>
 #include <QString>
 #include <QStringList>
@@ -77,6 +78,7 @@ public:
     ColorLabel getLabel(const mediaelch::FileList& fileNames);
 
 private:
+    QMutex m_mutex;
     QSqlDatabase* m_db;
     void updateDbVersion(int version);
 };

--- a/src/movies/CMakeLists.txt
+++ b/src/movies/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(
   MovieProxyModel.cpp
   MovieSet.cpp
   file_searcher/MovieFileSearcher.cpp
+  file_searcher/MovieDirectorySearcher.cpp
 )
 
 target_link_libraries(mediaelch_movies PRIVATE Qt5::Sql Qt5::MultimediaWidgets)

--- a/src/movies/MovieModel.cpp
+++ b/src/movies/MovieModel.cpp
@@ -30,6 +30,16 @@ void MovieModel::addMovie(Movie* movie)
     connect(movie, &Movie::sigChanged, this, &MovieModel::onMovieChanged, Qt::UniqueConnection);
 }
 
+void MovieModel::addMovies(const QVector<Movie*>& movies)
+{
+    beginInsertRows(QModelIndex(), rowCount(), rowCount() + movies.size() - 1);
+    m_movies.append(movies);
+    for (Movie* movie : movies) {
+        connect(movie, &Movie::sigChanged, this, &MovieModel::onMovieChanged, Qt::UniqueConnection);
+    }
+    endInsertRows();
+}
+
 /**
  * \brief Called when a movies data has changed
  * Emits dataChanged

--- a/src/movies/MovieModel.h
+++ b/src/movies/MovieModel.h
@@ -35,6 +35,7 @@ public:
     virtual QVector<Movie*> movies();
     Movie* movie(int row);
     void addMovie(Movie* movie);
+    void addMovies(const QVector<Movie*>& movies);
     void update();
     void clear();
     int countNewMovies();

--- a/src/movies/file_searcher/MovieDirectorySearcher.cpp
+++ b/src/movies/file_searcher/MovieDirectorySearcher.cpp
@@ -1,0 +1,330 @@
+#include "MovieDirectorySearcher.h"
+
+#include "file/FilenameUtils.h"
+#include "globals/Manager.h"
+#include "globals/MessageIds.h"
+
+#include "file/FilenameUtils.h"
+
+#include <QFutureWatcher>
+#include <QtConcurrent>
+
+namespace mediaelch {
+
+MovieDirectorySearcher::MovieDirectorySearcher(const SettingsDir& dir, bool inSeparateFolders, QObject* parent) :
+    QObject(parent), m_dir{dir}, m_inSeparateFolders{inSeparateFolders}
+{
+}
+
+void MovieDirectorySearcher::load()
+{
+    if (m_aborted) {
+        return;
+    }
+
+    Manager::instance()->database()->clearMoviesInDirectory(m_dir.path);
+
+    // No filter, no media files...
+    if (!Settings::instance()->advanced()->movieFilters().hasFilter()) {
+        emit loaded(this);
+        return;
+    }
+
+    qDebug() << "[MovieDirectorySearcher] Scanning directory:" << QDir::toNativeSeparators(m_dir.path.path());
+    loadMovieContents();
+
+    const int approximateMovieCount = m_inSeparateFolders ? m_contents.size() : 0;
+    emit startLoading(approximateMovieCount);
+
+    qDebug() << "[MovieDirectorySearcher] Creating movies for" << QDir::toNativeSeparators(m_dir.path.path());
+    createMovies();
+}
+
+void MovieDirectorySearcher::abort()
+{
+    m_aborted = true;
+    m_watcher.cancel();
+    m_watcher.waitForFinished();
+}
+
+void MovieDirectorySearcher::loadMovieContents()
+{
+    QDirIterator it(m_dir.path.path(),
+        Settings::instance()->advanced()->movieFilters().filters(),
+        QDir::NoDotAndDotDot | QDir::Dirs | QDir::Files,
+        QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
+
+    QString lastDir;
+
+    while (it.hasNext()) {
+        if (m_aborted) {
+            // 0, because "contents" isn't stored, yet
+            emit loaded(this);
+            return;
+        }
+        it.next();
+
+        QString dirName = it.fileInfo().dir().dirName();
+        QString fileName = it.fileName(); // may actually be a directory name
+
+        const bool isFile = it.fileInfo().isFile();
+        const bool isDir = it.fileInfo().isDir();
+        bool isSpecialDir = false; // set to true for DVD or BluRay Structure
+
+        if (isFile && Settings::instance()->advanced()->isFileExcluded(fileName)) {
+            continue;
+        }
+
+        // TODO: If there is a BluRay structure then the directory filter may not work
+        // because BDMV's parent directory is not listed.
+        if ((isDir && Settings::instance()->advanced()->isFolderExcluded(fileName))
+            || Settings::instance()->advanced()->isFolderExcluded(dirName)) {
+            continue;
+        }
+
+        // Skips Extras files
+        if (isFile
+            && (fileName.contains("-trailer", Qt::CaseInsensitive)            //
+                || fileName.contains("-sample", Qt::CaseInsensitive)          //
+                || fileName.contains("-behindthescenes", Qt::CaseInsensitive) //
+                || fileName.contains("-deleted", Qt::CaseInsensitive)         //
+                || fileName.contains("-featurette", Qt::CaseInsensitive)      //
+                || fileName.contains("-interview", Qt::CaseInsensitive)       //
+                || fileName.contains("-scene", Qt::CaseInsensitive)           //
+                || fileName.contains("-short", Qt::CaseInsensitive))) {
+            continue;
+        }
+
+        // Skip actors folder and all files inside it
+        if (QString::compare(".actors", dirName, Qt::CaseInsensitive) == 0) {
+            continue;
+        }
+
+        // Skip extras folder and all files inside it
+        if (QString::compare("extras", dirName, Qt::CaseInsensitive) == 0) {
+            continue;
+        }
+
+        // Skip extra fanarts folder and all files inside it
+        if (QString::compare("extrafanart", dirName, Qt::CaseInsensitive) == 0) {
+            continue;
+        }
+
+        // Skip extra thumbs folder and all files inside it
+        if (QString::compare("extrathumbs", dirName, Qt::CaseInsensitive) == 0) {
+            continue;
+        }
+
+        // Skip BluRay backup folder
+        if (QString::compare("backup", dirName, Qt::CaseInsensitive) == 0
+            && QString::compare("index.bdmv", fileName, Qt::CaseInsensitive) == 0) {
+            continue;
+        }
+
+        if (dirName != lastDir) {
+            lastDir = dirName;
+            if (m_contents.count() % 20 == 0) {
+                // TODO  emit currentDir(dirName);
+            }
+        }
+
+        if (isFile && QString::compare("index.bdmv", fileName, Qt::CaseInsensitive) == 0) {
+            qDebug() << "[MovieDirectorySearcher] Found BluRay structure";
+            QDir bluRayDir(it.fileInfo().dir());
+            if (QString::compare(bluRayDir.dirName(), "BDMV", Qt::CaseInsensitive) == 0) {
+                bluRayDir.cdUp();
+            }
+            m_bluRayDirectories << bluRayDir.path();
+            isSpecialDir = true;
+        }
+        if (QString::compare("VIDEO_TS.IFO", fileName, Qt::CaseInsensitive) == 0) {
+            qDebug() << "[MovieDirectorySearcher] Found DVD structure";
+            QDir videoDir(it.fileInfo().dir());
+            if (QString::compare(videoDir.dirName(), "VIDEO_TS", Qt::CaseInsensitive) == 0) {
+                videoDir.cdUp();
+            }
+            m_dvdDirectories << videoDir.path();
+            isSpecialDir = true;
+        }
+
+        const QString dirPath = it.fileInfo().path();
+        if (!m_contents.contains(dirPath)) {
+            m_contents.insert(dirPath, {});
+        }
+        if (isFile || isSpecialDir) {
+            m_contents[dirPath].append(it.filePath());
+            m_lastModifications.insert(it.filePath(), it.fileInfo().lastModified());
+        }
+    }
+}
+
+void MovieDirectorySearcher::createMovies()
+{
+    std::function<QVector<Movie*>(QStringList files)> fct = [this](QStringList files) -> QVector<Movie*> {
+        return createMovie(std::move(files));
+    };
+
+    connect(&m_watcher, &QFutureWatcher<QVector<Movie*>>::finished, this, [this]() { emit loaded(this); });
+    connect(&m_watcher, &QFutureWatcher<QVector<Movie*>>::resultReadyAt, this, [this](int index) {
+        // Called in the main thread, so no need for a mutex.
+        const QVector<Movie*> movies = m_watcher.resultAt(index);
+        for (Movie* movie : movies) {
+            postProcessMovie(movie);
+        }
+    });
+    QFuture<QVector<Movie*>> future = QtConcurrent::mapped(m_contents, fct);
+    m_watcher.setFuture(future);
+}
+
+QVector<Movie*> MovieDirectorySearcher::createMovie(QStringList files)
+{
+    // TODO: Atomic
+    if (m_aborted) {
+        return {};
+    }
+
+    QVector<Movie*> movies;
+
+    DiscType discType = DiscType::Single;
+
+    // BluRay handling
+    for (const QString& path : asConst(m_bluRayDirectories)) {
+        if (!files.isEmpty() && (files.first().startsWith(path + "/") || files.first().startsWith(path + "\\"))) {
+            QStringList f;
+            for (const QString& file : files) {
+                if (file.endsWith("index.bdmv", Qt::CaseInsensitive)) {
+                    f.append(file);
+                }
+            }
+            files = f;
+            discType = DiscType::BluRay;
+            qDebug() << "It's a BluRay structure";
+        }
+    }
+
+    // DVD handling
+    for (const QString& path : asConst(m_dvdDirectories)) {
+        if (!files.isEmpty() && (files.first().startsWith(path + "/") || files.first().startsWith(path + "\\"))) {
+            QStringList f;
+            for (const QString& file : files) {
+                if (file.endsWith("VIDEO_TS.IFO", Qt::CaseInsensitive)) {
+                    f.append(file);
+                }
+            }
+            files = f;
+            discType = DiscType::Dvd;
+            qDebug() << "It's a DVD structure";
+        }
+    }
+
+    if (files.isEmpty()) {
+        return {};
+    }
+
+    if (files.count() == 1 || m_inSeparateFolders) {
+        // single file or in separate folder
+        files.sort();
+        auto* movie = new Movie(files);
+        movie->setInSeparateFolder(m_inSeparateFolders);
+        movie->setFileLastModified(m_lastModifications.value(files.at(0)));
+        movie->setDiscType(discType);
+        movie->setLabel(Manager::instance()->database()->getLabel(movie->files()));
+        movie->setChanged(false);
+        movie->controller()->loadData(Manager::instance()->mediaCenterInterface());
+        if (discType == DiscType::Single) {
+            QFileInfo mFi(files.first());
+            const QList<QFileInfo> subFiles = mFi.dir().entryInfoList(
+                QStringList{"*.sub", "*.srt", "*.smi", "*.ssa"}, QDir::Files | QDir::NoDotAndDotDot);
+            for (const QFileInfo& subFi : subFiles) {
+                QString subFileName = subFi.fileName().mid(mFi.completeBaseName().length() + 1);
+                QStringList parts = subFileName.split(QRegExp(R"(\s+|\-+|\.+)"));
+                if (parts.isEmpty()) {
+                    continue;
+                }
+                parts.takeLast();
+
+                QStringList subFiles = QStringList() << subFi.fileName();
+                if (QString::compare(subFi.suffix(), "sub", Qt::CaseInsensitive) == 0) {
+                    QFileInfo subIdxFi(subFi.absolutePath() + "/" + subFi.completeBaseName() + ".idx");
+                    if (subIdxFi.exists()) {
+                        subFiles << subIdxFi.fileName();
+                    }
+                }
+                auto* subtitle = new Subtitle(movie);
+                subtitle->setFiles(subFiles);
+                if (parts.contains("forced", Qt::CaseInsensitive)) {
+                    subtitle->setForced(true);
+                    parts.removeAll("forced");
+                }
+                if (!parts.isEmpty()) {
+                    subtitle->setLanguage(parts.first());
+                }
+                subtitle->setChanged(false);
+                movie->addSubtitle(subtitle, true);
+            }
+        }
+
+        // This method is called in parallel. Move it to the main object's thread.
+        movie->moveToThread(thread());
+        movies << movie;
+
+    } else {
+        QMap<QString, QStringList> stacked;
+        while (!files.isEmpty()) {
+            QString file = files.takeLast();
+
+            QString stackedBase = mediaelch::file::stackedBaseName(file);
+            stacked.insert(stackedBase, {file});
+
+            for (int fileIndex = 0; fileIndex < files.count();) {
+                const QString& f = files[fileIndex];
+
+                if (mediaelch::file::stackedBaseName(f) == stackedBase) {
+                    stacked[stackedBase].append(f);
+                    files.removeAt(fileIndex);
+                } else {
+                    fileIndex++;
+                }
+            }
+        }
+        QMapIterator<QString, QStringList> it(stacked);
+        while (it.hasNext()) {
+            it.next();
+            if (it.value().isEmpty()) {
+                continue;
+            }
+            QStringList stackedFiles = it.value();
+            stackedFiles.sort();
+            auto* movie = new Movie(stackedFiles);
+            movie->setInSeparateFolder(m_inSeparateFolders);
+            movie->setFileLastModified(m_lastModifications.value(it.value().at(0)));
+            movie->controller()->loadData(Manager::instance()->mediaCenterInterface());
+            movie->setLabel(Manager::instance()->database()->getLabel(movie->files()));
+            // This method is called in parallel. Move it to the main object's thread.
+            movie->moveToThread(thread());
+            movies << movie;
+        }
+    }
+    return movies;
+}
+
+void MovieDirectorySearcher::postProcessMovie(Movie* movie)
+{
+    m_movies.push_back(movie);
+    emit movieProcessed(movie);
+}
+
+QStringList MovieDirectorySearcher::getFiles(QString path)
+{
+    const auto& filters = Settings::instance()->advanced()->movieFilters();
+    QStringList files;
+
+    for (const QString& file : filters.files(QDir(path))) {
+        m_lastModifications.insert(
+            QDir::toNativeSeparators(path + "/" + file), QFileInfo(path + QDir::separator() + file).lastModified());
+        files.append(file);
+    }
+    return files;
+}
+
+} // namespace mediaelch

--- a/src/movies/file_searcher/MovieDirectorySearcher.h
+++ b/src/movies/file_searcher/MovieDirectorySearcher.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "globals/Globals.h"
+
+#include <QFutureWatcher>
+#include <QString>
+#include <QVector>
+
+class Movie;
+
+namespace mediaelch {
+
+/// \brief   Searches for movies in a given directory.
+/// \details Create an instance of this class and connect to \see movieProcessed(Movie*).
+///          The caller must take ownership of the created movies.
+class MovieDirectorySearcher : public QObject
+{
+    Q_OBJECT
+public:
+    MovieDirectorySearcher(const SettingsDir& dir, bool inSeparateFolders, QObject* parent = nullptr);
+    ~MovieDirectorySearcher() override = default;
+
+signals:
+    void startLoading(int approximateMovieCount);
+    void loaded(MovieDirectorySearcher* self);
+    void movieProcessed(Movie* movie);
+
+public:
+    void load();
+    void abort();
+
+    const QVector<Movie*> movies() const { return m_movies; }
+    SettingsDir directory() const { return m_dir; }
+    int currentMovieCount() const { return m_movies.size(); }
+
+private:
+    void loadMovieContents();
+    void createMovies();
+    QVector<Movie*> createMovie(QStringList files);
+
+    void postProcessMovie(Movie* movie);
+
+    /// Get a list of files in a directory
+    QStringList getFiles(QString path);
+
+private:
+    const SettingsDir& m_dir;
+    QHash<QString, QDateTime> m_lastModifications;
+
+    QFutureWatcher<QVector<Movie*>> m_watcher;
+
+    QStringList m_bluRayDirectories;
+    QStringList m_dvdDirectories;
+
+    QMap<QString, QStringList> m_contents;
+    QVector<Movie*> m_movies;
+
+    bool m_inSeparateFolders = false;
+    bool m_aborted = false;
+};
+
+
+} // namespace mediaelch

--- a/src/movies/file_searcher/MovieFileSearcher.h
+++ b/src/movies/file_searcher/MovieFileSearcher.h
@@ -3,6 +3,7 @@
 #include "movies/Movie.h"
 
 #include <QDir>
+#include <QElapsedTimer>
 #include <QHash>
 #include <QObject>
 #include <QTime>
@@ -55,6 +56,10 @@ signals:
     void moviesLoaded();
     void currentDir(QString);
 
+    // private signals
+
+    void directoriesLoaded();
+
 private:
     struct MovieContents
     {
@@ -65,24 +70,34 @@ private:
 
     static void loadMovieData(Movie* movie);
 
+private slots:
+    void onDirectoriesLoaded();
+
+private:
+    /// \brief Resets all counters, internal variables and so on.
+    void resetInternalState();
     QStringList getFiles(QString path);
 
-    int loadMoviesContentFromDirectory(const SettingsDir& movieDir,
-        bool force,
-        QVector<MovieContents>& moviesContent,
-        QVector<Movie*>& dbMovies,
-        QStringList& bluRays,
-        QStringList& dvds);
-    QVector<Movie*> loadAndStoreMoviesContents(QVector<MovieContents>& moviesContent,
-        QStringList& bluRays,
-        QStringList& dvds,
-        int& movieSum,
-        int& movieCounter);
+    int loadMoviesContentFromDirectory(const SettingsDir& movieDir, bool force);
 
+    QVector<Movie*> loadAndStoreMoviesContents(int& movieCounter);
+
+private:
     QVector<SettingsDir> m_directories;
     int m_progressMessageId;
     QHash<QString, QDateTime> m_lastModifications;
-    bool m_aborted;
+
+    QVector<MovieContents> m_movieDirectoriesContent;
+    QVector<Movie*> m_dbMovies;
+    QStringList m_bluRayDirectories;
+    QStringList m_dvdDirectories;
+
+    QElapsedTimer m_reloadTimer;
+
+    int m_movieSum = 0;
+
+    bool m_running = false;
+    bool m_aborted = false;
 };
 
 } // namespace mediaelch

--- a/src/movies/file_searcher/MovieFileSearcher.h
+++ b/src/movies/file_searcher/MovieFileSearcher.h
@@ -59,6 +59,8 @@ signals:
     // private signals
 
     void directoriesLoaded();
+    void movieContentsLoadedAndStored(QVector<Movie*> movies);
+    void movieProcessed(Movie* movie);
 
 private:
     struct MovieContents
@@ -72,19 +74,24 @@ private:
 
 private slots:
     void onDirectoriesLoaded();
+    void onDirectoryLoaded(SettingsDir dir, int moviesInDir);
+    void onMovieContentsLoadedAndStored(QVector<Movie*> movies);
+    void onMovieProcessed(Movie* movie);
 
 private:
     /// \brief Resets all counters, internal variables and so on.
     void resetInternalState();
     QStringList getFiles(QString path);
 
-    int loadMoviesContentFromDirectory(const SettingsDir& movieDir, bool force);
+    void loadDirectoryContents(const SettingsDir& movieDir, bool force);
 
-    QVector<Movie*> loadAndStoreMoviesContents(int& movieCounter);
+    QVector<Movie*> loadAndStoreMoviesContents();
 
 private:
-    QVector<SettingsDir> m_directories;
     int m_progressMessageId;
+
+    QVector<SettingsDir> m_directories;
+
     QHash<QString, QDateTime> m_lastModifications;
 
     QVector<MovieContents> m_movieDirectoriesContent;
@@ -94,7 +101,9 @@ private:
 
     QElapsedTimer m_reloadTimer;
 
+    int m_directoriesProcessed = 0;
     int m_movieSum = 0;
+    int m_movieProcessed = 0;
 
     bool m_running = false;
     bool m_aborted = false;

--- a/src/movies/file_searcher/MovieFileSearcher.h
+++ b/src/movies/file_searcher/MovieFileSearcher.h
@@ -12,6 +12,8 @@
 
 namespace mediaelch {
 
+class MovieDirectorySearcher;
+
 /// \brief Class responsible for (re-)loading all movies inside given directories.
 ///
 /// \par Example
@@ -52,58 +54,37 @@ public slots:
 
 signals:
     void searchStarted(QString);
-    void progress(int, int, int);
+    void progress(int current, int max, int messageBarId);
     void moviesLoaded();
     void currentDir(QString);
 
-    // private signals
-
-    void directoriesLoaded();
-    void movieContentsLoadedAndStored(QVector<Movie*> movies);
-    void movieProcessed(Movie* movie);
-
-private:
-    struct MovieContents
-    {
-        QString path;
-        bool inSeparateFolder;
-        QMap<QString, QStringList> contents;
-    };
-
+public:
     static void loadMovieData(Movie* movie);
 
 private slots:
-    void onDirectoriesLoaded();
-    void onDirectoryLoaded(SettingsDir dir, int moviesInDir);
-    void onMovieContentsLoadedAndStored(QVector<Movie*> movies);
+    void onDirectoryLoaded(MovieDirectorySearcher* searcher);
+    void onDirectoryStartsLoading(int approximateMovieCount);
     void onMovieProcessed(Movie* movie);
 
 private:
     /// \brief Resets all counters, internal variables and so on.
     void resetInternalState();
+
+    /// Get a list of files in a directory
+    /// \deprecated Remove with scanDir
     QStringList getFiles(QString path);
 
-    void loadDirectoryContents(const SettingsDir& movieDir, bool force);
-
-    QVector<Movie*> loadAndStoreMoviesContents();
-
 private:
-    int m_progressMessageId;
-
     QVector<SettingsDir> m_directories;
-
-    QHash<QString, QDateTime> m_lastModifications;
-
-    QVector<MovieContents> m_movieDirectoriesContent;
-    QVector<Movie*> m_dbMovies;
-    QStringList m_bluRayDirectories;
-    QStringList m_dvdDirectories;
-
+    QVector<MovieDirectorySearcher*> m_searchers;
     QElapsedTimer m_reloadTimer;
 
+    /// \deprecated Remove with scanDir
+    QHash<QString, QDateTime> m_lastModifications;
+
+    int m_approxMovieSum = 0;
+    int m_moviesProcessed = 0;
     int m_directoriesProcessed = 0;
-    int m_movieSum = 0;
-    int m_movieProcessed = 0;
 
     bool m_running = false;
     bool m_aborted = false;

--- a/src/scrapers/image/ImageProvider.h
+++ b/src/scrapers/image/ImageProvider.h
@@ -122,8 +122,8 @@ public slots:
     virtual void searchAlbum(QString artistName, QString searchStr, int limit) = 0;
 
 signals:
-    void sigSearchDone(QVector<ScraperSearchResult>, ScraperError error);
-    void sigImagesLoaded(QVector<Poster>, ScraperError error);
+    void sigSearchDone(QVector<ScraperSearchResult>, mediaelch::ScraperError error);
+    void sigImagesLoaded(QVector<Poster>, mediaelch::ScraperError error);
     void sigMovieImagesLoaded(Movie*, QMap<ImageType, QVector<Poster>>);
     void sigConcertImagesLoaded(Concert*, QMap<ImageType, QVector<Poster>>);
     void sigTvShowImagesLoaded(TvShow*, QMap<ImageType, QVector<Poster>>);

--- a/src/ui/movies/MovieFilesWidget.cpp
+++ b/src/ui/movies/MovieFilesWidget.cpp
@@ -128,21 +128,12 @@ MovieFilesWidget::MovieFilesWidget(QWidget* parent) : QWidget(parent), ui(new Ui
     connect(ui->sortBySeen,      &MyLabel::clicked, this, &MovieFilesWidget::onSortBySeen);
     connect(ui->sortByYear,      &MyLabel::clicked, this, &MovieFilesWidget::onSortByYear);
 
-    connect(m_movieProxyModel, &QAbstractItemModel::rowsInserted, this, &MovieFilesWidget::updateStatusLabel);
-    connect(m_movieProxyModel, &QAbstractItemModel::rowsRemoved,  this, &MovieFilesWidget::updateStatusLabel);
-    // clang-format on
-
-    // FIXME:
     // For some reason, the proxy model emits "rowsRemoved" before "endRemoveRows()" is called in the source model.
-    connect(Manager::instance()->movieFileSearcher(),
-        &mediaelch::MovieFileSearcher::moviesLoaded,
-        this,
-        &MovieFilesWidget::updateStatusLabel);
+    connect(Manager::instance()->movieModel(), &QAbstractItemModel::rowsInserted, this, &MovieFilesWidget::updateStatusLabel);
+    connect(Manager::instance()->movieModel(), &QAbstractItemModel::rowsRemoved,  this, &MovieFilesWidget::updateStatusLabel);
+    // clang-format on
 }
 
-/**
- * \brief MovieFilesWidget::~MovieFilesWidget
- */
 MovieFilesWidget::~MovieFilesWidget()
 {
     delete ui;


### PR DESCRIPTION
 - MediaElch now searches for movies in parallel (#1230)  
   Improvements can vary. During tests on different hard drives with
   1000 movie directories, the time improvements were:
   - 3.8s -> 1.3s (SSD)
   - 4.1s -> 1.4s (HDD)