### PR TITLE
[UI] Fix large icon column sizes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - Renamer: On macOS, the renamer was sometimes so large that buttons were not visible (#1227)
  - Local trailers for movies are now detected if the filename contains square brackets such as `Movie[BLURAY]` (#1231)
  - Fix translations on some Windows systems (#1191)
+ - Fix spacing between icons for movie and TV show views (#793)
 
 ### Changes
 

--- a/src/movies/MovieModel.cpp
+++ b/src/movies/MovieModel.cpp
@@ -99,10 +99,13 @@ QVariant MovieModel::data(const QModelIndex& index, int role) const
     if (role == Qt::UserRole) {
         return index.row();
     }
+    if (!index.isValid()) {
+        return QVariant(); // root
+    }
 
     Movie* movie = m_movies[index.row()];
 
-    if (role == Qt::UserRole + 22) {
+    if (role == Roles::MoviePointerRole) {
         return QVariant::fromValue(movie);
     }
 

--- a/src/movies/MovieModel.h
+++ b/src/movies/MovieModel.h
@@ -21,7 +21,8 @@ public:
         FileLastModifiedRole = Qt::UserRole + 5,
         SyncNeededRole = Qt::UserRole + 6,
         FileNameRole = Qt::UserRole + 7,
-        SortTitleRole = Qt::UserRole + 8
+        SortTitleRole = Qt::UserRole + 8,
+        MoviePointerRole = Qt::UserRole + 22
     };
 
     explicit MovieModel(QObject* parent = nullptr);

--- a/src/ui/movies/MovieFilesWidget.cpp
+++ b/src/ui/movies/MovieFilesWidget.cpp
@@ -40,7 +40,8 @@ MovieFilesWidget::MovieFilesWidget(QWidget* parent) : QWidget(parent), ui(new Ui
     m_movieProxyModel->setDynamicSortFilter(true);
     ui->files->setModel(m_movieProxyModel);
     for (int i = 1, n = ui->files->model()->columnCount(); i < n; ++i) {
-        ui->files->setColumnWidth(i, 24);
+        // Note: Minimum section size is changed to 22 in the UI file!
+        ui->files->setColumnWidth(i, 22);
         ui->files->setColumnHidden(i, true);
     }
     ui->files->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);

--- a/src/ui/movies/MovieFilesWidget.ui
+++ b/src/ui/movies/MovieFilesWidget.ui
@@ -50,6 +50,7 @@
        <widget class="QLabel" name="statusLabel">
         <property name="font">
          <font>
+          <pointsize>9</pointsize>
           <weight>75</weight>
           <bold>true</bold>
          </font>
@@ -106,13 +107,16 @@
      <attribute name="horizontalHeaderVisible">
       <bool>false</bool>
      </attribute>
+     <attribute name="horizontalHeaderMinimumSectionSize">
+      <number>22</number>
+     </attribute>
      <attribute name="verticalHeaderVisible">
       <bool>false</bool>
      </attribute>
-     <attribute name="verticalHeaderDefaultSectionSize">
+     <attribute name="verticalHeaderMinimumSectionSize">
       <number>22</number>
      </attribute>
-     <attribute name="verticalHeaderMinimumSectionSize">
+     <attribute name="verticalHeaderDefaultSectionSize">
       <number>22</number>
      </attribute>
     </widget>

--- a/src/ui/tv_show/TvShowFilesWidget.ui
+++ b/src/ui/tv_show/TvShowFilesWidget.ui
@@ -92,6 +92,9 @@
      <attribute name="headerVisible">
       <bool>false</bool>
      </attribute>
+     <attribute name="headerMinimumSectionSize">
+      <number>16</number>
+     </attribute>
      <attribute name="headerDefaultSectionSize">
       <number>16</number>
      </attribute>


### PR DESCRIPTION
Some Qt version apparently increased the default "minimum section size"
to 41px. But our icons are just 16px wide so there was a lot of
white-space.  Even though we explicitly set the column width to "22",
it was ignored because the minimum width was higher.

This commit fixes the huge space between icons.

Fix https://github.com/Komet/MediaElch/issues/793

| Before | After |
|:-----:|:-----:|
| tv shows | 
| ![Screenshot_20210331_181801](https://user-images.githubusercontent.com/1667306/113178216-a77ca400-924e-11eb-86ad-742e918b86cc.png) | ![Screenshot_20210331_182003](https://user-images.githubusercontent.com/1667306/113178231-ab102b00-924e-11eb-8f10-77185dd4dc3d.png) |
| movies |  |
| ![Screenshot_20210331_183043](https://user-images.githubusercontent.com/1667306/113178837-443f4180-924f-11eb-809c-805cffd23812.png) | ![Screenshot_20210331_182127](https://user-images.githubusercontent.com/1667306/113178842-45706e80-924f-11eb-891c-0c918913a26f.png) |