### PR TITLE
[Actor] Fix memory leak in `removeActor()`

### DIFF
--- a/src/data/Actor.cpp
+++ b/src/data/Actor.cpp
@@ -29,6 +29,7 @@ void Actors::removeActor(Actor* actor)
     auto i = std::find(m_actors.begin(), m_actors.end(), actor);
     if (i != m_actors.end()) {
         m_actors.erase(i);
+        delete actor;
     }
 }
 
@@ -44,7 +45,11 @@ void Actors::clearImages()
     }
 }
 
-Actors::~Actors() = default;
+Actors::~Actors()
+{
+    qDeleteAll(m_actors);
+    m_actors.clear();
+}
 
 void Actors::setActors(QVector<Actor> actors)
 {

--- a/src/scrapers/movie/aebn/AEBN.cpp
+++ b/src/scrapers/movie/aebn/AEBN.cpp
@@ -65,9 +65,6 @@ AEBN::AEBN(QObject* parent) :
     m_meta.defaultLocale = "en";
     m_meta.isAdult = true;
 
-    m_widget = new QWidget(MainWindow::instance());
-    m_box = new QComboBox(m_widget);
-
     for (const mediaelch::Locale& lang : m_meta.supportedLanguages) {
         m_box->addItem(lang.languageTranslated(), lang.toString());
     }
@@ -84,6 +81,16 @@ AEBN::AEBN(QObject* parent) :
     layout->setColumnStretch(2, 1);
     layout->setContentsMargins(12, 0, 12, 12);
     m_widget->setLayout(layout);
+}
+
+AEBN::~AEBN()
+{
+    if (m_widget != nullptr && m_widget->parent() == nullptr) {
+        // We set MainWindow::instance() as this Widget's parent.
+        // But at construction time, the instance is not setup, yet.
+        // See settingsWidget()
+        delete m_widget;
+    }
 }
 
 const MovieScraper::ScraperMeta& AEBN::meta() const
@@ -360,6 +367,9 @@ void AEBN::saveSettings(ScraperSettings& settings)
 
 QWidget* AEBN::settingsWidget()
 {
+    if (m_widget->parent() == nullptr) {
+        m_widget->setParent(MainWindow::instance());
+    }
     return m_widget;
 }
 

--- a/src/scrapers/movie/aebn/AEBN.h
+++ b/src/scrapers/movie/aebn/AEBN.h
@@ -7,8 +7,8 @@
 #include <QComboBox>
 #include <QMap>
 #include <QObject>
+#include <QPointer>
 #include <QWidget>
-
 
 namespace mediaelch {
 namespace scraper {
@@ -18,6 +18,7 @@ class AEBN : public MovieScraper
     Q_OBJECT
 public:
     explicit AEBN(QObject* parent = nullptr);
+    ~AEBN() override;
     static constexpr const char* ID = "aebn";
 
     const ScraperMeta& meta() const override;
@@ -47,7 +48,7 @@ private:
     mediaelch::network::NetworkManager m_network;
     mediaelch::Locale m_language;
     QString m_genreId;
-    QWidget* m_widget;
+    QPointer<QWidget> m_widget;
     QComboBox* m_box;
     QComboBox* m_genreBox;
 

--- a/src/scrapers/movie/imdb/ImdbMovie.cpp
+++ b/src/scrapers/movie/imdb/ImdbMovie.cpp
@@ -44,12 +44,22 @@ ImdbMovie::ImdbMovie(QObject* parent) : MovieScraper(parent)
     m_meta.defaultLocale = "en";
     m_meta.isAdult = false;
 
-    m_settingsWidget = new QWidget(MainWindow::instance());
+    m_settingsWidget = new QWidget;
     m_loadAllTagsWidget = new QCheckBox(tr("Load all tags"), m_settingsWidget);
     auto* layout = new QGridLayout(m_settingsWidget);
     layout->addWidget(m_loadAllTagsWidget, 0, 0);
     layout->setContentsMargins(12, 0, 12, 12);
     m_settingsWidget->setLayout(layout);
+}
+
+ImdbMovie::~ImdbMovie()
+{
+    if (m_settingsWidget != nullptr && m_settingsWidget->parent() == nullptr) {
+        // We set MainWindow::instance() as this Widget's parent.
+        // But at construction time, the instance is not setup, yet.
+        // See settingsWidget()
+        delete m_settingsWidget;
+    }
 }
 
 const MovieScraper::ScraperMeta& ImdbMovie::meta() const
@@ -81,6 +91,9 @@ MovieSearchJob* ImdbMovie::search(MovieSearchJob::Config config)
 
 QWidget* ImdbMovie::settingsWidget()
 {
+    if (m_settingsWidget->parent() == nullptr) {
+        m_settingsWidget->setParent(MainWindow::instance());
+    }
     return m_settingsWidget;
 }
 

--- a/src/scrapers/movie/imdb/ImdbMovie.h
+++ b/src/scrapers/movie/imdb/ImdbMovie.h
@@ -6,6 +6,7 @@
 #include "scrapers/movie/MovieScraper.h"
 
 #include <QNetworkReply>
+#include <QPointer>
 
 class QCheckBox;
 
@@ -19,6 +20,7 @@ class ImdbMovie : public MovieScraper
     Q_OBJECT
 public:
     explicit ImdbMovie(QObject* parent = nullptr);
+    ~ImdbMovie() override;
     static constexpr const char* ID = "IMDb";
 
     const ScraperMeta& meta() const override;
@@ -52,7 +54,7 @@ private slots:
 private:
     ImdbApi m_api;
     ScraperMeta m_meta;
-    QWidget* m_settingsWidget;
+    QPointer<QWidget> m_settingsWidget;
     QCheckBox* m_loadAllTagsWidget;
 
     bool m_loadAllTags = false;

--- a/src/scrapers/movie/tmdb/TmdbMovie.cpp
+++ b/src/scrapers/movie/tmdb/TmdbMovie.cpp
@@ -148,7 +148,7 @@ TmdbMovie::TmdbMovie(QObject* parent) :
     m_meta.defaultLocale = mediaelch::Locale::English;
     m_meta.isAdult = false;
 
-    m_widget = new QWidget(MainWindow::instance());
+    m_widget = new QWidget;
     m_box = new QComboBox(m_widget);
 
     for (const mediaelch::Locale& lang : m_meta.supportedLanguages) {
@@ -164,6 +164,16 @@ TmdbMovie::TmdbMovie(QObject* parent) :
 
     // TODO: Should not be called by the constructor
     initialize();
+}
+
+TmdbMovie::~TmdbMovie()
+{
+    if (m_widget != nullptr && m_widget->parent() == nullptr) {
+        // We set MainWindow::instance() as this Widget's parent.
+        // But at construction time, the instance is not setup, yet.
+        // See settingsWidget()
+        delete m_widget;
+    }
 }
 
 const MovieScraper::ScraperMeta& TmdbMovie::meta() const
@@ -193,6 +203,9 @@ bool TmdbMovie::hasSettings() const
 
 QWidget* TmdbMovie::settingsWidget()
 {
+    if (m_widget->parent() == nullptr) {
+        m_widget->setParent(MainWindow::instance());
+    }
     return m_widget;
 }
 

--- a/src/scrapers/movie/tmdb/TmdbMovie.h
+++ b/src/scrapers/movie/tmdb/TmdbMovie.h
@@ -21,7 +21,7 @@ class TmdbMovie : public MovieScraper
     Q_OBJECT
 public:
     explicit TmdbMovie(QObject* parent = nullptr);
-    ~TmdbMovie() override = default;
+    ~TmdbMovie() override;
     static constexpr const char* ID = "TMDb";
 
     const ScraperMeta& meta() const override;
@@ -57,7 +57,7 @@ private:
     QString m_baseUrl;
     QMutex m_mutex;
     QSet<MovieScraperInfo> m_scraperNativelySupports;
-    QWidget* m_widget;
+    QPointer<QWidget> m_widget;
     QComboBox* m_box;
 
     QString localeForTMDb() const;

--- a/src/ui/small_widgets/FilterWidget.h
+++ b/src/ui/small_widgets/FilterWidget.h
@@ -45,6 +45,9 @@ private:
     // Available filters for current widget
     QVector<Filter*> m_availableFilters;
 
+    // Store filters so that they can be deleted in the destructor.
+    QVector<Filter*> m_tempFilterStore;
+
     // Unique available filters
     QVector<Filter*> m_availableMovieFilters;
     QVector<Filter*> m_availableTvShowFilters;
@@ -55,6 +58,8 @@ private:
     QVector<Filter*> m_activeFilters;
     QMap<MainWidgets, QVector<Filter*>> m_storedFilters;
 
+private:
+    void clearTempFilterStore();
     void initAvailableFilters();
     QVector<Filter*> setupMovieFilters();
     QVector<Filter*> setupTvShowFilters();

--- a/src/ui/small_widgets/MyLineEdit.cpp
+++ b/src/ui/small_widgets/MyLineEdit.cpp
@@ -19,6 +19,11 @@ MyLineEdit::MyLineEdit(QWidget* parent) : QLineEdit(parent), m_loadingLabel{new 
     connect(this, &QLineEdit::textChanged, this, &MyLineEdit::myTextChanged);
 }
 
+MyLineEdit::~MyLineEdit()
+{
+    delete m_loadingLabel;
+}
+
 void MyLineEdit::resizeEvent(QResizeEvent* /*event*/)
 {
     int frameWidth = style()->pixelMetric(QStyle::PM_DefaultFrameWidth);

--- a/src/ui/small_widgets/MyLineEdit.h
+++ b/src/ui/small_widgets/MyLineEdit.h
@@ -27,6 +27,8 @@ public:
     };
 
     explicit MyLineEdit(QWidget* parent = nullptr);
+    ~MyLineEdit() override;
+
     void setLoading(bool loading);
     void setType(LineEditType type);
     void addAdditionalStyleSheet(QString style);


### PR DESCRIPTION
`Actor` is not a QObject class and we therefore have to delete it
explicitly.  In `clear()` we do that by calling `qDeleteAll()` but
not in `removeActor()`.

------------

As reported in https://github.com/Komet/MediaElch/issues/1315#issuecomment-835861035