### PR TITLE
[Qt] Fix builds for Qt < 5.10

### DIFF
--- a/.ci/docker/Dockerfile.ci.linux
+++ b/.ci/docker/Dockerfile.ci.linux
@@ -26,12 +26,12 @@ RUN apt-get update && \
         curl \
         zlib1g \
         zlib1g-dev \
-        g++-10 \
-        gcc-10 \
+        g++-11 \
+        gcc-11 \
         libclang-11-dev \
         clang-tidy-11 \
         clang-tools-11 \
-        clang-format-11 \
+        clang-format-12 \
         clang-11 \
         llvm-11-dev && \
     apt-get install -y --no-install-recommends \
@@ -63,12 +63,12 @@ RUN apt-get update && \
         libqt5svg5 \
         libqt5svg5-dev && \
     apt-get autoremove && \
-    update-alternatives --install /usr/bin/gcc           gcc          /usr/bin/gcc-10          10 && \
-    update-alternatives --install /usr/bin/gcov          gcov         /usr/bin/gcov-10         10 && \
-    update-alternatives --install /usr/bin/g++           g++          /usr/bin/g++-10          10 && \
+    update-alternatives --install /usr/bin/gcc           gcc          /usr/bin/gcc-11          10 && \
+    update-alternatives --install /usr/bin/gcov          gcov         /usr/bin/gcov-11         10 && \
+    update-alternatives --install /usr/bin/g++           g++          /usr/bin/g++-11          10 && \
     update-alternatives --install /usr/bin/clang++       clang++      /usr/bin/clang++-11      10 && \
     update-alternatives --install /usr/bin/clang         clang        /usr/bin/clang-11        10 && \
-    update-alternatives --install /usr/bin/clang-format  clang-format /usr/bin/clang-format-11 10 && \
+    update-alternatives --install /usr/bin/clang-format  clang-format /usr/bin/clang-format-12 10 && \
     update-alternatives --install /usr/bin/clang-tidy    clang-tidy   /usr/bin/clang-tidy-11   10 && \
     update-alternatives --install /usr/bin/llvm-config   llvm-config  /usr/bin/llvm-config-11  10 && \
     update-alternatives --install /usr/bin/llvm-cov      llvm-cov     /usr/bin/llvm-cov-11     10 && \
@@ -85,11 +85,10 @@ RUN pip3 install cmake cmake_format
 
 # Multicore build always fails for some reason, so we use -j1
 RUN cd /opt && git clone https://github.com/KDE/clazy.git && \
-    cd /opt/clazy && git checkout 1.9 && \
-    mkdir build && cd build && \
-    cmake -DCMAKE_BUILD_TYPE=Release .. && \
-    make -j1 && \
-    make install && \
+    cd /opt/clazy && git checkout 1.10 && \
+    cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -GNinja && \
+    cmake --build build && \
+    cmake --build build --target install && \
     cd /opt && rm -rf clazy
 
 RUN mkdir /opt/src

--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -28,7 +28,11 @@ INCLUDEPATH += $$PWD/src
 }
 
 QT += core gui network xml sql widgets multimedia multimediawidgets \
-      concurrent qml quick quickwidgets opengl svg core5compat
+      concurrent qml quick quickwidgets opengl svg
+
+equals(QT_MAJOR_VERSION, 6) {
+    QT += core5compat
+}
 
 CONFIG += warn_on c++14
 CONFIG += lrelease embed_translations

--- a/src/data/Actor.h
+++ b/src/data/Actor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "globals/Meta.h"
+
 #include <QDebug>
 #include <QMetaType>
 #include <QString>
@@ -29,7 +31,7 @@ public:
     /// \brief Removes the given actor. Actors are compared by pointer and not by value.
     void removeActor(Actor* actor);
 
-    qsizetype size() { return m_actors.size(); }
+    elch_size_t size() { return m_actors.size(); }
     bool hasActors() const;
 
     /// \brief Clears all images from all actors.

--- a/src/data/Rating.h
+++ b/src/data/Rating.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "globals/Meta.h"
+
 #include <QMetaType>
 #include <QObject>
 #include <QString>
@@ -67,7 +69,7 @@ public:
 
     // For STL container compatibility
 
-    qsizetype size() const { return m_ratings.size(); }
+    elch_size_t size() const { return m_ratings.size(); }
     auto begin() { return m_ratings.begin(); }
     auto end() { return m_ratings.end(); }
     auto begin() const { return m_ratings.begin(); }

--- a/src/file/Path.h
+++ b/src/file/Path.h
@@ -115,8 +115,8 @@ public:
         }
     }
 
-    qsizetype size() const { return m_files.size(); }
-    qsizetype count() const { return m_files.count(); }
+    elch_size_t size() const { return m_files.size(); }
+    elch_size_t count() const { return m_files.count(); }
     bool isEmpty() const { return m_files.isEmpty(); }
 
     void clear() { m_files.clear(); }

--- a/src/globals/Meta.h
+++ b/src/globals/Meta.h
@@ -5,10 +5,13 @@
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #    define ELCH_QHASH_RETURN_TYPE uint
 #    define ELCH_MEDIA_PLAYBACK_STATE QMediaPlayer::State
+// most size() and count() functions return int.
+using elch_size_t = int;
 #else
 // With Qt 6, qHash uses size_t
 #    define ELCH_QHASH_RETURN_TYPE size_t
 #    define ELCH_MEDIA_PLAYBACK_STATE QMediaPlayer::PlaybackState
+using elch_size_t = qsizetype;
 #endif
 
 #define ELCH_NODISCARD Q_REQUIRED_RESULT

--- a/src/ui/main/AboutDialog.cpp
+++ b/src/ui/main/AboutDialog.cpp
@@ -105,12 +105,12 @@ void AboutDialog::copyToClipboard()
 
 void AboutDialog::setLibraryDetails()
 {
-    qsizetype episodes = 0;
+    elch_size_t episodes = 0;
     for (TvShow* show : Manager::instance()->tvShowModel()->tvShows()) {
         episodes += show->episodes().count();
     }
 
-    qsizetype albums = 0;
+    elch_size_t albums = 0;
     for (Artist* artist : Manager::instance()->musicModel()->artists()) {
         albums += artist->albums().count();
     }

--- a/src/ui/main/MainWindow.cpp
+++ b/src/ui/main/MainWindow.cpp
@@ -396,7 +396,7 @@ void MainWindow::onActionSearch()
         }
 
     } else if (current == MainWidgets::TvShows) {
-        const qsizetype itemsSelected = ui->tvShowFilesWidget->selectedEpisodes(false).count() + //
+        const elch_size_t itemsSelected = ui->tvShowFilesWidget->selectedEpisodes(false).count() + //
                                         ui->tvShowFilesWidget->selectedShows().count();
         if (itemsSelected > 1) {
             ui->tvShowFilesWidget->multiScrape();

--- a/src/ui/settings/GlobalSettingsWidget.cpp
+++ b/src/ui/settings/GlobalSettingsWidget.cpp
@@ -95,19 +95,19 @@ void GlobalSettingsWidget::loadSettings()
     ui->dirs->setRowCount(0);
     ui->dirs->clearContents();
     QVector<SettingsDir> movieDirectories = m_settings->directorySettings().movieDirectories();
-    for (qsizetype i = 0, n = movieDirectories.count(); i < n; ++i) {
+    for (elch_size_t i = 0, n = movieDirectories.count(); i < n; ++i) {
         addDir(movieDirectories.at(i), SettingsDirType::Movies);
     }
     QVector<SettingsDir> tvShowDirectories = m_settings->directorySettings().tvShowDirectories();
-    for (qsizetype i = 0, n = tvShowDirectories.count(); i < n; ++i) {
+    for (elch_size_t i = 0, n = tvShowDirectories.count(); i < n; ++i) {
         addDir(tvShowDirectories.at(i), SettingsDirType::TvShows);
     }
     QVector<SettingsDir> concertDirectories = m_settings->directorySettings().concertDirectories();
-    for (qsizetype i = 0, n = concertDirectories.count(); i < n; ++i) {
+    for (elch_size_t i = 0, n = concertDirectories.count(); i < n; ++i) {
         addDir(concertDirectories.at(i), SettingsDirType::Concerts);
     }
     QVector<SettingsDir> downloadDirectories = m_settings->directorySettings().downloadDirectories();
-    for (qsizetype i = 0, n = downloadDirectories.count(); i < n; ++i) {
+    for (elch_size_t i = 0, n = downloadDirectories.count(); i < n; ++i) {
         SettingsDir dir;
         dir.path = downloadDirectories.at(i).path;
         addDir(downloadDirectories.at(i), SettingsDirType::Downloads);


### PR DESCRIPTION
I added usage of `qsizetype` about 5 months ago, to fix some warnings
for Qt6.  I tested it with Qt 5.15 but forgot to test 5.6.

Turns out `qsizetype` was introduced in Qt 5.10.