### PR TITLE
[MainWindow] Fix "new" media count on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  - Local trailers for movies are now detected if the filename contains square brackets such as `Movie[BLURAY]` (#1231)
  - Fix translations on some Windows systems (#1191)
  - Fix spacing between icons for movie and TV show views (#793)
+ - macOS: Fix text spacing of "new" count bubble
 
 ### Changes
 


### PR DESCRIPTION
The spacing was too high.  The reason for this was that the font ""
(empty string) was used.  This must have used some font with high
spacing.  We now simply use an empty QFont and set the font size
explicitly.

<img width="58" alt="Screen Shot 2021-04-05 at 14 20 12" src="https://user-images.githubusercontent.com/1667306/113574119-c2b72d00-961b-11eb-8fcd-52f257e203ad.png">
