### PR TITLE
[Project] More changes towards Qt6 compatibility

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -156,7 +156,10 @@ int main(int argc, char** argv)
     QCoreApplication::setOrganizationName(mediaelch::constants::OrganizationName);
     QCoreApplication::setApplicationName(mediaelch::constants::AppName);
     QCoreApplication::setApplicationVersion(mediaelch::constants::AppVersionFullStr);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // Default in Qt 6
     QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps, true);
+#endif
 
     qInstallMessageHandler(mediaelch::cli::messageHandler);
 

--- a/src/file/Path.h
+++ b/src/file/Path.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "globals/Meta.h"
+
 #include <QDebug>
 #include <QDir>
 #include <QFile>
@@ -52,7 +54,7 @@ bool operator!=(const DirectoryPath& lhs, const DirectoryPath& rhs);
 
 QDebug operator<<(QDebug debug, const DirectoryPath& dir);
 
-inline uint qHash(const DirectoryPath& key, uint seed)
+inline ELCH_QHASH_RETURN_TYPE qHash(const DirectoryPath& key, uint seed)
 {
     return qHash(key.toString(), seed);
 }
@@ -92,7 +94,7 @@ bool operator!=(const FilePath& lhs, const FilePath& rhs);
 
 QDebug operator<<(QDebug debug, const FilePath& dir);
 
-inline uint qHash(const FilePath& key, uint seed)
+inline ELCH_QHASH_RETURN_TYPE qHash(const FilePath& key, uint seed)
 {
     return qHash(key.toString(), seed);
 }

--- a/src/globals/Globals.h
+++ b/src/globals/Globals.h
@@ -200,7 +200,7 @@ enum class ImageType : int {
     AlbumBooklet         = 38
 };
 
-inline uint qHash(const ImageType& type, uint seed)
+inline ELCH_QHASH_RETURN_TYPE qHash(const ImageType& type, uint seed)
 {
     return qHash(static_cast<int>(type), seed);
 }

--- a/src/globals/Meta.h
+++ b/src/globals/Meta.h
@@ -2,6 +2,13 @@
 
 #include <QtGlobal>
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#    define ELCH_QHASH_RETURN_TYPE uint
+#else
+// With Qt 6, qHash uses size_t
+#    define ELCH_QHASH_RETURN_TYPE size_t
+#endif
+
 #define ELCH_NODISCARD Q_REQUIRED_RESULT
 #define ELCH_DEPRECATED Q_DECL_DEPRECATED
 

--- a/src/globals/ScraperInfos.h
+++ b/src/globals/ScraperInfos.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "globals/Meta.h"
+
 #include <QHash>
 #include <QObject>
 #include <QSet>
@@ -44,7 +46,7 @@ QSet<MovieScraperInfo> allMovieScraperInfos();
 } // namespace scraper
 } // namespace mediaelch
 
-inline uint qHash(const MovieScraperInfo& key, uint seed)
+inline ELCH_QHASH_RETURN_TYPE qHash(const MovieScraperInfo& key, uint seed)
 {
     return qHash(static_cast<int>(key), seed);
 }
@@ -83,7 +85,7 @@ QString scraperInfoToTranslatedString(ShowScraperInfo info);
 QSet<ShowScraperInfo> allShowScraperInfos();
 } // namespace mediaelch
 
-inline uint qHash(const ShowScraperInfo& key, uint seed)
+inline ELCH_QHASH_RETURN_TYPE qHash(const ShowScraperInfo& key, uint seed)
 {
     return qHash(static_cast<int>(key), seed);
 }
@@ -123,7 +125,7 @@ QString scraperInfoToTranslatedString(EpisodeScraperInfo info);
 QSet<EpisodeScraperInfo> allEpisodeScraperInfos();
 } // namespace mediaelch
 
-inline uint qHash(const EpisodeScraperInfo& key, uint seed)
+inline ELCH_QHASH_RETURN_TYPE qHash(const EpisodeScraperInfo& key, uint seed)
 {
     return qHash(static_cast<int>(key), seed);
 }
@@ -147,7 +149,7 @@ enum class ConcertScraperInfo : int
     ExtraFanarts = 14
 };
 
-inline uint qHash(const ConcertScraperInfo& key, uint seed)
+inline ELCH_QHASH_RETURN_TYPE qHash(const ConcertScraperInfo& key, uint seed)
 {
     return qHash(static_cast<int>(key), seed);
 }
@@ -183,7 +185,7 @@ enum class MusicScraperInfo : int
 
 // clang-format: on
 
-inline uint qHash(const MusicScraperInfo& key, uint seed)
+inline ELCH_QHASH_RETURN_TYPE qHash(const MusicScraperInfo& key, uint seed)
 {
     return qHash(static_cast<int>(key), seed);
 }

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -9,7 +9,5 @@ target_link_libraries(
                             Qt5::Xml Qt5::MultimediaWidgets
 )
 
-target_link_libraries(
-  mediaelch_network PUBLIC Qt5::Network
-)
+target_link_libraries(mediaelch_network PUBLIC Qt5::Network)
 mediaelch_post_target_defaults(mediaelch_network)

--- a/src/tv_shows/EpisodeNumber.h
+++ b/src/tv_shows/EpisodeNumber.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "globals/Meta.h"
+
 #include <QHash>
 #include <QString>
 #include <ostream>
@@ -25,7 +27,7 @@ private:
     int m_episodeNumber = -1; // No episode
 };
 
-inline uint qHash(const EpisodeNumber& episode, uint seed)
+inline ELCH_QHASH_RETURN_TYPE qHash(const EpisodeNumber& episode, uint seed)
 {
     return qHash(episode.toInt(), seed);
 }

--- a/src/tv_shows/SeasonNumber.h
+++ b/src/tv_shows/SeasonNumber.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "globals/Meta.h"
+
 #include <QHash>
 #include <QString>
 #include <ostream>
@@ -26,7 +28,7 @@ private:
     int m_seasonNumber = -2; // No season; not -1 because Kodi uses it for "no season"
 };
 
-inline uint qHash(const SeasonNumber& season, uint seed)
+inline ELCH_QHASH_RETURN_TYPE qHash(const SeasonNumber& season, uint seed)
 {
     return qHash(season.toInt(), seed);
 }

--- a/src/tv_shows/SeasonOrder.h
+++ b/src/tv_shows/SeasonOrder.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "globals/Meta.h"
+
 #include <QHash>
 #include <ostream>
 
@@ -9,7 +11,7 @@ enum class SeasonOrder : int
     Dvd = 2
 };
 
-inline uint qHash(SeasonOrder order, uint seed)
+inline ELCH_QHASH_RETURN_TYPE qHash(SeasonOrder order, uint seed)
 {
     return qHash(static_cast<int>(order), seed);
 }

--- a/src/ui/music/MusicFilesWidget.cpp
+++ b/src/ui/music/MusicFilesWidget.cpp
@@ -139,9 +139,15 @@ void MusicFilesWidget::onItemSelected(QModelIndex index)
 
 void MusicFilesWidget::updateStatusLabel()
 {
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
     if (m_proxyModel->filterRegExp().pattern().isEmpty() || m_proxyModel->filterRegExp().pattern() == "**") {
+#else
+    if (m_proxyModel->filterRegularExpression().pattern().isEmpty()
+        || m_proxyModel->filterRegularExpression().pattern() == "**") {
+#endif
         int albumCount = 0;
-        for (Artist* artist : Manager::instance()->musicModel()->artists()) {
+        const auto artists = Manager::instance()->musicModel()->artists();
+        for (Artist* artist : artists) {
             albumCount += artist->albums().count();
         }
         ui->statusLabel->setText(

--- a/src/ui/settings/GlobalSettingsWidget.cpp
+++ b/src/ui/settings/GlobalSettingsWidget.cpp
@@ -286,7 +286,6 @@ void GlobalSettingsWidget::onDirTypeChanged(QComboBox* box)
 
     QTableWidgetItem* itemCheck = box->property("itemCheck").value<Storage*>()->tableWidgetItem();
     QTableWidgetItem* itemCheckReload = box->property("itemCheckReload").value<Storage*>()->tableWidgetItem();
-    QTableWidgetItem* itemCheckDisabled = box->property("itemCheckDisabled").value<Storage*>()->tableWidgetItem();
 
     if (box->currentIndex() == 0) {
         itemCheck->setFlags(Qt::ItemIsEnabled | Qt::ItemIsUserCheckable);

--- a/src/ui/tv_show/TvShowFilesWidget.cpp
+++ b/src/ui/tv_show/TvShowFilesWidget.cpp
@@ -642,8 +642,14 @@ void TvShowFilesWidget::updateStatusLabel()
 {
     const int rowCount = m_tvShowProxyModel->rowCount();
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
     if (m_tvShowProxyModel->filterRegExp().pattern().isEmpty()
         || m_tvShowProxyModel->filterRegExp().pattern() == "**") {
+#else
+    if (m_tvShowProxyModel->filterRegularExpression().pattern().isEmpty()
+        || m_tvShowProxyModel->filterRegularExpression().pattern() == "**") {
+#endif
+
         int episodeCount = 0;
         for (const auto* show : Manager::instance()->tvShowModel()->tvShows()) {
             episodeCount += show->episodeCount();

--- a/test/integration/media_centers/testKodi_v18_concert.cpp
+++ b/test/integration/media_centers/testKodi_v18_concert.cpp
@@ -57,7 +57,8 @@ TEST_CASE("Concert XML writer for Kodi v18", "[data][concert][kodi][nfo]")
             REQUIRE(!concert.ratings().isEmpty());
             CHECK(concert.ratings().first().voteCount == 15);
             // TODO: Difference to posters()?
-            // CHECK(concert.image(ImageType::ConcertPoster).size() == 176);  // TODO: currently every thumb is a poster...
+            // CHECK(concert.image(ImageType::ConcertPoster).size() == 176);  // TODO: currently every thumb is a
+            // poster...
             CHECK(concert.posters().size() == 4);
             // TODO: Difference to backdrops()?
             // CHECK(concert.image(ImageType::ConcertBackdrop).size() == 57); // <fanart>


### PR DESCRIPTION
This commit has some fixes for Qt6.  These changes include:

 - use size_t instead of uint for qHash()'s return type
 - Qt6 has some other defaults
 - Use QProxyModel's `filterRegularExpression` instead of `filterRegExp`

Because we still support Qt 5.6, we have to use a few macros.