### PR TITLE
[MainWindow] Fix loading of MainWindow size

### DIFF
--- a/src/ui/main/MainWindow.cpp
+++ b/src/ui/main/MainWindow.cpp
@@ -139,8 +139,6 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
         }
 #endif
     }
-    // Size for Screenshots
-    resize(1200, 676);
 
     const auto onMenuFromSender = [this]() {
         auto* button = dynamic_cast<QToolButton*>(QObject::sender());


### PR DESCRIPTION
I accidentally left in this code. It was only meant for screenshots.