### PR TITLE
[MovieFileSearcher] Run searcher in another thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@
 
 ### Internal Improvements and Changes
 
- - *tbd*
+ - The movie file searcher has been reworked again.  
+   It now runs in another thread so that MediaElch now longer "freezes".
 
 
 ## 2.8.12 - Coridian (2021-05-10)

--- a/src/data/Database.cpp
+++ b/src/data/Database.cpp
@@ -220,7 +220,7 @@ void Database::update(Movie* movie)
     }
 }
 
-QVector<Movie*> Database::moviesInDirectory(DirectoryPath path)
+QVector<Movie*> Database::moviesInDirectory(DirectoryPath path, QObject* movieParent)
 {
     transaction();
     QSqlQuery query(db());
@@ -248,7 +248,7 @@ QVector<Movie*> Database::moviesInDirectory(DirectoryPath path)
 
         } else {
             ColorLabel label = static_cast<ColorLabel>(query.value(query.record().indexOf("color")).toInt());
-            movie = new Movie(QStringList(), Manager::instance()->movieFileSearcher());
+            movie = new Movie(QStringList(), movieParent);
             movie->setDatabaseId(query.value(query.record().indexOf("idMovie")).toInt());
             movie->setFileLastModified(query.value(query.record().indexOf("lastModified")).toDateTime());
             movie->setInSeparateFolder(query.value(query.record().indexOf("inSeparateFolder")).toInt() == 1);

--- a/src/data/Database.h
+++ b/src/data/Database.h
@@ -34,7 +34,7 @@ public:
     void clearMoviesInDirectory(mediaelch::DirectoryPath path);
     void addMovie(Movie* movie, mediaelch::DirectoryPath path);
     void update(Movie* movie);
-    QVector<Movie*> moviesInDirectory(mediaelch::DirectoryPath path);
+    QVector<Movie*> moviesInDirectory(mediaelch::DirectoryPath path, QObject* movieParent);
 
     void clearAllConcerts();
     void clearConcertsInDirectory(mediaelch::DirectoryPath path);

--- a/src/log/Log.cpp
+++ b/src/log/Log.cpp
@@ -5,7 +5,7 @@
 #include <QMessageBox>
 
 Q_LOGGING_CATEGORY(generic, "generic")
-Q_LOGGING_CATEGORY(movie, "movie")
+Q_LOGGING_CATEGORY(c_movie, "movie")
 
 
 static QFile data;

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -7,7 +7,7 @@
 // We plan on adding more put to make the switch from qCDebug(generic) to qCDebug() easier,
 // we create a common category that can be used by all modules.
 Q_DECLARE_LOGGING_CATEGORY(generic)
-Q_DECLARE_LOGGING_CATEGORY(movie)
+Q_DECLARE_LOGGING_CATEGORY(c_movie)
 
 namespace mediaelch {
 

--- a/src/media_centers/KodiXml.cpp
+++ b/src/media_centers/KodiXml.cpp
@@ -182,6 +182,7 @@ bool KodiXml::saveMovie(Movie* movie)
         }
     }
 
+    // TODO: Multithreaded?
     Manager::instance()->database()->update(movie);
 
     return true;

--- a/src/movies/file_searcher/MovieDirectorySearcher.h
+++ b/src/movies/file_searcher/MovieDirectorySearcher.h
@@ -1,62 +1,128 @@
 #pragma once
 
+#include "file/FileFilter.h"
 #include "globals/Globals.h"
 
-#include <QFutureWatcher>
+#include <QMutex>
 #include <QString>
+#include <QThread>
+#include <QTimer>
 #include <QVector>
 #include <atomic>
 
 class Movie;
+class Database;
 
 namespace mediaelch {
 
-/// \brief   Searches for movies in a given directory.
-/// \details Create an instance of this class and connect to \see movieProcessed(Movie*).
-///          The caller must take ownership of the created movies.
-class MovieDirectorySearcher : public QObject
+/// \brief   Thread safe store for movies.
+/// \details An instance of this class must be provided when using any MovieLoader.
+///          All MovieLoaders move their newly created movies into a store.
+class MovieLoaderStore : public QObject
 {
     Q_OBJECT
 public:
-    MovieDirectorySearcher(const SettingsDir& dir, bool inSeparateFolders, QObject* parent = nullptr);
-    ~MovieDirectorySearcher() override;
+    MovieLoaderStore(QObject* parent = nullptr) : QObject(parent) {}
+    ~MovieLoaderStore() override = default;
 
-signals:
-    void startLoading(int approximateMovieCount);
-    void loaded(MovieDirectorySearcher* self);
-    void movieProcessed(Movie* movie);
+    void addMovie(Movie* movie);
+    void addMovies(const QVector<Movie*>& movies);
+
+    QVector<Movie*> takeAll(QObject* parent);
+    /// \brief Clear and delete all stored movies.
+    void clear();
+
+private:
+    QVector<Movie*> m_movies;
+    QMutex m_lock;
+};
+
+/// \brief Interface for loading movies.
+class MovieLoader : public QObject
+{
+    Q_OBJECT
+public:
+    explicit MovieLoader(MovieLoaderStore* store, QObject* parent = nullptr) : QObject(parent), m_store{store} {}
+    ~MovieLoader() override = default;
 
 public:
-    void load();
-    /// \brief   Aborts the filesearcher and all operations.
-    /// \details The filesearcher goes into an unusable state after calling abort.
-    ///          You have to construct a new filesearcher after calling abort().
-    void abort();
+    virtual void start() = 0;
+    /// \brief   Thread-safe way to abort the MovieLoader.
+    /// \details Implementations must ensure that this method can be called from
+    ///          any thread, i.e. this function must be thread safe.
+    ///          Furthermore, the finished() signal MUST still be emitted.
+    virtual void abort() = 0;
+    /// \brief Thread-safe way to check whether the MovieLoader was aborted.
+    virtual bool isAborted() = 0;
 
-    const QVector<Movie*> movies() const { return m_movies; }
-    SettingsDir directory() const { return m_dir; }
-    int currentMovieCount() const { return m_movies.size(); }
+signals:
+    void progress(MovieLoader* job, int processed, int total);
+    /// \brief   A translated string representing the current loading state.
+    /// \details For example the currently scanned directory.
+    void progressText(MovieLoader* job, QString text);
+    void finished(MovieLoader* job);
+
+protected:
+    MovieLoaderStore* m_store = nullptr;
+};
+
+
+/// \brief Creates a thread and moves the worker to it. Auto deletes thread when worker is finished.
+QThread* createAutoDeleteThreadWithMovieLoader(MovieLoader* worker, QObject* threadParent);
+
+/// \brief Load movies from disk.
+class MovieDiskLoader : public MovieLoader
+{
+    Q_OBJECT
+public:
+    MovieDiskLoader(SettingsDir dir, MovieLoaderStore& store, FileFilter filter, QObject* parent = nullptr);
+    ~MovieDiskLoader() override;
+
+public:
+    void start() override;
+    void abort() override;
+    bool isAborted() override { return m_aborted.load(); }
 
 private:
     void loadMovieContents();
-    void createMovies();
-    QVector<Movie*> createMovie(QStringList files);
-
-    void postProcessMovie(Movie* movie);
+    void createMovie(QStringList files);
+    /// \brief Store all loaded movies into the MovieLoaderStore and database.
+    void storeAndAddToDatabase();
 
 private:
     SettingsDir m_dir;
+    FileFilter m_filter;
+    Database* m_db = nullptr;
+    QMutex m_mutex;
+    QVector<Movie*> m_movies;
+    std::atomic_bool m_aborted{false};
+    std::atomic_int m_processed{0};
+    int m_approxTotal{0};
+
+    // TODO: Streamline, e.g. use one vector of directories with DiscType tags
     QHash<QString, QDateTime> m_lastModifications;
-
-    QFutureWatcher<QVector<Movie*>> m_watcher;
-
     QStringList m_bluRayDirectories;
     QStringList m_dvdDirectories;
-
     QMap<QString, QStringList> m_contents;
-    QVector<Movie*> m_movies;
+};
 
-    bool m_inSeparateFolders{false};
+/// \brief Load movies from database
+class MovieDatabaseLoader : public MovieLoader
+{
+    Q_OBJECT
+public:
+    MovieDatabaseLoader(SettingsDir dir, MovieLoaderStore& store, QObject* parent = nullptr) :
+        MovieLoader(&store, parent), m_dir{dir}
+    {
+    }
+    ~MovieDatabaseLoader() override = default;
+
+    void start() override;
+    void abort() override;
+    bool isAborted() override { return m_aborted.load(); }
+
+private:
+    SettingsDir m_dir;
     std::atomic_bool m_aborted{false};
 };
 

--- a/src/ui/main/FileScannerDialog.cpp
+++ b/src/ui/main/FileScannerDialog.cpp
@@ -34,24 +34,23 @@ FileScannerDialog::FileScannerDialog(QWidget* parent) : QDialog(parent), ui(new 
     connect(manager->tvShowFileSearcher(),  &TvShowFileSearcher::progress,  this, &FileScannerDialog::onProgress);
     connect(manager->musicFileSearcher(),   &MusicFileSearcher::progress,   this, &FileScannerDialog::onProgress);
 
-    connect(manager->movieFileSearcher(),   &MovieFileSearcher::currentDir, this, [this](QString dir){
+    connect(manager->movieFileSearcher(),   &MovieFileSearcher::progressText, this, [this](QString dir){
         ui->currentDir->setText(dir);
-        // The next line is disabled on purpose, see https://github.com/Komet/MediaElch/issues/1315
-        // The issue seems to be an event in Qt's event queue that is executed after the object
-        // was deleted by deleteLater().
+        // Do not enable the following line. The movie file searcher is currently the only
+        // one that uses multithreading which means there is no need for this call.
         // QApplication::processEvents();
     });
     connect(manager->concertFileSearcher(), &ConcertFileSearcher::currentDir, this, &FileScannerDialog::onCurrentDir);
     connect(manager->tvShowFileSearcher(),  &TvShowFileSearcher::currentDir,  this, &FileScannerDialog::onCurrentDir);
     connect(manager->musicFileSearcher(),   &MusicFileSearcher::currentDir,   this, &FileScannerDialog::onCurrentDir);
 
-    connect(manager->movieFileSearcher(),   &MovieFileSearcher::searchStarted,   ui->status, &QLabel::setText);
+    connect(manager->movieFileSearcher(),   &MovieFileSearcher::statusChanged,   ui->status, &QLabel::setText);
     connect(manager->tvShowFileSearcher(),  &TvShowFileSearcher::searchStarted,  ui->status, &QLabel::setText);
     connect(manager->concertFileSearcher(), &ConcertFileSearcher::searchStarted, ui->status, &QLabel::setText);
     connect(manager->musicFileSearcher(),   &MusicFileSearcher::searchStarted,   ui->status, &QLabel::setText);
     // clang-format on
 
-    connect(manager->movieFileSearcher(), &MovieFileSearcher::moviesLoaded, [this]() {
+    connect(manager->movieFileSearcher(), &MovieFileSearcher::finished, [this]() {
         if (m_reloadType != ReloadType::All) {
             accept();
         } else {
@@ -135,39 +134,43 @@ void FileScannerDialog::setReloadType(ReloadType type)
 }
 
 /**
- * \brief Rejecting should not be possible
+ * \brief Rejected, e.g. by pressing ESC
  */
 void FileScannerDialog::reject()
 {
+    // Note: We use "singleShot" simply because the same is done for reload().
+    //       If we call it directly, abort() may be called _before_ reload().
+
     if (m_reloadType == ReloadType::Movies || m_reloadType == ReloadType::All) {
-        Manager::instance()->movieFileSearcher()->abort();
-        Manager::instance()->movieModel()->clear();
+        QTimer::singleShot(0, this, []() { Manager::instance()->movieFileSearcher()->abort(); });
+        // Don't clear when aborted. All movies that are shown, exist in the database.
     }
     if (m_reloadType == ReloadType::TvShows || m_reloadType == ReloadType::All) {
-        Manager::instance()->tvShowFileSearcher()->abort();
-        Manager::instance()->tvShowModel()->clear();
-        Manager::instance()->tvShowFilesWidget()->renewModel();
+        QTimer::singleShot(0, this, []() {
+            Manager::instance()->tvShowFileSearcher()->abort();
+            Manager::instance()->tvShowModel()->clear();
+            Manager::instance()->tvShowFilesWidget()->renewModel();
+        });
     }
     if (m_reloadType == ReloadType::Concerts || m_reloadType == ReloadType::All) {
-        Manager::instance()->concertFileSearcher()->abort();
-        Manager::instance()->concertModel()->clear();
+        QTimer::singleShot(0, this, []() {
+            Manager::instance()->concertFileSearcher()->abort();
+            Manager::instance()->concertModel()->clear();
+        });
     }
     if (m_reloadType == ReloadType::Music || m_reloadType == ReloadType::All) {
-        Manager::instance()->musicFileSearcher()->abort();
-        Manager::instance()->musicModel()->clear();
+        QTimer::singleShot(0, this, []() {
+            Manager::instance()->musicFileSearcher()->abort();
+            Manager::instance()->musicModel()->clear();
+        });
     }
 
     QDialog::reject();
 }
 
-/**
- * \brief Starts the movie file searcher
- */
 void FileScannerDialog::onStartMovieScanner()
 {
     ui->progressBar->setValue(0);
-    Manager::instance()->movieModel()->clear();
-    QApplication::processEvents();
     if (m_forceReload) {
         QTimer::singleShot(0, this, &FileScannerDialog::onStartMovieScannerForce);
     } else {
@@ -190,7 +193,6 @@ void FileScannerDialog::onStartTvShowScanner()
 {
     ui->progressBar->setValue(0);
     Manager::instance()->tvShowModel()->clear();
-    QApplication::processEvents();
     if (m_forceReload) {
         QTimer::singleShot(0, this, &FileScannerDialog::onStartTvShowScannerForce);
     } else {
@@ -220,7 +222,6 @@ void FileScannerDialog::onStartConcertScanner()
 {
     ui->progressBar->setValue(0);
     Manager::instance()->concertModel()->clear();
-    QApplication::processEvents();
     if (m_forceReload) {
         QTimer::singleShot(0, this, &FileScannerDialog::onStartConcertScannerForce);
     } else {
@@ -242,7 +243,6 @@ void FileScannerDialog::onStartMusicScanner()
 {
     ui->progressBar->setValue(0);
     Manager::instance()->musicModel()->clear();
-    QApplication::processEvents();
     if (m_forceReload) {
         QTimer::singleShot(0, this, &FileScannerDialog::onStartMusicScannerForce);
     } else {
@@ -278,6 +278,7 @@ void FileScannerDialog::onProgress(int current, int max)
 void FileScannerDialog::onCurrentDir(QString dir)
 {
     ui->currentDir->setText(dir);
+    // TODO: Remove once all file searchers run in another thread.
     QApplication::processEvents();
 }
 


### PR DESCRIPTION
This change reworks the file searcher (again).  It now runs in another
thread, or rather: The jobs for each directory run in another thread.
We had to make the database access work with multiple threads and fix
some other multithreading issues.  But this was worth the cost because
now MediaElch no longer freezes for reloading movies from slow disks.

It also makes it possible to remove calls to
`QApplication::processEvents()` that previously were the causes for
crashes.

-------------

Fix #1326