### PR TITLE
[CSV Export] Escape characters according to OWASP recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ### Changes
 
- - *tbd*
+ - To avoid the possibility of CSV injection, prepend certain fields with an apostrophe according
+   to [OWASP recommendations](https://owasp.org/www-community/attacks/CSV_Injection) (#1338)
 
 ### Added
 


### PR DESCRIPTION
To avoid the possibility of CSV injection, prepend certain fields with
an apostrophe according to OWASP recommendations

 - https://owasp.org/www-community/attacks/CSV_Injection

Fix #1338