### PR TITLE
[CI] Add missing Qt SVG module to docker files

### DIFF
--- a/.ci/docker/Dockerfile.build-opensuse-leap-15
+++ b/.ci/docker/Dockerfile.build-opensuse-leap-15
@@ -20,6 +20,7 @@ RUN zypper --non-interactive install \
         libqt5-qtmultimedia-devel \
         libqt5-qttools \
         libqt5-qttools-devel \
+        libqt5-qtsvg-devel \
         libQt5Concurrent5 \
         libQt5Concurrent-devel \
         libQt5OpenGL5 \

--- a/.ci/docker/Dockerfile.build-opensuse-leap-42.3
+++ b/.ci/docker/Dockerfile.build-opensuse-leap-42.3
@@ -20,6 +20,7 @@ RUN zypper --non-interactive install \
         libqt5-qtmultimedia-devel \
         libqt5-qttools \
         libqt5-qttools-devel \
+        libqt5-qtsvg-devel \
         libQt5Concurrent5 \
         libQt5Concurrent-devel \
         libQt5OpenGL5 \

--- a/.ci/docker/Dockerfile.build-opensuse-tumbleweed
+++ b/.ci/docker/Dockerfile.build-opensuse-tumbleweed
@@ -20,6 +20,7 @@ RUN zypper --non-interactive install \
         libqt5-qtmultimedia-devel \
         libqt5-qttools \
         libqt5-qttools-devel \
+        libqt5-qtsvg-devel \
         libQt5Concurrent5 \
         libQt5Concurrent-devel \
         libQt5OpenGL5 \

--- a/.ci/docker/Dockerfile.build-ubuntu-16.04
+++ b/.ci/docker/Dockerfile.build-ubuntu-16.04
@@ -28,7 +28,8 @@ RUN apt-get update && \
         qt512tools \
         qt512multimedia \
         qt512declarative \
-        qt512quickcontrols
+        qt512quickcontrols \
+        qt512svg
 
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 90 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 90

--- a/.ci/docker/Dockerfile.build-ubuntu-18.04
+++ b/.ci/docker/Dockerfile.build-ubuntu-18.04
@@ -16,4 +16,6 @@ RUN apt-get update && \
         qtmultimedia5-dev \
         qtdeclarative5-dev \
         libqt5opengl5 \
-        libqt5opengl5-dev
+        libqt5opengl5-dev \
+        libqt5svg5 \
+        libqt5svg5-dev

--- a/.ci/docker/Dockerfile.build-ubuntu-20.04
+++ b/.ci/docker/Dockerfile.build-ubuntu-20.04
@@ -16,4 +16,6 @@ RUN apt-get update && \
         qtmultimedia5-dev \
         qtdeclarative5-dev \
         libqt5opengl5 \
-        libqt5opengl5-dev
+        libqt5opengl5-dev \
+        libqt5svg5 \
+        libqt5svg5-dev

--- a/.ci/docker/Dockerfile.ci.linux
+++ b/.ci/docker/Dockerfile.ci.linux
@@ -57,7 +57,9 @@ RUN apt-get update && \
         qttools5-dev \
         qttools5-dev-tools \
         libqt5opengl5 \
-        libqt5opengl5-dev && \
+        libqt5opengl5-dev \
+        libqt5svg5 \
+        libqt5svg5-dev && \
     apt-get autoremove && \
     update-alternatives --install /usr/bin/gcc           gcc          /usr/bin/gcc-10          10 && \
     update-alternatives --install /usr/bin/gcov          gcov         /usr/bin/gcov-10         10 && \

--- a/.ci/docker/docker-build-dist.sh
+++ b/.ci/docker/docker-build-dist.sh
@@ -57,7 +57,7 @@ if [ ! -f "${DOCKERFILE}" ]; then
 fi
 
 print_important "Building ${IMAGE} from ${DOCKERFILE} if necessary."
-docker build -t "${IMAGE}" -f "${DOCKERFILE}" .
+docker build --pull -t "${IMAGE}" -f "${DOCKERFILE}" .
 
 # We use the first part of the distro to distinguish between build scripts
 build_sh="build-$(echo ${DIST} | cut -f1 -d-).sh"

--- a/src/data/ImageCache.cpp
+++ b/src/data/ImageCache.cpp
@@ -133,9 +133,10 @@ QSize ImageCache::imageSize(mediaelch::FilePath path)
 
 qint64 ImageCache::getLastModified(const mediaelch::FilePath& fileName)
 {
-    qint64 now = QDateTime::currentDateTime().toSecsSinceEpoch();
+    // TODO: Use toSecsSinceEpoch() when Qt 5.8 is required.
+    qint64 now = QDateTime::currentDateTime().toMSecsSinceEpoch() / 1000;
     if (!m_lastModifiedTimes.contains(fileName) || m_lastModifiedTimes.value(fileName).first() < now - 10) {
-        qint64 lastMod = QFileInfo(fileName.toString()).lastModified().toSecsSinceEpoch();
+        qint64 lastMod = QFileInfo(fileName.toString()).lastModified().toMSecsSinceEpoch() / 1000;
         m_lastModifiedTimes.insert(fileName, {now, lastMod});
     }
     return m_lastModifiedTimes.value(fileName).last();

--- a/src/scrapers/imdb/ImdbApi.h
+++ b/src/scrapers/imdb/ImdbApi.h
@@ -15,7 +15,6 @@
 #include <QObject>
 #include <QString>
 #include <QUrl>
-
 #include <functional>
 
 namespace mediaelch {

--- a/src/scrapers/music/AllMusic.h
+++ b/src/scrapers/music/AllMusic.h
@@ -8,6 +8,7 @@
 
 #include <QObject>
 #include <QString>
+#include <functional>
 
 class Album;
 class Artist;

--- a/src/scrapers/music/MusicBrainz.h
+++ b/src/scrapers/music/MusicBrainz.h
@@ -8,6 +8,7 @@
 
 #include <QObject>
 #include <QString>
+#include <functional>
 
 class Album;
 class Artist;

--- a/src/scrapers/music/TheAudioDb.h
+++ b/src/scrapers/music/TheAudioDb.h
@@ -11,6 +11,7 @@
 #include <QJsonObject>
 #include <QObject>
 #include <QString>
+#include <functional>
 
 class Artist;
 class Album;

--- a/src/scrapers/tmdb/TmdbApi.h
+++ b/src/scrapers/tmdb/TmdbApi.h
@@ -17,7 +17,6 @@
 #include <QObject>
 #include <QString>
 #include <QUrl>
-
 #include <functional>
 
 namespace mediaelch {

--- a/src/scrapers/tv_show/thetvdb/TheTvDbApi.h
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbApi.h
@@ -15,7 +15,6 @@
 #include <QObject>
 #include <QString>
 #include <QUrl>
-
 #include <functional>
 
 namespace mediaelch {

--- a/src/scrapers/tv_show/thetvdb/TheTvDbEpisodesParser.h
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbEpisodesParser.h
@@ -3,6 +3,7 @@
 #include "scrapers/tv_show/thetvdb/TheTvDbApi.h"
 
 #include <QJsonDocument>
+#include <functional>
 #include <memory>
 
 class TvShowEpisode;

--- a/src/scrapers/tv_show/tvmaze/TvMazeApi.h
+++ b/src/scrapers/tv_show/tvmaze/TvMazeApi.h
@@ -12,7 +12,6 @@
 #include <QNetworkRequest>
 #include <QString>
 #include <QUrl>
-
 #include <functional>
 
 namespace mediaelch {

--- a/third_party/kfts/kfts_fuzzy_match.h
+++ b/third_party/kfts/kfts_fuzzy_match.h
@@ -10,6 +10,8 @@
 
 #include <QString>
 
+// TODO: Use QStringView when we update Qt.
+
 /**
  * This is based on https://github.com/forrestthewoods/lib_fts/blob/master/code/fts_fuzzy_match.h
  * with modifications for Qt
@@ -22,21 +24,22 @@ namespace kfts
 /**
  * @brief simple fuzzy matching of chars in @a pattern with chars in @a str sequentially
  */
-Q_DECL_UNUSED static bool fuzzy_match_simple(const QStringView pattern, const QStringView str);
+Q_DECL_UNUSED static bool fuzzy_match_simple(const QString& pattern, const QString& str);
 
 /**
  * @brief This should be the main function you should use. @a outscore is the score
  * of this match and should be used to sort the results later. Without sorting of the
  * results this function won't be as effective.
  */
-Q_DECL_UNUSED static bool fuzzy_match(const QStringView pattern, const QStringView str, int &outScore);
-Q_DECL_UNUSED static bool fuzzy_match(const QStringView pattern, const QStringView str, int &outScore, uint8_t *matches, int maxMatches);
+Q_DECL_UNUSED static bool fuzzy_match(const QString& pattern, const QString& str, int& outScore);
+Q_DECL_UNUSED static bool
+fuzzy_match(const QString& pattern, const QString& str, int& outScore, uint8_t* matches, int maxMatches);
 
 /**
  * @brief This is a special case function which doesn't score separator matches higher than sequential matches.
  * This is currently used in Kate's command bar where the string items are usually space separated names.
  */
-Q_DECL_UNUSED static bool fuzzy_match_sequential(const QStringView pattern, const QStringView str, int &outScore);
+Q_DECL_UNUSED static bool fuzzy_match_sequential(const QString& pattern, const QString& str, int& outScore);
 /**
  * @brief get string for display in treeview / listview. This should be used from style delegate.
  * For example: with @a pattern = "kate", @a str = "kateapp" and @htmlTag = "<b>
@@ -46,7 +49,10 @@ Q_DECL_UNUSED static bool fuzzy_match_sequential(const QStringView pattern, cons
  * TODO: improve this so that we don't have to put html tags on every char probably using some kind
  * of interval container
  */
-Q_DECL_UNUSED static QString to_fuzzy_matched_display_string(const QStringView pattern, QString &str, const QString &htmlTag, const QString &htmlTagClose);
+Q_DECL_UNUSED static QString to_fuzzy_matched_display_string(const QString& pattern,
+    QString& str,
+    const QString& htmlTag,
+    const QString& htmlTagClose);
 }
 
 namespace kfts
@@ -54,22 +60,22 @@ namespace kfts
 // Forward declarations for "private" implementation
 namespace fuzzy_internal
 {
-static bool fuzzy_match_recursive(QStringView::const_iterator pattern,
-                                  QStringView::const_iterator str,
-                                  int &outScore,
-                                  const QStringView::const_iterator strBegin,
-                                  const QStringView::const_iterator strEnd,
-                                  const QStringView::const_iterator patternEnd,
-                                  uint8_t const *srcMatches,
-                                  uint8_t *newMatches,
-                                  int maxMatches,
-                                  int nextMatch,
-                                  int &recursionCount,
-                                  int seqBonus = 15);
+static bool fuzzy_match_recursive(QString::const_iterator pattern,
+    QString::const_iterator str,
+    int& outScore,
+    const QString::const_iterator strBegin,
+    const QString::const_iterator strEnd,
+    const QString::const_iterator patternEnd,
+    uint8_t const* srcMatches,
+    uint8_t* newMatches,
+    int maxMatches,
+    int nextMatch,
+    int& recursionCount,
+    int seqBonus = 15);
 }
 
 // Public interface
-static bool fuzzy_match_simple(const QStringView pattern, const QStringView str)
+static bool fuzzy_match_simple(const QString& pattern, const QString& str)
 {
     auto patternIt = pattern.cbegin();
     for (auto strIt = str.cbegin(); strIt != str.cend() && patternIt != pattern.cend(); ++strIt) {
@@ -80,13 +86,13 @@ static bool fuzzy_match_simple(const QStringView pattern, const QStringView str)
     return patternIt == pattern.cend();
 }
 
-static bool fuzzy_match(const QStringView pattern, const QStringView str, int &outScore)
+static bool fuzzy_match(const QString& pattern, const QString& str, int& outScore)
 {
     uint8_t matches[256];
     return fuzzy_match(pattern, str, outScore, matches, sizeof(matches));
 }
 
-static bool fuzzy_match(const QStringView pattern, const QStringView str, int &outScore, uint8_t *matches, int maxMatches)
+static bool fuzzy_match(const QString& pattern, const QString& str, int& outScore, uint8_t* matches, int maxMatches)
 {
     int recursionCount = 0;
 
@@ -98,7 +104,7 @@ static bool fuzzy_match(const QStringView pattern, const QStringView str, int &o
     return fuzzy_internal::fuzzy_match_recursive(patternIt, strIt, outScore, strIt, strEnd, patternEnd, nullptr, matches, maxMatches, 0, recursionCount);
 }
 
-static bool fuzzy_match_sequential(const QStringView pattern, const QStringView str, int &outScore)
+static bool fuzzy_match_sequential(const QString& pattern, const QString& str, int& outScore)
 {
     int recursionCount = 0;
     uint8_t matches[256];
@@ -112,18 +118,18 @@ static bool fuzzy_match_sequential(const QStringView pattern, const QStringView 
 }
 
 // Private implementation
-static bool fuzzy_internal::fuzzy_match_recursive(QStringView::const_iterator pattern,
-                                                  QStringView::const_iterator str,
-                                                  int &outScore,
-                                                  const QStringView::const_iterator strBegin,
-                                                  const QStringView::const_iterator strEnd,
-                                                  const QStringView::const_iterator patternEnd,
-                                                  const uint8_t *srcMatches,
-                                                  uint8_t *matches,
-                                                  int maxMatches,
-                                                  int nextMatch,
-                                                  int &recursionCount,
-                                                  int seqBonus)
+static bool fuzzy_internal::fuzzy_match_recursive(QString::const_iterator pattern,
+    QString::const_iterator str,
+    int& outScore,
+    const QString::const_iterator strBegin,
+    const QString::const_iterator strEnd,
+    const QString::const_iterator patternEnd,
+    const uint8_t* srcMatches,
+    uint8_t* matches,
+    int maxMatches,
+    int nextMatch,
+    int& recursionCount,
+    int seqBonus)
 {
     // Count recursions
     static constexpr int recursionLimit = 10;
@@ -270,7 +276,10 @@ static bool fuzzy_internal::fuzzy_match_recursive(QStringView::const_iterator pa
     }
 }
 
-static QString to_fuzzy_matched_display_string(const QStringView pattern, QString &str, const QString &htmlTag, const QString &htmlTagClose)
+static QString to_fuzzy_matched_display_string(const QString& pattern,
+    QString& str,
+    const QString& htmlTag,
+    const QString& htmlTagClose)
 {
     /**
      * FIXME Don't do so many appends. Instead consider using some interval based solution to wrap a range


### PR DESCRIPTION
This PR fixes compilation issues with Qt 5.6 and therefore on some older distributions.

TODO:

- [ ] Run `docker-build-all.sh`