### PR TITLE
[Movie] Fix local trailer search for names containing square brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugfixes
 
  - Renamer: On macOS, the renamer was sometimes so large that buttons were not visible (#1227)
+ - Local trailers for movies are now detected if the filename contains square brackets such as `Movie[BLURAY]` (#1231)
 
 ### Changes
 

--- a/src/data/Database.cpp
+++ b/src/data/Database.cpp
@@ -230,16 +230,13 @@ Database::Database(QObject* parent) : QObject(parent)
     }
 }
 
-/**
- * \brief Database::~Database
- */
 Database::~Database()
 {
-    if ((m_db != nullptr) && m_db->isOpen()) {
+    if (m_db != nullptr && m_db->isOpen()) {
         m_db->close();
-        delete m_db;
-        m_db = nullptr;
     }
+    delete m_db;
+    m_db = nullptr;
 }
 
 void Database::updateDbVersion(int version)


### PR DESCRIPTION
The filename was interpreted as a global pattern, e.g. `Movie[BLURAY]`
would be interpreted as the regular expression `Movie(?:B|L|U|R|A|Y)`.