### PR TITLE
[QuaZip] Use header include path "quazip/" instead of "quazip5/"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 
  - The movie file searcher has been reworked again.  
    It now runs in another thread so that MediaElch now longer "freezes".
+ - MediaElch will check for QuaZip 1.x if `USE_EXTERN_QUAZIP` is provided in CMake configuration.
+   If it cannot be found, `quazip5` is expected to exist (which is the previous behavior).
+   MediaElch now also search for QuaZip headers in `quazip/` and no longer `quazip5/`.
 
 
 ## 2.8.12 - Coridian (2021-05-10)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,24 @@ configure_file(data/i18n.qrc ${CMAKE_BINARY_DIR} COPYONLY)
 
 add_subdirectory(docs)
 add_subdirectory(third_party EXCLUDE_FROM_ALL)
+
+if(USE_EXTERN_QUAZIP)
+  find_package(QuaZip-Qt5 QUIET)
+
+  if(TARGET QuaZip::QuaZip)
+    message(STATUS "Using system's QuaZip 1.x library")
+    # We use this alias to still support QuaZip 0.9 which doesn't provide a
+    # CMake config file which means we can't use find_package() on it.
+    add_library(quazip5 ALIAS QuaZip::QuaZip)
+  else()
+    # The system's quazip, e.g. libquazip5-dev on Ubuntu
+    message(
+      STATUS
+        "Using system's QuaZip 0.9 library; expecting quazip5 shared library to exist"
+    )
+  endif()
+endif()
+
 add_subdirectory(src)
 
 add_executable(

--- a/src/export/ExportTemplateLoader.cpp
+++ b/src/export/ExportTemplateLoader.cpp
@@ -6,13 +6,8 @@
 #include <QNetworkReply>
 #include <QXmlStreamReader>
 
-#ifndef EXTERN_QUAZIP
-#    include "quazip/quazip/quazip.h"
-#    include "quazip/quazip/quazipfile.h"
-#else
-#    include "quazip5/quazip.h"
-#    include "quazip5/quazipfile.h"
-#endif
+#include "quazip/quazip.h"
+#include "quazip/quazipfile.h"
 
 #include "globals/VersionInfo.h"
 #include "log/Log.h"

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,14 +1,9 @@
-if(USE_EXTERN_QUAZIP)
-  # The system's quazip, e.g. libquazip5-dev on Ubuntu
-  message(STATUS "Using system's QuaZip library")
-  add_library(quazip5 SHARED IMPORTED)
-
-else()
+if(NOT USE_EXTERN_QUAZIP)
   find_package(ZLIB REQUIRED)
 
   add_library(quazip5 STATIC)
 
-  target_include_directories(quazip5 SYSTEM INTERFACE .)
+  target_include_directories(quazip5 SYSTEM INTERFACE quazip)
   target_include_directories(quazip5 PRIVATE quazip/quazip)
   target_compile_definitions(quazip5 PRIVATE QUAZIP_BUILD)
   target_compile_options(quazip5 PRIVATE -w) # Disable warnings for third-party


### PR DESCRIPTION
This makes it possible to use MediaElch with QuaZip 1.1

Tested with openSUSE Tumbleweed and QuaZip 1.1. Also tested on Ubuntu 18.04 with QuaZip 0.9. Builds using the git submodule still work as well. QMake build works as well.

Fix https://github.com/Komet/MediaElch/issues/1339