### PR TITLE
[MovieFileSearcher] Copy "searcher" data QApplication::processEvents(); 

### DIFF
--- a/.ci/ci_utils.sh
+++ b/.ci/ci_utils.sh
@@ -56,7 +56,8 @@ gather_project_and_system_details() {
 	GIT_HASH=$(git --git-dir=".git" show --no-patch --pretty="%h")
 	DATE_HASH=$(date -u +"%Y-%m-%d_%H-%M")
 	DATE_DESC=$(date -u +"%Y-%m-%d %H:%M")
-	ME_VERSION_NAME="${ME_VERSION}_${DATE_HASH}_git-${GIT_BRANCH}-${GIT_HASH}"
+	GIT_BRANCH_FILENAME="$(echo "${GIT_BRANCH}" | sed 's$/$_$g')"
+	ME_VERSION_NAME="${ME_VERSION}_${DATE_HASH}_git-${GIT_BRANCH_FILENAME}-${GIT_HASH}"
 
 	if [[ -z "$GIT_REVISION" ]] || [[ "$GIT_VERSION" == "$GIT_REVISION" ]]; then
 		GIT_REVISION="0" # May be empty or equal to the current tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugfixes
 
- - *tbd*
+ - The movie file searcher could crash if you have more than two movie directories (#1315, #1316)
 
 ### Changes
 

--- a/src/movies/file_searcher/MovieDirectorySearcher.cpp
+++ b/src/movies/file_searcher/MovieDirectorySearcher.cpp
@@ -81,8 +81,6 @@ void MovieDirectorySearcher::loadMovieContents()
 
     while (it.hasNext()) {
         if (m_aborted.load()) {
-            // 0, because "contents" isn't stored, yet
-            emit loaded(this);
             return;
         }
         it.next();

--- a/src/movies/file_searcher/MovieDirectorySearcher.cpp
+++ b/src/movies/file_searcher/MovieDirectorySearcher.cpp
@@ -20,10 +20,14 @@ MovieDirectorySearcher::MovieDirectorySearcher(const SettingsDir& dir, bool inSe
         }
     });
     connect(&m_watcher, &QFutureWatcher<QVector<Movie*>>::resultReadyAt, this, [this](int index) {
-        // Called in the main thread, so no need for a mutex.
-        const QVector<Movie*> movies = m_watcher.resultAt(index);
-        for (Movie* movie : movies) {
-            postProcessMovie(movie);
+        // It could be that abort() was called, and this event is still
+        // executed because it was enqueued.
+        if (!m_aborted.load()) {
+            // Called in the main thread, so no need for a mutex.
+            const QVector<Movie*> movies = m_watcher.resultAt(index);
+            for (Movie* movie : movies) {
+                postProcessMovie(movie);
+            }
         }
     });
 }

--- a/src/movies/file_searcher/MovieDirectorySearcher.h
+++ b/src/movies/file_searcher/MovieDirectorySearcher.h
@@ -19,7 +19,7 @@ class MovieDirectorySearcher : public QObject
     Q_OBJECT
 public:
     MovieDirectorySearcher(const SettingsDir& dir, bool inSeparateFolders, QObject* parent = nullptr);
-    ~MovieDirectorySearcher() override = default;
+    ~MovieDirectorySearcher() override;
 
 signals:
     void startLoading(int approximateMovieCount);

--- a/src/movies/file_searcher/MovieDirectorySearcher.h
+++ b/src/movies/file_searcher/MovieDirectorySearcher.h
@@ -45,7 +45,7 @@ private:
     QStringList getFiles(QString path);
 
 private:
-    const SettingsDir& m_dir;
+    SettingsDir m_dir;
     QHash<QString, QDateTime> m_lastModifications;
 
     QFutureWatcher<QVector<Movie*>> m_watcher;

--- a/src/movies/file_searcher/MovieFileSearcher.cpp
+++ b/src/movies/file_searcher/MovieFileSearcher.cpp
@@ -137,6 +137,7 @@ void MovieFileSearcher::onDirectoryLoaded(MovieDirectorySearcher* searcher)
     // TODO: Do in another thread.
     QVector<Movie*> movies = searcher->movies();
     Manager::instance()->database()->transaction();
+    const mediaelch::DirectoryPath dir(searcher->directory().path);
     for (int i = 0; i < movies.size(); ++i) {
         if (i % 40 == 0 && i > 0) {
             // Commit previous transaction and begin new one
@@ -147,7 +148,7 @@ void MovieFileSearcher::onDirectoryLoaded(MovieDirectorySearcher* searcher)
         Movie* movie = movies.at(i);
         // Note: We can't do it in MovieDirectorySearcher, because we have to use the database connection's thread.
         movie->setLabel(Manager::instance()->database()->getLabel(movie->files()));
-        Manager::instance()->database()->add(movie, mediaelch::DirectoryPath(searcher->directory().path));
+        Manager::instance()->database()->add(movie, dir);
 
         if (i % 40 == 0 && i > 0) {
             QApplication::processEvents();

--- a/src/music/MusicModel.cpp
+++ b/src/music/MusicModel.cpp
@@ -157,9 +157,12 @@ bool MusicModel::removeRows(int row, int count, const QModelIndex& parent)
 
 void MusicModel::clear()
 {
-    beginRemoveRows(QModelIndex(), 0, m_rootItem->childCount() - 1);
-    m_rootItem->removeChildren(0, m_rootItem->childCount());
-    endRemoveRows();
+    const int size = m_rootItem->childCount();
+    if (size > 0) {
+        beginRemoveRows(QModelIndex(), 0, size - 1);
+        m_rootItem->removeChildren(0, size);
+        endRemoveRows();
+    }
 }
 
 void MusicModel::onSigChanged(MusicModelItem* artistItem, MusicModelItem* albumItem)

--- a/src/tv_shows/TvShowFileSearcher.cpp
+++ b/src/tv_shows/TvShowFileSearcher.cpp
@@ -443,8 +443,8 @@ void TvShowFileSearcher::clearOldTvShows(bool forceClear)
         return;
     }
 
-    for (const SettingsDir& dir : m_directories) {
-        if (dir.autoReload) {
+    for (const SettingsDir& dir : asConst(m_directories)) {
+        if (dir.autoReload || dir.disabled) {
             database().clearTvShowsInDirectory(mediaelch::DirectoryPath(dir.path));
         }
     }

--- a/src/tv_shows/TvShowModel.cpp
+++ b/src/tv_shows/TvShowModel.cpp
@@ -317,9 +317,11 @@ int TvShowModel::rowCount(const QModelIndex& parent) const
 void TvShowModel::clear()
 {
     const auto size = m_rootItem.shows().size();
-    beginRemoveRows(QModelIndex(), 0, size - 1);
-    m_rootItem.removeChildren(0, size);
-    endRemoveRows();
+    if (size > 0) {
+        beginRemoveRows(QModelIndex(), 0, size - 1);
+        m_rootItem.removeChildren(0, size);
+        endRemoveRows();
+    }
 }
 
 void TvShowModel::onSigChanged(TvShowModelItem* showItem, SeasonModelItem* seasonItem, EpisodeModelItem* episodeItem)


### PR DESCRIPTION
It could happen that we run multiple times into `onDirectoryLoaded()`
at once because of the call to `QApplication::processEvents();`.

This also meant that it could happen that the searchers are already
deleted before we return to the normal control flow in the first
call to `onDirectoryLoaded()`.  All references to `searcher` after
`QApplication::processEvents();` were therefore use-after-free bugs.

-----------

See #1316, #1315