### PR TITLE
[MediaStatusColumn] Add columns for subtitles and tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
  - Local trailers for movies are now detected if the filename contains square brackets such as `Movie[BLURAY]` (#1231)
  - Fix translations on some Windows systems (#1191)
  - Fix spacing between icons for movie and TV show views (#793)
- - macOS: Fix text spacing of "new" count bubble
+ - macOS: Fix text spacing of "new" count bubble (#1275)
 
 ### Changes
 
@@ -18,18 +18,19 @@
 
 ### Added
 
- - A quick-open menu for movies was added. Open it by clicking <kbd>Ctrl+O</kbd> (<kbd>⌘+O</kbd> on macOS).  
+ - A quick-open menu for movies was added. Open it by clicking <kbd>Ctrl+O</kbd> (<kbd>⌘+O</kbd> on macOS) (#1214)  
    It uses a Fuzzy matching algorithm. The menu was inspired and partially taken from the
    Kate editor (see https://invent.kde.org/utilities/kate/-/merge_requests/179).
    Our gratitude goes to the Kate team and to Ahmed Waqar for allowing us to use it!
- - You can now disable folders in MediaElch's settings.
- - You can now name your TV show seasons in the GUI
+ - You can now disable folders in MediaElch's settings (#1244)
+ - You can now name your TV show seasons in the GUI (#1261)
  - Multiple ratings for TV shows/episodes, movies and concerts can now be managed in the UI (#750)  
    Even though MediaElch supported Kodi's "multiple rating"-feature internally, it was limited in
    the UI.  MediaElch now uses a table view for ratings.  Double click on an existing rating to change
    a field.  
    _Limitations:_ Currently scraping a media item will replace (!) the existing ratings and will not add/update them.
- - The CSV Exporter can now be opened from the GUI.
+ - The CSV Exporter can now be opened from the GUI (#1277)
+ - New movie media columns "subtitles" and "tags" can now be used (#795, #425)
 
 ### Removed
 
@@ -49,7 +50,7 @@
    - 3.8s -> 1.3s (SSD)
    - 4.1s -> 1.4s (HDD)
  - Fix unuseful log warning `[KodiXml] NFO file could not be opened for reading` for TV shows that do not have a NFO file.   
- - MediaElch now uses Qt's logging categories
+ - MediaElch now uses Qt's logging categories (#1278)
 
 ## 2.8.6 - Coridian (2021-01-22)
 

--- a/data/MediaElch.qrc
+++ b/data/MediaElch.qrc
@@ -47,6 +47,8 @@
         <file>img/placeholders/thumb.png</file>
         <file>img/photo.png</file>
 
+        <file>icons/actions/16/add-subtitle.svg</file>
+        <file>icons/actions/16/tag.svg</file>
         <file>icons/actions/16/tools-media-optical-burn-image.svg</file>
         <file>icons/actions/16/snap-page.svg</file>
         <file>icons/actions/16/tool_imageeffects.svg</file>
@@ -56,6 +58,8 @@
         <file>icons/actions/16/edit-image-face-show.svg</file>
         <file>icons/actions/16/insert-image.svg</file>
 
+        <file>icons/actions/22/add-subtitle.svg</file>
+        <file>icons/actions/22/tag.svg</file>
         <file>icons/actions/22/tools-media-optical-burn-image.svg</file>
         <file>icons/actions/22/snap-page.svg</file>
         <file>icons/actions/22/filmgrain.svg</file>

--- a/data/icons/actions/16/add-subtitle.svg
+++ b/data/icons/actions/16/add-subtitle.svg
@@ -1,0 +1,8 @@
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <style id="current-color-scheme" type="text/css">.ColorScheme-Text {
+        color:#232629;
+      }</style>
+    </defs>
+    <path class="ColorScheme-Text" d="m10.005155 10v1h1.994845v-1zm-6.005155-2v1h8v-1zm0 2v1h4v-1zm-2-7v10h12v-10zm1 1h10v8h-10z" fill="currentColor"/>
+</svg>

--- a/data/icons/actions/16/tag.svg
+++ b/data/icons/actions/16/tag.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs id="defs3051">
+    <style type="text/css" id="current-color-scheme">
+      .ColorScheme-Text {
+        color:#232629;
+      }
+      </style>
+  </defs>
+ <path 
+     style="fill:currentColor;fill-opacity:1;stroke:none" 
+     d="m8 2l-5.969.031-.031 5.969 6.5 6 5.5-5.5zm-2.5 2c.828 0 1.5.672 1.5 1.5 0 .828-.672 1.5-1.5 1.5-.828 0-1.5-.672-1.5-1.5 0-.828.672-1.5 1.5-1.5"
+     class="ColorScheme-Text"/>
+</svg>

--- a/data/icons/actions/22/add-subtitle.svg
+++ b/data/icons/actions/22/add-subtitle.svg
@@ -1,0 +1,8 @@
+<svg version="1.1" viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <style id="current-color-scheme" type="text/css">.ColorScheme-Text {
+        color:#232629;
+      }</style>
+    </defs>
+    <path class="ColorScheme-Text" d="m12.988351 13.005255v0.999097h4.009739v-0.999097zm-7.9879705-1.993516v1.004563h11.99611v-1.004563zm0 1.992483v0.999097h6.0046925v-0.999097zm-2.0083673-8.0012635v12.002158h16.017557v-12.002158zm1.0136936 1.0060301h13.999508v10.002165h-13.999508z" fill="currentColor"/>
+</svg>

--- a/data/icons/actions/22/tag.svg
+++ b/data/icons/actions/22/tag.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
+  <defs id="defs3051">
+    <style type="text/css" id="current-color-scheme">
+      .ColorScheme-Text {
+        color:#232629;
+      }
+      .ColorScheme-Highlight {
+        color:#3daee9;
+      }
+      </style>
+  </defs>
+ <path 
+     style="fill:currentColor;fill-opacity:1;stroke:none" 
+     d="M 9 3 L 3 5 L 5 11 L 15 16 L 19 8 L 9 3 z M 3 5 L 3 11 L 11 19 L 13.705078 16.294922 L 4 11 L 3 5 z M 6.5 5 C 7.331 5 8 5.669 8 6.5 C 8 7.331 7.331 8 6.5 8 C 5.669 8 5 7.331 5 6.5 C 5 5.669 5.669 5 6.5 5 z "
+     class="ColorScheme-Text"
+     />
+</svg>

--- a/src/data/StreamDetails.cpp
+++ b/src/data/StreamDetails.cpp
@@ -268,6 +268,11 @@ bool StreamDetails::hasAudioQuality(QString quality) const
     return m_availableQualities.contains(quality);
 }
 
+bool StreamDetails::hasSubtitles() const
+{
+    return !m_subtitles.isEmpty();
+}
+
 int StreamDetails::audioChannels() const
 {
     int channels = 0;

--- a/src/data/StreamDetails.h
+++ b/src/data/StreamDetails.h
@@ -46,6 +46,7 @@ public:
     void clear();
     bool hasAudioChannels(int channels) const;
     bool hasAudioQuality(QString quality) const;
+    bool hasSubtitles() const;
     int audioChannels() const;
     QString audioCodec() const;
     QString videoCodec() const;

--- a/src/movies/MovieModel.cpp
+++ b/src/movies/MovieModel.cpp
@@ -231,6 +231,15 @@ QVariant MovieModel::data(const QModelIndex& index, int role) const
             color = (!movie->hasLocalTrailer()) ? MediaStatusState::RED : MediaStatusState::GREEN;
             icon = "filmgrain";
             break;
+        case MediaStatusColumn::Subtitles:
+            color = (movie->streamDetailsLoaded() && movie->streamDetails()->hasSubtitles()) ? MediaStatusState::GREEN
+                                                                                             : MediaStatusState::RED;
+            icon = "add-subtitle";
+            break;
+        case MediaStatusColumn::Tags:
+            color = (movie->tags().isEmpty()) ? MediaStatusState::RED : MediaStatusState::GREEN;
+            icon = "tag";
+            break;
         case MediaStatusColumn::Poster:
             color = (!movie->hasImage(ImageType::MoviePoster)) ? MediaStatusState::RED : MediaStatusState::GREEN;
             icon = "viewimage";
@@ -346,6 +355,8 @@ int MovieModel::mediaStatusToColumn(MediaStatusColumn column)
     case MediaStatusColumn::Trailer: return 6;
     case MediaStatusColumn::LocalTrailer: return 7;
     case MediaStatusColumn::Id: return 1;
+    case MediaStatusColumn::Subtitles: return 10;
+    case MediaStatusColumn::Tags: return 11;
     case MediaStatusColumn::Unknown: return -1;
     }
     return -1;
@@ -373,6 +384,8 @@ QString MovieModel::mediaStatusToText(MediaStatusColumn column)
     case MediaStatusColumn::StreamDetails: return tr("Stream Details");
     case MediaStatusColumn::Trailer: return tr("Trailer");
     case MediaStatusColumn::LocalTrailer: return tr("Local Trailer");
+    case MediaStatusColumn::Subtitles: return tr("Subtitles");
+    case MediaStatusColumn::Tags: return tr("Tags");
     case MediaStatusColumn::Id: return tr("IMDb ID");
     case MediaStatusColumn::Unknown: return {};
     }

--- a/src/movies/MovieModel.h
+++ b/src/movies/MovieModel.h
@@ -10,19 +10,21 @@
 enum class MediaStatusColumn
 {
     // TODO: Use explicit integers, as their values are stored on disk.
-    Id,            // globe
-    StreamDetails, // snap-page
-    Trailer,       // filmgrain
-    LocalTrailer,  // filmgrain
-    Poster,        // viewimage
-    Fanart,        // kdenlive-select-images
-    ExtraArts,     // tools-media-optical-burn-image
-    ExtraFanarts,  // insert-image
-    Actors,        // edit-image-face-show OR im-user
+    Id,
+    StreamDetails,
+    Trailer,
+    LocalTrailer,
+    Poster,
+    Fanart,
+    ExtraArts,
+    ExtraFanarts,
+    Actors,
+    Tags,      // since v2.8.7
+    Subtitles, // since v2.8.7
     Unknown,
 
     First = Id,
-    Last = Actors
+    Last = Subtitles
 };
 
 class MovieModel : public QAbstractItemModel


### PR DESCRIPTION
- fix #795
- fix https://github.com/Komet/MediaElch/issues/425

TODO

- [x] Add new icons; I currently re-use the one for "trailer"