### PR TITLE
[Qt] Improve MediaElch to (nearly) support Qt6

### DIFF
--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -4,6 +4,7 @@ equals(QT_MAJOR_VERSION, 5) {
     lessThan(QT_MINOR_VERSION, 6): error(Qt 5.6 or higher is required!)
 }
 equals(QT_MAJOR_VERSION, 6) {
+    lessThan(QT_MINOR_VERSION, 2): error("Qt 6.2 is required as 6.0 and 6.1 do not support QMultiMedia!")
     warning("Qt 6 has not been tested with MediaElch, yet!")
 }
 contains(CONFIG, USE_EXTERN_QUAZIP) {

--- a/src/globals/Meta.h
+++ b/src/globals/Meta.h
@@ -4,9 +4,11 @@
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #    define ELCH_QHASH_RETURN_TYPE uint
+#    define ELCH_MEDIA_PLAYBACK_STATE QMediaPlayer::State
 #else
 // With Qt 6, qHash uses size_t
 #    define ELCH_QHASH_RETURN_TYPE size_t
+#    define ELCH_MEDIA_PLAYBACK_STATE QMediaPlayer::PlaybackState
 #endif
 
 #define ELCH_NODISCARD Q_REQUIRED_RESULT

--- a/src/globals/TrailerDialog.h
+++ b/src/globals/TrailerDialog.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "globals/Globals.h"
+#include "globals/Meta.h"
 #include "globals/ScraperResult.h"
 #include "movies/Movie.h"
 #include "network/NetworkManager.h"
@@ -46,11 +47,17 @@ private slots:
     void downloadFinished();
     void downloadReadyRead();
     void onNewTotalTime(qint64 totalTime);
-    void onStateChanged(QMediaPlayer::State newState);
+    void onStateChanged(ELCH_MEDIA_PLAYBACK_STATE newState);
     void onPlayPause();
     void onAnimationFinished();
     void onUpdateTime(qint64 currentTime);
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     void onTrailerError(QMediaPlayer::Error error);
+#else
+    void onTrailerError(QMediaPlayer::Error error, const QString& errorString);
+#endif
+
     void onSliderPositionChanged();
 
 private:

--- a/src/ui/export/CsvExportDialog.h
+++ b/src/ui/export/CsvExportDialog.h
@@ -71,8 +71,11 @@ private:
             return;
         }
         QTextStream out(&file);
-        // UTF-8 BOM required for e.g. Excel
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+        // Default in Qt6
         out.setCodec("UTF-8");
+#endif
+        // UTF-8 BOM required for e.g. Excel
         out.setGenerateByteOrderMark(true);
         callback(out);
         // flush before closing the file or the data won't be written

--- a/src/ui/tv_show/TvTunesDialog.cpp
+++ b/src/ui/tv_show/TvTunesDialog.cpp
@@ -42,7 +42,11 @@ TvTunesDialog::TvTunesDialog(TvShow& show, QWidget* parent) : QDialog(parent), u
     m_mediaPlayer = new QMediaPlayer();
     connect(m_mediaPlayer, &QMediaPlayer::durationChanged, this, &TvTunesDialog::onNewTotalTime);
     connect(m_mediaPlayer, &QMediaPlayer::positionChanged, this, &TvTunesDialog::onUpdateTime);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     connect(m_mediaPlayer, &QMediaPlayer::stateChanged, this, &TvTunesDialog::onStateChanged);
+#else
+    connect(m_mediaPlayer, &QMediaPlayer::playbackStateChanged, this, &TvTunesDialog::onStateChanged);
+#endif
     connect(ui->btnPlayPause, &QAbstractButton::clicked, this, &TvTunesDialog::onPlayPause);
 }
 
@@ -104,7 +108,11 @@ void TvTunesDialog::onResultClicked(QTableWidgetItem* item)
     QString url = item->data(Qt::UserRole).toString();
     m_themeUrl = url;
     m_totalTime = 0;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     m_mediaPlayer->setMedia(QMediaContent(url));
+#else
+    m_mediaPlayer->setSource(url);
+#endif
     m_mediaPlayer->play();
     ui->btnPlayPause->setEnabled(true);
     ui->buttonDownload->setEnabled(true);
@@ -132,7 +140,7 @@ void TvTunesDialog::onUpdateTime(qint64 currentTime)
     ui->seekSlider->setValue(position);
 }
 
-void TvTunesDialog::onStateChanged(QMediaPlayer::State newState)
+void TvTunesDialog::onStateChanged(ELCH_MEDIA_PLAYBACK_STATE newState)
 {
     switch (newState) {
     case QMediaPlayer::PlayingState: ui->btnPlayPause->setIcon(QIcon(":/img/video_pause_64.png")); break;
@@ -143,7 +151,11 @@ void TvTunesDialog::onStateChanged(QMediaPlayer::State newState)
 
 void TvTunesDialog::onPlayPause()
 {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     switch (m_mediaPlayer->state()) {
+#else
+    switch (m_mediaPlayer->playbackState()) {
+#endif
     case QMediaPlayer::PlayingState: m_mediaPlayer->stop(); break;
     case QMediaPlayer::StoppedState:
     case QMediaPlayer::PausedState: m_mediaPlayer->play(); break;

--- a/src/ui/tv_show/TvTunesDialog.h
+++ b/src/ui/tv_show/TvTunesDialog.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "globals/Meta.h"
 #include "globals/ScraperResult.h"
 #include "network/NetworkManager.h"
 #include "tv_shows/TvShow.h"
@@ -35,7 +36,7 @@ public slots:
 private slots:
     void onSearch();
     void onShowResults(QVector<ScraperSearchResult> results);
-    void onStateChanged(QMediaPlayer::State newState);
+    void onStateChanged(ELCH_MEDIA_PLAYBACK_STATE newState);
     void onPlayPause();
     void onResultClicked(QTableWidgetItem* item);
     void startDownload();


### PR DESCRIPTION
This is another step towards support for Qt 6.2.

What's left:

 - Fix QuaZip (currently only support Qt5)

Note that I still got linker errors on my machine due to some OpenGL
issues.  But Qt 6.2 is still alpha, so that's not a big issue (yet).