### PR TITLE
[CustomTvScraper] Do not fail if TMDb isn't used for anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  - Fix translations on some Windows systems (#1191)
  - Fix spacing between icons for movie and TV show views (#793)
  - macOS: Fix text spacing of "new" count bubble (#1275)
+ - Custom TV scraper: Fix scraping of TV shows when TMDb isn't used at all (#1293)
 
 ### Changes
 

--- a/src/scrapers/tv_show/ShowMerger.cpp
+++ b/src/scrapers/tv_show/ShowMerger.cpp
@@ -23,7 +23,9 @@ static void copyDetailToShow(TvShow& target, TvShow& source, ShowScraperInfo det
         target.setTvMazeId(source.tvmazeId());
     }
     switch (detail) {
-    case ShowScraperInfo::Invalid: qCCritical(generic) << "[ShowMerger] Cannot copy details 'invalid'"; break;
+    case ShowScraperInfo::Invalid:
+        // Ignore invalid state
+        break;
     case ShowScraperInfo::Title: {
         target.setTitle(source.title());
         target.setOriginalTitle(source.originalTitle());

--- a/src/scrapers/tv_show/custom/CustomEpisodeScrapeJob.cpp
+++ b/src/scrapers/tv_show/custom/CustomEpisodeScrapeJob.cpp
@@ -29,6 +29,14 @@ void CustomEpisodeScrapeJob::execute()
     // we have to correctly set the details that we want to load from TmdbTv.
     EpisodeScrapeJob::Config tmdbConfig = configFor(TmdbTv::ID, config().identifier);
 
+    if (tmdbConfig.details.isEmpty()) {
+        // HACK: in onTmdbLoaded() we copy details to this job's show.
+        //       But if we do not load any details from TMDb, we don't copy anything
+        //       not even the IDs that are needed for TheTvDb, etc.
+        //       By using this hack, we always invoke copyDetailsToShow() so that IDs are copied.
+        tmdbConfig.details.insert(EpisodeScraperInfo::Invalid);
+    }
+
     auto* tmdbJob = m_customConfig.tmdbTv->loadEpisode(tmdbConfig);
     connect(tmdbJob, &TmdbTvEpisodeScrapeJob::sigFinished, this, &CustomEpisodeScrapeJob::onTmdbLoaded);
     tmdbJob->execute();

--- a/src/scrapers/tv_show/custom/CustomShowScrapeJob.cpp
+++ b/src/scrapers/tv_show/custom/CustomShowScrapeJob.cpp
@@ -29,6 +29,14 @@ void CustomShowScrapeJob::execute()
     // we have to correctly set the details that we want to load from TmdbTv.
     ShowScrapeJob::Config tmdbConfig = configFor(TmdbTv::ID, config().identifier);
 
+    if (tmdbConfig.details.isEmpty()) {
+        // HACK: in onTmdbLoaded() we copy details to this job's show.
+        //       But if we do not load any details from TMDb, we don't copy anything
+        //       not even the IDs that are needed for TheTvDb, etc.
+        //       By using this hack, we always invoke copyDetailsToShow() so that IDs are copied.
+        tmdbConfig.details.insert(ShowScraperInfo::Invalid);
+    }
+
     auto* tmdbJob = m_customConfig.tmdbTv->loadShow(tmdbConfig);
     connect(tmdbJob, &TmdbTvShowScrapeJob::sigFinished, this, &CustomShowScrapeJob::onTmdbLoaded);
     tmdbJob->execute();


### PR DESCRIPTION
Previously, when TMDb was NOT used for anything, TheTvDb/IMDb/... IDs
were not copied so no data was loaded.

This commit fixes this bug by forcing some details to be copied
(with IDs).