### PR TITLE
[TvScraperSettings] Avoid description being cut off

### DIFF
--- a/src/ui/settings/TvScraperSettingsWidget.ui
+++ b/src/ui/settings/TvScraperSettingsWidget.ui
@@ -131,24 +131,35 @@
          <item row="2" column="1">
           <widget class="QLabel" name="txtDescription">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
              <horstretch>1</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="minimumSize">
+            <size>
+             <width>340</width>
+             <height>140</height>
+            </size>
+           </property>
            <property name="maximumSize">
             <size>
-             <width>400</width>
+             <width>480</width>
              <height>800</height>
             </size>
            </property>
            <property name="text">
             <string notr="true">This is the scraper
 description which may span
-multiple lines.</string>
+multiple lines.
+
+</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
            </property>
            <property name="wordWrap">
             <bool>true</bool>


### PR DESCRIPTION
For some reason it was only cut off for "Custom TV Scraper"