### PR TITLE
[Project] More changes towards Qt6 compatibility 

### DIFF
--- a/src/export/ExportTemplateLoader.cpp
+++ b/src/export/ExportTemplateLoader.cpp
@@ -58,7 +58,7 @@ void ExportTemplateLoader::onLoadRemoteTemplatesFinished()
     QString msg = QString::fromUtf8(reply->readAll());
     QXmlStreamReader xml(msg);
 
-    if (!xml.readNextStartElement() || xml.name() != "themes") {
+    if (!xml.readNextStartElement() || xml.name() != QLatin1String("themes")) {
         qWarning() << "[ExportTemplateLoader] export_themes.xml does not have a root <themes> element";
         emit sigTemplatesLoaded(mergeTemplates(m_localTemplates, m_remoteTemplates));
         return;
@@ -66,7 +66,7 @@ void ExportTemplateLoader::onLoadRemoteTemplatesFinished()
 
     QVector<ExportTemplate*> templates;
     while (xml.readNextStartElement()) {
-        if (xml.name() == "theme") {
+        if (xml.name() == QLatin1String("theme")) {
             templates << parseTemplate(xml);
         } else {
             qWarning() << "[ExportTemplateLoader] Found unknown XML tag in theme list:" << xml.name();
@@ -124,18 +124,18 @@ ExportTemplate* ExportTemplateLoader::parseTemplate(QXmlStreamReader& xml)
     exportTemplate->setRemote(true);
 
     while (xml.readNextStartElement()) {
-        if (xml.name() == "name") {
+        if (xml.name() == QLatin1String("name")) {
             exportTemplate->setName(xml.readElementText().trimmed());
-        } else if (xml.name() == "identifier") {
+        } else if (xml.name() == QLatin1String("identifier")) {
             exportTemplate->setIdentifier(xml.readElementText().trimmed());
-        } else if (xml.name() == "website") {
+        } else if (xml.name() == QLatin1String("website")) {
             exportTemplate->setWebsite(xml.readElementText().trimmed());
-        } else if (xml.name() == "description") {
+        } else if (xml.name() == QLatin1String("description")) {
             exportTemplate->addDescription(xml.attributes().value("lang").toString(), xml.readElementText());
-        } else if (xml.name() == "author") {
+        } else if (xml.name() == QLatin1String("author")) {
             exportTemplate->setAuthor(xml.readElementText().trimmed());
 
-        } else if (xml.name() == "engine") {
+        } else if (xml.name() == QLatin1String("engine")) {
             // \since v2.6.3
             QString engine = xml.readElementText();
             Q_UNUSED(engine)
@@ -146,29 +146,29 @@ ExportTemplate* ExportTemplateLoader::parseTemplate(QXmlStreamReader& xml)
             exportTemplate->setTemplateEngine(ExportEngine::Simple);
             // }
 
-        } else if (xml.name() == "mediaelch-min") {
+        } else if (xml.name() == QLatin1String("mediaelch-min")) {
             // \since v2.6.3
             exportTemplate->setMediaElchVersionMin(mediaelch::VersionInfo(xml.readElementText()));
 
-        } else if (xml.name() == "mediaelch-max") {
+        } else if (xml.name() == QLatin1String("mediaelch-max")) {
             // \since v2.6.3
             exportTemplate->setMediaElchVersionMax(mediaelch::VersionInfo(xml.readElementText()));
 
-        } else if (xml.name() == "file") {
+        } else if (xml.name() == QLatin1String("file")) {
             exportTemplate->setRemoteFile(xml.readElementText().trimmed());
-        } else if (xml.name() == "checksum") {
-            if (xml.attributes().value("format") != "sha256") {
+        } else if (xml.name() == QLatin1String("checksum")) {
+            if (xml.attributes().value("format") != QLatin1String("sha256")) {
                 // Assume name is set first. If not, its just an empty string.
                 qWarning() << "[ExportTemplateLoader] Unsupported checksum type; default to sha256 for"
                            << exportTemplate->name();
             }
             exportTemplate->setRemoteFileChecksum(xml.readElementText().trimmed());
-        } else if (xml.name() == "version") {
+        } else if (xml.name() == QLatin1String("version")) {
             exportTemplate->setVersion(xml.readElementText());
-        } else if (xml.name() == "supports") {
+        } else if (xml.name() == QLatin1String("supports")) {
             QVector<ExportTemplate::ExportSection> sections;
             while (xml.readNextStartElement()) {
-                if (xml.name() == "section") {
+                if (xml.name() == QLatin1String("section")) {
                     QString section = xml.readElementText();
                     if (section == "movies") {
                         sections << ExportTemplate::ExportSection::Movies;
@@ -418,7 +418,7 @@ ExportTemplate* ExportTemplateLoader::getTemplateByIdentifier(QString identifier
     if (identifier.isEmpty()) {
         return nullptr;
     }
-    auto* result = std::find_if(m_localTemplates.begin(), m_localTemplates.end(), [&identifier](auto& exportTemplate) {
+    auto result = std::find_if(m_localTemplates.begin(), m_localTemplates.end(), [&identifier](auto& exportTemplate) {
         return (exportTemplate->identifier() == identifier);
     });
     return (result != m_localTemplates.cend()) ? *result : nullptr;

--- a/src/globals/Actor.cpp
+++ b/src/globals/Actor.cpp
@@ -6,11 +6,11 @@ QDebug operator<<(QDebug dbg, const Actor& actor)
     QString nl = "\n";
     QString out;
     out.append("Actor").append(nl);
-    out.append(QString("  Name:  ").append(actor.name).append(nl));
-    out.append(QString("  Role:  ").append(actor.role).append(nl));
-    out.append(QString("  Thumb: ").append(actor.thumb).append(nl));
-    out.append(QString("  ID:    ").append(actor.id).append(nl));
-    out.append(QString("  Order: ").append(actor.order).append(nl));
+    out.append(QStringLiteral("  Name:  ").append(actor.name).append(nl));
+    out.append(QStringLiteral("  Role:  ").append(actor.role).append(nl));
+    out.append(QStringLiteral("  Thumb: ").append(actor.thumb).append(nl));
+    out.append(QStringLiteral("  ID:    ").append(actor.id).append(nl));
+    out.append(QStringLiteral("  Order: ").append(QString::number(actor.order)).append(nl));
     dbg.nospace() << out;
     return dbg.maybeSpace();
 }

--- a/src/globals/Helper.cpp
+++ b/src/globals/Helper.cpp
@@ -16,7 +16,6 @@
 #include <QListWidget>
 #include <QPainter>
 #include <QPushButton>
-#include <QRegExp>
 #include <QRegularExpression>
 #include <QSpinBox>
 #include <QWidget>

--- a/src/network/NetworkRequest.cpp
+++ b/src/network/NetworkRequest.cpp
@@ -8,7 +8,11 @@ namespace network {
 QNetworkRequest requestWithDefaults(const QUrl& url)
 {
     QNetworkRequest request(url);
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // Default in Qt6
     request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+#endif
     request.setHeader(QNetworkRequest::UserAgentHeader, mediaelch::currentVersionIdentifier());
     // Default value is 50, but we have at most 2 redirects. For example:
     //  1. http://example.com/tt1234

--- a/src/scrapers/movie/adultdvdempire/AdultDvdEmpire.cpp
+++ b/src/scrapers/movie/adultdvdempire/AdultDvdEmpire.cpp
@@ -1,7 +1,6 @@
 #include "AdultDvdEmpire.h"
 
 #include <QDebug>
-#include <QRegExp>
 #include <QTextDocument>
 
 #include "data/Storage.h"

--- a/src/scrapers/movie/ofdb/OFDb.cpp
+++ b/src/scrapers/movie/ofdb/OFDb.cpp
@@ -287,7 +287,7 @@ void OFDb::parseAndAssignInfos(QString data, Movie* movie, QSet<MovieScraperInfo
     }
 
     while (xml.readNextStartElement()) {
-        if (xml.name() != "resultat") {
+        if (xml.name() != QLatin1String("resultat")) {
             xml.skipCurrentElement();
         } else {
             break;
@@ -295,19 +295,19 @@ void OFDb::parseAndAssignInfos(QString data, Movie* movie, QSet<MovieScraperInfo
     }
 
     while (xml.readNextStartElement()) {
-        if (infos.contains(MovieScraperInfo::Title) && xml.name() == "titel") {
+        if (infos.contains(MovieScraperInfo::Title) && xml.name() == QLatin1String("titel")) {
             movie->setName(xml.readElementText());
-        } else if (infos.contains(MovieScraperInfo::Released) && xml.name() == "jahr") {
+        } else if (infos.contains(MovieScraperInfo::Released) && xml.name() == QLatin1String("jahr")) {
             movie->setReleased(QDate::fromString(xml.readElementText(), "yyyy"));
-        } else if (infos.contains(MovieScraperInfo::Poster) && xml.name() == "bild") {
+        } else if (infos.contains(MovieScraperInfo::Poster) && xml.name() == QLatin1String("bild")) {
             QString url = xml.readElementText();
             Poster p;
             p.originalUrl = QUrl(url);
             p.thumbUrl = QUrl(url);
             movie->images().addPoster(p);
-        } else if (infos.contains(MovieScraperInfo::Rating) && xml.name() == "bewertung") {
+        } else if (infos.contains(MovieScraperInfo::Rating) && xml.name() == QLatin1String("bewertung")) {
             while (xml.readNextStartElement()) {
-                if (xml.name() == "note") {
+                if (xml.name() == QLatin1String("note")) {
                     Rating rating;
                     rating.source = "OFDb";
                     rating.rating = xml.readElementText().toDouble();
@@ -321,27 +321,27 @@ void OFDb::parseAndAssignInfos(QString data, Movie* movie, QSet<MovieScraperInfo
                     xml.skipCurrentElement();
                 }
             }
-        } else if (infos.contains(MovieScraperInfo::Genres) && xml.name() == "genre") {
+        } else if (infos.contains(MovieScraperInfo::Genres) && xml.name() == QLatin1String("genre")) {
             while (xml.readNextStartElement()) {
-                if (xml.name() == "titel") {
+                if (xml.name() == QLatin1String("titel")) {
                     movie->addGenre(helper::mapGenre(xml.readElementText()));
                 } else {
                     xml.skipCurrentElement();
                 }
             }
-        } else if (infos.contains(MovieScraperInfo::Actors) && xml.name() == "besetzung") {
+        } else if (infos.contains(MovieScraperInfo::Actors) && xml.name() == QLatin1String("besetzung")) {
             // clear actors
             movie->setActors({});
 
             while (xml.readNextStartElement()) {
-                if (xml.name() != "person") {
+                if (xml.name() != QLatin1String("person")) {
                     xml.skipCurrentElement();
                 } else {
                     Actor actor;
                     while (xml.readNextStartElement()) {
-                        if (xml.name() == "name") {
+                        if (xml.name() == QLatin1String("name")) {
                             actor.name = xml.readElementText();
-                        } else if (xml.name() == "rolle") {
+                        } else if (xml.name() == QLatin1String("rolle")) {
                             actor.role = xml.readElementText();
                         } else {
                             xml.skipCurrentElement();
@@ -350,17 +350,17 @@ void OFDb::parseAndAssignInfos(QString data, Movie* movie, QSet<MovieScraperInfo
                     movie->addActor(actor);
                 }
             }
-        } else if (infos.contains(MovieScraperInfo::Countries) && xml.name() == "produktionsland") {
+        } else if (infos.contains(MovieScraperInfo::Countries) && xml.name() == QLatin1String("produktionsland")) {
             while (xml.readNextStartElement()) {
-                if (xml.name() == "name") {
+                if (xml.name() == QLatin1String("name")) {
                     movie->addCountry(helper::mapCountry(xml.readElementText()));
                 } else {
                     xml.skipCurrentElement();
                 }
             }
-        } else if (infos.contains(MovieScraperInfo::Title) && xml.name() == "alternativ") {
+        } else if (infos.contains(MovieScraperInfo::Title) && xml.name() == QLatin1String("alternativ")) {
             movie->setOriginalName(xml.readElementText());
-        } else if (infos.contains(MovieScraperInfo::Overview) && xml.name() == "beschreibung") {
+        } else if (infos.contains(MovieScraperInfo::Overview) && xml.name() == QLatin1String("beschreibung")) {
             movie->setOverview(xml.readElementText());
             if (Settings::instance()->usePlotForOutline()) {
                 movie->setOutline(xml.readElementText());

--- a/src/scrapers/movie/tmdb/TmdbMovie.cpp
+++ b/src/scrapers/movie/tmdb/TmdbMovie.cpp
@@ -315,8 +315,8 @@ void TmdbMovie::search(QString searchStr)
     QUrl url;
     QString includeAdult = (Settings::instance()->showAdultScrapers()) ? "true" : "false";
 
-    const bool isSearchByImdbId = QRegExp("^tt\\d+$").exactMatch(searchStr);
-    const bool isSearchByTmdbId = QRegExp("^id\\d+$").exactMatch(searchStr);
+    const bool isSearchByImdbId = QRegularExpression("^tt\\d+$").match(searchStr).hasMatch();
+    const bool isSearchByTmdbId = QRegularExpression("^id\\d+$").match(searchStr).hasMatch();
 
     if (isSearchByImdbId) {
         QUrl newUrl(getMovieUrl(

--- a/src/scrapers/music/UniversalMusicScraper.cpp
+++ b/src/scrapers/music/UniversalMusicScraper.cpp
@@ -12,6 +12,7 @@
 #include <QJsonValue>
 #include <QLabel>
 #include <QMutexLocker>
+#include <QRegularExpression>
 
 namespace mediaelch {
 namespace scraper {
@@ -576,7 +577,7 @@ QWidget* UniversalMusicScraper::settingsWidget()
 
 QString UniversalMusicScraper::trim(QString text)
 {
-    return text.replace(QRegExp("\\s{1,}"), " ").trimmed();
+    return text.replace(QRegularExpression("\\s\\s+"), " ").trimmed();
 }
 
 bool UniversalMusicScraper::shouldLoad(MusicScraperInfo info, QSet<MusicScraperInfo> infos, Album* album)

--- a/src/scrapers/trailer/HdTrailers.cpp
+++ b/src/scrapers/trailer/HdTrailers.cpp
@@ -58,7 +58,13 @@ void HdTrailers::searchMovie(QString searchStr)
 
     } else {
         QVector<ScraperSearchResult> results;
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         QMapIterator<QString, QUrl> it(m_urls);
+#else
+        QMultiMapIterator<QString, QUrl> it(m_urls);
+#endif
+
         while (it.hasNext()) {
             it.next();
             if (it.key().contains(searchStr, Qt::CaseInsensitive)) {

--- a/src/settings/AdvancedSettings.cpp
+++ b/src/settings/AdvancedSettings.cpp
@@ -193,6 +193,11 @@ bool AdvancedSettings::isFolderExcluded(QString dir) const
     return false;
 }
 
+bool AdvancedSettings::isUserDefined() const
+{
+    return m_userDefined;
+}
+
 bool AdvancedSettings::useFirstStudioOnly() const
 {
     return m_useFirstStudioOnly;

--- a/src/settings/AdvancedSettings.h
+++ b/src/settings/AdvancedSettings.h
@@ -102,6 +102,10 @@ public:
     bool isFileExcluded(QString file) const;
     bool isFolderExcluded(QString dir) const;
 
+    /// \brief Returns true if the user has provided a custom advancedsettings.xml
+    ///        "false" if default values are used.
+    bool isUserDefined() const;
+
     friend class AdvancedSettingsXmlReader;
     friend QDebug operator<<(QDebug dbg, const AdvancedSettings& settings);
 
@@ -131,6 +135,7 @@ private:
     int m_bookletCut = 2;
     bool m_writeThumbUrlsToNfo = true;
     bool m_useFirstStudioOnly = false;
+    bool m_userDefined = false;
 };
 
 QDebug operator<<(QDebug dbg, const AdvancedSettings& settings);

--- a/src/settings/AdvancedSettingsXmlReader.cpp
+++ b/src/settings/AdvancedSettingsXmlReader.cpp
@@ -28,8 +28,10 @@ QPair<AdvancedSettings, AdvancedSettingsXmlReader::ValidationMessages> AdvancedS
         if (!xml.isEmpty()) {
             reader.parseSettings(xml);
         }
+        reader.m_settings.m_userDefined = true;
     } else {
         qWarning() << "[AdvancedSettings] advancedsettings.xml not found at " << path.toString();
+        reader.m_settings.m_userDefined = false;
         reader.addWarning("advancedsettings.xml", ParseErrorType::FileNotFound);
     }
 

--- a/src/settings/AdvancedSettingsXmlReader.cpp
+++ b/src/settings/AdvancedSettingsXmlReader.cpp
@@ -5,6 +5,7 @@
 #include <QDebug>
 #include <QDesktopServices>
 #include <QFile>
+#include <QStandardPaths>
 
 /// translations for parser errors / messages
 const QMap<AdvancedSettingsXmlReader::ParseErrorType, QString> AdvancedSettingsXmlReader::errors = {
@@ -47,7 +48,8 @@ mediaelch::FilePath AdvancedSettingsXmlReader::getFilePath()
 {
     QFile file(Settings::applicationDir() + "/advancedsettings.xml");
     if (!file.exists()) {
-        file.setFileName(QStandardPaths::writableLocation(QStandardPaths::DataLocation) + "/advancedsettings.xml");
+        file.setFileName(
+            QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/advancedsettings.xml");
     }
     return mediaelch::FilePath(file.fileName());
 }
@@ -84,29 +86,29 @@ void AdvancedSettingsXmlReader::parseSettings(const QString& xmlSource)
     }
 
     while (m_xml.readNextStartElement()) {
-        if (m_xml.name() == "log") {
+        if (m_xml.name() == QLatin1String("log")) {
             loadLog();
 
-        } else if (m_xml.name() == "locale") {
+        } else if (m_xml.name() == QLatin1String("locale")) {
             m_settings.setLocale(m_xml.readElementText());
 
-        } else if (m_xml.name() == "portableMode") {
+        } else if (m_xml.name() == QLatin1String("portableMode")) {
             expectBool(m_settings.m_portableMode);
 
-        } else if (m_xml.name() == "gui") {
+        } else if (m_xml.name() == QLatin1String("gui")) {
             loadGui();
 
-        } else if (m_xml.name() == "writeThumbUrlsToNfo") {
+        } else if (m_xml.name() == QLatin1String("writeThumbUrlsToNfo")) {
             expectBool(m_settings.m_writeThumbUrlsToNfo);
 
-        } else if (m_xml.name() == "episodeThumb") {
+        } else if (m_xml.name() == QLatin1String("episodeThumb")) {
             while (m_xml.readNextStartElement()) {
-                if (m_xml.name() == "width") {
+                if (m_xml.name() == QLatin1String("width")) {
                     // must be at least 100 pixel wide and should be small than ~4 Mio.
                     const auto inRange = [](int width) { return width >= 100 && width <= (2 << 22); };
                     expectIntChecked(m_settings.m_episodeThumbnailDimensions.width, inRange);
 
-                } else if (m_xml.name() == "height") {
+                } else if (m_xml.name() == QLatin1String("height")) {
                     // must be at least 100 pixel wide and should be small than ~4 Mio.
                     const auto inRange = [](int height) { return height >= 100 && height <= (2 << 22); };
                     expectIntChecked(m_settings.m_episodeThumbnailDimensions.height, inRange);
@@ -116,38 +118,38 @@ void AdvancedSettingsXmlReader::parseSettings(const QString& xmlSource)
                 }
             }
 
-        } else if (m_xml.name() == "bookletCut") {
+        } else if (m_xml.name() == QLatin1String("bookletCut")) {
             expectInt(m_settings.m_bookletCut);
 
-        } else if (m_xml.name() == "sorttokens") {
+        } else if (m_xml.name() == QLatin1String("sorttokens")) {
             loadSortTokens();
 
-        } else if (m_xml.name() == "genres") {
+        } else if (m_xml.name() == QLatin1String("genres")) {
             loadMappings(m_settings.m_genreMappings);
 
-        } else if (m_xml.name() == "audioCodecs") {
+        } else if (m_xml.name() == QLatin1String("audioCodecs")) {
             loadMappings(m_settings.m_audioCodecMappings);
 
-        } else if (m_xml.name() == "videoCodecs") {
+        } else if (m_xml.name() == QLatin1String("videoCodecs")) {
             loadMappings(m_settings.m_videoCodecMappings);
 
-        } else if (m_xml.name() == "certifications") {
+        } else if (m_xml.name() == QLatin1String("certifications")) {
             loadMappings(m_settings.m_certificationMappings);
 
-        } else if (m_xml.name() == "studios") {
+        } else if (m_xml.name() == QLatin1String("studios")) {
             if (m_xml.attributes().hasAttribute("useFirstStudioOnly")) {
                 const auto firstStudioOnly = m_xml.attributes().value("useFirstStudioOnly").trimmed();
-                m_settings.m_useFirstStudioOnly = (firstStudioOnly == "true");
+                m_settings.m_useFirstStudioOnly = (firstStudioOnly == QLatin1String("true"));
             }
             loadMappings(m_settings.m_studioMappings);
 
-        } else if (m_xml.name() == "countries") {
+        } else if (m_xml.name() == QLatin1String("countries")) {
             loadMappings(m_settings.m_countryMappings);
 
-        } else if (m_xml.name() == "fileFilters") {
+        } else if (m_xml.name() == QLatin1String("fileFilters")) {
             loadFilters();
 
-        } else if (m_xml.name() == "exclude") {
+        } else if (m_xml.name() == QLatin1String("exclude")) {
             loadExcludePatterns();
 
         } else {
@@ -159,9 +161,9 @@ void AdvancedSettingsXmlReader::parseSettings(const QString& xmlSource)
 void AdvancedSettingsXmlReader::loadLog()
 {
     while (m_xml.readNextStartElement()) {
-        if (m_xml.name() == "debug") {
+        if (m_xml.name() == QLatin1String("debug")) {
             expectBool(m_settings.m_debugLog);
-        } else if (m_xml.name() == "file") {
+        } else if (m_xml.name() == QLatin1String("file")) {
             m_settings.m_logFile = m_xml.readElementText().trimmed();
         } else {
             skipUnsupportedTag();
@@ -172,9 +174,9 @@ void AdvancedSettingsXmlReader::loadLog()
 void AdvancedSettingsXmlReader::loadGui()
 {
     while (m_xml.readNextStartElement()) {
-        if (m_xml.name() == "forceCache") {
+        if (m_xml.name() == QLatin1String("forceCache")) {
             expectBool(m_settings.m_forceCache);
-        } else if (m_xml.name() == "stylesheet") {
+        } else if (m_xml.name() == QLatin1String("stylesheet")) {
             m_settings.m_customStylesheet = m_xml.readElementText().trimmed();
         } else {
             skipUnsupportedTag();
@@ -186,7 +188,7 @@ void AdvancedSettingsXmlReader::loadSortTokens()
 {
     m_settings.m_sortTokens.clear();
     while (m_xml.readNextStartElement()) {
-        if (m_xml.name() == "token") {
+        if (m_xml.name() == QLatin1String("token")) {
             m_settings.m_sortTokens << m_xml.readElementText().trimmed();
         } else {
             skipUnsupportedTag();
@@ -208,16 +210,16 @@ void AdvancedSettingsXmlReader::loadFilters()
     };
 
     while (m_xml.readNextStartElement()) {
-        if (m_xml.name() == "movies") {
+        if (m_xml.name() == QLatin1String("movies")) {
             appendNextFiltersToList(m_settings.m_movieFilters);
 
-        } else if (m_xml.name() == "concerts") {
+        } else if (m_xml.name() == QLatin1String("concerts")) {
             appendNextFiltersToList(m_settings.m_concertFilters);
 
-        } else if (m_xml.name() == "tvShows") {
+        } else if (m_xml.name() == QLatin1String("tvShows")) {
             appendNextFiltersToList(m_settings.m_tvShowFilters);
 
-        } else if (m_xml.name() == "subtitle") {
+        } else if (m_xml.name() == QLatin1String("subtitle")) {
             appendNextFiltersToList(m_settings.m_subtitleFilters);
 
         } else {
@@ -232,7 +234,7 @@ void AdvancedSettingsXmlReader::loadMappings(QHash<QString, QString>& mappings)
 {
     mappings.clear();
     while (m_xml.readNextStartElement()) {
-        if (m_xml.name() == "map" && m_xml.attributes().hasAttribute("from")) {
+        if (m_xml.name() == QLatin1String("map") && m_xml.attributes().hasAttribute("from")) {
             const auto from = m_xml.attributes().value("from").trimmed();
             const auto to = m_xml.attributes().value("to").trimmed();
             if (!from.isEmpty() && !to.isEmpty()) {
@@ -249,8 +251,8 @@ void AdvancedSettingsXmlReader::loadExcludePatterns()
 {
     m_settings.m_sortTokens.clear();
     while (m_xml.readNextStartElement()) {
-        if (m_xml.name() == "pattern") {
-            QStringRef applyTo = m_xml.attributes().value("applyTo");
+        if (m_xml.name() == QLatin1String("pattern")) {
+            QString applyTo = m_xml.attributes().value("applyTo").toString();
             QRegularExpression pattern(m_xml.readElementText().trimmed());
             if (!pattern.isValid()) {
                 qCritical() << "[AdvancedSettings] Invalid regular expression! Message:" << pattern.errorString();

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -13,6 +13,7 @@
 #include <QDesktopServices>
 #include <QMutex>
 #include <QMutexLocker>
+#include <QStandardPaths>
 
 static constexpr char KEY_ALL_DATA_FILES[] = "AllDataFiles";
 static constexpr char KEY_AUTO_LOAD_STREAM_DETAILS[] = "AutoLoadStreamDetails";
@@ -1328,7 +1329,7 @@ mediaelch::DirectoryPath Settings::databaseDir()
     if (advanced()->portableMode()) {
         return mediaelch::DirectoryPath(applicationDir());
     }
-    return mediaelch::DirectoryPath(QStandardPaths::writableLocation(QStandardPaths::DataLocation));
+    return mediaelch::DirectoryPath(QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation));
 }
 
 mediaelch::DirectoryPath Settings::imageCacheDir()
@@ -1336,7 +1337,7 @@ mediaelch::DirectoryPath Settings::imageCacheDir()
     if (advanced()->portableMode()) {
         return mediaelch::DirectoryPath(applicationDir());
     }
-    return mediaelch::DirectoryPath(QStandardPaths::writableLocation(QStandardPaths::DataLocation));
+    return mediaelch::DirectoryPath(QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation));
 }
 
 mediaelch::DirectoryPath Settings::exportTemplatesDir()
@@ -1345,7 +1346,7 @@ mediaelch::DirectoryPath Settings::exportTemplatesDir()
         return mediaelch::DirectoryPath(applicationDir() + QDir::separator() + "export_themes");
     }
     return mediaelch::DirectoryPath(
-        QStandardPaths::writableLocation(QStandardPaths::DataLocation) + QDir::separator() + "export_themes");
+        QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + QDir::separator() + "export_themes");
 }
 
 void Settings::setShowAdultScrapers(bool show)

--- a/src/ui/concerts/ConcertFilesWidget.cpp
+++ b/src/ui/concerts/ConcertFilesWidget.cpp
@@ -284,7 +284,11 @@ void ConcertFilesWidget::resizeEvent(QResizeEvent* event)
     m_alphaList->adjustSize();
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 void ConcertFilesWidget::enterEvent(QEvent* event)
+#else
+void ConcertFilesWidget::enterEvent(QEnterEvent* event)
+#endif
 {
     Q_UNUSED(event)
     m_mouseIsIn = true;

--- a/src/ui/concerts/ConcertFilesWidget.h
+++ b/src/ui/concerts/ConcertFilesWidget.h
@@ -3,6 +3,7 @@
 #include "concerts/Concert.h"
 #include "concerts/ConcertModel.h"
 #include "concerts/ConcertProxyModel.h"
+#include "globals/Filter.h"
 #include "ui/small_widgets/AlphabeticalList.h"
 
 #include <QLabel>
@@ -44,7 +45,12 @@ signals:
     void concertSelected(Concert*);
 
 protected:
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     void enterEvent(QEvent* event) override;
+#else
+    void enterEvent(QEnterEvent* event) override;
+#endif
+
     void leaveEvent(QEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
 

--- a/src/ui/main/AboutDialog.cpp
+++ b/src/ui/main/AboutDialog.cpp
@@ -84,7 +84,7 @@ void AboutDialog::setDeveloperInformation()
                << "Application dir: " << QDir::toNativeSeparators(Settings::applicationDir()) << "<br>"
                << "Settings file: " << Settings::instance()->settings()->fileName() << "<br>"
                << "Data dir: "
-               << QDir::toNativeSeparators(QStandardPaths::writableLocation(QStandardPaths::DataLocation)) << "<br>"
+               << QDir::toNativeSeparators(QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation)) << "<br>"
                << "MediaInfo Version: ";
 
 #ifdef Q_OS_WIN

--- a/src/ui/main/AboutDialog.cpp
+++ b/src/ui/main/AboutDialog.cpp
@@ -73,19 +73,30 @@ void AboutDialog::setDeveloperInformation()
     QString infos;
     QTextStream infoStream(&infos);
     infoStream << mediaelch::constants::AppName << " " << mediaelch::constants::AppVersionFullStr << " - "
-               << mediaelch::constants::VersionName << "<br><br>"
-               << QStringLiteral("Compiled with Qt version %1 (%2 %3, %4)<br>")
+               << mediaelch::constants::VersionName << "<br><br>";
+
+    // Compilation Details
+    infoStream << QStringLiteral("Compiled with Qt version %1 (%2 %3, %4)<br>")
                       .arg(QT_VERSION_STR,
                           QString::number(QSysInfo::WordSize),
                           mediaelch::constants::CompilationType,
                           mediaelch::constants::CompilerString)
                << QStringLiteral("Using Qt version %1<br>").arg(qVersion())
-               << QStringLiteral("System: %1 (%2)<br><br>").arg(QSysInfo::prettyProductName(), QSysInfo::buildAbi())
-               << "Application dir: " << QDir::toNativeSeparators(Settings::applicationDir()) << "<br>"
+               << QStringLiteral("System: %1 (%2)").arg(QSysInfo::prettyProductName(), QSysInfo::buildAbi())
+               << "<br><br>";
+
+    // Directories
+    infoStream << "Application dir: " << QDir::toNativeSeparators(Settings::applicationDir()) << "<br>"
                << "Settings file: " << Settings::instance()->settings()->fileName() << "<br>"
                << "Data dir: "
-               << QDir::toNativeSeparators(QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation)) << "<br>"
-               << "MediaInfo Version: ";
+               << QDir::toNativeSeparators(QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation))
+               << "<br>"
+               << "Qt Translation Path: "
+               << QDir::toNativeSeparators(QLibraryInfo::location(QLibraryInfo::TranslationsPath)) //
+               << "<br><br>";
+
+    // Dependencies
+    infoStream << "MediaInfo Version: ";
 
 #ifdef Q_OS_WIN
     infoStream << (mediaInfoVersion.empty() ? QString("&lt;not available&gt;")
@@ -94,8 +105,11 @@ void AboutDialog::setDeveloperInformation()
     infoStream << (mediaInfoVersion.empty() ? "&lt;not available&gt;" : mediaInfoVersion.c_str());
 #endif
     infoStream << "<br><br>";
-    infoStream << "Qt Translation Path: "
-               << QDir::toNativeSeparators(QLibraryInfo::location(QLibraryInfo::TranslationsPath));
+    infoStream << "Default UI languages: " << QLocale().uiLanguages().join(", ");
+    infoStream << "<br><br>";
+    infoStream << "Custom advancedsettings.xml: "
+               << (Settings::instance()->advanced()->isUserDefined() ? "true" : "false");
+    infoStream << "<br>";
 
     ui->txtDetails->setHtml(infos);
 }

--- a/src/ui/main/MainWindow.cpp
+++ b/src/ui/main/MainWindow.cpp
@@ -334,7 +334,7 @@ void MainWindow::setupToolbar()
     });
 
     // TODO: There is currently no GUI-way to do this.
-    QShortcut* shortcut = new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_E, this);
+    QShortcut* shortcut = new QShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_E, this);
     QObject::connect(shortcut, &QShortcut::activated, this, [this]() {
         auto* csvExportDialog = new CsvExportDialog(*m_settings, this);
         csvExportDialog->exec();
@@ -349,7 +349,7 @@ void MainWindow::setupToolbar()
     auto* commandModelAction = new QAction("Test", this);
     commandModelAction->setIcon(QIcon::fromTheme(QStringLiteral("quickopen")));
     commandModelAction->setText(tr("&Quick Open"));
-    commandModelAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_O));
+    commandModelAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_O));
     connect(commandModelAction, &QAction::triggered, this, &MainWindow::onCommandBarOpen);
     addAction(commandModelAction);
 }

--- a/src/ui/main/Navbar.cpp
+++ b/src/ui/main/Navbar.cpp
@@ -19,7 +19,7 @@ Navbar::Navbar(QWidget* parent) : QWidget(parent), ui(new Ui::Navbar)
     ui->btnSave->setShortcut(QKeySequence::Save);
     ui->btnSave->setToolTip(tr("Save (%1)").arg(QKeySequence(QKeySequence::Save).toString(QKeySequence::NativeText)));
 
-    QKeySequence seqSaveAll(Qt::CTRL + Qt::ShiftModifier + Qt::Key_S);
+    QKeySequence seqSaveAll(Qt::CTRL | Qt::SHIFT | Qt::Key_S);
     ui->btnSaveAll->setShortcut(seqSaveAll);
     ui->btnSaveAll->setToolTip(tr("Save All (%1)").arg(seqSaveAll.toString(QKeySequence::NativeText)));
 
@@ -27,9 +27,9 @@ Navbar::Navbar(QWidget* parent) : QWidget(parent), ui(new Ui::Navbar)
     ui->btnReload->setToolTip(
         tr("Reload all files (%1)").arg(QKeySequence(QKeySequence::Refresh).toString(QKeySequence::NativeText)));
 
-    ui->btnExport->setShortcut(Qt::CTRL + Qt::Key_E);
+    ui->btnExport->setShortcut(Qt::CTRL | Qt::Key_E);
     ui->btnExport->setToolTip(
-        tr("Export Database (%1)").arg(QKeySequence(Qt::CTRL + Qt::Key_E).toString(QKeySequence::NativeText)));
+        tr("Export Database (%1)").arg(QKeySequence(Qt::CTRL | Qt::Key_E).toString(QKeySequence::NativeText)));
 
     // clang-format off
     connect(ui->btnSearch,   &QAbstractButton::clicked, this, &Navbar::sigSearch);
@@ -59,6 +59,7 @@ Navbar::Navbar(QWidget* parent) : QWidget(parent), ui(new Ui::Navbar)
     navbarColors << QColor(107, 183, 228, 255);
     navbarColors << QColor(206, 139, 188, 255);
 
+#ifndef Q_OS_MAC
     QStringList menuIcons = QStringList() << "scrape"
                                           << "save"
                                           << "saveall"
@@ -68,6 +69,7 @@ Navbar::Navbar(QWidget* parent) : QWidget(parent), ui(new Ui::Navbar)
                                           << "reload"
                                           << "settings"
                                           << "about";
+#endif
 
 #ifdef Q_OS_MAC
     int i = 0;

--- a/src/ui/main/Update.cpp
+++ b/src/ui/main/Update.cpp
@@ -97,16 +97,16 @@ bool Update::checkIfNewVersion(QString xmlString, QString& version, QString& dow
 
     const auto extractVersion = [&]() {
         while (xml.readNextStartElement()) {
-            if (xml.name() == "version") {
+            if (xml.name() == QLatin1String("version")) {
                 versionInfo = mediaelch::VersionInfo(xml.readElementText());
 
-            } else if (xml.name() == "name") {
+            } else if (xml.name() == QLatin1String("name")) {
                 versionName = xml.readElementText();
 
-            } else if (xml.name() == "released") {
+            } else if (xml.name() == QLatin1String("released")) {
                 released = xml.readElementText();
 
-            } else if (xml.name() == "downloadUrl") {
+            } else if (xml.name() == QLatin1String("downloadUrl")) {
                 QString system = xml.attributes().value("system").toString();
                 if (system == os) {
                     downloadUrlOs = xml.readElementText();
@@ -118,7 +118,7 @@ bool Update::checkIfNewVersion(QString xmlString, QString& version, QString& dow
     };
 
     while (xml.readNextStartElement()) {
-        if (xml.name() == "latestVersion") {
+        if (xml.name() == QLatin1String("latestVersion")) {
             extractVersion();
         }
     }

--- a/src/ui/movies/MovieFilesWidget.cpp
+++ b/src/ui/movies/MovieFilesWidget.cpp
@@ -428,7 +428,11 @@ QVector<Movie*> MovieFilesWidget::selectedMovies()
     return movies;
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 void MovieFilesWidget::enterEvent(QEvent* event)
+#else
+void MovieFilesWidget::enterEvent(QEnterEvent* event)
+#endif
 {
     Q_UNUSED(event);
     m_mouseIsIn = true;

--- a/src/ui/movies/MovieFilesWidget.h
+++ b/src/ui/movies/MovieFilesWidget.h
@@ -47,7 +47,12 @@ signals:
     void sigStartSearch();
 
 protected:
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     void enterEvent(QEvent* event) override;
+#else
+    void enterEvent(QEnterEvent* event) override;
+#endif
+
     void leaveEvent(QEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
 

--- a/src/ui/small_widgets/AlphabeticalList.cpp
+++ b/src/ui/small_widgets/AlphabeticalList.cpp
@@ -8,7 +8,7 @@
 AlphabeticalList::AlphabeticalList(QWidget* parent, MyTableView* parentTableView) :
     QWidget(parent), m_layout{new QVBoxLayout(this)}, m_tableView{parentTableView}
 {
-    m_layout->setMargin(0);
+    m_layout->setContentsMargins(0, 0, 0, 0);
     setContentsMargins(0, 0, 0, 0);
     QString style =
         "QWidget { background-color: rgba(0, 0, 0, 80); border: 1px solid rgba(0, 0, 0, 20); border-radius: 7px; }";
@@ -31,7 +31,7 @@ void AlphabeticalList::adjustSize()
 void AlphabeticalList::paintEvent(QPaintEvent* /*event*/)
 {
     QStyleOption opt;
-    opt.init(this);
+    opt.initFrom(this);
     QPainter p(this);
     style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
 }

--- a/src/ui/small_widgets/SearchOverlay.cpp
+++ b/src/ui/small_widgets/SearchOverlay.cpp
@@ -29,7 +29,7 @@ void SearchOverlay::paintEvent(QPaintEvent* event)
 {
     Q_UNUSED(event);
     QStyleOption opt;
-    opt.init(this);
+    opt.initFrom(this);
     QPainter p(this);
     style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
 }

--- a/test/helpers/matchers.cpp
+++ b/test/helpers/matchers.cpp
@@ -54,7 +54,7 @@ RegexMatcher::RegexMatcher(QString regex) : m_regex(regex)
 
 bool RegexMatcher::match(const QString& matchee) const
 {
-    return m_regex.indexIn(matchee) != -1;
+    return m_regex.match(matchee).hasMatch();
 }
 
 std::string RegexMatcher::describe() const

--- a/test/helpers/matchers.h
+++ b/test/helpers/matchers.h
@@ -2,7 +2,7 @@
 
 #include "third_party/catch2/catch.hpp"
 
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QString>
 #include <QStringList>
 #include <string>
@@ -54,7 +54,7 @@ struct RegexMatcher : Catch::MatcherBase<QString>
     std::string describe() const override;
 
 private:
-    QRegExp m_regex;
+    QRegularExpression m_regex;
 };
 
 EqualsMatcher Equals(const QString& str);

--- a/test/scrapers/testTmdbMovie.cpp
+++ b/test/scrapers/testTmdbMovie.cpp
@@ -49,8 +49,8 @@ TEST_CASE("TmdbMovie scrapes correct movie details", "[TmdbMovie][load_data]")
         CHECK(m.set().name == "Finding Nemo Collection");
         CHECK_THAT(m.set().overview, StartsWithMatcher("A computer-animated adventure film series"));
 
-        // https://www.youtube.com/watch?v=iG0P6bjyUNI | may change from time to time
-        CHECK_THAT(m.trailer().toString(), Contains("iG0P6bjyUNI"));
+        // https://www.youtube.com/watch?v=JhvrQeY3doI | may change from time to time
+        CHECK_THAT(m.trailer().toString(), Contains("JhvrQeY3doI"));
         // There are more than 20 posters and backdrops
         // on TmdbMovie (using the API)
         CHECK(m.images().posters().size() >= 9);


### PR DESCRIPTION
This commit has some fixes for Qt6.  Some deprecated enums/methods
were replaced.  Comparisons between QStringView and char* required
either QStringView on the right-hand-side or QLatin1String.  We use
the latter now as that's supported on older Qt versions as well.

Some unused `QRegEx` includes were removed.

Some conditionals were used, e.g. for method calls that are required
in Qt5 but are the default (and therefore removed) in Qt6.

This commit does NOT make MediaElch compatible with Qt6.
We still use QRegEx in a lot of places.  Furthermore, we have to wait
for Qt 6.2 to finally get QMultiMediaWidgets.

