### PR TITLE
[Scraper] Rename execute() to start() 

### DIFF
--- a/src/scrapers/concert/ConcertSearchJob.h
+++ b/src/scrapers/concert/ConcertSearchJob.h
@@ -53,7 +53,7 @@ public:
     explicit ConcertSearchJob(Config config, QObject* parent = nullptr);
     virtual ~ConcertSearchJob() = default;
 
-    virtual void execute() = 0;
+    virtual void start() = 0;
 
 public:
     ELCH_NODISCARD const Config& config() const;

--- a/src/scrapers/concert/tmdb/TmdbConcertSearchJob.cpp
+++ b/src/scrapers/concert/tmdb/TmdbConcertSearchJob.cpp
@@ -12,7 +12,7 @@ TmdbConcertSearchJob::TmdbConcertSearchJob(TmdbApi& api, ConcertSearchJob::Confi
 {
 }
 
-void TmdbConcertSearchJob::execute()
+void TmdbConcertSearchJob::start()
 {
     m_api.searchForConcert(config().locale, config().query, [this](QJsonDocument json, ScraperError error) {
         if (!error.hasError()) {

--- a/src/scrapers/concert/tmdb/TmdbConcertSearchJob.h
+++ b/src/scrapers/concert/tmdb/TmdbConcertSearchJob.h
@@ -17,7 +17,7 @@ class TmdbConcertSearchJob : public ConcertSearchJob
 public:
     explicit TmdbConcertSearchJob(TmdbApi& api, ConcertSearchJob::Config _config, QObject* parent = nullptr);
     ~TmdbConcertSearchJob() override = default;
-    void execute() override;
+    void start() override;
 
 private:
     QVector<ConcertSearchJob::Result> parseSearch(const QJsonDocument& json);

--- a/src/scrapers/image/FanartTv.cpp
+++ b/src/scrapers/image/FanartTv.cpp
@@ -158,7 +158,7 @@ void FanartTv::searchMovie(QString searchStr, int limit)
 
     auto* searchJob = m_tmdb->search(config);
     connect(searchJob, &mediaelch::scraper::MovieSearchJob::sigFinished, this, &FanartTv::onSearchMovieFinished);
-    searchJob->execute();
+    searchJob->start();
 }
 
 /**
@@ -500,7 +500,7 @@ void FanartTv::searchTvShow(QString searchStr, mediaelch::Locale locale, int lim
     ShowSearchJob::Config config{searchStr, locale, false};
     auto* searchJob = tvdb->search(config);
     connect(searchJob, &ShowSearchJob::sigFinished, this, &FanartTv::onSearchTvShowFinished, Qt::UniqueConnection);
-    searchJob->execute();
+    searchJob->start();
 }
 
 void FanartTv::onSearchTvShowFinished(ShowSearchJob* searchJob)

--- a/src/scrapers/image/TMDbImages.cpp
+++ b/src/scrapers/image/TMDbImages.cpp
@@ -130,7 +130,7 @@ void TMDbImages::searchMovie(QString searchStr, int limit)
     auto* searchJob = m_tmdb->search(config);
 
     connect(searchJob, &MovieSearchJob::sigFinished, this, &TMDbImages::onSearchMovieFinished);
-    searchJob->execute();
+    searchJob->start();
 }
 
 /**

--- a/src/scrapers/image/TheTvDbImages.cpp
+++ b/src/scrapers/image/TheTvDbImages.cpp
@@ -112,7 +112,7 @@ void TheTvDbImages::searchTvShow(QString searchStr, mediaelch::Locale locale, in
 
     auto* searchJob = tvdb->search(config);
     connect(searchJob, &ShowSearchJob::sigFinished, this, &TheTvDbImages::onSearchTvShowFinished, Qt::UniqueConnection);
-    searchJob->execute();
+    searchJob->start();
 }
 
 void TheTvDbImages::onSearchTvShowFinished(mediaelch::scraper::ShowSearchJob* searchJob)
@@ -150,7 +150,7 @@ void TheTvDbImages::loadTvShowData(TvDbId tvdbId, ImageType type, const mediaelc
 
         auto* scrapeJob = tvdb->loadEpisode(config);
         connect(scrapeJob, &EpisodeScrapeJob::sigFinished, this, episodeLoaded, Qt::UniqueConnection);
-        scrapeJob->execute();
+        scrapeJob->start();
 
     } else {
         const QSet<ShowScraperInfo> infosToLoad{ShowScraperInfo::Banner,

--- a/src/scrapers/imdb/ImdbApi.cpp
+++ b/src/scrapers/imdb/ImdbApi.cpp
@@ -33,7 +33,7 @@ void ImdbApi::sendGetRequest(const Locale& locale, const QUrl& url, ImdbApi::Api
     if (m_cache.hasValidElement(url, locale)) {
         // Do not immediately run the callback because classes higher up may
         // set up a Qt connection while the network request is running.
-        QTimer::singleShot(0, [cb = std::move(callback), element = m_cache.getElement(url, locale)]() { //
+        QTimer::singleShot(0, this, [cb = std::move(callback), element = m_cache.getElement(url, locale)]() { //
             cb(element, {});
         });
         return;

--- a/src/scrapers/movie/MovieSearchJob.h
+++ b/src/scrapers/movie/MovieSearchJob.h
@@ -54,7 +54,7 @@ public:
     explicit MovieSearchJob(Config config, QObject* parent = nullptr);
     virtual ~MovieSearchJob() = default;
 
-    virtual void execute() = 0;
+    virtual void start() = 0;
 
 public:
     ELCH_NODISCARD const Config& config() const;

--- a/src/scrapers/movie/adultdvdempire/AdultDvdEmpireApi.cpp
+++ b/src/scrapers/movie/adultdvdempire/AdultDvdEmpireApi.cpp
@@ -16,9 +16,10 @@ void AdultDvdEmpireApi::sendGetRequest(const QUrl& url, AdultDvdEmpireApi::ApiCa
     if (m_cache.hasValidElement(url, Locale::English)) {
         // Do not immediately run the callback because classes higher up may
         // set up a Qt connection while the network request is running.
-        QTimer::singleShot(0, [cb = std::move(callback), element = m_cache.getElement(url, Locale::English)]() { //
-            cb(element, {});
-        });
+        QTimer::singleShot(
+            0, this, [cb = std::move(callback), element = m_cache.getElement(url, Locale::English)]() { //
+                cb(element, {});
+            });
         return;
     }
 

--- a/src/scrapers/movie/adultdvdempire/AdultDvdEmpireSearchJob.cpp
+++ b/src/scrapers/movie/adultdvdempire/AdultDvdEmpireSearchJob.cpp
@@ -15,7 +15,7 @@ AdultDvdEmpireSearchJob::AdultDvdEmpireSearchJob(AdultDvdEmpireApi& api,
 {
 }
 
-void AdultDvdEmpireSearchJob::execute()
+void AdultDvdEmpireSearchJob::start()
 {
     m_api.searchForMovie(config().query, [this](QString data, ScraperError error) {
         if (error.hasError()) {

--- a/src/scrapers/movie/adultdvdempire/AdultDvdEmpireSearchJob.h
+++ b/src/scrapers/movie/adultdvdempire/AdultDvdEmpireSearchJob.h
@@ -15,7 +15,7 @@ public:
     explicit AdultDvdEmpireSearchJob(AdultDvdEmpireApi& api, MovieSearchJob::Config _config, QObject* parent = nullptr);
     ~AdultDvdEmpireSearchJob() override = default;
 
-    void execute() override;
+    void start() override;
 
 private:
     void parseSearch(const QString& html);

--- a/src/scrapers/movie/aebn/AEBN.cpp
+++ b/src/scrapers/movie/aebn/AEBN.cpp
@@ -316,7 +316,7 @@ void AEBN::downloadActors(Movie* movie, QStringList actorIds)
         // Try to avoid a huge stack of nested lambdas.
         // With this we should return to the event loop and then execute this.
         // TODO: I'm not 100% sure that it works, though...
-        QTimer::singleShot(0, [this, movie, actorIds]() { downloadActors(movie, actorIds); });
+        QTimer::singleShot(0, this, [this, movie, actorIds]() { downloadActors(movie, actorIds); });
     });
 }
 

--- a/src/scrapers/movie/aebn/AebnApi.cpp
+++ b/src/scrapers/movie/aebn/AebnApi.cpp
@@ -16,7 +16,7 @@ void AebnApi::sendGetRequest(const QUrl& url, const Locale& locale, AebnApi::Api
     if (m_cache.hasValidElement(url, locale)) {
         // Do not immediately run the callback because classes higher up may
         // set up a Qt connection while the network request is running.
-        QTimer::singleShot(0, [cb = std::move(callback), element = m_cache.getElement(url, locale)]() { //
+        QTimer::singleShot(0, this, [cb = std::move(callback), element = m_cache.getElement(url, locale)]() { //
             cb(element, {});
         });
         return;

--- a/src/scrapers/movie/aebn/AebnSearchJob.cpp
+++ b/src/scrapers/movie/aebn/AebnSearchJob.cpp
@@ -12,7 +12,7 @@ AebnSearchJob::AebnSearchJob(AebnApi& api, MovieSearchJob::Config _config, QStri
 {
 }
 
-void AebnSearchJob::execute()
+void AebnSearchJob::start()
 {
     m_api.searchForMovie(config().query, config().locale, m_genreId, [this](QString data, ScraperError error) {
         if (error.hasError()) {
@@ -31,9 +31,6 @@ void AebnSearchJob::parseSearch(const QString& html)
                           "href=\"/dispatcher/"
                           "movieDetail\\?genreId=([0-9]+)&amp;theaterId=([0-9]+)&amp;movieId=([0-9]+?)([^\"]*)\" "
                           "title=\"([^\"]*)\"><img src=\"([^\"]*)\" alt=\"([^\"]*)\" /></a>");
-    //    QRegularExpression rx("<a id=\"FTSMovieSearch_link_image_detail_[0-9]+\"
-    //    href=\"/dispatcher/movieDetail\\?movieId=([0-9]+)([^\"]*)\" title=\"([^\"]*)\"><img src=\"([^\"]*)\"
-    //    alt=\"([^\"]*)\" /></a>");
     rx.setPatternOptions(QRegularExpression::InvertedGreedinessOption | QRegularExpression::DotMatchesEverythingOption);
 
     QRegularExpressionMatchIterator matches = rx.globalMatch(html);

--- a/src/scrapers/movie/aebn/AebnSearchJob.h
+++ b/src/scrapers/movie/aebn/AebnSearchJob.h
@@ -17,7 +17,7 @@ public:
     explicit AebnSearchJob(AebnApi& api, MovieSearchJob::Config _config, QString genre, QObject* parent = nullptr);
     ~AebnSearchJob() override = default;
 
-    void execute() override;
+    void start() override;
 
 private:
     void parseSearch(const QString& html);

--- a/src/scrapers/movie/hotmovies/HotMoviesApi.cpp
+++ b/src/scrapers/movie/hotmovies/HotMoviesApi.cpp
@@ -16,9 +16,10 @@ void HotMoviesApi::sendGetRequest(const QUrl& url, HotMoviesApi::ApiCallback cal
     if (m_cache.hasValidElement(url, Locale::English)) {
         // Do not immediately run the callback because classes higher up may
         // set up a Qt connection while the network request is running.
-        QTimer::singleShot(0, [cb = std::move(callback), element = m_cache.getElement(url, Locale::English)]() { //
-            cb(element, {});
-        });
+        QTimer::singleShot(
+            0, this, [cb = std::move(callback), element = m_cache.getElement(url, Locale::English)]() { //
+                cb(element, {});
+            });
         return;
     }
 

--- a/src/scrapers/movie/hotmovies/HotMoviesSearchJob.cpp
+++ b/src/scrapers/movie/hotmovies/HotMoviesSearchJob.cpp
@@ -13,7 +13,7 @@ HotMoviesSearchJob::HotMoviesSearchJob(HotMoviesApi& api, MovieSearchJob::Config
 {
 }
 
-void HotMoviesSearchJob::execute()
+void HotMoviesSearchJob::start()
 {
     m_api.searchForMovie(config().query, [this](QString data, ScraperError error) {
         if (error.hasError()) {

--- a/src/scrapers/movie/hotmovies/HotMoviesSearchJob.h
+++ b/src/scrapers/movie/hotmovies/HotMoviesSearchJob.h
@@ -15,7 +15,7 @@ public:
     explicit HotMoviesSearchJob(HotMoviesApi& api, MovieSearchJob::Config _config, QObject* parent = nullptr);
     ~HotMoviesSearchJob() override = default;
 
-    void execute() override;
+    void start() override;
 
 private:
     void parseSearch(const QString& html);

--- a/src/scrapers/movie/imdb/ImdbMovieSearchJob.cpp
+++ b/src/scrapers/movie/imdb/ImdbMovieSearchJob.cpp
@@ -12,7 +12,7 @@ ImdbMovieSearchJob::ImdbMovieSearchJob(ImdbApi& api, MovieSearchJob::Config _con
 {
 }
 
-void ImdbMovieSearchJob::execute()
+void ImdbMovieSearchJob::start()
 {
     if (ImdbId::isValidFormat(config().query)) {
         m_api.loadMovie(Locale("en"), ImdbId(config().query), [this](QString data, ScraperError error) {

--- a/src/scrapers/movie/imdb/ImdbMovieSearchJob.h
+++ b/src/scrapers/movie/imdb/ImdbMovieSearchJob.h
@@ -15,7 +15,7 @@ public:
     explicit ImdbMovieSearchJob(ImdbApi& api, MovieSearchJob::Config _config, QObject* parent = nullptr);
     ~ImdbMovieSearchJob() override = default;
 
-    void execute() override;
+    void start() override;
 
 private:
     void parseSearch(const QString& html);

--- a/src/scrapers/movie/ofdb/OfdbApi.cpp
+++ b/src/scrapers/movie/ofdb/OfdbApi.cpp
@@ -16,9 +16,10 @@ void OfdbApi::sendGetRequest(const QUrl& url, OfdbApi::ApiCallback callback)
     if (m_cache.hasValidElement(url, Locale::English)) {
         // Do not immediately run the callback because classes higher up may
         // set up a Qt connection while the network request is running.
-        QTimer::singleShot(0, [cb = std::move(callback), element = m_cache.getElement(url, Locale::English)]() { //
-            cb(element, {});
-        });
+        QTimer::singleShot(
+            0, this, [cb = std::move(callback), element = m_cache.getElement(url, Locale::English)]() { //
+                cb(element, {});
+            });
         return;
     }
 

--- a/src/scrapers/movie/ofdb/OfdbSearchJob.cpp
+++ b/src/scrapers/movie/ofdb/OfdbSearchJob.cpp
@@ -13,7 +13,7 @@ OfdbSearchJob::OfdbSearchJob(OfdbApi& api, MovieSearchJob::Config _config, QObje
 {
 }
 
-void OfdbSearchJob::execute()
+void OfdbSearchJob::start()
 {
     const auto onDone = [this](QString data, ScraperError error) {
         if (error.hasError()) {

--- a/src/scrapers/movie/ofdb/OfdbSearchJob.h
+++ b/src/scrapers/movie/ofdb/OfdbSearchJob.h
@@ -15,7 +15,7 @@ public:
     explicit OfdbSearchJob(OfdbApi& api, MovieSearchJob::Config _config, QObject* parent = nullptr);
     ~OfdbSearchJob() override = default;
 
-    void execute() override;
+    void start() override;
 
 private:
     void parseSearch(const QString& html);

--- a/src/scrapers/movie/tmdb/TmdbMovieSearchJob.cpp
+++ b/src/scrapers/movie/tmdb/TmdbMovieSearchJob.cpp
@@ -13,7 +13,7 @@ TmdbMovieSearchJob::TmdbMovieSearchJob(TmdbApi& api, MovieSearchJob::Config _con
 {
 }
 
-void TmdbMovieSearchJob::execute()
+void TmdbMovieSearchJob::start()
 {
     QString searchStr = QString(config().query).replace("-", " ").trimmed();
 

--- a/src/scrapers/movie/tmdb/TmdbMovieSearchJob.h
+++ b/src/scrapers/movie/tmdb/TmdbMovieSearchJob.h
@@ -17,7 +17,7 @@ public:
     explicit TmdbMovieSearchJob(TmdbApi& api, MovieSearchJob::Config _config, QObject* parent = nullptr);
     ~TmdbMovieSearchJob() override = default;
 
-    void execute() override;
+    void start() override;
 
 private:
     /// \brief Parses the JSON search results

--- a/src/scrapers/movie/videobuster/VideoBusterApi.cpp
+++ b/src/scrapers/movie/videobuster/VideoBusterApi.cpp
@@ -17,9 +17,10 @@ void VideoBusterApi::sendGetRequest(const QUrl& url, VideoBusterApi::ApiCallback
     if (m_cache.hasValidElement(url, Locale::English)) {
         // Do not immediately run the callback because classes higher up may
         // set up a Qt connection while the network request is running.
-        QTimer::singleShot(0, [cb = std::move(callback), element = m_cache.getElement(url, Locale::English)]() { //
-            cb(element, {});
-        });
+        QTimer::singleShot(
+            0, this, [cb = std::move(callback), element = m_cache.getElement(url, Locale::English)]() { //
+                cb(element, {});
+            });
         return;
     }
 

--- a/src/scrapers/movie/videobuster/VideoBusterSearchJob.cpp
+++ b/src/scrapers/movie/videobuster/VideoBusterSearchJob.cpp
@@ -12,7 +12,7 @@ VideoBusterSearchJob::VideoBusterSearchJob(VideoBusterApi& api, MovieSearchJob::
 {
 }
 
-void VideoBusterSearchJob::execute()
+void VideoBusterSearchJob::start()
 {
     m_api.searchForMovie(config().query, [this](QString data, ScraperError error) {
         if (error.hasError()) {

--- a/src/scrapers/movie/videobuster/VideoBusterSearchJob.h
+++ b/src/scrapers/movie/videobuster/VideoBusterSearchJob.h
@@ -15,7 +15,7 @@ public:
     explicit VideoBusterSearchJob(VideoBusterApi& api, MovieSearchJob::Config _config, QObject* parent = nullptr);
     ~VideoBusterSearchJob() override = default;
 
-    void execute() override;
+    void start() override;
 
 private:
     void parseSearch(const QString& html);

--- a/src/scrapers/music/MusicBrainz.cpp
+++ b/src/scrapers/music/MusicBrainz.cpp
@@ -21,7 +21,7 @@ void MusicBrainzApi::sendGetRequest(const Locale& locale, const QUrl& url, Music
     if (m_cache.hasValidElement(url, locale)) {
         // Do not immediately run the callback because classes higher up may
         // set up a Qt connection while the network request is running.
-        QTimer::singleShot(0, [cb = std::move(callback), element = m_cache.getElement(url, locale)]() { //
+        QTimer::singleShot(0, this, [cb = std::move(callback), element = m_cache.getElement(url, locale)]() { //
             cb(element, {});
         });
         return;

--- a/src/scrapers/music/TheAudioDb.cpp
+++ b/src/scrapers/music/TheAudioDb.cpp
@@ -21,7 +21,7 @@ void TheAudioDbApi::sendGetRequest(const Locale& locale, const QUrl& url, TheAud
     if (m_cache.hasValidElement(url, locale)) {
         // Do not immediately run the callback because classes higher up may
         // set up a Qt connection while the network request is running.
-        QTimer::singleShot(0, [cb = std::move(callback), element = m_cache.getElement(url, locale)]() { //
+        QTimer::singleShot(0, this, [cb = std::move(callback), element = m_cache.getElement(url, locale)]() { //
             cb(element, {});
         });
         return;

--- a/src/scrapers/tmdb/TmdbApi.cpp
+++ b/src/scrapers/tmdb/TmdbApi.cpp
@@ -60,7 +60,7 @@ void TmdbApi::sendGetRequest(const Locale& locale, const QUrl& url, TmdbApi::Api
     if (m_cache.hasValidElement(url, locale)) {
         // Do not immediately run the callback because classes higher up may
         // set up a Qt connection while the network request is running.
-        QTimer::singleShot(0, [cb = std::move(callback), element = m_cache.getElement(url, locale)]() {
+        QTimer::singleShot(0, this, [cb = std::move(callback), element = m_cache.getElement(url, locale)]() {
             // should not result in a parse error because the cache element is
             // only stored if no error occured at all.
             cb(QJsonDocument::fromJson(element.toUtf8()), {});

--- a/src/scrapers/tv_show/EpisodeScrapeJob.h
+++ b/src/scrapers/tv_show/EpisodeScrapeJob.h
@@ -44,7 +44,7 @@ public:
     EpisodeScrapeJob(Config config, QObject* parent = nullptr);
     virtual ~EpisodeScrapeJob() = default;
 
-    virtual void execute() = 0;
+    virtual void start() = 0;
 
     ELCH_NODISCARD TvShowEpisode& episode() { return *m_episode; }
     ELCH_NODISCARD const Config& config() { return m_config; }

--- a/src/scrapers/tv_show/SeasonScrapeJob.h
+++ b/src/scrapers/tv_show/SeasonScrapeJob.h
@@ -63,7 +63,7 @@ public:
     SeasonScrapeJob(Config config, QObject* parent = nullptr);
     virtual ~SeasonScrapeJob() = default;
 
-    virtual void execute() = 0;
+    virtual void start() = 0;
 
 public:
     ELCH_NODISCARD const EpisodeMap& episodes() const { return m_episodes; }

--- a/src/scrapers/tv_show/ShowScrapeJob.h
+++ b/src/scrapers/tv_show/ShowScrapeJob.h
@@ -36,7 +36,7 @@ public:
     ShowScrapeJob(Config config, QObject* parent = nullptr);
     virtual ~ShowScrapeJob() = default;
 
-    virtual void execute() = 0;
+    virtual void start() = 0;
 
 public:
     ELCH_NODISCARD TvShow& tvShow() { return *m_tvShow; }

--- a/src/scrapers/tv_show/ShowSearchJob.h
+++ b/src/scrapers/tv_show/ShowSearchJob.h
@@ -13,7 +13,6 @@
 namespace mediaelch {
 namespace scraper {
 
-
 /// \brief A TV show search request resolved by a scraper.
 class ShowSearchJob : public QObject
 {

--- a/src/scrapers/tv_show/ShowSearchJob.h
+++ b/src/scrapers/tv_show/ShowSearchJob.h
@@ -59,7 +59,7 @@ public:
     explicit ShowSearchJob(Config config, QObject* parent = nullptr);
     virtual ~ShowSearchJob() = default;
 
-    virtual void execute() = 0;
+    virtual void start() = 0;
 
 public:
     ELCH_NODISCARD const Config& config() const;

--- a/src/scrapers/tv_show/custom/CustomEpisodeScrapeJob.cpp
+++ b/src/scrapers/tv_show/custom/CustomEpisodeScrapeJob.cpp
@@ -23,7 +23,7 @@ CustomEpisodeScrapeJob::CustomEpisodeScrapeJob(CustomTvScraperConfig customConfi
 {
 }
 
-void CustomEpisodeScrapeJob::execute()
+void CustomEpisodeScrapeJob::start()
 {
     // Because the custom TV scraper always starts with TMDb, the query should stay the same but
     // we have to correctly set the details that we want to load from TmdbTv.
@@ -39,7 +39,7 @@ void CustomEpisodeScrapeJob::execute()
 
     auto* tmdbJob = m_customConfig.tmdbTv->loadEpisode(tmdbConfig);
     connect(tmdbJob, &TmdbTvEpisodeScrapeJob::sigFinished, this, &CustomEpisodeScrapeJob::onTmdbLoaded);
-    tmdbJob->execute();
+    tmdbJob->start();
 }
 
 void CustomEpisodeScrapeJob::onTmdbLoaded(EpisodeScrapeJob* job)
@@ -97,7 +97,7 @@ void CustomEpisodeScrapeJob::loadWithScraper(const QString& scraperId, const Epi
         job->deleteLater();
         decreaseCounterAndCheckIfFinished();
     });
-    scrapeJob->execute();
+    scrapeJob->start();
 }
 
 void CustomEpisodeScrapeJob::decreaseCounterAndCheckIfFinished()

--- a/src/scrapers/tv_show/custom/CustomEpisodeScrapeJob.h
+++ b/src/scrapers/tv_show/custom/CustomEpisodeScrapeJob.h
@@ -16,7 +16,7 @@ class CustomEpisodeScrapeJob : public EpisodeScrapeJob
 public:
     CustomEpisodeScrapeJob(CustomTvScraperConfig customConfig, Config config, QObject* parent = nullptr);
     ~CustomEpisodeScrapeJob() override = default;
-    void execute() override;
+    void start() override;
 
 private slots:
     void onTmdbLoaded(EpisodeScrapeJob* job);

--- a/src/scrapers/tv_show/custom/CustomSeasonScrapeJob.cpp
+++ b/src/scrapers/tv_show/custom/CustomSeasonScrapeJob.cpp
@@ -24,7 +24,7 @@ CustomSeasonScrapeJob::CustomSeasonScrapeJob(CustomTvScraperConfig customConfig,
 {
 }
 
-void CustomSeasonScrapeJob::execute()
+void CustomSeasonScrapeJob::start()
 {
     // Because the custom TV scraper always starts with TMDb, we have to load the show identifiers
     // from TMDb before starting to load episodes.
@@ -35,7 +35,7 @@ void CustomSeasonScrapeJob::execute()
 
     auto* tmdbJob = m_customConfig.tmdbTv->loadShow(tmdbConfig);
     connect(tmdbJob, &TmdbTvShowScrapeJob::sigFinished, this, &CustomSeasonScrapeJob::onTmdbShowLoaded);
-    tmdbJob->execute();
+    tmdbJob->start();
 }
 
 void CustomSeasonScrapeJob::onTmdbShowLoaded(ShowScrapeJob* job)
@@ -99,7 +99,7 @@ void CustomSeasonScrapeJob::loadWithScraper(const QString& scraperId, const Show
         job->deleteLater();
         decreaseCounterAndCheckIfFinished();
     });
-    scrapeJob->execute();
+    scrapeJob->start();
 }
 
 void CustomSeasonScrapeJob::decreaseCounterAndCheckIfFinished()

--- a/src/scrapers/tv_show/custom/CustomSeasonScrapeJob.h
+++ b/src/scrapers/tv_show/custom/CustomSeasonScrapeJob.h
@@ -16,7 +16,7 @@ class CustomSeasonScrapeJob : public SeasonScrapeJob
 public:
     CustomSeasonScrapeJob(CustomTvScraperConfig customConfig, Config config, QObject* parent = nullptr);
     ~CustomSeasonScrapeJob() override = default;
-    void execute() override;
+    void start() override;
 
 private slots:
     void onTmdbShowLoaded(ShowScrapeJob* job);

--- a/src/scrapers/tv_show/custom/CustomShowScrapeJob.cpp
+++ b/src/scrapers/tv_show/custom/CustomShowScrapeJob.cpp
@@ -23,7 +23,7 @@ CustomShowScrapeJob::CustomShowScrapeJob(CustomTvScraperConfig customConfig,
 {
 }
 
-void CustomShowScrapeJob::execute()
+void CustomShowScrapeJob::start()
 {
     // Because the custom TV scraper always starts with TMDb, the query should stay the same but
     // we have to correctly set the details that we want to load from TmdbTv.
@@ -39,7 +39,7 @@ void CustomShowScrapeJob::execute()
 
     auto* tmdbJob = m_customConfig.tmdbTv->loadShow(tmdbConfig);
     connect(tmdbJob, &TmdbTvShowScrapeJob::sigFinished, this, &CustomShowScrapeJob::onTmdbLoaded);
-    tmdbJob->execute();
+    tmdbJob->start();
 }
 
 void CustomShowScrapeJob::onTmdbLoaded(ShowScrapeJob* job)
@@ -97,7 +97,7 @@ void CustomShowScrapeJob::loadWithScraper(const QString& scraperId, const ShowId
         job->deleteLater();
         decreaseCounterAndCheckIfFinished();
     });
-    scrapeJob->execute();
+    scrapeJob->start();
 }
 
 void CustomShowScrapeJob::decreaseCounterAndCheckIfFinished()

--- a/src/scrapers/tv_show/custom/CustomShowScrapeJob.h
+++ b/src/scrapers/tv_show/custom/CustomShowScrapeJob.h
@@ -16,7 +16,7 @@ class CustomShowScrapeJob : public ShowScrapeJob
 public:
     CustomShowScrapeJob(CustomTvScraperConfig customConfig, Config config, QObject* parent = nullptr);
     ~CustomShowScrapeJob() override = default;
-    void execute() override;
+    void start() override;
 
 private slots:
     void onTmdbLoaded(ShowScrapeJob* job);

--- a/src/scrapers/tv_show/empty/EmptyTvScraper.cpp
+++ b/src/scrapers/tv_show/empty/EmptyTvScraper.cpp
@@ -11,7 +11,7 @@ EmptyShowSearchJob::EmptyShowSearchJob(ShowSearchJob::Config _config, QObject* p
 
 void EmptyShowSearchJob::start()
 {
-    QTimer::singleShot(0, [this]() { emit sigFinished(this); });
+    QTimer::singleShot(0, this, [this]() { emit sigFinished(this); });
 }
 
 EmptyShowScrapeJob::EmptyShowScrapeJob(ShowScrapeJob::Config _config, QObject* parent) : ShowScrapeJob(_config, parent)
@@ -20,7 +20,7 @@ EmptyShowScrapeJob::EmptyShowScrapeJob(ShowScrapeJob::Config _config, QObject* p
 
 void EmptyShowScrapeJob::start()
 {
-    QTimer::singleShot(0, [this]() { emit sigFinished(this); });
+    QTimer::singleShot(0, this, [this]() { emit sigFinished(this); });
 }
 
 EmptySeasonScrapeJob::EmptySeasonScrapeJob(SeasonScrapeJob::Config _config, QObject* parent) :
@@ -30,7 +30,7 @@ EmptySeasonScrapeJob::EmptySeasonScrapeJob(SeasonScrapeJob::Config _config, QObj
 
 void EmptySeasonScrapeJob::start()
 {
-    QTimer::singleShot(0, [this]() { emit sigFinished(this); });
+    QTimer::singleShot(0, this, [this]() { emit sigFinished(this); });
 }
 
 EmptyEpisodeScrapeJob::EmptyEpisodeScrapeJob(EpisodeScrapeJob::Config _config, QObject* parent) :
@@ -40,7 +40,7 @@ EmptyEpisodeScrapeJob::EmptyEpisodeScrapeJob(EpisodeScrapeJob::Config _config, Q
 
 void EmptyEpisodeScrapeJob::start()
 {
-    QTimer::singleShot(0, [this]() { emit sigFinished(this); });
+    QTimer::singleShot(0, this, [this]() { emit sigFinished(this); });
 }
 
 } // namespace scraper

--- a/src/scrapers/tv_show/empty/EmptyTvScraper.cpp
+++ b/src/scrapers/tv_show/empty/EmptyTvScraper.cpp
@@ -9,7 +9,7 @@ EmptyShowSearchJob::EmptyShowSearchJob(ShowSearchJob::Config _config, QObject* p
 {
 }
 
-void EmptyShowSearchJob::execute()
+void EmptyShowSearchJob::start()
 {
     QTimer::singleShot(0, [this]() { emit sigFinished(this); });
 }
@@ -18,7 +18,7 @@ EmptyShowScrapeJob::EmptyShowScrapeJob(ShowScrapeJob::Config _config, QObject* p
 {
 }
 
-void EmptyShowScrapeJob::execute()
+void EmptyShowScrapeJob::start()
 {
     QTimer::singleShot(0, [this]() { emit sigFinished(this); });
 }
@@ -28,7 +28,7 @@ EmptySeasonScrapeJob::EmptySeasonScrapeJob(SeasonScrapeJob::Config _config, QObj
 {
 }
 
-void EmptySeasonScrapeJob::execute()
+void EmptySeasonScrapeJob::start()
 {
     QTimer::singleShot(0, [this]() { emit sigFinished(this); });
 }
@@ -38,7 +38,7 @@ EmptyEpisodeScrapeJob::EmptyEpisodeScrapeJob(EpisodeScrapeJob::Config _config, Q
 {
 }
 
-void EmptyEpisodeScrapeJob::execute()
+void EmptyEpisodeScrapeJob::start()
 {
     QTimer::singleShot(0, [this]() { emit sigFinished(this); });
 }

--- a/src/scrapers/tv_show/empty/EmptyTvScraper.h
+++ b/src/scrapers/tv_show/empty/EmptyTvScraper.h
@@ -15,7 +15,7 @@ class EmptyShowSearchJob : public ShowSearchJob
 public:
     explicit EmptyShowSearchJob(ShowSearchJob::Config _config, QObject* parent = nullptr);
     ~EmptyShowSearchJob() override = default;
-    void execute() override;
+    void start() override;
 };
 
 /// \brief   Empty show scrape job for testing purposes.
@@ -28,7 +28,7 @@ class EmptyShowScrapeJob : public ShowScrapeJob
 public:
     EmptyShowScrapeJob(Config _config, QObject* parent = nullptr);
     ~EmptyShowScrapeJob() override = default;
-    void execute() override;
+    void start() override;
 };
 
 /// \brief   Empty season scrape job for testing purposes.
@@ -41,7 +41,7 @@ class EmptySeasonScrapeJob : public SeasonScrapeJob
 public:
     EmptySeasonScrapeJob(Config _config, QObject* parent = nullptr);
     ~EmptySeasonScrapeJob() = default;
-    void execute() override;
+    void start() override;
 };
 
 /// \brief   Empty episode scrape job for testing purposes.
@@ -54,7 +54,7 @@ class EmptyEpisodeScrapeJob : public EpisodeScrapeJob
 public:
     EmptyEpisodeScrapeJob(Config _config, QObject* parent = nullptr);
     ~EmptyEpisodeScrapeJob() = default;
-    void execute() override;
+    void start() override;
 };
 
 } // namespace scraper

--- a/src/scrapers/tv_show/imdb/ImdbTv.cpp
+++ b/src/scrapers/tv_show/imdb/ImdbTv.cpp
@@ -57,7 +57,7 @@ const TvScraper::ScraperMeta& ImdbTv::meta() const
 
 void ImdbTv::initialize()
 {
-    QTimer::singleShot(0, [this]() { emit initialized(true, this); });
+    QTimer::singleShot(0, this, [this]() { emit initialized(true, this); });
 }
 
 bool ImdbTv::isInitialized() const

--- a/src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp
+++ b/src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp
@@ -15,7 +15,7 @@ ImdbTvEpisodeScrapeJob::ImdbTvEpisodeScrapeJob(ImdbApi& api, EpisodeScrapeJob::C
 {
 }
 
-void ImdbTvEpisodeScrapeJob::execute()
+void ImdbTvEpisodeScrapeJob::start()
 {
     if (config().identifier.hasEpisodeIdentifier()) {
         loadEpisode(ImdbId(config().identifier.episodeIdentifier));

--- a/src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.h
+++ b/src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.h
@@ -14,7 +14,7 @@ class ImdbTvEpisodeScrapeJob : public EpisodeScrapeJob
 public:
     ImdbTvEpisodeScrapeJob(ImdbApi& api, Config _config, QObject* parent = nullptr);
     ~ImdbTvEpisodeScrapeJob() = default;
-    void execute() override;
+    void start() override;
 
 private:
     void loadSeason();

--- a/src/scrapers/tv_show/imdb/ImdbTvSeasonScrapeJob.cpp
+++ b/src/scrapers/tv_show/imdb/ImdbTvSeasonScrapeJob.cpp
@@ -22,7 +22,7 @@ void ImdbTvSeasonScrapeJob::start()
         qCWarning(generic) << "[ImdbTv] Provided IMDb id is invalid:" << config().showIdentifier;
         m_error.error = ScraperError::Type::ConfigError;
         m_error.message = tr("Show is missing an IMDb id");
-        QTimer::singleShot(0, [this]() { emit sigFinished(this); });
+        QTimer::singleShot(0, this, [this]() { emit sigFinished(this); });
         return;
     }
 

--- a/src/scrapers/tv_show/imdb/ImdbTvSeasonScrapeJob.cpp
+++ b/src/scrapers/tv_show/imdb/ImdbTvSeasonScrapeJob.cpp
@@ -16,7 +16,7 @@ ImdbTvSeasonScrapeJob::ImdbTvSeasonScrapeJob(ImdbApi& api, SeasonScrapeJob::Conf
 {
 }
 
-void ImdbTvSeasonScrapeJob::execute()
+void ImdbTvSeasonScrapeJob::start()
 {
     if (!m_showId.isValid()) {
         qCWarning(generic) << "[ImdbTv] Provided IMDb id is invalid:" << config().showIdentifier;

--- a/src/scrapers/tv_show/imdb/ImdbTvSeasonScrapeJob.h
+++ b/src/scrapers/tv_show/imdb/ImdbTvSeasonScrapeJob.h
@@ -17,7 +17,7 @@ class ImdbTvSeasonScrapeJob : public SeasonScrapeJob
 public:
     ImdbTvSeasonScrapeJob(ImdbApi& api, Config _config, QObject* parent = nullptr);
     ~ImdbTvSeasonScrapeJob() = default;
-    void execute() override;
+    void start() override;
 
 private:
     /// \brief Loads the given episodes in a sequential way

--- a/src/scrapers/tv_show/imdb/ImdbTvShowScrapeJob.cpp
+++ b/src/scrapers/tv_show/imdb/ImdbTvShowScrapeJob.cpp
@@ -25,7 +25,7 @@ ImdbTvShowScrapeJob::ImdbTvShowScrapeJob(ImdbApi& api, ShowScrapeJob::Config _co
 {
 }
 
-void ImdbTvShowScrapeJob::execute()
+void ImdbTvShowScrapeJob::start()
 {
     if (!m_id.isValid()) {
         qCWarning(generic) << "[ImdbTv] Provided IMDb id is invalid:" << config().identifier;

--- a/src/scrapers/tv_show/imdb/ImdbTvShowScrapeJob.cpp
+++ b/src/scrapers/tv_show/imdb/ImdbTvShowScrapeJob.cpp
@@ -31,7 +31,7 @@ void ImdbTvShowScrapeJob::start()
         qCWarning(generic) << "[ImdbTv] Provided IMDb id is invalid:" << config().identifier;
         m_error.error = ScraperError::Type::ConfigError;
         m_error.message = tr("Show is missing an IMDb id");
-        QTimer::singleShot(0, [this]() { emit sigFinished(this); });
+        QTimer::singleShot(0, this, [this]() { emit sigFinished(this); });
         return;
     }
     tvShow().setImdbId(m_id);

--- a/src/scrapers/tv_show/imdb/ImdbTvShowScrapeJob.h
+++ b/src/scrapers/tv_show/imdb/ImdbTvShowScrapeJob.h
@@ -14,7 +14,7 @@ class ImdbTvShowScrapeJob : public ShowScrapeJob
 public:
     ImdbTvShowScrapeJob(ImdbApi& api, Config _config, QObject* parent = nullptr);
     ~ImdbTvShowScrapeJob() override = default;
-    void execute() override;
+    void start() override;
 
 private:
     void loadTvShow();

--- a/src/scrapers/tv_show/imdb/ImdbTvShowSearchJob.cpp
+++ b/src/scrapers/tv_show/imdb/ImdbTvShowSearchJob.cpp
@@ -10,7 +10,7 @@ ImdbTvShowSearchJob::ImdbTvShowSearchJob(ImdbApi& api, ShowSearchJob::Config _co
 {
 }
 
-void ImdbTvShowSearchJob::execute()
+void ImdbTvShowSearchJob::start()
 {
     m_api.searchForShow(config().locale, config().query, [this](QString html, ScraperError error) {
         if (error.hasError()) {

--- a/src/scrapers/tv_show/imdb/ImdbTvShowSearchJob.h
+++ b/src/scrapers/tv_show/imdb/ImdbTvShowSearchJob.h
@@ -13,7 +13,7 @@ class ImdbTvShowSearchJob : public ShowSearchJob
 public:
     explicit ImdbTvShowSearchJob(ImdbApi& api, ShowSearchJob::Config _config, QObject* parent = nullptr);
     ~ImdbTvShowSearchJob() override = default;
-    void execute() override;
+    void start() override;
 
 private:
     QVector<ShowSearchJob::Result> parseSearch(const QString& html);

--- a/src/scrapers/tv_show/thetvdb/TheTvDbApi.cpp
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbApi.cpp
@@ -68,7 +68,7 @@ void TheTvDbApi::sendGetRequest(const Locale& locale, const QUrl& url, TheTvDbAp
     if (m_cache.hasValidElement(url, locale)) {
         // Do not immediately run the callback because classes higher up may
         // set up a Qt connection while the network request is running.
-        QTimer::singleShot(0, [cb = std::move(callback), element = m_cache.getElement(url, locale)]() {
+        QTimer::singleShot(0, this, [cb = std::move(callback), element = m_cache.getElement(url, locale)]() {
             // should not result in a parse error because the cache element is
             // only stored if no error occured at all.
             cb(QJsonDocument::fromJson(element.toUtf8()), {});

--- a/src/scrapers/tv_show/thetvdb/TheTvDbEpisodeScrapeJob.cpp
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbEpisodeScrapeJob.cpp
@@ -19,7 +19,7 @@ TheTvDbEpisodeScrapeJob::TheTvDbEpisodeScrapeJob(TheTvDbApi& api, Config config,
     setParent(parent);
 }
 
-void TheTvDbEpisodeScrapeJob::execute()
+void TheTvDbEpisodeScrapeJob::start()
 {
     if (config().identifier.hasEpisodeIdentifier()) {
         loadEpisode(TvDbId(config().identifier.episodeIdentifier));

--- a/src/scrapers/tv_show/thetvdb/TheTvDbEpisodeScrapeJob.h
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbEpisodeScrapeJob.h
@@ -15,7 +15,7 @@ class TheTvDbEpisodeScrapeJob : public EpisodeScrapeJob
 public:
     TheTvDbEpisodeScrapeJob(TheTvDbApi& api, Config config, QObject* parent = nullptr);
     ~TheTvDbEpisodeScrapeJob() override = default;
-    void execute() override;
+    void start() override;
 
 private:
     void loadSeason();

--- a/src/scrapers/tv_show/thetvdb/TheTvDbSeasonScrapeJob.cpp
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbSeasonScrapeJob.cpp
@@ -23,7 +23,7 @@ void TheTvDbSeasonScrapeJob::start()
         qCWarning(generic) << "[TheTvDb] Provided TheTvDb id is invalid:" << config().showIdentifier;
         m_error.error = ScraperError::Type::ConfigError;
         m_error.message = tr("Show is missing a TheTvDb id");
-        QTimer::singleShot(0, [this]() { emit sigFinished(this); });
+        QTimer::singleShot(0, this, [this]() { emit sigFinished(this); });
         return;
     }
     loadEpisodePage(TheTvDbApi::ApiPage{1});

--- a/src/scrapers/tv_show/thetvdb/TheTvDbSeasonScrapeJob.cpp
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbSeasonScrapeJob.cpp
@@ -17,7 +17,7 @@ TheTvDbSeasonScrapeJob::TheTvDbSeasonScrapeJob(TheTvDbApi& api, Config _config, 
 {
 }
 
-void TheTvDbSeasonScrapeJob::execute()
+void TheTvDbSeasonScrapeJob::start()
 {
     if (!m_showId.isValid()) {
         qCWarning(generic) << "[TheTvDb] Provided TheTvDb id is invalid:" << config().showIdentifier;

--- a/src/scrapers/tv_show/thetvdb/TheTvDbSeasonScrapeJob.h
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbSeasonScrapeJob.h
@@ -19,7 +19,7 @@ class TheTvDbSeasonScrapeJob : public SeasonScrapeJob
 public:
     TheTvDbSeasonScrapeJob(TheTvDbApi& api, Config _config, QObject* parent = nullptr);
     ~TheTvDbSeasonScrapeJob() override = default;
-    void execute() override;
+    void start() override;
 
 private:
     void loadEpisodePage(TheTvDbApi::ApiPage page);

--- a/src/scrapers/tv_show/thetvdb/TheTvDbShowScrapeJob.cpp
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbShowScrapeJob.cpp
@@ -37,13 +37,13 @@ TheTvDbShowScrapeJob::TheTvDbShowScrapeJob(TheTvDbApi& api, Config _config, QObj
     m_notLoaded.intersect(config().details);
 }
 
-void TheTvDbShowScrapeJob::execute()
+void TheTvDbShowScrapeJob::start()
 {
     if (!m_id.isValid()) {
         qCWarning(generic) << "[TheTvDb] Provided TheTvDb id is invalid:" << config().identifier;
         m_error.error = ScraperError::Type::ConfigError;
         m_error.message = tr("Show is missing a TheTvDb id");
-        QTimer::singleShot(0, [this]() { emit sigFinished(this); });
+        QTimer::singleShot(0, this, [this]() { emit sigFinished(this); });
         return;
     }
 

--- a/src/scrapers/tv_show/thetvdb/TheTvDbShowScrapeJob.h
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbShowScrapeJob.h
@@ -18,7 +18,7 @@ class TheTvDbShowScrapeJob : public ShowScrapeJob
 public:
     TheTvDbShowScrapeJob(TheTvDbApi& api, Config _config, QObject* parent = nullptr);
     ~TheTvDbShowScrapeJob() override = default;
-    void execute() override;
+    void start() override;
 
 private:
     void loadTvShow();

--- a/src/scrapers/tv_show/thetvdb/TheTvDbShowSearchJob.cpp
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbShowSearchJob.cpp
@@ -18,7 +18,7 @@ TheTvDbShowSearchJob::TheTvDbShowSearchJob(TheTvDbApi& api, ShowSearchJob::Confi
 {
 }
 
-void TheTvDbShowSearchJob::execute()
+void TheTvDbShowSearchJob::start()
 {
     if (config().query.isEmpty()) {
         // Searching for an empty string results in a network error.

--- a/src/scrapers/tv_show/thetvdb/TheTvDbShowSearchJob.h
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbShowSearchJob.h
@@ -18,7 +18,7 @@ public:
     explicit TheTvDbShowSearchJob(TheTvDbApi& api, ShowSearchJob::Config config, QObject* parent = nullptr);
     ~TheTvDbShowSearchJob() override = default;
 
-    void execute() override;
+    void start() override;
 
 private:
     TheTvDbApi& m_api;

--- a/src/scrapers/tv_show/tmdb/TmdbTvEpisodeScrapeJob.cpp
+++ b/src/scrapers/tv_show/tmdb/TmdbTvEpisodeScrapeJob.cpp
@@ -15,7 +15,7 @@ TmdbTvEpisodeScrapeJob::TmdbTvEpisodeScrapeJob(TmdbApi& api, EpisodeScrapeJob::C
 {
 }
 
-void TmdbTvEpisodeScrapeJob::execute()
+void TmdbTvEpisodeScrapeJob::start()
 {
     TmdbId showId(config().identifier.showIdentifier);
 

--- a/src/scrapers/tv_show/tmdb/TmdbTvEpisodeScrapeJob.cpp
+++ b/src/scrapers/tv_show/tmdb/TmdbTvEpisodeScrapeJob.cpp
@@ -23,7 +23,7 @@ void TmdbTvEpisodeScrapeJob::start()
         qCWarning(generic) << "[TmdbTvEpisodeScrapeJob] Invalid TMDb ID for TV show, cannot scrape episode!";
         m_error.error = ScraperError::Type::ConfigError;
         m_error.message = tr("TMDb show ID is invalid! Cannot load requested episode.");
-        QTimer::singleShot(0, [this]() { emit sigFinished(this); });
+        QTimer::singleShot(0, this, [this]() { emit sigFinished(this); });
         return;
     }
 

--- a/src/scrapers/tv_show/tmdb/TmdbTvEpisodeScrapeJob.h
+++ b/src/scrapers/tv_show/tmdb/TmdbTvEpisodeScrapeJob.h
@@ -14,7 +14,7 @@ class TmdbTvEpisodeScrapeJob : public EpisodeScrapeJob
 public:
     TmdbTvEpisodeScrapeJob(TmdbApi& api, Config _config, QObject* parent = nullptr);
     ~TmdbTvEpisodeScrapeJob() = default;
-    void execute() override;
+    void start() override;
 
 private:
     TmdbApi& m_api;

--- a/src/scrapers/tv_show/tmdb/TmdbTvSeasonScrapeJob.cpp
+++ b/src/scrapers/tv_show/tmdb/TmdbTvSeasonScrapeJob.cpp
@@ -16,7 +16,7 @@ TmdbTvSeasonScrapeJob::TmdbTvSeasonScrapeJob(TmdbApi& api, SeasonScrapeJob::Conf
 {
 }
 
-void TmdbTvSeasonScrapeJob::execute()
+void TmdbTvSeasonScrapeJob::start()
 {
     if (!m_showId.isValid()) {
         qCWarning(generic) << "[TmdbTv] Provided Tmdb id is invalid:" << config().showIdentifier;

--- a/src/scrapers/tv_show/tmdb/TmdbTvSeasonScrapeJob.h
+++ b/src/scrapers/tv_show/tmdb/TmdbTvSeasonScrapeJob.h
@@ -17,7 +17,7 @@ class TmdbTvSeasonScrapeJob : public SeasonScrapeJob
 public:
     TmdbTvSeasonScrapeJob(TmdbApi& api, Config _config, QObject* parent = nullptr);
     ~TmdbTvSeasonScrapeJob() = default;
-    void execute() override;
+    void start() override;
 
 private:
     void loadSeasons(QList<SeasonNumber> seasons);

--- a/src/scrapers/tv_show/tmdb/TmdbTvShowScrapeJob.cpp
+++ b/src/scrapers/tv_show/tmdb/TmdbTvShowScrapeJob.cpp
@@ -20,7 +20,7 @@ void TmdbTvShowScrapeJob::start()
         qCWarning(generic) << "[TmdbTv] Provided TMDb id is invalid:" << config().identifier;
         m_error.error = ScraperError::Type::ConfigError;
         m_error.message = tr("Show is missing a TMDb id");
-        QTimer::singleShot(0, [this]() { emit sigFinished(this); });
+        QTimer::singleShot(0, this, [this]() { emit sigFinished(this); });
         return;
     }
     loadTvShow();

--- a/src/scrapers/tv_show/tmdb/TmdbTvShowScrapeJob.cpp
+++ b/src/scrapers/tv_show/tmdb/TmdbTvShowScrapeJob.cpp
@@ -14,7 +14,7 @@ TmdbTvShowScrapeJob::TmdbTvShowScrapeJob(TmdbApi& api, ShowScrapeJob::Config _co
 {
 }
 
-void TmdbTvShowScrapeJob::execute()
+void TmdbTvShowScrapeJob::start()
 {
     if (!m_id.isValid()) {
         qCWarning(generic) << "[TmdbTv] Provided TMDb id is invalid:" << config().identifier;

--- a/src/scrapers/tv_show/tmdb/TmdbTvShowScrapeJob.h
+++ b/src/scrapers/tv_show/tmdb/TmdbTvShowScrapeJob.h
@@ -16,7 +16,7 @@ class TmdbTvShowScrapeJob : public ShowScrapeJob
 public:
     TmdbTvShowScrapeJob(TmdbApi& api, Config _config, QObject* parent = nullptr);
     ~TmdbTvShowScrapeJob() override = default;
-    void execute() override;
+    void start() override;
 
 private:
     void loadTvShow();

--- a/src/scrapers/tv_show/tmdb/TmdbTvShowSearchJob.cpp
+++ b/src/scrapers/tv_show/tmdb/TmdbTvShowSearchJob.cpp
@@ -12,7 +12,7 @@ TmdbTvShowSearchJob::TmdbTvShowSearchJob(TmdbApi& api, ShowSearchJob::Config _co
 {
 }
 
-void TmdbTvShowSearchJob::execute()
+void TmdbTvShowSearchJob::start()
 {
     if (config().query.isEmpty()) {
         // TODO: Set a config error

--- a/src/scrapers/tv_show/tmdb/TmdbTvShowSearchJob.h
+++ b/src/scrapers/tv_show/tmdb/TmdbTvShowSearchJob.h
@@ -17,7 +17,7 @@ class TmdbTvShowSearchJob : public ShowSearchJob
 public:
     explicit TmdbTvShowSearchJob(TmdbApi& api, ShowSearchJob::Config _config, QObject* parent = nullptr);
     ~TmdbTvShowSearchJob() override = default;
-    void execute() override;
+    void start() override;
 
 private:
     QVector<ShowSearchJob::Result> parseSearch(const QJsonDocument& json);

--- a/src/scrapers/tv_show/tvmaze/TvMazeApi.cpp
+++ b/src/scrapers/tv_show/tvmaze/TvMazeApi.cpp
@@ -31,7 +31,7 @@ void TvMazeApi::sendGetRequest(const QUrl& url, TvMazeApi::ApiCallback callback)
     if (m_cache.hasValidElement(url, Locale::English)) {
         // Do not immediately run the callback because classes higher up may
         // set up a Qt connection while the network request is running.
-        QTimer::singleShot(0, [cb = std::move(callback), element = m_cache.getElement(url, Locale::English)]() {
+        QTimer::singleShot(0, this, [cb = std::move(callback), element = m_cache.getElement(url, Locale::English)]() {
             // should not result in a parse error because the cache element is
             // only stored if no error occured at all.
             cb(QJsonDocument::fromJson(element.toUtf8()), {});

--- a/src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.cpp
+++ b/src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.cpp
@@ -18,7 +18,7 @@ TvMazeEpisodeScrapeJob::TvMazeEpisodeScrapeJob(TvMazeApi& api, Config config, QO
 {
 }
 
-void TvMazeEpisodeScrapeJob::execute()
+void TvMazeEpisodeScrapeJob::start()
 {
     if (config().identifier.hasEpisodeIdentifier()) {
         loadEpisode(TvMazeId(config().identifier.episodeIdentifier));

--- a/src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.h
+++ b/src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.h
@@ -15,7 +15,7 @@ class TvMazeEpisodeScrapeJob : public EpisodeScrapeJob
 public:
     TvMazeEpisodeScrapeJob(TvMazeApi& api, Config config, QObject* parent = nullptr);
     ~TvMazeEpisodeScrapeJob() override = default;
-    void execute() override;
+    void start() override;
 
 private:
     void loadEpisode(const TvMazeId& episodeId);

--- a/src/scrapers/tv_show/tvmaze/TvMazeSeasonScrapeJob.cpp
+++ b/src/scrapers/tv_show/tvmaze/TvMazeSeasonScrapeJob.cpp
@@ -16,7 +16,7 @@ TvMazeSeasonScrapeJob::TvMazeSeasonScrapeJob(TvMazeApi& api, SeasonScrapeJob::Co
 {
 }
 
-void TvMazeSeasonScrapeJob::execute()
+void TvMazeSeasonScrapeJob::start()
 {
     if (!m_showId.isValid()) {
         qCWarning(generic) << "[TmdbTv] Provided Tmdb id is invalid:" << config().showIdentifier;

--- a/src/scrapers/tv_show/tvmaze/TvMazeSeasonScrapeJob.h
+++ b/src/scrapers/tv_show/tvmaze/TvMazeSeasonScrapeJob.h
@@ -18,7 +18,7 @@ public:
     ~TvMazeSeasonScrapeJob() override = default;
 
 public:
-    void execute() override;
+    void start() override;
 
 private:
     TvMazeApi& m_api;

--- a/src/scrapers/tv_show/tvmaze/TvMazeShowScrapeJob.cpp
+++ b/src/scrapers/tv_show/tvmaze/TvMazeShowScrapeJob.cpp
@@ -18,7 +18,7 @@ TvMazeShowScrapeJob::TvMazeShowScrapeJob(TvMazeApi& api, Config _config, QObject
 {
 }
 
-void TvMazeShowScrapeJob::execute()
+void TvMazeShowScrapeJob::start()
 {
     TvMazeId id{config().identifier.str()};
 

--- a/src/scrapers/tv_show/tvmaze/TvMazeShowScrapeJob.h
+++ b/src/scrapers/tv_show/tvmaze/TvMazeShowScrapeJob.h
@@ -15,7 +15,7 @@ class TvMazeShowScrapeJob : public ShowScrapeJob
 public:
     TvMazeShowScrapeJob(TvMazeApi& api, Config _config, QObject* parent = nullptr);
     ~TvMazeShowScrapeJob() override = default;
-    void execute() override;
+    void start() override;
 
 private:
     TvMazeApi& m_api;

--- a/src/scrapers/tv_show/tvmaze/TvMazeShowSearchJob.cpp
+++ b/src/scrapers/tv_show/tvmaze/TvMazeShowSearchJob.cpp
@@ -16,7 +16,7 @@ TvMazeShowSearchJob::TvMazeShowSearchJob(TvMazeApi& api, ShowSearchJob::Config c
 {
 }
 
-void TvMazeShowSearchJob::execute()
+void TvMazeShowSearchJob::start()
 {
     m_api.searchForShow(config().query, [this](QJsonDocument json, ScraperError error) {
         if (!error.hasError()) {

--- a/src/scrapers/tv_show/tvmaze/TvMazeShowSearchJob.h
+++ b/src/scrapers/tv_show/tvmaze/TvMazeShowSearchJob.h
@@ -18,7 +18,7 @@ public:
     explicit TvMazeShowSearchJob(TvMazeApi& api, ShowSearchJob::Config config, QObject* parent = nullptr);
     ~TvMazeShowSearchJob() override = default;
 
-    void execute() override;
+    void start() override;
 
 private:
     QVector<ShowSearchJob::Result> parseSearch(const QJsonDocument& json) const;

--- a/src/tv_shows/TvShow.cpp
+++ b/src/tv_shows/TvShow.cpp
@@ -295,7 +295,7 @@ void TvShow::scrapeData(mediaelch::scraper::TvScraper* scraper,
         };
         auto* scrapeJob = scraper->loadSeasons(seasonScrapeConfig);
         connect(scrapeJob, &scraper::SeasonScrapeJob::sigFinished, this, onSeasonsDone);
-        scrapeJob->execute();
+        scrapeJob->start();
     };
 
     const auto onShowLoaded = [this, updateType, loadEpisodes](scraper::ShowScrapeJob* job) {
@@ -323,7 +323,7 @@ void TvShow::scrapeData(mediaelch::scraper::TvScraper* scraper,
         // First load TV show and then episodes.
         auto* scrapeJob = scraper->loadShow(showScrapeConfig);
         connect(scrapeJob, &scraper::ShowScrapeJob::sigFinished, this, onShowLoaded);
-        scrapeJob->execute();
+        scrapeJob->start();
 
     } else if (isEpisodeUpdateType(updateType)) {
         // Only update episodes

--- a/src/tv_shows/TvShowEpisode.cpp
+++ b/src/tv_shows/TvShowEpisode.cpp
@@ -217,7 +217,7 @@ void TvShowEpisode::scrapeData(mediaelch::scraper::TvScraper* scraper,
         job->deleteLater();
         emit sigLoaded(this);
     });
-    scrapeJob->execute();
+    scrapeJob->start();
 }
 
 /**

--- a/src/tv_shows/TvShowUpdater.cpp
+++ b/src/tv_shows/TvShowUpdater.cpp
@@ -76,5 +76,5 @@ void TvShowUpdater::updateShow(TvShow* show, bool force)
 
         show->fillMissingEpisodes();
     });
-    scrapeJob->execute();
+    scrapeJob->start();
 }

--- a/src/ui/concerts/ConcertSearchWidget.cpp
+++ b/src/ui/concerts/ConcertSearchWidget.cpp
@@ -125,7 +125,7 @@ void ConcertSearchWidget::startSearch()
     ConcertSearchJob::Config config{ui->searchString->text().trimmed(), m_currentLanguage};
     auto* searchJob = m_currentScraper->search(config);
     connect(searchJob, &ConcertSearchJob::sigFinished, this, &ConcertSearchWidget::onConcertResults);
-    searchJob->execute();
+    searchJob->start();
 }
 
 void ConcertSearchWidget::onConcertResults(ConcertSearchJob* searchJob)

--- a/src/ui/movies/MovieMultiScrapeDialog.cpp
+++ b/src/ui/movies/MovieMultiScrapeDialog.cpp
@@ -258,7 +258,7 @@ void MovieMultiScrapeDialog::scrapeNext()
     auto* searchJob = m_scraperInterface->search(config);
     searchJob->setProperty("scraper", QVariant::fromValue(scraperForSearchJob));
     connect(searchJob, &MovieSearchJob::sigFinished, this, &MovieMultiScrapeDialog::onSearchFinished);
-    searchJob->execute();
+    searchJob->start();
 }
 
 void MovieMultiScrapeDialog::loadMovieData(Movie* movie, ImdbId id)
@@ -335,7 +335,7 @@ void MovieMultiScrapeDialog::onSearchFinished(mediaelch::scraper::MovieSearchJob
             auto* nextSearchJob = searchScrapers.first()->search(config);
             nextSearchJob->setProperty("scraper", QVariant::fromValue(searchScrapers.first()));
             connect(nextSearchJob, &MovieSearchJob::sigFinished, this, &MovieMultiScrapeDialog::onSearchFinished);
-            nextSearchJob->execute();
+            nextSearchJob->start();
 
             return;
         }

--- a/src/ui/movies/MovieSearchWidget.cpp
+++ b/src/ui/movies/MovieSearchWidget.cpp
@@ -91,7 +91,7 @@ void MovieSearchWidget::startSearch()
 
     auto* searchJob = m_currentScraper->search(config);
     connect(searchJob, &MovieSearchJob::sigFinished, this, &MovieSearchWidget::showResults);
-    searchJob->execute();
+    searchJob->start();
     Settings::instance()->setCurrentMovieScraper(ui->comboScraper->currentIndex());
 }
 

--- a/src/ui/tv_show/TvShowMultiScrapeDialog.cpp
+++ b/src/ui/tv_show/TvShowMultiScrapeDialog.cpp
@@ -371,7 +371,7 @@ void TvShowMultiScrapeDialog::scrapeNext()
             ShowSearchJob::Config config{searchQuery, m_locale, Settings::instance()->showAdultScrapers()};
             auto* searchJob = m_currentScraper->search(config);
             connect(searchJob, &ShowSearchJob::sigFinished, this, &TvShowMultiScrapeDialog::onSearchFinished);
-            searchJob->execute();
+            searchJob->start();
 
         } else {
             logToUser(tr("Scraping next TV show with ID \"%1\".").arg(id.str()));
@@ -410,7 +410,7 @@ void TvShowMultiScrapeDialog::scrapeNext()
                 m_currentEpisode->tvShow()->title(), m_locale, Settings::instance()->showAdultScrapers()};
             auto* searchJob = m_currentScraper->search(config);
             connect(searchJob, &ShowSearchJob::sigFinished, this, &TvShowMultiScrapeDialog::onSearchFinished);
-            searchJob->execute();
+            searchJob->start();
 
         } else {
             logToUser(tr("S%1E%2: Scraping next episode with show ID \"%3\".")

--- a/src/ui/tv_show/TvShowSearchWidget.cpp
+++ b/src/ui/tv_show/TvShowSearchWidget.cpp
@@ -167,7 +167,7 @@ void TvShowSearchWidget::startSearch()
         ui->searchString->text().trimmed(), m_currentLanguage, Settings::instance()->showAdultScrapers()};
     auto* searchJob = m_currentScraper->search(config);
     connect(searchJob, &ShowSearchJob::sigFinished, this, &TvShowSearchWidget::onShowResults);
-    searchJob->execute();
+    searchJob->start();
 }
 
 void TvShowSearchWidget::onShowResults(ShowSearchJob* searchJob)

--- a/test/scrapers/imdbtv/testImdbTvEpisodeLoader.cpp
+++ b/test/scrapers/imdbtv/testImdbTvEpisodeLoader.cpp
@@ -19,7 +19,7 @@ static void scrapeEpisodeSync(EpisodeScrapeJob* scrapeJob)
         REQUIRE(!scrapeJob->hasError());
         loop.quit();
     });
-    scrapeJob->execute();
+    scrapeJob->start();
     loop.exec();
 }
 

--- a/test/scrapers/imdbtv/testImdbTvSeasonLoader.cpp
+++ b/test/scrapers/imdbtv/testImdbTvSeasonLoader.cpp
@@ -18,7 +18,7 @@ static void scrapeSeasonSync(SeasonScrapeJob* scrapeJob)
         REQUIRE(!scrapeJob->hasError());
         loop.quit();
     });
-    scrapeJob->execute();
+    scrapeJob->start();
     loop.exec();
 }
 

--- a/test/scrapers/testScraperHelpers.cpp
+++ b/test/scrapers/testScraperHelpers.cpp
@@ -18,7 +18,7 @@ searchConcertScraperSync(mediaelch::scraper::ConcertSearchJob* searchJob, bool m
             searchJob->deleteLater();
             loop.quit();
         });
-    searchJob->execute();
+    searchJob->start();
     loop.exec();
     if (!mayError) {
         CAPTURE(error.message);
@@ -40,7 +40,7 @@ searchTvScraperSync(mediaelch::scraper::ShowSearchJob* searchJob, bool mayError)
             searchJob->deleteLater();
             loop.quit();
         });
-    searchJob->execute();
+    searchJob->start();
     loop.exec();
     if (!mayError) {
         CAPTURE(error.message);
@@ -64,7 +64,7 @@ searchMovieScraperSync(mediaelch::scraper::MovieSearchJob* searchJob, bool mayEr
             searchJob->deleteLater();
             loop.quit();
         });
-    searchJob->execute();
+    searchJob->start();
     loop.exec();
     if (!mayError) {
         CAPTURE(error.message);
@@ -80,7 +80,7 @@ void scrapeTvScraperSync(mediaelch::scraper::ShowScrapeJob* scrapeJob, bool mayE
     QEventLoop::connect(scrapeJob,
         &mediaelch::scraper::ShowScrapeJob::sigFinished,
         [&](mediaelch::scraper::ShowScrapeJob* /*unused*/) { loop.quit(); });
-    scrapeJob->execute();
+    scrapeJob->start();
     loop.exec();
     if (!mayError) {
         CAPTURE(scrapeJob->error().message);

--- a/test/scrapers/thetvdb/testTheTvDbEpisodeLoader.cpp
+++ b/test/scrapers/thetvdb/testTheTvDbEpisodeLoader.cpp
@@ -19,7 +19,7 @@ static void scrapeEpisodeSync(EpisodeScrapeJob* scrapeJob)
         REQUIRE(!scrapeJob->hasError());
         loop.quit();
     });
-    scrapeJob->execute();
+    scrapeJob->start();
     loop.exec();
 }
 

--- a/test/scrapers/tmdbtv/testTmdbTvEpisodeLoader.cpp
+++ b/test/scrapers/tmdbtv/testTmdbTvEpisodeLoader.cpp
@@ -20,7 +20,7 @@ static void scrapeEpisodeSync(EpisodeScrapeJob* scrapeJob)
         REQUIRE(!scrapeJob->hasError());
         loop.quit();
     });
-    scrapeJob->execute();
+    scrapeJob->start();
     loop.exec();
 }
 

--- a/test/scrapers/tmdbtv/testTmdbTvSeasonLoader.cpp
+++ b/test/scrapers/tmdbtv/testTmdbTvSeasonLoader.cpp
@@ -20,7 +20,7 @@ static void scrapeSeasonSync(SeasonScrapeJob* scrapeJob)
         REQUIRE(!scrapeJob->hasError());
         loop.quit();
     });
-    scrapeJob->execute();
+    scrapeJob->start();
     loop.exec();
 }
 

--- a/test/scrapers/tvmaze/testTvMazeEpisodeScrapeJob.cpp
+++ b/test/scrapers/tvmaze/testTvMazeEpisodeScrapeJob.cpp
@@ -20,7 +20,7 @@ static void scrapeEpisodeSync(EpisodeScrapeJob* scrapeJob)
         REQUIRE(!scrapeJob->hasError());
         loop.quit();
     });
-    scrapeJob->execute();
+    scrapeJob->start();
     loop.exec();
 }
 

--- a/test/scrapers/tvmaze/testTvMazeSeasonScrapeJob.cpp
+++ b/test/scrapers/tvmaze/testTvMazeSeasonScrapeJob.cpp
@@ -20,7 +20,7 @@ static void scrapeSeasonSync(SeasonScrapeJob* scrapeJob)
         REQUIRE(!scrapeJob->hasError());
         loop.quit();
     });
-    scrapeJob->execute();
+    scrapeJob->start();
     loop.exec();
 }
 

--- a/test/scrapers/universalmusicscraper/testUniversalMusicScraper.cpp
+++ b/test/scrapers/universalmusicscraper/testUniversalMusicScraper.cpp
@@ -17,7 +17,7 @@ static void scrapeAlbumSync()
     //        REQUIRE(!scrapeJob->hasError());
     //        loop.quit();
     //    });
-    //    scrapeJob->execute();
+    //    scrapeJob->start();
     //    loop.exec();
 }
 


### PR DESCRIPTION
The former is commonly used for _synchronous_ execution.  But jobs are
asynchronous.