### PR TITLE
[NameFormatter] Use singleton again

### DIFF
--- a/.ci/ci_utils.sh
+++ b/.ci/ci_utils.sh
@@ -56,7 +56,8 @@ gather_project_and_system_details() {
 	GIT_HASH=$(git --git-dir=".git" show --no-patch --pretty="%h")
 	DATE_HASH=$(date -u +"%Y-%m-%d_%H-%M")
 	DATE_DESC=$(date -u +"%Y-%m-%d %H:%M")
-	GIT_BRANCH_FILENAME="$(echo "${GIT_BRANCH}" | sed 's$/$_$g')"
+	# shellcheck disable=SC2001
+	GIT_BRANCH_FILENAME="$(echo "${GIT_BRANCH}" | sed 's%/%_%g')"
 	ME_VERSION_NAME="${ME_VERSION}_${DATE_HASH}_git-${GIT_BRANCH_FILENAME}-${GIT_HASH}"
 
 	if [[ -z "$GIT_REVISION" ]] || [[ "$GIT_VERSION" == "$GIT_REVISION" ]]; then

--- a/scripts/quick_checks.sh
+++ b/scripts/quick_checks.sh
@@ -11,18 +11,31 @@ cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1
 
 source ./utils.sh
 
-print_important "Run all 4 quick checks"
+print_important "Run all 5 quick checks"
 
-print_info "\nRunning check 1 / 4"
+print_info "\nRunning check 1 / 5 : Clang Format"
 ./run_clang_format.sh
 
-print_info "\nRunning check 2 / 4"
+print_info "\nRunning check 2 / 5 : Correct debug macros"
+if grep -r 'qInfo' ../src; then
+	print_error "Found usages of qInfo! Use qCInfo(category) instead!"
+elif grep -r 'qDebug' ../src; then
+	print_error "Found usages of qDebug! Use qCDebug(category) instead!"
+elif grep -r 'qWarning' ../src; then
+	print_error "Found usages of qWarning! Use qCWarning(category) instead!"
+elif grep -r 'qCritical' ../src; then
+	print_error "Found usages of qInqCriticalfo! Use qCCritical(category) instead!"
+else
+	print_success "Done."
+fi
+
+print_info "\nRunning check 3 / 5 : CMake Format"
 ./run_cmake_format.sh
 
-print_info "\nRunning check 3 / 4"
+print_info "\nRunning check 4 / 5 : Shellcheck"
 ./run_shellcheck.sh
 
-print_info "\nRunning check 4 / 4"
+print_info "\nRunning check 5 / 5 : shfmt"
 print_important "Running shfmt"
 find . -type f -iname '*.sh' -exec shfmt -l -w {} \+
 

--- a/src/concerts/ConcertController.cpp
+++ b/src/concerts/ConcertController.cpp
@@ -58,7 +58,7 @@ bool ConcertController::loadData(MediaCenterInterface* mediaCenterInterface, boo
     }
 
     m_concert->blockSignals(true);
-    NameFormatter nameFormatter(Settings::instance()->excludeWords());
+    NameFormatter::setExcludeWords(Settings::instance()->excludeWords());
 
     bool infoLoaded = false;
     if (reloadFromNfo) {
@@ -77,7 +77,7 @@ bool ConcertController::loadData(MediaCenterInterface* mediaCenterInterface, boo
                     pathElements.removeLast();
                 }
                 if (!pathElements.isEmpty()) {
-                    m_concert->setTitle(nameFormatter.formatName(pathElements.last()));
+                    m_concert->setTitle(NameFormatter::formatName(pathElements.last()));
                 }
             } else if (QString::compare(fi.fileName(), "index.bdmv", Qt::CaseInsensitive) == 0) {
                 QStringList pathElements = QDir::toNativeSeparators(fi.path()).split(QDir::separator());
@@ -86,24 +86,25 @@ bool ConcertController::loadData(MediaCenterInterface* mediaCenterInterface, boo
                     pathElements.removeLast();
                 }
                 if (!pathElements.isEmpty()) {
-                    m_concert->setTitle(nameFormatter.formatName(pathElements.last()));
+                    m_concert->setTitle(NameFormatter::formatName(pathElements.last()));
                 }
             } else if (m_concert->inSeparateFolder()) {
                 QStringList splitted = QDir::toNativeSeparators(fi.path()).split(QDir::separator());
                 if (!splitted.isEmpty()) {
-                    m_concert->setTitle(nameFormatter.formatName(splitted.last()));
+                    m_concert->setTitle(NameFormatter::formatName(splitted.last()));
                 } else {
                     if (m_concert->files().size() > 1) {
-                        m_concert->setTitle(nameFormatter.formatName(nameFormatter.removeParts(fi.completeBaseName())));
+                        m_concert->setTitle(
+                            NameFormatter::formatName(NameFormatter::removeParts(fi.completeBaseName())));
                     } else {
-                        m_concert->setTitle(nameFormatter.formatName(fi.completeBaseName()));
+                        m_concert->setTitle(NameFormatter::formatName(fi.completeBaseName()));
                     }
                 }
             } else {
                 if (m_concert->files().size() > 1) {
-                    m_concert->setTitle(nameFormatter.formatName(nameFormatter.removeParts(fi.completeBaseName())));
+                    m_concert->setTitle(NameFormatter::formatName(NameFormatter::removeParts(fi.completeBaseName())));
                 } else {
-                    m_concert->setTitle(nameFormatter.formatName(fi.completeBaseName()));
+                    m_concert->setTitle(NameFormatter::formatName(fi.completeBaseName()));
                 }
             }
         }

--- a/src/file/NameFormatter.h
+++ b/src/file/NameFormatter.h
@@ -1,27 +1,47 @@
 #pragma once
 
 #include <QObject>
+#include <QReadWriteLock>
+#include <QRegularExpression>
 #include <QStringList>
+#include <QVector>
 
-class NameFormatter : public QObject
+/// \brief Name formatter for movies/TV shows and other files.
+/// \details Singleton that provides thread-safe mechanism for "prettifying" names.
+/// \note  There is only one instance of this class (singleton).  While I
+///        mostly dislike singletons, in this case there are reasons.  If we
+///        do not use a singleton and do not store QRegularExpression objects,
+///        each movie that is loaded has to instantiate all QRegularExpressions
+///        for the "exclude word list".  Due to JIT compilation, this has
+///        a _huge_ time disadvantage.  In some tests, 50% of the time went
+///        into the NameFormatter prior to using a singleton.
+///        See https://github.com/Komet/MediaElch/pull/1229 for more details.
+class NameFormatter
 {
-    Q_OBJECT
 public:
-    explicit NameFormatter(QStringList excludeWords, QObject* parent = nullptr);
+    static NameFormatter& instance();
+
+    static void setExcludeWords(QStringList excludeWords);
 
     /// \brief Returns a new string with excluded words removed.
     /// \param name name to remove excluded words from
-    QString excludeWords(QString name);
+    static QString excludeWords(QString name);
 
     /// \brief Removes exclude dwords, changes "." and "_" to " " and removes all " - " at the end of the name.
-    QString formatName(QString name, bool replaceDots = true, bool replaceUnderscores = true);
+    static QString formatName(QString name, bool replaceDots = true, bool replaceUnderscores = true);
 
     /// \brief Removes the last part of a name, looking like " - cd1" or "_a"
-    QString removeParts(QString name);
+    static QString removeParts(QString name);
 
 private:
+    explicit NameFormatter() = default;
+
     static bool lengthLessThan(const QString& s1, const QString& s2);
 
 private:
-    QStringList m_excludedWords;
+    QStringList m_allExcludeWords;
+    /// \brief Exluded words that contain special characters not suitable for regular expressions.
+    QStringList m_excludeWordsNoRegEx;
+    QVector<QRegularExpression> m_excludeWordsRegEx;
+    QReadWriteLock m_lock;
 };

--- a/src/globals/ImageDialog.cpp
+++ b/src/globals/ImageDialog.cpp
@@ -957,8 +957,8 @@ QString ImageDialog::formatSearchText(const QString& text)
     QString fText = text;
     fText.replace(" - ", " ");
     fText.replace("-", " ");
-    NameFormatter nameFormatter(Settings::instance()->excludeWords());
-    fText = nameFormatter.formatName(fText);
+    NameFormatter::setExcludeWords(Settings::instance()->excludeWords());
+    fText = NameFormatter::formatName(fText);
     return fText;
 }
 

--- a/src/movies/MovieController.cpp
+++ b/src/movies/MovieController.cpp
@@ -73,7 +73,7 @@ bool MovieController::loadData(MediaCenterInterface* mediaCenterInterface, bool 
         return m_infoLoaded;
     }
 
-    NameFormatter nameFormatter(Settings::instance()->excludeWords());
+    NameFormatter::setExcludeWords(Settings::instance()->excludeWords());
     m_movie->blockSignals(true);
 
     bool infoLoaded = false;
@@ -93,7 +93,7 @@ bool MovieController::loadData(MediaCenterInterface* mediaCenterInterface, bool 
                     pathElements.removeLast();
                 }
                 if (!pathElements.isEmpty()) {
-                    m_movie->setName(nameFormatter.formatName(pathElements.last(), false));
+                    m_movie->setName(NameFormatter::formatName(pathElements.last(), false));
                 }
             } else if (QString::compare(fi.fileName(), "index.bdmv", Qt::CaseInsensitive) == 0) {
                 QStringList pathElements = QDir::toNativeSeparators(fi.path()).split(QDir::separator());
@@ -102,24 +102,24 @@ bool MovieController::loadData(MediaCenterInterface* mediaCenterInterface, bool 
                     pathElements.removeLast();
                 }
                 if (!pathElements.isEmpty()) {
-                    m_movie->setName(nameFormatter.formatName(pathElements.last(), false));
+                    m_movie->setName(NameFormatter::formatName(pathElements.last(), false));
                 }
             } else if (m_movie->inSeparateFolder()) {
                 QStringList splitted = QDir::toNativeSeparators(fi.path()).split(QDir::separator());
                 if (!splitted.isEmpty()) {
-                    m_movie->setName(nameFormatter.formatName(splitted.last(), false));
+                    m_movie->setName(NameFormatter::formatName(splitted.last(), false));
                 } else {
                     if (m_movie->files().size() > 1) {
-                        m_movie->setName(nameFormatter.formatName(nameFormatter.removeParts(fi.completeBaseName())));
+                        m_movie->setName(NameFormatter::formatName(NameFormatter::removeParts(fi.completeBaseName())));
                     } else {
-                        m_movie->setName(nameFormatter.formatName(fi.completeBaseName()));
+                        m_movie->setName(NameFormatter::formatName(fi.completeBaseName()));
                     }
                 }
             } else {
                 if (m_movie->files().size() > 1) {
-                    m_movie->setName(nameFormatter.formatName(nameFormatter.removeParts(fi.completeBaseName())));
+                    m_movie->setName(NameFormatter::formatName(NameFormatter::removeParts(fi.completeBaseName())));
                 } else {
-                    m_movie->setName(nameFormatter.formatName(fi.completeBaseName()));
+                    m_movie->setName(NameFormatter::formatName(fi.completeBaseName()));
                 }
             }
             QRegularExpression rx("tt\\d+");

--- a/src/movies/MovieFilesOrganizer.cpp
+++ b/src/movies/MovieFilesOrganizer.cpp
@@ -34,9 +34,9 @@ void MovieFilesOrganizer::moveToDirs(mediaelch::DirectoryPath dir)
     QString dirName = path.right(path.length() - pos - 1);
     QString fileName;
 
-    NameFormatter nameFormatter(Settings::instance()->excludeWords());
+    NameFormatter::setExcludeWords(Settings::instance()->excludeWords());
 
-    for (const QStringList& movie : contents) {
+    for (const QStringList& movie : asConst(contents)) {
         const int movieIndex = movie.at(0).lastIndexOf(QDir::separator());
         if (!(movie.at(0).left(movieIndex).endsWith(dirName))) {
             qCDebug(generic) << "[MovieFilesOrganizer] skipping " << movie.at(0);
@@ -49,9 +49,9 @@ void MovieFilesOrganizer::moveToDirs(mediaelch::DirectoryPath dir)
 
         QString newFolder;
         if (movie.length() == 1) {
-            newFolder = path + QDir::separator() + nameFormatter.formatName(fileName);
+            newFolder = path + QDir::separator() + NameFormatter::formatName(fileName);
         } else if (movie.length() > 1) {
-            newFolder = path + QDir::separator() + nameFormatter.formatName(nameFormatter.removeParts(fileName));
+            newFolder = path + QDir::separator() + NameFormatter::formatName(NameFormatter::removeParts(fileName));
         } else {
             continue;
         }

--- a/src/tv_shows/TvShow.cpp
+++ b/src/tv_shows/TvShow.cpp
@@ -206,8 +206,8 @@ bool TvShow::loadData(MediaCenterInterface* mediaCenterInterface, bool reloadFro
     }();
 
     if (!infoLoaded) {
-        NameFormatter nameFormatter(Settings::instance()->excludeWords());
-        setTitle(nameFormatter.formatName(dir().dirName()));
+        NameFormatter::setExcludeWords(Settings::instance()->excludeWords());
+        setTitle(NameFormatter::formatName(dir().dirName()));
     }
     m_infoLoaded = infoLoaded;
     m_infoFromNfoLoaded = infoLoaded && reloadFromNfo;

--- a/src/ui/imports/ImportDialog.cpp
+++ b/src/ui/imports/ImportDialog.cpp
@@ -123,8 +123,8 @@ int ImportDialog::execMovie(QString searchString)
     m_filesToMove.clear();
     ui->stackedWidget->setCurrentIndex(0);
 
-    NameFormatter nameFormatter(Settings::instance()->excludeWords());
-    ui->movieSearchWidget->search(nameFormatter.formatName(searchString), id, TmdbId::NoId);
+    NameFormatter::setExcludeWords(Settings::instance()->excludeWords());
+    ui->movieSearchWidget->search(NameFormatter::formatName(searchString), id, TmdbId::NoId);
 
     ui->placeholders->setType(Renamer::RenameType::Movies);
     ui->chkSeasonDirectories->setVisible(false);
@@ -187,8 +187,8 @@ int ImportDialog::execConcert(QString searchString)
     m_filesToMove.clear();
     ui->stackedWidget->setCurrentIndex(2);
 
-    NameFormatter nameFormatter(Settings::instance()->excludeWords());
-    ui->concertSearchWidget->search(nameFormatter.formatName(searchString));
+    NameFormatter::setExcludeWords(Settings::instance()->excludeWords());
+    ui->concertSearchWidget->search(NameFormatter::formatName(searchString));
 
     ui->placeholders->setType(Renamer::RenameType::Concerts);
     ui->chkSeasonDirectories->setVisible(false);

--- a/test/unit/file/testNameFormatter.cpp
+++ b/test/unit/file/testNameFormatter.cpp
@@ -13,102 +13,105 @@ TEST_CASE("NameFormatter formats names", "[rename]")
     {
         SECTION("Removes default excluded words from name")
         {
-            NameFormatter nf(defaultExcludeWords);
+            NameFormatter::setExcludeWords(defaultExcludeWords);
             // end
-            CHECK(nf.excludeWords("my-movie-480i") == "my-movie");
-            CHECK(nf.excludeWords("my-movie.480i") == "my-movie");
-            CHECK(nf.excludeWords("my-movie.ac3.dsr.480i") == "my-movie");
+            CHECK(NameFormatter::excludeWords("my-movie-480i") == "my-movie");
+            CHECK(NameFormatter::excludeWords("my-movie.480i") == "my-movie");
+            CHECK(NameFormatter::excludeWords("my-movie.ac3.dsr.480i") == "my-movie");
             // start
-            CHECK(nf.excludeWords("480i-my-movie") == "my-movie");
-            CHECK(nf.excludeWords("[480i]my-movie") == "my-movie");
+            CHECK(NameFormatter::excludeWords("480i-my-movie") == "my-movie");
+            CHECK(NameFormatter::excludeWords("[480i]my-movie") == "my-movie");
             // middle
-            CHECK(nf.excludeWords("my-480i-movie") == "my movie");
-            CHECK(nf.excludeWords("my.dsr.divx5.480i.movie") == "my movie");
-            CHECK(nf.excludeWords("my[480i]movie") == "my movie");
+            CHECK(NameFormatter::excludeWords("my-480i-movie") == "my movie");
+            CHECK(NameFormatter::excludeWords("my.dsr.divx5.480i.movie") == "my movie");
+            CHECK(NameFormatter::excludeWords("my[480i]movie") == "my movie");
         }
 
         SECTION("Only match basic words and not regex special characters")
         {
-            NameFormatter nf({".?", "(480i)", ".+"});
-            CHECK(nf.excludeWords("my.movie.480i") == "my.movie.480i");
-            CHECK(nf.excludeWords("my.movie.?.?.?480i") == "my.movie480i");
-            CHECK(nf.excludeWords("my(480i)movie") == "mymovie");
-            CHECK(nf.excludeWords("480i-..+my-movie") == "480i-.my-movie");
+            NameFormatter::setExcludeWords({".?", "(480i)", ".+"});
+            CHECK(NameFormatter::excludeWords("my.movie.480i") == "my.movie.480i");
+            CHECK(NameFormatter::excludeWords("my.movie.?.?.?480i") == "my.movie480i");
+            CHECK(NameFormatter::excludeWords("my(480i)movie") == "mymovie");
+            CHECK(NameFormatter::excludeWords("480i-..+my-movie") == "480i-.my-movie");
         }
 
         SECTION("Match braces")
         {
-            NameFormatter nf({"(", ")", "<", ">", "."});
-            CHECK(nf.excludeWords("my<movie>480i") == "mymovie480i");
-            CHECK(nf.excludeWords("my(480i)movie") == "my480imovie");
-            CHECK(nf.excludeWords("my.480i.movie") == "my480imovie");
-            CHECK(nf.excludeWords("480i-.+my-movie") == "480i-+my-movie");
+            NameFormatter::setExcludeWords({"(", ")", "<", ">", "."});
+            CHECK(NameFormatter::excludeWords("my<movie>480i") == "mymovie480i");
+            CHECK(NameFormatter::excludeWords("my(480i)movie") == "my480imovie");
+            CHECK(NameFormatter::excludeWords("my.480i.movie") == "my480imovie");
+            CHECK(NameFormatter::excludeWords("480i-.+my-movie") == "480i-+my-movie");
         }
 
         SECTION("Removes trailing _ -")
         {
-            NameFormatter nf(defaultExcludeWords);
-            CHECK(nf.excludeWords(" my-movie-480i_-_480i-") == "my-movie");
+            NameFormatter::setExcludeWords(defaultExcludeWords);
+            CHECK(NameFormatter::excludeWords(" my-movie-480i_-_480i-") == "my-movie");
         }
 
         SECTION("Removes words with Unicode characters")
         {
-            NameFormatter nf({"señor", "für", "✓"});
-            CHECK(nf.excludeWords("my-señor-movie") == "my movie");
-            CHECK(nf.excludeWords("my-señor-movie-für-mich.✓") == "my movie mich");
+            NameFormatter::setExcludeWords({"señor", "für", "✓"});
+            CHECK(NameFormatter::excludeWords("my-señor-movie") == "my movie");
+            CHECK(NameFormatter::excludeWords("my-señor-movie-für-mich.✓") == "my movie mich");
         }
 
         SECTION("Case-Insensitive")
         {
-            NameFormatter nf({"ä", "HELLO", "HELLO.LONG", "dvd.HD"});
+            NameFormatter::setExcludeWords({"ä", "HELLO", "HELLO.LONG", "dvd.HD"});
             // spaces after the replaced words because the "smart" regex is used
-            CHECK(nf.excludeWords("my.Ä.movie.Ä") == "my movie");
-            CHECK(nf.excludeWords("my.movie.hElLo.480i") == "my.movie 480i");
+            CHECK(NameFormatter::excludeWords("my.Ä.movie.Ä") == "my movie");
+            CHECK(NameFormatter::excludeWords("my.movie.hElLo.480i") == "my.movie 480i");
             // dot before 480i because the longer variant should simply be replaced
-            CHECK(nf.excludeWords("my.movie.hElLo.loNg.480i") == "my.movie.480i");
-            CHECK(nf.excludeWords("my.DVD.hd.movie") == "my.movie");
+            CHECK(NameFormatter::excludeWords("my.movie.hElLo.loNg.480i") == "my.movie.480i");
+            CHECK(NameFormatter::excludeWords("my.DVD.hd.movie") == "my.movie");
         }
 
         SECTION("Removes multiple dots and dashes")
         {
-            NameFormatter nf({});
-            CHECK(nf.excludeWords("my....movie..........in.480i") == "my.movie.in.480i");
-            CHECK(nf.excludeWords("my--480i---------movie") == "my-480i-movie");
+            NameFormatter::setExcludeWords({});
+            CHECK(NameFormatter::excludeWords("my....movie..........in.480i") == "my.movie.in.480i");
+            CHECK(NameFormatter::excludeWords("my--480i---------movie") == "my-480i-movie");
         }
     }
 
     SECTION("formatName works as expected")
     {
-        NameFormatter nf(defaultExcludeWords);
+        NameFormatter::setExcludeWords(defaultExcludeWords);
         SECTION("replaces dots and underscore")
         {
-            CHECK(nf.formatName("_movie_with_some_-_title.ac3", true, true) == "movie with some - title");
-            CHECK(nf.formatName(".movie_with_some_-_title.ac3  - ", true, true) == "movie with some - title");
+            CHECK(NameFormatter::formatName("_movie_with_some_-_title.ac3", true, true) == "movie with some - title");
+            CHECK(
+                NameFormatter::formatName(".movie_with_some_-_title.ac3  - ", true, true) == "movie with some - title");
         }
         SECTION("replaces empty parentheses")
         {
-            CHECK(nf.formatName("_movie_with_some_-_title( ac3 )  - ", true, true) == "movie with some - title");
-            CHECK(nf.formatName("_movie_with_some_-_title( _ac3__ )  - ", true, true) == "movie with some - title");
+            CHECK(NameFormatter::formatName("_movie_with_some_-_title( ac3 )  - ", true, true)
+                  == "movie with some - title");
+            CHECK(NameFormatter::formatName("_movie_with_some_-_title( _ac3__ )  - ", true, true)
+                  == "movie with some - title");
         }
     }
 
     SECTION("removeParts works as expected")
     {
-        NameFormatter nf({});
+        NameFormatter::setExcludeWords({});
         SECTION("removes the last part")
         {
-            CHECK(nf.removeParts("my-movie-part1") == "my-movie");
-            CHECK(nf.removeParts("my-movie cd 1") == "my-movie");
-            CHECK(nf.removeParts("my-movie cd_1") == "my-movie");
-            CHECK(nf.removeParts("my-movie a.") == "my-movie");
-            CHECK(nf.removeParts("my-movie_b") == "my-movie");
-            CHECK(nf.removeParts("my-movie-_-f") == "my-movie");
-            CHECK(nf.removeParts("my-movie  - part.45-") == "my-movie");
+            CHECK(NameFormatter::removeParts("my-movie-part1") == "my-movie");
+            CHECK(NameFormatter::removeParts("my-movie cd 1") == "my-movie");
+            CHECK(NameFormatter::removeParts("my-movie cd_1") == "my-movie");
+            CHECK(NameFormatter::removeParts("my-movie a.") == "my-movie");
+            CHECK(NameFormatter::removeParts("my-movie_b") == "my-movie");
+            CHECK(NameFormatter::removeParts("my-movie-_-f") == "my-movie");
+            CHECK(NameFormatter::removeParts("my-movie  - part.45-") == "my-movie");
         }
         SECTION("does not remove middle part")
         {
-            CHECK(nf.removeParts("my-part1-movie") == "my-part1-movie");
-            CHECK(nf.removeParts("my-cd.1-movie") == "my-cd.1-movie");
+            CHECK(NameFormatter::removeParts("my-part1-movie") == "my-part1-movie");
+            CHECK(NameFormatter::removeParts("my-cd.1-movie") == "my-cd.1-movie");
         }
     }
 }


### PR DESCRIPTION
There is only one instance of this class (singleton).  While I
mostly dislike singletons, in this case there are reasons.  If we
do not use a singleton and do not store QRegularExpression objects,
each movie that is loaded has to instantiate all QRegularExpressions
for the "exclude word list".  Due to JIT compilation, this has
a _huge_ time disadvantage.  In some tests, 50% of the time went
into the NameFormatter prior to using a singleton.
See #1229 for more details.