### PR TITLE
[Qt] Some Qt6 compatibility changes

### DIFF
--- a/src/concerts/ConcertFileSearcher.cpp
+++ b/src/concerts/ConcertFileSearcher.cpp
@@ -117,7 +117,7 @@ void ConcertFileSearcher::scanDir(QString startPath,
     }
 
     QStringList files;
-    const QStringList entries = getFiles(path);
+    const QStringList entries = getFiles(mediaelch::DirectoryPath(path));
     for (const QString& file : entries) {
         if (m_aborted) {
             return;
@@ -191,7 +191,7 @@ void ConcertFileSearcher::clearOldConcerts(bool forceClear)
 
     for (const SettingsDir& dir : asConst(m_directories)) {
         if (dir.autoReload || forceClear) {
-            database().clearConcertsInDirectory(dir.path);
+            database().clearConcertsInDirectory(mediaelch::DirectoryPath(dir.path));
         }
     }
 }
@@ -202,7 +202,7 @@ QVector<QStringList> ConcertFileSearcher::loadContentsFromDiskIfRequired(bool fo
 
     for (const SettingsDir& dir : asConst(m_directories)) {
         const QString path = dir.path.path();
-        QVector<Concert*> concertsFromDb = database().concertsInDirectory(dir.path);
+        QVector<Concert*> concertsFromDb = database().concertsInDirectory(mediaelch::DirectoryPath(dir.path));
         if (dir.autoReload || forceReload || concertsFromDb.isEmpty()) {
             scanDir(path, path, contents, dir.separateFolders, true);
         }
@@ -246,7 +246,7 @@ void ConcertFileSearcher::storeContentsInDatabase(const QVector<QStringList>& co
         concert.setInSeparateFolder(inSeparateFolder);
         concert.controller()->loadData(Manager::instance()->mediaCenterInterface());
         emit currentDir(concert.title());
-        database().add(&concert, path);
+        database().add(&concert, mediaelch::DirectoryPath(path));
     }
     database().commit();
 }
@@ -271,7 +271,7 @@ QVector<Concert*> ConcertFileSearcher::loadConcertsFromDatabase()
         if (m_aborted) {
             break;
         }
-        dbConcerts.append(database().concertsInDirectory(dir.path));
+        dbConcerts.append(database().concertsInDirectory(mediaelch::DirectoryPath(dir.path)));
     }
     setupDatabaseConcerts(dbConcerts);
     return dbConcerts;

--- a/src/data/Database.cpp
+++ b/src/data/Database.cpp
@@ -731,8 +731,8 @@ QVector<TvShow*> Database::showsInDirectory(DirectoryPath path)
     query.bindValue(":path", path.toString().toUtf8());
     query.exec();
     while (query.next()) {
-        auto* show = new TvShow(QString::fromUtf8(query.value(query.record().indexOf("dir")).toByteArray()),
-            Manager::instance()->tvShowFileSearcher());
+        mediaelch::DirectoryPath dir(QString::fromUtf8(query.value(query.record().indexOf("dir")).toByteArray()));
+        auto* show = new TvShow(dir, Manager::instance()->tvShowFileSearcher());
         show->setDatabaseId(query.value(query.record().indexOf("idShow")).toInt());
         show->setNfoContent(QString::fromUtf8(query.value(query.record().indexOf("content")).toByteArray()));
         shows.append(show);
@@ -1064,8 +1064,8 @@ QVector<Artist*> Database::artistsInDirectory(DirectoryPath path)
     query.bindValue(":path", path.toString().toUtf8());
     query.exec();
     while (query.next()) {
-        auto* artist = new Artist(QString::fromUtf8(query.value(query.record().indexOf("dir")).toByteArray()),
-            Manager::instance()->musicFileSearcher());
+        mediaelch::DirectoryPath dir(QString::fromUtf8(query.value(query.record().indexOf("dir")).toByteArray()));
+        auto* artist = new Artist(dir, Manager::instance()->musicFileSearcher());
         artist->setDatabaseId(query.value(query.record().indexOf("idArtist")).toInt());
         artist->setNfoContent(QString::fromUtf8(query.value(query.record().indexOf("content")).toByteArray()));
         artists.append(artist);
@@ -1120,8 +1120,8 @@ QVector<Album*> Database::albums(Artist* artist)
     query.bindValue(":idArtist", artist->databaseId());
     query.exec();
     while (query.next()) {
-        auto* album = new Album(QString::fromUtf8(query.value(query.record().indexOf("dir")).toByteArray()),
-            Manager::instance()->musicFileSearcher());
+        mediaelch::DirectoryPath dir(QString::fromUtf8(query.value(query.record().indexOf("dir")).toByteArray()));
+        auto* album = new Album(dir, Manager::instance()->musicFileSearcher());
         album->setDatabaseId(query.value(query.record().indexOf("idAlbum")).toInt());
         album->setNfoContent(QString::fromUtf8(query.value(query.record().indexOf("content")).toByteArray()));
         album->setArtistObj(artist);

--- a/src/data/ImageCache.cpp
+++ b/src/data/ImageCache.cpp
@@ -131,11 +131,11 @@ QSize ImageCache::imageSize(mediaelch::FilePath path)
     return {parts.at(3).toInt(), parts.at(4).toInt()};
 }
 
-unsigned ImageCache::getLastModified(const mediaelch::FilePath& fileName)
+qint64 ImageCache::getLastModified(const mediaelch::FilePath& fileName)
 {
-    unsigned now = QDateTime::currentDateTime().toTime_t();
+    qint64 now = QDateTime::currentDateTime().toSecsSinceEpoch();
     if (!m_lastModifiedTimes.contains(fileName) || m_lastModifiedTimes.value(fileName).first() < now - 10) {
-        unsigned lastMod = QFileInfo(fileName.toString()).lastModified().toTime_t();
+        qint64 lastMod = QFileInfo(fileName.toString()).lastModified().toSecsSinceEpoch();
         m_lastModifiedTimes.insert(fileName, {now, lastMod});
     }
     return m_lastModifiedTimes.value(fileName).last();

--- a/src/data/ImageCache.h
+++ b/src/data/ImageCache.h
@@ -21,8 +21,8 @@ public:
 
 private:
     mediaelch::DirectoryPath m_cacheDir;
-    QHash<mediaelch::FilePath, QVector<unsigned>> m_lastModifiedTimes;
+    QHash<mediaelch::FilePath, QVector<qint64>> m_lastModifiedTimes;
     QImage scaledImage(QImage img, int width, int height);
-    unsigned getLastModified(const mediaelch::FilePath& fileName);
+    qint64 getLastModified(const mediaelch::FilePath& fileName);
     bool m_forceCache;
 };

--- a/src/export/SimpleEngine.cpp
+++ b/src/export/SimpleEngine.cpp
@@ -34,7 +34,7 @@ SimpleEngine::SimpleEngine(ExportTemplate& exportTemplate,
     QObject(parent), m_cancelFlag{cancelFlag}, m_template{&exportTemplate}, m_dir{directory}
 {
     // Create the base structure
-    m_template->copyTo(m_dir.path());
+    m_template->copyTo(mediaelch::DirectoryPath(m_dir));
 }
 
 void SimpleEngine::exportMovies(QVector<Movie*> movies)

--- a/src/file/Path.cpp
+++ b/src/file/Path.cpp
@@ -19,7 +19,7 @@ QString DirectoryPath::filePath(const QString& fileName) const
 
 DirectoryPath DirectoryPath::subDir(const QString& dirName) const
 {
-    return {toString() + '/' + dirName};
+    return DirectoryPath{toString() + '/' + dirName};
 }
 
 

--- a/src/file/Path.h
+++ b/src/file/Path.h
@@ -21,8 +21,8 @@ class DirectoryPath
 {
 public:
     DirectoryPath() = default;
-    /* implicit */ DirectoryPath(const QString& path) : m_isValid{!path.isEmpty()}, m_dir(QDir(path)) {}
-    /* implicit */ DirectoryPath(QDir path) : m_isValid{true}, m_dir(std::move(path)) {}
+    explicit DirectoryPath(const QString& path) : m_isValid{!path.isEmpty()}, m_dir(QDir(path)) {}
+    explicit DirectoryPath(QDir path) : m_isValid{true}, m_dir(std::move(path)) {}
 
     bool isValid() const { return m_isValid; }
 
@@ -68,7 +68,7 @@ class FilePath
 {
 public:
     FilePath() = default;
-    /* implicit */ FilePath(const QString& path) : m_isValid{!path.isEmpty()}, m_fileInfo(path) {}
+    explicit FilePath(const QString& path) : m_isValid{!path.isEmpty()}, m_fileInfo(path) {}
     explicit FilePath(QFileInfo filePath) : m_isValid{true}, m_fileInfo(std::move(filePath)) {}
 
     bool isValid() const { return m_isValid; }

--- a/src/globals/Globals.h
+++ b/src/globals/Globals.h
@@ -5,7 +5,7 @@
 #include <QDate>
 #include <QDebug>
 #include <QDir>
-#include <QImage>
+#include <QImage> // TODO: Remove dependency on Qt::Gui
 #include <QMap>
 #include <QMetaType>
 #include <QString>

--- a/src/globals/ImageDialog.cpp
+++ b/src/globals/ImageDialog.cpp
@@ -521,7 +521,7 @@ void ImageDialog::chooseLocalImage()
     qWarning() << fileName;
 
     QFileInfo fi(fileName);
-    Settings::instance()->setLastImagePath(fi.absoluteDir().canonicalPath());
+    Settings::instance()->setLastImagePath(mediaelch::DirectoryPath(fi.absoluteDir().canonicalPath()));
     const int index = m_elements.size();
 
     DownloadElement d;

--- a/src/globals/ScraperManager.h
+++ b/src/globals/ScraperManager.h
@@ -36,7 +36,7 @@ public:
     ELCH_NODISCARD mediaelch::scraper::ConcertScraper* concertScraper(const QString& identifier);
     ELCH_NODISCARD mediaelch::scraper::TvScraper* tvScraper(const QString& identifier);
 
-    static ELCH_NODISCARD QVector<mediaelch::scraper::MovieScraper*> constructNativeScrapers(QObject* scraperParent);
+    ELCH_NODISCARD static QVector<mediaelch::scraper::MovieScraper*> constructNativeScrapers(QObject* scraperParent);
 
 private:
     void initMovieScrapers();

--- a/src/media_centers/KodiXml.cpp
+++ b/src/media_centers/KodiXml.cpp
@@ -1181,7 +1181,7 @@ bool KodiXml::saveFile(QString filename, QByteArray data)
 mediaelch::DirectoryPath KodiXml::getPath(const Movie* movie)
 {
     if (movie->files().isEmpty()) {
-        return QString();
+        return mediaelch::DirectoryPath();
     }
     QFileInfo fi(movie->files().first().toString());
     if (movie->discType() == DiscType::BluRay) {
@@ -1189,22 +1189,22 @@ mediaelch::DirectoryPath KodiXml::getPath(const Movie* movie)
         if (QString::compare(dir.dirName(), "BDMV", Qt::CaseInsensitive) == 0) {
             dir.cdUp();
         }
-        return dir;
+        return mediaelch::DirectoryPath(dir);
     }
     if (movie->discType() == DiscType::Dvd) {
         QDir dir = fi.dir();
         if (QString::compare(dir.dirName(), "VIDEO_TS", Qt::CaseInsensitive) == 0) {
             dir.cdUp();
         }
-        return dir;
+        return mediaelch::DirectoryPath(dir);
     }
-    return fi.dir();
+    return mediaelch::DirectoryPath(fi.dir());
 }
 
 mediaelch::DirectoryPath KodiXml::getPath(const Concert* concert)
 {
     if (concert->files().isEmpty()) {
-        return QString();
+        return mediaelch::DirectoryPath();
     }
     QFileInfo fi(concert->files().first().toString());
     if (concert->discType() == DiscType::BluRay) {
@@ -1212,16 +1212,16 @@ mediaelch::DirectoryPath KodiXml::getPath(const Concert* concert)
         if (QString::compare(dir.dirName(), "BDMV", Qt::CaseInsensitive) == 0) {
             dir.cdUp();
         }
-        return dir;
+        return mediaelch::DirectoryPath(dir);
     }
     if (concert->discType() == DiscType::Dvd) {
         QDir dir = fi.dir();
         if (QString::compare(dir.dirName(), "VIDEO_TS", Qt::CaseInsensitive) == 0) {
             dir.cdUp();
         }
-        return dir;
+        return mediaelch::DirectoryPath(dir);
     }
-    return fi.dir();
+    return mediaelch::DirectoryPath(fi.dir());
 }
 
 QString KodiXml::movieSetFileName(QString setName, DataFile* dataFile)
@@ -1431,7 +1431,7 @@ KodiXml::imageFileName(const TvShowEpisode* episode, ImageType type, QVector<Dat
         dataFiles = Settings::instance()->dataFiles(fileType);
     }
 
-    return saveDataFiles(fi.absolutePath(), fi.fileName(), dataFiles, constructName);
+    return saveDataFiles(mediaelch::DirectoryPath(fi.absolutePath()), fi.fileName(), dataFiles, constructName);
 }
 
 bool KodiXml::loadArtist(Artist* artist, QString initialNfoContent)

--- a/src/media_centers/kodi/ConcertXmlReader.cpp
+++ b/src/media_centers/kodi/ConcertXmlReader.cpp
@@ -22,7 +22,8 @@ void ConcertXmlReader::parse(QXmlStreamReader& reader)
     if (reader.readNextStartElement()) {
         // There is only "musicvideo" for concerts. But in case that there are other
         // NFO files, we also accept other root element names.
-        if (reader.name() == "musicvideo" || reader.name() == "concert" || reader.name() == "movie") {
+        if (reader.name() == QLatin1String("musicvideo") || reader.name() == QLatin1String("concert")
+            || reader.name() == QLatin1String("movie")) {
             parseConcert(reader);
         } else {
             reader.raiseError(QObject::tr("Not a cookbook file"));
@@ -34,70 +35,70 @@ void ConcertXmlReader::parseConcert(QXmlStreamReader& reader)
 {
     Rating oldStyleRating;
     while (reader.readNextStartElement()) {
-        if (reader.name() == "id") {
+        if (reader.name() == QLatin1String("id")) {
             // v16 imdbid
             m_concert.setImdbId(ImdbId(reader.readElementText()));
 
-        } else if (reader.name() == "tmdbid") {
+        } else if (reader.name() == QLatin1String("tmdbid")) {
             // v16 tmdbid
             m_concert.setTmdbId(TmdbId(reader.readElementText()));
 
-        } else if (reader.name() == "title") {
+        } else if (reader.name() == QLatin1String("title")) {
             m_concert.setTitle(reader.readElementText());
 
-        } else if (reader.name() == "originaltitle") {
+        } else if (reader.name() == QLatin1String("originaltitle")) {
             m_concert.setOriginalTitle(reader.readElementText());
 
-        } else if (reader.name() == "artist") {
+        } else if (reader.name() == QLatin1String("artist")) {
             m_concert.setArtist(reader.readElementText());
 
-        } else if (reader.name() == "album") {
+        } else if (reader.name() == QLatin1String("album")) {
             m_concert.setAlbum(reader.readElementText());
 
-        } else if (reader.name() == "userrating") {
+        } else if (reader.name() == QLatin1String("userrating")) {
             m_concert.setUserRating(reader.readElementText().toDouble());
 
-        } else if (reader.name() == "year") {
+        } else if (reader.name() == QLatin1String("year")) {
             m_concert.setReleased(QDate::fromString(reader.readElementText(), "yyyy"));
 
-        } else if (reader.name() == "plot") {
+        } else if (reader.name() == QLatin1String("plot")) {
             m_concert.setOverview(reader.readElementText());
 
-        } else if (reader.name() == "tagline") {
+        } else if (reader.name() == QLatin1String("tagline")) {
             m_concert.setTagline(reader.readElementText());
 
-        } else if (reader.name() == "runtime") {
+        } else if (reader.name() == QLatin1String("runtime")) {
             m_concert.setRuntime(std::chrono::minutes(reader.readElementText().toInt()));
 
-        } else if (reader.name() == "mpaa") {
+        } else if (reader.name() == QLatin1String("mpaa")) {
             m_concert.setCertification(Certification(reader.readElementText()));
 
-        } else if (reader.name() == "playcount") {
+        } else if (reader.name() == QLatin1String("playcount")) {
             m_concert.setPlayCount(reader.readElementText().toInt());
 
-        } else if (reader.name() == "lastplayed") {
+        } else if (reader.name() == QLatin1String("lastplayed")) {
             m_concert.setLastPlayed(QDateTime::fromString(reader.readElementText(), "yyyy-MM-dd HH:mm:ss"));
 
-        } else if (reader.name() == "trailer") {
+        } else if (reader.name() == QLatin1String("trailer")) {
             m_concert.setTrailer(QUrl(reader.readElementText()));
 
-        } else if (reader.name() == "genre") {
+        } else if (reader.name() == QLatin1String("genre")) {
             const QStringList genres = reader.readElementText().split(" / ", ElchSplitBehavior::SkipEmptyParts);
             for (const QString& genre : genres) {
                 m_concert.addGenre(genre);
             }
 
-        } else if (reader.name() == "tag") {
+        } else if (reader.name() == QLatin1String("tag")) {
             m_concert.addTag(reader.readElementText());
 
 
-        } else if (reader.name() == "uniqueid") {
+        } else if (reader.name() == QLatin1String("uniqueid")) {
             parseUniqueId(reader);
 
-        } else if (reader.name() == "ratings") {
+        } else if (reader.name() == QLatin1String("ratings")) {
             parseRatings(reader);
 
-        } else if (reader.name() == "rating") {
+        } else if (reader.name() == QLatin1String("rating")) {
             // otherwise use "old" syntax:
             // <rating>10.0</rating>
             // <votes>10.0</votes>
@@ -106,21 +107,21 @@ void ConcertXmlReader::parseConcert(QXmlStreamReader& reader)
                 oldStyleRating.rating = value.replace(",", ".").toDouble();
             }
 
-        } else if (reader.name() == "votes") {
+        } else if (reader.name() == QLatin1String("votes")) {
             QString value = reader.readElementText();
             if (!value.isEmpty()) {
                 oldStyleRating.voteCount = value.replace(",", "").replace(".", "").toInt();
             }
 
-        } else if (reader.name() == "thumb") {
+        } else if (reader.name() == QLatin1String("thumb")) {
             parsePoster(reader);
 
-        } else if (reader.name() == "fanart") {
+        } else if (reader.name() == QLatin1String("fanart")) {
             parseFanart(reader);
 
-        } else if (reader.name() == "fileinfo") {
+        } else if (reader.name() == QLatin1String("fileinfo")) {
             while (reader.readNextStartElement()) {
-                if (reader.name() == "streamdetails") {
+                if (reader.name() == QLatin1String("streamdetails")) {
                     parseStreamDetails(reader);
 
                 } else {
@@ -160,7 +161,7 @@ void ConcertXmlReader::parseRatings(QXmlStreamReader& reader)
     //   </rating>
     // </ratings>
     while (reader.readNextStartElement()) {
-        if (reader.name() == "rating") {
+        if (reader.name() == QLatin1String("rating")) {
             Rating rating;
             rating.source = reader.attributes().value("name").toString();
             if (rating.source.isEmpty()) {
@@ -190,10 +191,10 @@ void ConcertXmlReader::parseRatings(QXmlStreamReader& reader)
             }
 
             while (reader.readNextStartElement()) {
-                if (reader.name() == "value") {
+                if (reader.name() == QLatin1String("value")) {
                     rating.rating = reader.readElementText().replace(",", ".").toDouble();
 
-                } else if (reader.name() == "votes") {
+                } else if (reader.name() == QLatin1String("votes")) {
                     rating.voteCount = reader.readElementText().replace(",", "").replace(".", "").toInt();
 
                 } else {
@@ -212,7 +213,7 @@ void ConcertXmlReader::parseRatings(QXmlStreamReader& reader)
 void ConcertXmlReader::parseFanart(QXmlStreamReader& reader)
 {
     while (reader.readNextStartElement()) {
-        if (reader.name() != "thumb") {
+        if (reader.name() != QLatin1String("thumb")) {
             reader.skipCurrentElement();
             continue;
         }
@@ -256,14 +257,14 @@ void ConcertXmlReader::parseStreamDetails(QXmlStreamReader& reader)
     int subtitleStreamNumber = 0;
 
     while (reader.readNextStartElement()) {
-        if (reader.name() == "video") {
+        if (reader.name() == QLatin1String("video")) {
             parseVideoStreamDetails(reader, streamDetails);
 
-        } else if (reader.name() == "audio") {
+        } else if (reader.name() == QLatin1String("audio")) {
             parseAudioStreamDetails(reader, audioStreamNumber, streamDetails);
             ++audioStreamNumber;
 
-        } else if (reader.name() == "subtitle") {
+        } else if (reader.name() == QLatin1String("subtitle")) {
             parseSubtitleStreamDetails(reader, subtitleStreamNumber, streamDetails);
             ++subtitleStreamNumber;
 

--- a/src/movies/MovieController.cpp
+++ b/src/movies/MovieController.cpp
@@ -357,7 +357,7 @@ void MovieController::onDownloadFinished(DownloadManagerElement elem)
         m_movie->images().addExtraFanart(elem.data);
     } else if (!elem.data.isEmpty()) {
         ImageCache::instance()->invalidateImages(
-            Manager::instance()->mediaCenterInterface()->imageFileName(m_movie, elem.imageType));
+            mediaelch::FilePath(Manager::instance()->mediaCenterInterface()->imageFileName(m_movie, elem.imageType)));
         if (elem.imageType == ImageType::MovieBackdrop) {
             helper::resizeBackdrop(elem.data);
         }

--- a/src/movies/file_searcher/MovieDirectorySearcher.cpp
+++ b/src/movies/file_searcher/MovieDirectorySearcher.cpp
@@ -22,7 +22,7 @@ void MovieDirectorySearcher::load()
         return;
     }
 
-    Manager::instance()->database()->clearMoviesInDirectory(m_dir.path);
+    Manager::instance()->database()->clearMoviesInDirectory(mediaelch::DirectoryPath(m_dir.path));
 
     // No filter, no media files...
     if (!Settings::instance()->advanced()->movieFilters().hasFilter()) {

--- a/src/movies/file_searcher/MovieFileSearcher.cpp
+++ b/src/movies/file_searcher/MovieFileSearcher.cpp
@@ -92,7 +92,8 @@ void MovieFileSearcher::reload(bool force)
             // ...or from the cached database.
             // Note: We do this in a blocking way for now.
             // TODO: Move into worker.
-            const QVector<Movie*> moviesFromDb = Manager::instance()->database()->moviesInDirectory(movieDir.path);
+            const QVector<Movie*> moviesFromDb =
+                Manager::instance()->database()->moviesInDirectory(mediaelch::DirectoryPath(movieDir.path));
             if (moviesFromDb.count() > 0) {
                 QtConcurrent::blockingMap(moviesFromDb, MovieFileSearcher::loadMovieData);
                 Manager::instance()->movieModel()->addMovies(moviesFromDb);
@@ -139,7 +140,7 @@ void MovieFileSearcher::onDirectoryLoaded(MovieDirectorySearcher* searcher)
         }
 
         Movie* movie = movies.at(i);
-        Manager::instance()->database()->add(movie, searcher->directory().path);
+        Manager::instance()->database()->add(movie, mediaelch::DirectoryPath(searcher->directory().path));
 
         if (i % 40 == 0 && i > 0) {
             QApplication::processEvents();

--- a/src/music/AlbumController.cpp
+++ b/src/music/AlbumController.cpp
@@ -138,7 +138,7 @@ void AlbumController::onDownloadFinished(DownloadManagerElement elem)
         m_album->bookletModel()->addImage(image);
     } else if (!elem.data.isEmpty()) {
         ImageCache::instance()->invalidateImages(
-            Manager::instance()->mediaCenterInterface()->imageFileName(m_album, elem.imageType));
+            mediaelch::FilePath(Manager::instance()->mediaCenterInterface()->imageFileName(m_album, elem.imageType)));
         m_album->setRawImage(elem.imageType, elem.data);
     }
 

--- a/src/music/ArtistController.cpp
+++ b/src/music/ArtistController.cpp
@@ -137,7 +137,7 @@ void ArtistController::onDownloadFinished(DownloadManagerElement elem)
         m_artist->addExtraFanart(elem.data);
     } else if (!elem.data.isEmpty()) {
         ImageCache::instance()->invalidateImages(
-            Manager::instance()->mediaCenterInterface()->imageFileName(m_artist, elem.imageType));
+            mediaelch::FilePath(Manager::instance()->mediaCenterInterface()->imageFileName(m_artist, elem.imageType)));
         if (elem.imageType == ImageType::ArtistFanart) {
             helper::resizeBackdrop(elem.data);
         }

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -8,4 +8,8 @@ target_link_libraries(
   mediaelch_network PRIVATE Qt5::Core Qt5::Multimedia Qt5::Widgets Qt5::Sql
                             Qt5::Xml Qt5::MultimediaWidgets
 )
+
+target_link_libraries(
+  mediaelch_network PUBLIC Qt5::Network
+)
 mediaelch_post_target_defaults(mediaelch_network)

--- a/src/renamer/RenamerDialog.cpp
+++ b/src/renamer/RenamerDialog.cpp
@@ -307,7 +307,7 @@ void RenamerDialog::renameShows(QVector<TvShow*> shows,
             }
             const QString newShowDir = parentDir.absolutePath() + "/" + newFolderName;
             const QString oldShowDir = show->dir().toString();
-            show->setDir(newShowDir);
+            show->setDir(mediaelch::DirectoryPath(newShowDir));
             Manager::instance()->database()->update(show);
             for (TvShowEpisode* episode : show->episodes()) {
                 QStringList files;

--- a/src/scrapers/image/TheTvDbImages.cpp
+++ b/src/scrapers/image/TheTvDbImages.cpp
@@ -58,7 +58,7 @@ TheTvDbImages::TheTvDbImages(QObject* parent) : ImageProvider(parent)
         "tr"};
     m_meta.defaultLocale = Locale("en");
 
-    m_dummyShow = new TvShow(QString(), this);
+    m_dummyShow = new TvShow(mediaelch::DirectoryPath(), this);
     m_dummyEpisode = new TvShowEpisode(QStringList(), m_dummyShow);
     m_searchResultLimit = 0;
 

--- a/src/settings/AdvancedSettingsXmlReader.cpp
+++ b/src/settings/AdvancedSettingsXmlReader.cpp
@@ -49,7 +49,7 @@ mediaelch::FilePath AdvancedSettingsXmlReader::getFilePath()
     if (!file.exists()) {
         file.setFileName(QStandardPaths::writableLocation(QStandardPaths::DataLocation) + "/advancedsettings.xml");
     }
-    return file.fileName();
+    return mediaelch::FilePath(file.fileName());
 }
 
 QByteArray AdvancedSettingsXmlReader::getAdvancedSettingsXml(const mediaelch::FilePath& filepath)

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -181,7 +181,7 @@ void Settings::loadSettings()
     m_showAdultScrapers = settings()->value(KEY_SCRAPERS_SHOW_ADULT, false).toBool();
     m_startupSection = settings()->value(KEY_STARTUP_SECTION, "movies").toString();
     m_donated = settings()->value(KEY_DONATED, false).toBool();
-    m_lastImagePath = settings()->value(KEY_LAST_IMAGE_PATH, QDir::homePath()).toString();
+    m_lastImagePath = mediaelch::DirectoryPath(settings()->value(KEY_LAST_IMAGE_PATH, QDir::homePath()).toString());
 
     // Window positions
     m_mainWindowPosition = fixWindowPosition(settings()->value(KEY_MAIN_WINDOW_POSITION).toPoint());
@@ -297,7 +297,8 @@ void Settings::loadSettings()
 
     // Movie set artwork
     m_movieSetArtworkType = MovieSetArtworkType(settings()->value(KEY_MOVIE_SET_ARTWORK_STORING_TYPE, 0).toInt());
-    m_movieSetArtworkDirectory = settings()->value(KEY_MOVIE_SET_ARTWORK_DIRECTORY).toString();
+    m_movieSetArtworkDirectory =
+        mediaelch::DirectoryPath(settings()->value(KEY_MOVIE_SET_ARTWORK_DIRECTORY).toString());
 
     // Media Status Columns
     m_mediaStatusColumns.clear();
@@ -1325,25 +1326,26 @@ QString Settings::applicationDir()
 mediaelch::DirectoryPath Settings::databaseDir()
 {
     if (advanced()->portableMode()) {
-        return applicationDir();
+        return mediaelch::DirectoryPath(applicationDir());
     }
-    return QStandardPaths::writableLocation(QStandardPaths::DataLocation);
+    return mediaelch::DirectoryPath(QStandardPaths::writableLocation(QStandardPaths::DataLocation));
 }
 
 mediaelch::DirectoryPath Settings::imageCacheDir()
 {
     if (advanced()->portableMode()) {
-        return applicationDir();
+        return mediaelch::DirectoryPath(applicationDir());
     }
-    return QStandardPaths::writableLocation(QStandardPaths::DataLocation);
+    return mediaelch::DirectoryPath(QStandardPaths::writableLocation(QStandardPaths::DataLocation));
 }
 
 mediaelch::DirectoryPath Settings::exportTemplatesDir()
 {
     if (advanced()->portableMode()) {
-        return applicationDir() + QDir::separator() + "export_themes";
+        return mediaelch::DirectoryPath(applicationDir() + QDir::separator() + "export_themes");
     }
-    return QStandardPaths::writableLocation(QStandardPaths::DataLocation) + QDir::separator() + "export_themes";
+    return mediaelch::DirectoryPath(
+        QStandardPaths::writableLocation(QStandardPaths::DataLocation) + QDir::separator() + "export_themes");
 }
 
 void Settings::setShowAdultScrapers(bool show)

--- a/src/tv_shows/TvShowFileSearcher.cpp
+++ b/src/tv_shows/TvShowFileSearcher.cpp
@@ -100,7 +100,7 @@ void TvShowFileSearcher::reloadEpisodes(const mediaelch::DirectoryPath& showDir)
     }
 
     // get path
-    QString path;
+    mediaelch::DirectoryPath path;
     int index = -1;
     for (int i = 0, n = m_directories.count(); i < n; ++i) {
         if (m_aborted) {
@@ -114,7 +114,7 @@ void TvShowFileSearcher::reloadEpisodes(const mediaelch::DirectoryPath& showDir)
         }
     }
     if (index != -1) {
-        path = m_directories[index].path.path();
+        path = mediaelch::DirectoryPath(m_directories[index].path);
     }
 
     // search for contents
@@ -433,7 +433,7 @@ void TvShowFileSearcher::clearOldTvShows(bool forceClear)
 
     for (const SettingsDir& dir : m_directories) {
         if (dir.autoReload) {
-            database().clearTvShowsInDirectory(dir.path);
+            database().clearTvShowsInDirectory(mediaelch::DirectoryPath(dir.path));
         }
     }
 }
@@ -483,7 +483,7 @@ void TvShowFileSearcher::setupShows(QMap<QString, QVector<QStringList>>& content
         it.next();
 
         // get path
-        QString path;
+        mediaelch::DirectoryPath path;
         int index = -1;
         for (int i = 0, n = m_directories.count(); i < n; ++i) {
             if (it.key().startsWith(m_directories[i].path.path())) {
@@ -495,10 +495,10 @@ void TvShowFileSearcher::setupShows(QMap<QString, QVector<QStringList>>& content
             }
         }
         if (index != -1) {
-            path = m_directories[index].path.path();
+            path = mediaelch::DirectoryPath(m_directories[index].path);
         }
 
-        auto* show = new TvShow(it.key(), this);
+        auto* show = new TvShow(mediaelch::DirectoryPath(it.key()), this);
         show->loadData(Manager::instance()->mediaCenterInterfaceTvShow());
         emit currentDir(show->title());
         database().add(show, path);
@@ -544,15 +544,15 @@ QMap<QString, QVector<QStringList>> TvShowFileSearcher::readTvShowContent(bool f
         }
         // Do we need to reload shows from disk?
         if (dir.autoReload || forceReload) {
-            getTvShows(dir.path, contents);
+            getTvShows(mediaelch::DirectoryPath(dir.path), contents);
             continue;
         }
         // TODO: Check if necessary?
         // If there are no shows in the database for the directory, reload
         // all shows regardless of forceReload.
-        const int showsFromDatabase = database().showCount(dir.path);
+        const int showsFromDatabase = database().showCount(mediaelch::DirectoryPath(dir.path));
         if (showsFromDatabase == 0) {
-            getTvShows(dir.path, contents);
+            getTvShows(mediaelch::DirectoryPath(dir.path), contents);
             continue;
         }
     }
@@ -571,7 +571,7 @@ QVector<TvShow*> TvShowFileSearcher::getShowsFromDatabase(bool forceReload)
         if (dir.autoReload) { // Those directories are not read from database.
             continue;
         }
-        QVector<TvShow*> showsFromDatabase = database().showsInDirectory(dir.path);
+        QVector<TvShow*> showsFromDatabase = database().showsInDirectory(mediaelch::DirectoryPath(dir.path));
         if (!showsFromDatabase.isEmpty()) {
             dbShows.append(showsFromDatabase);
         }

--- a/src/ui/imports/DownloadsWidget.cpp
+++ b/src/ui/imports/DownloadsWidget.cpp
@@ -317,7 +317,8 @@ void DownloadsWidget::updateImportsList(const QMap<QString, mediaelch::DownloadF
                 importType->setCurrentIndex(1);
                 onChangeImportType(1, importType);
                 for (int i = 0, n = importDetail->count(); i < n; ++i) {
-                    if (importDetail->itemData(i, Qt::UserRole).value<Storage*>()->show()->dir() == guessedDir) {
+                    if (importDetail->itemData(i, Qt::UserRole).value<Storage*>()->show()->dir().toString()
+                        == guessedDir) {
                         importDetail->setCurrentIndex(i);
                         onChangeImportDetail(i, importDetail);
                         break;

--- a/src/ui/imports/ImportActions.cpp
+++ b/src/ui/imports/ImportActions.cpp
@@ -104,7 +104,7 @@ void ImportActions::onImport()
     if (type() == "movie") {
         importDialog->setImportDir(importDir());
         if (importDialog->execMovie(baseName()) == QDialog::Accepted) {
-            Manager::instance()->database()->addImport(baseName(), type(), importDir());
+            Manager::instance()->database()->addImport(baseName(), type(), mediaelch::DirectoryPath(importDir()));
         }
     } else if (type() == "tvshow") {
         if (importDialog->execTvShow(baseName(), tvShow()) == QDialog::Accepted) {
@@ -113,7 +113,7 @@ void ImportActions::onImport()
     } else if (type() == "concert") {
         importDialog->setImportDir(importDir());
         if (importDialog->execConcert(baseName()) == QDialog::Accepted) {
-            Manager::instance()->database()->addImport(baseName(), type(), importDir());
+            Manager::instance()->database()->addImport(baseName(), type(), mediaelch::DirectoryPath(importDir()));
         }
     }
 

--- a/src/ui/imports/ImportDialog.cpp
+++ b/src/ui/imports/ImportDialog.cpp
@@ -151,7 +151,7 @@ int ImportDialog::execTvShow(QString searchString, TvShow* tvShow)
     int index = -1;
     const QVector<SettingsDir>& dirs = Settings::instance()->directorySettings().tvShowDirectories();
     for (int i = 0, n = dirs.count(); i < n; ++i) {
-        if (tvShow->dir().isParentFolderOf(dirs.at(i).path)) {
+        if (tvShow->dir().isParentFolderOf(mediaelch::DirectoryPath(dirs.at(i).path))) {
             if (index == -1 || dirs.at(index).path.path().length() < dirs.at(i).path.path().length()) {
                 index = i;
             }
@@ -663,7 +663,7 @@ void ImportDialog::onMovingFilesFinished()
         m_movie->controller()->loadStreamDetailsFromFile();
         m_movie->controller()->saveData(Manager::instance()->mediaCenterInterface());
         m_movie->controller()->loadData(Manager::instance()->mediaCenterInterface());
-        Manager::instance()->database()->add(m_movie, importDir());
+        Manager::instance()->database()->add(m_movie, mediaelch::DirectoryPath(importDir()));
         Manager::instance()->database()->commit();
         Manager::instance()->movieModel()->addMovie(m_movie);
         m_movie = nullptr;
@@ -678,7 +678,7 @@ void ImportDialog::onMovingFilesFinished()
         m_show->addEpisode(m_episode);
         m_episode->saveData(Manager::instance()->mediaCenterInterfaceTvShow());
         m_episode->loadData(Manager::instance()->mediaCenterInterfaceTvShow(), true, false);
-        Manager::instance()->database()->add(m_episode, importDir(), m_show->databaseId());
+        Manager::instance()->database()->add(m_episode, mediaelch::DirectoryPath(importDir()), m_show->databaseId());
 
         if (m_show->showMissingEpisodes()) {
             m_show->fillMissingEpisodes();
@@ -699,7 +699,7 @@ void ImportDialog::onMovingFilesFinished()
         m_concert->controller()->loadStreamDetailsFromFile();
         m_concert->controller()->saveData(Manager::instance()->mediaCenterInterface());
         m_concert->controller()->loadData(Manager::instance()->mediaCenterInterface());
-        Manager::instance()->database()->add(m_concert, importDir());
+        Manager::instance()->database()->add(m_concert, mediaelch::DirectoryPath(importDir()));
         Manager::instance()->database()->commit();
         Manager::instance()->concertModel()->addConcert(m_concert);
         m_concert = nullptr;

--- a/src/ui/imports/MakeMkvDialog.cpp
+++ b/src/ui/imports/MakeMkvDialog.cpp
@@ -333,7 +333,7 @@ void MakeMkvDialog::onDiscBackedUp()
 void MakeMkvDialog::onTrackImported(int trackId)
 {
     mediaelch::FileList files = m_movie->files();
-    files << m_importDir + "/" + m_tracks[trackId];
+    files << mediaelch::FilePath(m_importDir + "/" + m_tracks[trackId]);
     m_movie->setFiles(files);
     m_tracks.remove(trackId);
 
@@ -379,7 +379,7 @@ void MakeMkvDialog::importFinished()
     m_movie->controller()->loadStreamDetailsFromFile();
     m_movie->controller()->saveData(Manager::instance()->mediaCenterInterface());
     m_movie->controller()->loadData(Manager::instance()->mediaCenterInterface());
-    Manager::instance()->database()->add(m_movie, ui->comboImportDir->currentText());
+    Manager::instance()->database()->add(m_movie, mediaelch::DirectoryPath(ui->comboImportDir->currentText()));
     Manager::instance()->database()->commit();
     Manager::instance()->movieModel()->addMovie(m_movie);
     m_movie = nullptr;

--- a/src/ui/movies/MovieWidget.cpp
+++ b/src/ui/movies/MovieWidget.cpp
@@ -1717,7 +1717,8 @@ void MovieWidget::onCaptureImage(ImageType type)
         ui->backdrop->setImage(ba);
     }
 
-    ImageCache::instance()->invalidateImages(Manager::instance()->mediaCenterInterface()->imageFileName(m_movie, type));
+    ImageCache::instance()->invalidateImages(
+        mediaelch::FilePath(Manager::instance()->mediaCenterInterface()->imageFileName(m_movie, type)));
     m_movie->images().setImage(type, ba);
 }
 

--- a/src/ui/settings/ExportSettingsWidget.cpp
+++ b/src/ui/settings/ExportSettingsWidget.cpp
@@ -1,7 +1,6 @@
 #include "ui/settings/ExportSettingsWidget.h"
 #include "ui_ExportSettingsWidget.h"
 
-#include "export/ExportTemplate.h"
 #include "export/ExportTemplateLoader.h"
 #include "settings/DataFile.h"
 #include "settings/Settings.h"

--- a/src/ui/settings/ExportSettingsWidget.h
+++ b/src/ui/settings/ExportSettingsWidget.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "export/ExportTemplate.h"
 #include "globals/Globals.h"
 
 #include <QWidget>
@@ -9,7 +10,6 @@ class ExportSettingsWidget;
 }
 
 class Settings;
-class ExportTemplate;
 
 class ExportSettingsWidget : public QWidget
 {

--- a/src/ui/settings/GlobalSettingsWidget.cpp
+++ b/src/ui/settings/GlobalSettingsWidget.cpp
@@ -257,7 +257,7 @@ void GlobalSettingsWidget::organize()
 
     switch (ret) {
     case QMessageBox::Ok:
-        organizer->moveToDirs(ui->dirs->item(ui->dirs->currentRow(), 1)->text());
+        organizer->moveToDirs(mediaelch::DirectoryPath(ui->dirs->item(ui->dirs->currentRow(), 1)->text()));
         ui->dirs->item(ui->dirs->currentRow(), 2)->setCheckState(Qt::Checked);
         break;
     case QMessageBox::Cancel:

--- a/src/ui/settings/MovieSettingsWidget.cpp
+++ b/src/ui/settings/MovieSettingsWidget.cpp
@@ -104,7 +104,7 @@ void MovieSettingsWidget::saveSettings()
     // Movie set artwork
     m_settings->setMovieSetArtworkType(static_cast<MovieSetArtworkType>(
         ui->comboMovieSetArtwork->itemData(ui->comboMovieSetArtwork->currentIndex()).toInt()));
-    m_settings->setMovieSetArtworkDirectory(ui->movieSetArtworkDir->text());
+    m_settings->setMovieSetArtworkDirectory(mediaelch::DirectoryPath(ui->movieSetArtworkDir->text()));
 }
 
 void MovieSettingsWidget::onComboMovieSetArtworkChanged(int comboIndex)

--- a/src/ui/small_widgets/ClosableImage.cpp
+++ b/src/ui/small_widgets/ClosableImage.cpp
@@ -164,7 +164,7 @@ void ClosableImage::paintEvent(QPaintEvent* event)
         origHeight = img.height();
         img = img.scaledToWidth(w, Qt::SmoothTransformation);
     } else if (!m_imagePath.isEmpty()) {
-        img = ImageCache::instance()->image(m_imagePath, w, 0, origWidth, origHeight);
+        img = ImageCache::instance()->image(mediaelch::FilePath(m_imagePath), w, 0, origWidth, origHeight);
     } else {
         const int x =
             static_cast<int>((width() - (m_defaultPixmap.width() / helper::devicePixelRatio(m_defaultPixmap))) / 2);
@@ -255,7 +255,7 @@ void ClosableImage::setImageByPath(const QString& image)
 {
     clear();
     m_imagePath = image;
-    QSize size = ImageCache::instance()->imageSize(image);
+    QSize size = ImageCache::instance()->imageSize(mediaelch::FilePath(image));
     updateSize(size.width(), size.height());
 }
 

--- a/src/ui/tv_show/TvShowMultiScrapeDialog.cpp
+++ b/src/ui/tv_show/TvShowMultiScrapeDialog.cpp
@@ -712,15 +712,15 @@ void TvShowMultiScrapeDialog::onDownloadFinished(DownloadManagerElement elem)
             if (elem.imageType == ImageType::TvShowSeasonBackdrop) {
                 helper::resizeBackdrop(elem.data);
             }
-            ImageCache::instance()->invalidateImages(
-                Manager::instance()->mediaCenterInterface()->imageFileName(elem.show, elem.imageType, elem.season));
+            ImageCache::instance()->invalidateImages(mediaelch::FilePath(
+                Manager::instance()->mediaCenterInterface()->imageFileName(elem.show, elem.imageType, elem.season)));
             elem.show->setSeasonImage(elem.season, elem.imageType, elem.data);
         } else if (elem.imageType != ImageType::Actor) {
             if (elem.imageType == ImageType::TvShowBackdrop) {
                 helper::resizeBackdrop(elem.data);
             }
-            ImageCache::instance()->invalidateImages(
-                Manager::instance()->mediaCenterInterface()->imageFileName(elem.show, elem.imageType));
+            ImageCache::instance()->invalidateImages(mediaelch::FilePath(
+                Manager::instance()->mediaCenterInterface()->imageFileName(elem.show, elem.imageType)));
             elem.show->setImage(elem.imageType, elem.data);
         }
     } else if ((elem.episode != nullptr) && elem.imageType == ImageType::TvShowEpisodeThumb) {

--- a/src/ui/tv_show/TvShowWidgetEpisode.cpp
+++ b/src/ui/tv_show/TvShowWidgetEpisode.cpp
@@ -779,8 +779,8 @@ void TvShowWidgetEpisode::onPosterDownloadFinished(DownloadManagerElement elem)
         if (m_episode == elem.episode) {
             ui->thumbnail->setImage(elem.data);
         }
-        ImageCache::instance()->invalidateImages(
-            Manager::instance()->mediaCenterInterface()->imageFileName(elem.episode, ImageType::TvShowEpisodeThumb));
+        ImageCache::instance()->invalidateImages(mediaelch::FilePath(
+            Manager::instance()->mediaCenterInterface()->imageFileName(elem.episode, ImageType::TvShowEpisodeThumb)));
         elem.episode->setThumbnailImage(elem.data);
     }
     if (m_posterDownloadManager->downloadQueueSize() == 0) {
@@ -1241,7 +1241,7 @@ void TvShowWidgetEpisode::onCaptureImage(ImageType type)
     img.save(&buffer, "JPG", 85);
 
     ui->thumbnail->setImage(ba);
-    ImageCache::instance()->invalidateImages(
-        Manager::instance()->mediaCenterInterface()->imageFileName(m_episode, ImageType::TvShowEpisodeThumb));
+    ImageCache::instance()->invalidateImages(mediaelch::FilePath(
+        Manager::instance()->mediaCenterInterface()->imageFileName(m_episode, ImageType::TvShowEpisodeThumb)));
     m_episode->setThumbnailImage(ba);
 }

--- a/src/ui/tv_show/TvShowWidgetSeason.cpp
+++ b/src/ui/tv_show/TvShowWidgetSeason.cpp
@@ -202,8 +202,8 @@ void TvShowWidgetSeason::onDownloadFinished(DownloadManagerElement elem)
             if (m_show == elem.show) {
                 image->setImage(elem.data);
             }
-            ImageCache::instance()->invalidateImages(
-                Manager::instance()->mediaCenterInterface()->imageFileName(elem.show, elem.imageType, elem.season));
+            ImageCache::instance()->invalidateImages(mediaelch::FilePath(
+                Manager::instance()->mediaCenterInterface()->imageFileName(elem.show, elem.imageType, elem.season)));
             elem.show->setSeasonImage(elem.season, elem.imageType, elem.data);
             break;
         }

--- a/src/ui/tv_show/TvShowWidgetTvShow.cpp
+++ b/src/ui/tv_show/TvShowWidgetTvShow.cpp
@@ -746,8 +746,8 @@ void TvShowWidgetTvShow::onPosterDownloadFinished(DownloadManagerElement elem)
         if (elem.imageType == ImageType::TvShowSeasonBackdrop) {
             helper::resizeBackdrop(elem.data);
         }
-        ImageCache::instance()->invalidateImages(
-            Manager::instance()->mediaCenterInterface()->imageFileName(elem.show, elem.imageType, elem.season));
+        ImageCache::instance()->invalidateImages(mediaelch::FilePath(
+            Manager::instance()->mediaCenterInterface()->imageFileName(elem.show, elem.imageType, elem.season)));
         elem.show->setSeasonImage(elem.season, elem.imageType, elem.data);
     } else if (elem.imageType == ImageType::TvShowExtraFanart) {
         helper::resizeBackdrop(elem.data);
@@ -764,8 +764,8 @@ void TvShowWidgetTvShow::onPosterDownloadFinished(DownloadManagerElement elem)
                 if (m_show == elem.show) {
                     image->setImage(elem.data);
                 }
-                ImageCache::instance()->invalidateImages(
-                    Manager::instance()->mediaCenterInterface()->imageFileName(elem.show, elem.imageType));
+                ImageCache::instance()->invalidateImages(mediaelch::FilePath(
+                    Manager::instance()->mediaCenterInterface()->imageFileName(elem.show, elem.imageType)));
                 elem.show->setImage(elem.imageType, elem.data);
                 break;
             }

--- a/test/integration/export/testSimpleExport.cpp
+++ b/test/integration/export/testSimpleExport.cpp
@@ -46,7 +46,7 @@ TEST_CASE("Simple HTML export", "[export][simple]")
     exportTemplate.setVersion("0.0.1");
     exportTemplate.setIdentifier("test-template");
     exportTemplate.addDescription("en", "Export Template for Testing");
-    exportTemplate.setDirectory(exportDir("simple"));
+    exportTemplate.setDirectory(mediaelch::DirectoryPath(exportDir("simple")));
 
     std::atomic_bool cancelFlag{false};
 


### PR DESCRIPTION
This PR contains a few changes that are required for Qt6.
MediaElch does _not_ work with Qt 6.1, yet. We have to wait for 6.2 as only then MultimediaWidgets will be ported.