### PR TITLE
[MovieScraper] Minor refactoring + scraperLoadDone also expects an error 

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,22 @@
+# Since version 2.23 (released in August 2019), git-blame has a feature
+# to ignore or bypass certain commits.
+#
+# This file contains a list of commits that are not likely what you
+# are looking for in a blame, such as mass reformatting or renaming.
+# You can set this file as a default ignore file for blame by running
+# the following command.
+#
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# clang-format changes
+fed0b4d2cb62464ca3bf926fb86c009d86df57c7
+fa5217edac407127a9de8d3bed39dc8d2198252a
+653f9a02980b75e6b1ed691e83bede0c2d65e92e
+92c4b78444b48ace46209dfe5341eb2e77352450
+0503c8442e79a88279d8738232b5656f7f097d44
+31cdde8cd5574a364823e4a2c9c4cc844580e8e9
+439afd298f5320c07cf1e2cf12f41a760f615169
+4279f03ba3c294ea139898c65f25aca31713b83f
+44d4b05d859025657154c9e84bdffd505872e54e
+163a9b6ebee37a641d6d921d8b27fe4c7d3f8fdf
+f96f470a03e762c0f3830f03fd06b061287ac70e

--- a/scripts/update_translation_source.sh
+++ b/scripts/update_translation_source.sh
@@ -16,7 +16,6 @@ export PATH="$HOME/Qt/5.15.2/gcc_64/bin/:$PATH"
 # second run.
 lupdate -verbose -no-obsolete MediaElch.pro
 lupdate -verbose -no-obsolete MediaElch.pro
-lrelease data/i18n/*.ts
 
 # Update source
 tx push -s

--- a/src/data/MediaInfoFile.cpp
+++ b/src/data/MediaInfoFile.cpp
@@ -62,17 +62,19 @@ std::chrono::milliseconds MediaInfoFile::duration(int streamIndex) const
 std::size_t MediaInfoFile::videoWidth(int streamIndex) const
 {
     // Width should be an integer but just to be safe, use a floating point number first.
+    // Also, toInt() may return an invalid / unexpected value because Width may be written as 1024.0
     const double widthDouble = getVideo(streamIndex, "Width").toDouble();
     const qint64 width = static_cast<qint64>(widthDouble);
-    return width < 0 ? 0 : width;
+    return width < 0 ? 0 : static_cast<std::size_t>(width);
 }
 
 std::size_t MediaInfoFile::videoHeight(int streamIndex) const
 {
     // Height should be an integer but just to be safe, use a floating point number first.
+    // Also, toInt() may return an invalid / unexpected value because Height may be written as 1024.0
     const double heightDouble = getVideo(streamIndex, "Height").toDouble();
     const qint64 height = static_cast<qint64>(heightDouble);
-    return height < 0 ? 0 : height;
+    return height < 0 ? 0 : static_cast<std::size_t>(height);
 }
 
 double MediaInfoFile::aspectRatio(int streamIndex) const

--- a/src/export/SimpleEngine.cpp
+++ b/src/export/SimpleEngine.cpp
@@ -131,7 +131,7 @@ void SimpleEngine::replaceVars(QString& m, Movie* movie, bool subDir)
         m.replace("{{ MOVIE.VOTES }}", "n/a");
     }
 
-    m.replace("{{ MOVIE.RUNTIME }}", QString::number(movie->runtime().count(), 'f', 0));
+    m.replace("{{ MOVIE.RUNTIME }}", QString::number(static_cast<double>(movie->runtime().count()), 'f', 0));
     m.replace("{{ MOVIE.PLAY_COUNT }}", QString::number(movie->playcount(), 'f', 0));
     m.replace("{{ MOVIE.LAST_PLAYED }}",
         movie->lastPlayed().isValid() ? movie->lastPlayed().toString("yyyy-MM-dd hh:mm") : "");
@@ -231,7 +231,7 @@ void SimpleEngine::replaceVars(QString& m, const Concert* concert, bool subDir)
     }
 
     m.replace("{{ CONCERT.YEAR }}", concert->released().isValid() ? concert->released().toString("yyyy") : "");
-    m.replace("{{ CONCERT.RUNTIME }}", QString::number(concert->runtime().count(), 'f', 0));
+    m.replace("{{ CONCERT.RUNTIME }}", QString::number(static_cast<double>(concert->runtime().count()), 'f', 0));
     m.replace("{{ CONCERT.CERTIFICATION }}", concert->certification().toString().toHtmlEscaped());
     m.replace("{{ CONCERT.TRAILER }}", concert->trailer().toString());
     m.replace("{{ CONCERT.PLAY_COUNT }}", QString::number(concert->playcount(), 'f', 0));

--- a/src/globals/TrailerDialog.cpp
+++ b/src/globals/TrailerDialog.cpp
@@ -302,15 +302,15 @@ void TrailerDialog::downloadProgress(int received, int total)
     ui->progressBar->setRange(0, total);
     ui->progressBar->setValue(received);
 
-    double speed = received * 1000.0 / m_downloadTime.elapsed();
+    double speed = received * 1000.0 / static_cast<double>(m_downloadTime.elapsed());
     QString unit;
-    if (speed < 1024) {
+    if (speed < 1024.0) {
         unit = "bytes/sec";
-    } else if (speed < 1024 * 1024) {
-        speed /= 1024;
+    } else if (speed < 1024.0 * 1024.0) {
+        speed /= 1024.0;
         unit = "kB/s";
     } else {
-        speed /= 1024 * 1024;
+        speed /= 1024.0 * 1024.0;
         unit = "MB/s";
     }
     ui->progress->setText(QString("%1 %2").arg(speed, 3, 'f', 1).arg(unit));
@@ -396,7 +396,7 @@ void TrailerDialog::onUpdateTime(qint64 currentTime)
 
     int position = 0;
     if (m_totalTime > 0) {
-        position = qRound((static_cast<float>(currentTime) / m_totalTime) * 100.0f);
+        position = qRound((static_cast<float>(currentTime) / static_cast<float>(m_totalTime)) * 100.0f);
     }
     ui->seekSlider->setValue(position);
 }

--- a/src/imports/DownloadFileSearcher.cpp
+++ b/src/imports/DownloadFileSearcher.cpp
@@ -2,6 +2,7 @@
 
 #include <QRegularExpression>
 
+// Still required for wildcards at the moment.
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
 #    include <QRegExp>
 #endif

--- a/src/log/CMakeLists.txt
+++ b/src/log/CMakeLists.txt
@@ -1,8 +1,9 @@
 add_library(mediaelch_log OBJECT Log.cpp)
 
-# GUI is required due to Globals.h
+# GUI is required due to Globals.h Network due to HttpStatusCodes.h
 target_link_libraries(
-  mediaelch_log PRIVATE Qt${QT_VERSION_MAJOR}::Core
-                        Qt${QT_VERSION_MAJOR}::Widgets
+  mediaelch_log
+  PRIVATE Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets
+          Qt${QT_VERSION_MAJOR}::Network
 )
 mediaelch_post_target_defaults(mediaelch_log)

--- a/src/movies/MovieController.cpp
+++ b/src/movies/MovieController.cpp
@@ -4,6 +4,7 @@
 #include <QFileInfo>
 #include <QRegularExpression>
 #include <QtCore/qmath.h>
+#include <chrono>
 
 #include "data/ImageCache.h"
 #include "file/NameFormatter.h"
@@ -17,6 +18,8 @@
 #include "scrapers/movie/imdb/ImdbMovie.h"
 #include "scrapers/movie/tmdb/TmdbMovie.h"
 #include "settings/Settings.h"
+// TODO: Remove UI dependency
+#include "ui/notifications/NotificationBox.h"
 
 MovieController::MovieController(Movie* parent) :
     QObject(parent),
@@ -175,8 +178,16 @@ void MovieController::setInfosToLoad(QSet<MovieScraperInfo> infos)
     m_infosToLoad = std::move(infos);
 }
 
-void MovieController::scraperLoadDone(mediaelch::scraper::MovieScraper* scraper)
+void MovieController::scraperLoadDone(mediaelch::scraper::MovieScraper* scraper, mediaelch::ScraperError error)
 {
+    using namespace std::chrono_literals;
+
+    if (error.hasError() && !error.is404()) {
+        // TODO: 404 not necessary but avoids false positives at the moment.
+        // TODO: Remove UI dependency
+        NotificationBox::instance()->showError(error.message, 6s);
+    }
+
     m_customScraperMutex.lock();
     if (!property("customMovieScraperLoads").isNull() && property("customMovieScraperLoads").toInt() > 1) {
         setProperty("customMovieScraperLoads", property("customMovieScraperLoads").toInt() - 1);
@@ -418,7 +429,7 @@ void MovieController::removeFromLoadsLeft(ScraperData load)
     m_loadMutex.lock();
     if (m_loadsLeft.isEmpty() && !m_loadDoneFired) {
         m_loadDoneFired = true;
-        scraperLoadDone(Manager::instance()->scrapers().movieScraper(mediaelch::scraper::TmdbMovie::ID));
+        scraperLoadDone(Manager::instance()->scrapers().movieScraper(mediaelch::scraper::TmdbMovie::ID), {});
     }
     m_loadMutex.unlock();
 }

--- a/src/movies/MovieController.h
+++ b/src/movies/MovieController.h
@@ -3,6 +3,7 @@
 #include "globals/DownloadManagerElement.h"
 #include "globals/Poster.h"
 #include "globals/ScraperInfos.h"
+#include "scrapers/ScraperError.h"
 #include "scrapers/movie/MovieIdentifier.h"
 
 #include <QMap>
@@ -49,7 +50,7 @@ public:
 
     /// \brief Called when a ScraperInterface has finished loading
     ///        Emits the loaded signal
-    void scraperLoadDone(mediaelch::scraper::MovieScraper* scraper);
+    void scraperLoadDone(mediaelch::scraper::MovieScraper* scraper, mediaelch::ScraperError error);
 
     QSet<MovieScraperInfo> infosToLoad();
 

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -7,9 +7,13 @@ add_library(
 target_link_libraries(
   mediaelch_network
   PRIVATE
-    Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Multimedia
-    Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Sql
-    Qt${QT_VERSION_MAJOR}::Xml Qt${QT_VERSION_MAJOR}::MultimediaWidgets
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Multimedia
+    Qt${QT_VERSION_MAJOR}::Widgets
+    Qt${QT_VERSION_MAJOR}::Sql
+    Qt${QT_VERSION_MAJOR}::Network
+    Qt${QT_VERSION_MAJOR}::Xml
+    Qt${QT_VERSION_MAJOR}::MultimediaWidgets
 )
 
 target_link_libraries(mediaelch_network PUBLIC Qt${QT_VERSION_MAJOR}::Network)

--- a/src/scrapers/CMakeLists.txt
+++ b/src/scrapers/CMakeLists.txt
@@ -40,7 +40,9 @@ add_library(
 
 target_link_libraries(
   mediaelch_scrapers
-  PRIVATE Qt${QT_VERSION_MAJOR}::Sql Qt${QT_VERSION_MAJOR}::Widgets
-          Qt${QT_VERSION_MAJOR}::Multimedia Qt${QT_VERSION_MAJOR}::Xml
+  PRIVATE
+    Qt${QT_VERSION_MAJOR}::Sql Qt${QT_VERSION_MAJOR}::Widgets
+    Qt${QT_VERSION_MAJOR}::Multimedia Qt${QT_VERSION_MAJOR}::Xml
+    Qt${QT_VERSION_MAJOR}::Network
 )
 mediaelch_post_target_defaults(mediaelch_scrapers)

--- a/src/scrapers/movie/adultdvdempire/AdultDvdEmpire.cpp
+++ b/src/scrapers/movie/adultdvdempire/AdultDvdEmpire.cpp
@@ -118,13 +118,9 @@ void AdultDvdEmpire::loadData(QHash<MovieScraper*, mediaelch::scraper::MovieIden
     m_api.loadMovie(ids.values().first().str(), [movie, infos, this](QString data, ScraperError error) {
         if (!error.hasError()) {
             parseAndAssignInfos(data, movie, infos);
-
-        } else {
-            // TODO
-            showNetworkError(error);
         }
 
-        movie->controller()->scraperLoadDone(this);
+        movie->controller()->scraperLoadDone(this, error);
     });
 }
 

--- a/src/scrapers/movie/aebn/AEBN.cpp
+++ b/src/scrapers/movie/aebn/AEBN.cpp
@@ -157,7 +157,7 @@ void AEBN::loadData(QHash<MovieScraper*, mediaelch::scraper::MovieIdentifier> id
     QSet<MovieScraperInfo> infos)
 {
     if (ids.isEmpty()) {
-        movie->controller()->scraperLoadDone(this);
+        movie->controller()->scraperLoadDone(this, {});
         return;
     }
 
@@ -178,7 +178,7 @@ void AEBN::loadData(QHash<MovieScraper*, mediaelch::scraper::MovieIdentifier> id
                 // TODO
                 showNetworkError(error);
             }
-            movie->controller()->scraperLoadDone(this);
+            movie->controller()->scraperLoadDone(this, error);
         });
 }
 
@@ -325,7 +325,7 @@ void AEBN::parseAndAssignInfos(QString html, Movie* movie, QSet<MovieScraperInfo
 void AEBN::downloadActors(Movie* movie, QStringList actorIds)
 {
     if (actorIds.isEmpty()) {
-        movie->controller()->scraperLoadDone(this);
+        movie->controller()->scraperLoadDone(this, {}); // done
         return;
     }
 

--- a/src/scrapers/movie/custom/CustomMovieScraper.h
+++ b/src/scrapers/movie/custom/CustomMovieScraper.h
@@ -57,9 +57,9 @@ private:
     QSet<MovieScraperInfo> infosForScraper(MovieScraper* scraper, QSet<MovieScraperInfo> selectedInfos);
     void loadAllData(QHash<MovieScraper*, mediaelch::scraper::MovieIdentifier> ids,
         Movie* movie,
-        QSet<MovieScraperInfo> infos,
-        QString tmdbId,
-        QString imdbId);
+        const QSet<MovieScraperInfo>& infos,
+        TmdbId tmdbId,
+        ImdbId imdbId);
     mediaelch::network::NetworkManager* network();
 };
 

--- a/src/scrapers/movie/hotmovies/HotMovies.cpp
+++ b/src/scrapers/movie/hotmovies/HotMovies.cpp
@@ -121,7 +121,7 @@ void HotMovies::loadData(QHash<MovieScraper*, mediaelch::scraper::MovieIdentifie
             showNetworkError(error);
         }
 
-        movie->controller()->scraperLoadDone(this);
+        movie->controller()->scraperLoadDone(this, error);
     });
 }
 

--- a/src/scrapers/movie/imdb/ImdbMovie.cpp
+++ b/src/scrapers/movie/imdb/ImdbMovie.cpp
@@ -222,7 +222,7 @@ void ImdbMovie::loadData(QHash<MovieScraper*, mediaelch::scraper::MovieIdentifie
 void ImdbMovie::onLoadDone(Movie& movie, mediaelch::scraper::ImdbMovieLoader* loader)
 {
     loader->deleteLater();
-    movie.controller()->scraperLoadDone(this);
+    movie.controller()->scraperLoadDone(this, {}); // TODO: Error
 }
 
 void ImdbMovie::parseAndAssignInfos(const QString& html, Movie* movie, QSet<MovieScraperInfo> infos) const

--- a/src/scrapers/movie/ofdb/OfdbApi.cpp
+++ b/src/scrapers/movie/ofdb/OfdbApi.cpp
@@ -31,9 +31,6 @@ void OfdbApi::sendGetRequest(const QUrl& url, OfdbApi::ApiCallback callback)
         QString data;
         if (reply->error() == QNetworkReply::NoError) {
             data = QString::fromUtf8(reply->readAll());
-
-        } else {
-            qWarning() << "[OfdbApi] Network Error:" << reply->errorString() << "for URL" << reply->url();
         }
 
         if (!data.isEmpty()) {

--- a/src/scrapers/movie/tmdb/TmdbMovie.cpp
+++ b/src/scrapers/movie/tmdb/TmdbMovie.cpp
@@ -306,7 +306,7 @@ void TmdbMovie::search(QString searchStr)
 
     if (searchStr.isEmpty()) {
         // searching without a query results in a network error
-        QTimer::singleShot(0, [this]() { emit searchDone({}, {}); });
+        QTimer::singleShot(0, this, [this]() { emit searchDone({}, {}); });
         return;
     }
 
@@ -489,9 +489,8 @@ void TmdbMovie::loadData(QHash<MovieScraper*, mediaelch::scraper::MovieIdentifie
     QSet<MovieScraperInfo> infos)
 {
     const QString id = ids.values().first().str();
-    const bool isImdbId = id.startsWith("tt");
 
-    if (isImdbId) {
+    if (ImdbId::isValidFormat(id)) {
         movie->setImdbId(ImdbId(id));
     } else {
         movie->setTmdbId(TmdbId(id));

--- a/src/scrapers/movie/videobuster/VideoBuster.cpp
+++ b/src/scrapers/movie/videobuster/VideoBuster.cpp
@@ -132,7 +132,7 @@ void VideoBuster::loadData(QHash<MovieScraper*, mediaelch::scraper::MovieIdentif
             // TODO
             showNetworkError(error);
         }
-        movie->controller()->scraperLoadDone(this);
+        movie->controller()->scraperLoadDone(this, error);
     });
 }
 

--- a/src/scrapers/movie/videobuster/VideoBusterApi.cpp
+++ b/src/scrapers/movie/videobuster/VideoBusterApi.cpp
@@ -76,5 +76,14 @@ QUrl VideoBusterApi::makeMovieUrl(const QString& id) const
     return makeApiUrl(id, {});
 }
 
+QString VideoBusterApi::replaceEntities(const QString& msg) const
+{
+    // not nice but I don't know other methods which don't require the gui module
+    QString m = msg;
+    m.replace("&#039;", "'");
+    return m;
+}
+
+
 } // namespace scraper
 } // namespace mediaelch

--- a/src/scrapers/movie/videobuster/VideoBusterApi.h
+++ b/src/scrapers/movie/videobuster/VideoBusterApi.h
@@ -30,6 +30,9 @@ public:
     void searchForMovie(const QString& query, ApiCallback callback);
     void loadMovie(const QString& id, ApiCallback callback);
 
+    /// \brief This function replaces entities with their unicode counterparts
+    QString replaceEntities(const QString& msg) const;
+
 public:
     static QUrl makeFullUrl(const QString& suffix);
 

--- a/src/scrapers/tmdb/TmdbApi.cpp
+++ b/src/scrapers/tmdb/TmdbApi.cpp
@@ -68,7 +68,7 @@ void TmdbApi::sendGetRequest(const Locale& locale, const QUrl& url, TmdbApi::Api
         return;
     }
 
-    QNetworkRequest request = mediaelch::network::requestWithDefaults(url);
+    QNetworkRequest request = mediaelch::network::jsonRequestWithDefaults(url);
     QNetworkReply* reply = m_network.getWithWatcher(request);
 
     connect(reply, &QNetworkReply::finished, this, [reply, cb = std::move(callback), locale, this]() {
@@ -140,7 +140,7 @@ void TmdbApi::searchForConcert(const Locale& locale, const QString& query, TmdbA
 
 QUrl TmdbApi::makeApiUrl(const QString& suffix, const Locale& locale, QUrlQuery query) const
 {
-    query.addQueryItem("api_key", apiKey());
+    query.addQueryItem("api_key", TmdbApi::apiKey());
     query.addQueryItem("language", locale.toString('-'));
 
     return QStringLiteral("https://api.themoviedb.org/3%1?%2").arg(suffix, query.toString());

--- a/src/scrapers/tv_show/tmdb/TmdbTvShowSearchJob.cpp
+++ b/src/scrapers/tv_show/tmdb/TmdbTvShowSearchJob.cpp
@@ -15,6 +15,7 @@ TmdbTvShowSearchJob::TmdbTvShowSearchJob(TmdbApi& api, ShowSearchJob::Config _co
 void TmdbTvShowSearchJob::execute()
 {
     if (config().query.isEmpty()) {
+        // TODO: Set a config error
         // searching without a query results in a network error
         emit sigFinished(this);
         return;

--- a/src/ui/movies/MovieSearchWidget.cpp
+++ b/src/ui/movies/MovieSearchWidget.cpp
@@ -74,6 +74,7 @@ void MovieSearchWidget::search(QString searchString, ImdbId id, TmdbId tmdbId)
 
 void MovieSearchWidget::startSearch()
 {
+    using namespace mediaelch::scraper;
     if (m_currentScraper == nullptr) {
         qWarning() << "Tried to search for movie without active scraper!";
         showError(tr("Cannot scrape a movie without an active scraper!"));
@@ -153,7 +154,7 @@ void MovieSearchWidget::setupLanguageDropdown()
     m_currentLanguage = defaultLanguage;
     m_currentScraper->changeLanguage(defaultLanguage); // store the default language
 
-    ui->comboLanguage->setupLanguages(supportedLocales, mediaelch::Locale(m_currentLanguage));
+    ui->comboLanguage->setupLanguages(supportedLocales, m_currentLanguage);
 }
 
 void MovieSearchWidget::showResults(QVector<ScraperSearchResult> results, mediaelch::ScraperError error)
@@ -250,7 +251,8 @@ void MovieSearchWidget::updateInfoToLoad()
 
 void MovieSearchWidget::toggleAllInfo(bool checked)
 {
-    for (MyCheckBox* box : ui->groupBox->findChildren<MyCheckBox*>()) {
+    const auto& boxes = ui->groupBox->findChildren<MyCheckBox*>();
+    for (MyCheckBox* box : boxes) {
         if (box->myData().toInt() > 0 && box->isEnabled()) {
             box->setChecked(checked);
         }

--- a/src/ui/small_widgets/MyLineEdit.cpp
+++ b/src/ui/small_widgets/MyLineEdit.cpp
@@ -257,7 +257,7 @@ void MyLineEdit::removeLastFilter()
  */
 void MyLineEdit::clearFilters()
 {
-    for (QLabel* label : m_filterLabels) {
+    for (QLabel* label : asConst(m_filterLabels)) {
         label->deleteLater();
     }
     m_filterLabels.clear();
@@ -278,14 +278,14 @@ void MyLineEdit::drawFilters()
     int paddingLeft = m_paddingLeft;
     int labelWidth = 0;
     int hidden = 0;
-    for (QLabel* l : m_filterLabels) {
+    for (QLabel* l : asConst(m_filterLabels)) {
         labelWidth += l->width() + 2;
         l->show();
     }
     while (labelWidth + 50 > width() && hidden < m_filterLabels.count()) {
         m_filterLabels.at(hidden++)->hide();
         labelWidth = 0;
-        for (QLabel* l : m_filterLabels) {
+        for (QLabel* l : asConst(m_filterLabels)) {
             if (l->isVisible()) {
                 labelWidth += l->width() + 2;
             }
@@ -300,7 +300,7 @@ void MyLineEdit::drawFilters()
         m_moreLabel->hide();
     }
 
-    for (QLabel* l : m_filterLabels) {
+    for (QLabel* l : asConst(m_filterLabels)) {
         if (l->isVisible() || l == m_filterLabels.last()) {
             l->move(paddingLeft, 1);
             paddingLeft += l->width() + 2;
@@ -321,7 +321,7 @@ int MyLineEdit::paddingLeft()
     if (m_moreLabel->isVisible()) {
         paddingLeft += m_moreLabel->width();
     }
-    for (QLabel* l : m_filterLabels) {
+    for (QLabel* l : asConst(m_filterLabels)) {
         if (l->isVisible()) {
             paddingLeft += l->width() + 2;
         }

--- a/test/scrapers/testAdultDvdEmpire.cpp
+++ b/test/scrapers/testAdultDvdEmpire.cpp
@@ -39,7 +39,7 @@ TEST_CASE("AdultDvdEmpire scrapes correct movie details", "[AdultDvdEmpire][load
         CHECK(m.director() == "Brad Armstrong");
 
         const auto genres = m.genres();
-        REQUIRE(genres.size() == 10);
+        REQUIRE(genres.size() >= 10);
         CHECK(genres[0] == "Big Budget");
         CHECK_THAT(genres[1], StartsWith("Big"));
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -23,7 +23,8 @@ target_sources(
 )
 
 target_link_libraries(
-  mediaelch_unit PRIVATE libmediaelch libmediaelch_testhelpers Qt${QT_VERSION_MAJOR}::Test
+  mediaelch_unit PRIVATE libmediaelch libmediaelch_testhelpers
+                         Qt${QT_VERSION_MAJOR}::Test
 )
 
 generate_coverage_report(mediaelch_unit)

--- a/third_party/kfts/kfts_fuzzy_match.h
+++ b/third_party/kfts/kfts_fuzzy_match.h
@@ -182,7 +182,7 @@ static bool fuzzy_internal::fuzzy_match_recursive(QStringView::const_iterator pa
             }
 
             // Advance
-            matches[nextMatch++] = (uint8_t)(std::distance(strBegin, str));
+            matches[nextMatch++] = static_cast<uint8_t>(std::distance(strBegin, str));
             ++pattern;
         }
         ++str;
@@ -218,7 +218,7 @@ static bool fuzzy_internal::fuzzy_match_recursive(QStringView::const_iterator pa
         outScore += penalty;
 
         // Apply unmatched penalty
-        const int unmatched = (int)(std::distance(strBegin, str)) - nextMatch;
+        const int unmatched = static_cast<int>(std::distance(strBegin, str)) - nextMatch;
         outScore += unmatched_letter_penalty * unmatched;
 
         // Apply ordering bonuses


### PR DESCRIPTION
Refactoring:

 - Use TmdbId/ImdbId instead of strings
 - make Movie::scraperLaodDone take an error object
 - remove duplicate warnings
 - Fix some compiler warnings
 - MovieMultiScraper: Replace "." with " " when scraping  
   This is also done in MovieSearchWidget