### PR TITLE
[QuaZip] Update submodule to QuaZip 1.1 and add basic support for Qt6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
  - CMake: Option `ENABLE_TESTS` was added. Without it, MediaElch's tests will
    not be build.  The reason is that normal users, that only want to build
    MediaElch, do not need them.
+ - QuaZip was updated to v1.1.  Note that `-DUSE_EXTERN_QUAZIP=ON` for CMake and
+   `CONFIG+=USE_EXTERN_QUAZIP` for QMake can still be used to use the system's QuaZip.
+   QuaZip v0.9 is still supported as well.
+   This step was necessary for Qt6 support.
 
 
 ## 2.8.12 - Coridian (2021-05-10)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,19 +218,18 @@ add_subdirectory(docs)
 add_subdirectory(third_party EXCLUDE_FROM_ALL)
 
 if(USE_EXTERN_QUAZIP)
-  find_package(QuaZip-Qt5 QUIET)
-
-  if(TARGET QuaZip::QuaZip)
-    message(STATUS "Using system's QuaZip 1.x library")
+  find_package(QuaZip-Qt${QT_VERSION_MAJOR} QUIET)
+  if(NOT TARGET QuaZip::QuaZip)
+    if (${QT_VERSION_MAJOR} GREATER 5)
+      message(FATAL_ERROR "Could not find QuaZip 1.x using CMake. And can't use quazip5 as Qt 6 was requested!")
+    endif()
+    message(STATUS "Using system's QuaZip 0.x library")
+    add_library(MEDIAELCH_QUAZIP_TMP INTERFACE)
+    # We assume that a library "quazip5" exists
+    target_link_libraries(MEDIAELCH_QUAZIP_TMP INTERFACE quazip5)
     # We use this alias to still support QuaZip 0.9 which doesn't provide a
     # CMake config file which means we can't use find_package() on it.
-    add_library(quazip5 ALIAS QuaZip::QuaZip)
-  else()
-    # The system's quazip, e.g. libquazip5-dev on Ubuntu
-    message(
-      STATUS
-        "Using system's QuaZip 0.9 library; expecting quazip5 shared library to exist"
-    )
+    add_library(QuaZip::QuaZip ALIAS MEDIAELCH_QUAZIP_TMP)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,18 +122,10 @@ set(CMAKE_AUTOMOC ON) # Instruct CMake to run moc automatically when needed
 set(CMAKE_AUTOUIC ON) # Create code from a list of Qt designer ui files
 set(CMAKE_AUTORCC ON) # For .qrc files
 
-# Min version required; keep in sync with MediaElch.plist macOS 10.14 is
-# required for some std::variant features required by Qt.
-if(NOT Qt6_FOUND)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14)
-else()
-  set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
-endif()
-
 # ------------------------------------------------------------------------------
 # Qt5/6: You may need to set CMAKE_PREFIX_PATH e.g. to ~/Qt/5.11.2/gcc_64/
 find_package(
-  QT NAMES Qt6 Qt5
+  QT NAMES Qt6 Qt5 QUIET
   COMPONENTS Core
   REQUIRED
 )
@@ -164,6 +156,17 @@ if(ENABLE_TESTS)
 else()
   message(STATUS "Tests disabled")
 endif()
+
+# Min version required; keep in sync with MediaElch.plist macOS 10.14 is
+# required for some std::variant features required by Qt.
+if(Qt6_FOUND)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14)
+  find_package(Qt6 QUIET REQUIRED COMPONENTS Core5Compat)
+else()
+  set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
+endif()
+
+message(STATUS "Using Qt ${QT_VERSION}")
 
 # -----------------------------------------------------------------------------
 # Translations

--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -15,7 +15,7 @@ contains(CONFIG, USE_EXTERN_QUAZIP) {
     # using internal 3rd party QUAZIP
     DEFINES += QUAZIP_BUILD
     DEFINES += QUAZIP_STATIC # Required by Quazip to export symbols
-    include(third_party/quazip/quazip/quazip.pri)
+    include(third_party/quazip.pri)
     # For correct include paths
     INCLUDEPATH += third_party/quazip
 }
@@ -35,7 +35,7 @@ CONFIG += warn_on c++14
 CONFIG += lrelease embed_translations
 
 !contains(DEFINES, EXTERN_QUAZIP) {
-    # using internal 3rd party QUAZIP
+    # using internal 3rd party QUAZIP which is part of SOURCES
     LIBS += -lz
 } else {
     #using external quazip

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(
     Qt${QT_VERSION_MAJOR}::Widgets
     Qt${QT_VERSION_MAJOR}::Xml
   PRIVATE
-    quazip5
+    QuaZip::QuaZip
     # MediaElch object libraries
     mediaelch_concert
     mediaelch_data

--- a/src/export/CMakeLists.txt
+++ b/src/export/CMakeLists.txt
@@ -9,4 +9,9 @@ target_link_libraries(
   PRIVATE Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets
           Qt${QT_VERSION_MAJOR}::Network Qt${QT_VERSION_MAJOR}::Sql quazip5
 )
+
+if(Qt6_FOUND)
+  target_link_libraries(mediaelch_export PRIVATE Qt6::Network Qt6::Core5Compat)
+endif()
+
 mediaelch_post_target_defaults(mediaelch_export)

--- a/src/export/CMakeLists.txt
+++ b/src/export/CMakeLists.txt
@@ -6,8 +6,9 @@ add_library(
 
 target_link_libraries(
   mediaelch_export
-  PRIVATE Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets
-          Qt${QT_VERSION_MAJOR}::Network Qt${QT_VERSION_MAJOR}::Sql quazip5
+  PRIVATE
+    Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets
+    Qt${QT_VERSION_MAJOR}::Network Qt${QT_VERSION_MAJOR}::Sql QuaZip::QuaZip
 )
 
 if(Qt6_FOUND)

--- a/src/movies/MovieFilesOrganizer.cpp
+++ b/src/movies/MovieFilesOrganizer.cpp
@@ -82,7 +82,6 @@ void MovieFilesOrganizer::canceled(QString msg)
     msgBox.setText(tr("Operation not possible."));
     msgBox.setInformativeText(tr("%1\n Operation Canceled.").arg(msg));
     msgBox.setStandardButtons(QMessageBox::Ok);
-    msgBox.setButtonText(1, "Ok");
     msgBox.setDefaultButton(QMessageBox::Ok);
     msgBox.exec();
 }

--- a/src/tv_shows/CMakeLists.txt
+++ b/src/tv_shows/CMakeLists.txt
@@ -25,6 +25,6 @@ target_link_libraries(
   PRIVATE
     Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Sql
     Qt${QT_VERSION_MAJOR}::Network Qt${QT_VERSION_MAJOR}::Xml
-    Qt${QT_VERSION_MAJOR}::MultimediaWidgets quazip5
+    Qt${QT_VERSION_MAJOR}::MultimediaWidgets QuaZip::QuaZip
 )
 mediaelch_post_target_defaults(mediaelch_tvShows)

--- a/src/ui/main/MyIconFont.cpp
+++ b/src/ui/main/MyIconFont.cpp
@@ -78,9 +78,9 @@ public:
 #ifdef Q_OS_MAC
         drawSize *= 0.8;
 #else
-        drawSize *= 0.94;
+        drawSize *= 0.94f;
 #endif
-        drawSize = drawSize - (digits * 2 + 2);
+        drawSize = drawSize - (digits * 2.f + 2.f);
 
         QFont f;
         f.setPointSizeF(drawSize);

--- a/src/ui/settings/GlobalSettingsWidget.cpp
+++ b/src/ui/settings/GlobalSettingsWidget.cpp
@@ -261,10 +261,8 @@ void GlobalSettingsWidget::organize()
     msgBox.setText(tr("Are you sure?"));
     msgBox.setInformativeText(
         tr("This operation sorts all movies in this directory to separate "
-           "sub-directories based on the file name. Click \"Ok\", if thats, what you want to do. "));
+           "sub-directories based on the file name. Click \"Ok\", if that's, what you want to do. "));
     msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
-    msgBox.setButtonText(1, tr("Ok"));
-    msgBox.setButtonText(2, tr("Cancel"));
     msgBox.setDefaultButton(QMessageBox::Cancel);
     int ret = msgBox.exec();
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,56 +1,8 @@
 if(NOT USE_EXTERN_QUAZIP)
-  find_package(ZLIB REQUIRED)
-
-  add_library(quazip5 STATIC)
-
-  target_include_directories(quazip5 SYSTEM INTERFACE quazip)
-  target_include_directories(quazip5 PRIVATE quazip/quazip)
-  target_compile_definitions(quazip5 PRIVATE QUAZIP_BUILD)
-  target_compile_options(quazip5 PRIVATE -w) # Disable warnings for third-party
-                                             # software
-
-  target_sources(
-    quazip5
-    PRIVATE
-      quazip/quazip/ioapi.h
-      quazip/quazip/JlCompress.cpp
-      quazip/quazip/JlCompress.h
-      quazip/quazip/minizip_crypt.h
-      quazip/quazip/qioapi.cpp
-      quazip/quazip/quaadler32.cpp
-      quazip/quazip/quaadler32.h
-      quazip/quazip/quachecksum32.h
-      quazip/quazip/quacrc32.cpp
-      quazip/quazip/quacrc32.h
-      quazip/quazip/quagzipfile.cpp
-      quazip/quazip/quagzipfile.h
-      quazip/quazip/quaziodevice.cpp
-      quazip/quazip/quaziodevice.h
-      quazip/quazip/quazip.cpp
-      quazip/quazip/quazip.h
-      quazip/quazip/quazip.pri
-      quazip/quazip/quazip.pro
-      quazip/quazip/quazip.sln
-      quazip/quazip/quazip.vcproj
-      quazip/quazip/quazip.vcxproj
-      quazip/quazip/quazip.vcxproj.filters
-      quazip/quazip/quazip_global.h
-      quazip/quazip/quazipdir.cpp
-      quazip/quazip/quazipdir.h
-      quazip/quazip/quazipfile.cpp
-      quazip/quazip/quazipfile.h
-      quazip/quazip/quazipfileinfo.cpp
-      quazip/quazip/quazipfileinfo.h
-      quazip/quazip/quazipnewinfo.cpp
-      quazip/quazip/quazipnewinfo.h
-      quazip/quazip/run_moc.bat
-      quazip/quazip/unzip.c
-      quazip/quazip/unzip.h
-      quazip/quazip/zip.c
-      quazip/quazip/zip.h
+  message(STATUS "Using QuaZip from submodule")
+  set(QUAZIP_QT_MAJOR_VERSION
+      ${QT_VERSION_MAJOR}
+      CACHE STRING "Qt version to use (4, 5 or 6), defaults to 5" FORCE
   )
-
-  target_link_libraries(quazip5 PUBLIC Qt${QT_VERSION_MAJOR}::Core ZLIB::ZLIB)
-  # We don't want e.g. clang-tidy warnings to quazip
-  set_target_properties(quazip5 PROPERTIES CXX_CLANG_TIDY "")
+  add_subdirectory(quazip)
 endif()

--- a/third_party/quazip.pri
+++ b/third_party/quazip.pri
@@ -1,0 +1,37 @@
+INCLUDEPATH += $$PWD/quazip/quazip
+DEPENDPATH += $$PWD/quazip/quazip
+
+HEADERS += \
+        $$PWD/quazip/quazip/JlCompress.h \
+        $$PWD/quazip/quazip/ioapi.h \
+        $$PWD/quazip/quazip/minizip_crypt.h \
+        $$PWD/quazip/quazip/quaadler32.h \
+        $$PWD/quazip/quazip/quachecksum32.h \
+        $$PWD/quazip/quazip/quacrc32.h \
+        $$PWD/quazip/quazip/quagzipfile.h \
+        $$PWD/quazip/quazip/quaziodevice.h \
+        $$PWD/quazip/quazip/quazip.h \
+        $$PWD/quazip/quazip/quazip_global.h \
+        $$PWD/quazip/quazip/quazip_qt_compat.h \
+        $$PWD/quazip/quazip/quazipdir.h \
+        $$PWD/quazip/quazip/quazipfile.h \
+        $$PWD/quazip/quazip/quazipfileinfo.h \
+        $$PWD/quazip/quazip/quazipnewinfo.h \
+        $$PWD/quazip/quazip/unzip.h \
+        $$PWD/quazip/quazip/zip.h
+
+SOURCES += \
+        $$PWD/quazip/quazip/unzip.c \
+        $$PWD/quazip/quazip/zip.c \
+        $$PWD/quazip/quazip/JlCompress.cpp \
+        $$PWD/quazip/quazip/qioapi.cpp \
+        $$PWD/quazip/quazip/quaadler32.cpp \
+        $$PWD/quazip/quazip/quachecksum32.cpp \
+        $$PWD/quazip/quazip/quacrc32.cpp \
+        $$PWD/quazip/quazip/quagzipfile.cpp \
+        $$PWD/quazip/quazip/quaziodevice.cpp \
+        $$PWD/quazip/quazip/quazip.cpp \
+        $$PWD/quazip/quazip/quazipdir.cpp \
+        $$PWD/quazip/quazip/quazipfile.cpp \
+        $$PWD/quazip/quazip/quazipfileinfo.cpp \
+        $$PWD/quazip/quazip/quazipnewinfo.cpp


### PR DESCRIPTION
Update submodule to QuaZip 1.1.  Furthermore, apply fixes so that we
can also work with QuaZip 1.1 for Qt6.