### PR TITLE
[Project] Fix `-Wconversion` warnings for Qt6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,15 @@
    `CONFIG+=USE_EXTERN_QUAZIP` for QMake can still be used to use the system's QuaZip.
    QuaZip v0.9 is still supported as well.
    This step was necessary for Qt6 support.
+ - MediaElch now supports Qt6!
+
+### Changes for Package Maintainers
+
+If you package MediaElch, e.g. for some Linux distributions, these notes may be important for you:
+
+ - MediaElch now fully supports Qt6!  Note however, that if you use `USE_EXTERN_QUAZIP`
+   with Qt6, only the CMake build is supported! Qt6 with QMake is only supported
+   without `USE_EXTERN_QUAZIP`!
 
 
 ## 2.8.12 - Coridian (2021-05-10)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 # cmake build of MediaElch
 
-# Please note that CMake support is experimental.
-
 # Uncomment this to see all commands cmake actually executes
 # set(CMAKE_VERBOSE_MAKEFILE ON)
 

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -35,7 +35,7 @@ function(enable_warnings warning_target)
       -Wno-error=unsafe-loop-optimizations
       -Wformat=2
       -Wmissing-field-initializers
-      # disabled for now due to Qt6 type change for .size() -Wconversion
+      -Wconversion
       -Wsign-conversion
       >
       $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:

--- a/src/concerts/Concert.cpp
+++ b/src/concerts/Concert.cpp
@@ -270,7 +270,7 @@ QStringList Concert::genres() const
 QVector<QString*> Concert::genresPointer()
 {
     QVector<QString*> genres;
-    for (int i = 0, n = m_concert.genres.size(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_concert.genres.size(); i < n; ++i) {
         genres.append(&m_concert.genres[i]);
     }
     return genres;

--- a/src/concerts/ConcertController.cpp
+++ b/src/concerts/ConcertController.cpp
@@ -204,8 +204,8 @@ void ConcertController::onFanartLoadDone(Concert* concert, QMap<ImageType, QVect
     }
 
     m_downloadsInProgress = !downloads.isEmpty();
-    m_downloadsSize = downloads.count();
-    m_downloadsLeft = downloads.count();
+    m_downloadsSize = qsizetype_to_int(downloads.count());
+    m_downloadsLeft = qsizetype_to_int(downloads.count());
     m_downloadManager->setDownloads(downloads);
 }
 

--- a/src/concerts/ConcertFileSearcher.cpp
+++ b/src/concerts/ConcertFileSearcher.cpp
@@ -149,7 +149,7 @@ void ConcertFileSearcher::scanDir(QString startPath,
 
     QRegularExpression rx("((part|cd)[\\s_]*)(\\d+)");
     rx.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
-    for (int i = 0, n = files.size(); i < n; i++) {
+    for (elch_size_t i = 0, n = files.size(); i < n; i++) {
         if (m_aborted) {
             return;
         }
@@ -163,7 +163,7 @@ void ConcertFileSearcher::scanDir(QString startPath,
         concertFiles << QDir(path + QDir::separator() + file).path();
 
         QRegularExpressionMatch match = rx.match(file);
-        const int pos = match.capturedStart();
+        const elch_size_t pos = match.capturedStart();
         if (pos != -1) {
             QString left = file.left(pos) + match.captured(1);
             QString right = file.mid(pos + match.captured(1).size() + match.captured(2).size());
@@ -229,12 +229,12 @@ void ConcertFileSearcher::storeContentsInDatabase(const QVector<QStringList>& co
         QString path;
         // get directory
         if (!files.isEmpty()) {
-            int index = -1;
+            elch_size_t index = -1;
             // Get a normalized path so that we can compare it to QPath().path().
             // Otherwise we may still have a Windows-style path, e.g. "G:\Test"
             // instead of "G:/Test". "files" should already be normalized, though.
             const QString filePath = QDir(files.at(0)).path();
-            for (int i = 0, n = m_directories.count(); i < n; ++i) {
+            for (elch_size_t i = 0, n = m_directories.count(); i < n; ++i) {
                 if (filePath.startsWith(m_directories[i].path.path())) {
                     if (index == -1) {
                         index = i;
@@ -266,7 +266,7 @@ void ConcertFileSearcher::setupDatabaseConcerts(const QVector<Concert*>& dbConce
         }
         concert->controller()->loadData(Manager::instance()->mediaCenterInterface(), false, false);
         emit currentDir(concert->title());
-        emit progress(++concertCounter, dbConcerts.size(), m_progressMessageId);
+        emit progress(++concertCounter, qsizetype_to_int(dbConcerts.size()), m_progressMessageId);
     }
 }
 

--- a/src/concerts/ConcertModel.cpp
+++ b/src/concerts/ConcertModel.cpp
@@ -37,7 +37,7 @@ void ConcertModel::addConcert(Concert* concert)
  */
 void ConcertModel::onConcertChanged(Concert* concert)
 {
-    QModelIndex index = createIndex(m_concerts.indexOf(concert), 0);
+    QModelIndex index = createIndex(qsizetype_to_int(m_concerts.indexOf(concert)), 0);
     emit dataChanged(index, index);
 }
 
@@ -66,7 +66,7 @@ int ConcertModel::rowCount(const QModelIndex& parent) const
         // Root has an invalid model index.
         return 0;
     }
-    return m_concerts.size();
+    return qsizetype_to_int(m_concerts.size());
 }
 
 int ConcertModel::columnCount(const QModelIndex& parent) const
@@ -170,7 +170,7 @@ void ConcertModel::clear()
     if (m_concerts.isEmpty()) {
         return;
     }
-    beginRemoveRows(QModelIndex(), 0, m_concerts.size() - 1);
+    beginRemoveRows(QModelIndex(), 0, qsizetype_to_int(m_concerts.size() - 1));
     for (Concert* concert : asConst(m_concerts)) {
         concert->deleteLater();
     }

--- a/src/data/ActorModel.cpp
+++ b/src/data/ActorModel.cpp
@@ -27,7 +27,7 @@ int ActorModel::rowCount(const QModelIndex& parent) const
         // Root has an invalid model index.
         return 0;
     }
-    return m_actors->actors().size();
+    return qsizetype_to_int(m_actors->actors().size());
 }
 
 int ActorModel::columnCount(const QModelIndex& parent) const

--- a/src/data/StreamDetails.cpp
+++ b/src/data/StreamDetails.cpp
@@ -292,7 +292,7 @@ QString StreamDetails::audioCodec() const
     QString normalCodec;
     QString sdCodec;
     QString defaultCodec;
-    for (int i = 0, n = m_audioDetails.count(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_audioDetails.count(); i < n; ++i) {
         QString codec = m_audioDetails.at(i).value(AudioDetails::Codec);
         if (m_hdAudioCodecs.contains(codec)) {
             hdCodec = codec;

--- a/src/export/SimpleEngine.cpp
+++ b/src/export/SimpleEngine.cpp
@@ -479,7 +479,7 @@ void SimpleEngine::replaceStreamDetailsVars(QString& m, const StreamDetails* det
     QStringList audioCodecs;
     QStringList audioChannels;
     QStringList audioLanguages;
-    for (int i = 0, n = audioDetails.count(); i < n; ++i) {
+    for (elch_size_t i = 0, n = audioDetails.count(); i < n; ++i) {
         audioCodecs << audioDetails.at(i).value(StreamDetails::AudioDetails::Codec);
         audioChannels << audioDetails.at(i).value(StreamDetails::AudioDetails::Channels);
         audioLanguages << audioDetails.at(i).value(StreamDetails::AudioDetails::Language);
@@ -514,9 +514,9 @@ void SimpleEngine::replaceMultiBlock(QString& m,
         QString block = match.captured(0);
         QString item = match.captured(1).trimmed();
         QStringList list;
-        for (int i = 0, n = replaces.at(0).count(); i < n; ++i) {
+        for (elch_size_t i = 0, n = replaces.at(0).count(); i < n; ++i) {
             QString subItem = item;
-            for (int x = 0, y = itemNames.count(); x < y; ++x) {
+            for (elch_size_t x = 0, y = itemNames.count(); x < y; ++x) {
                 subItem.replace("{{ " + itemNames.at(x) + " }}", replaces.at(x).at(i).toHtmlEscaped());
             }
             list << subItem;

--- a/src/globals/DownloadManager.cpp
+++ b/src/globals/DownloadManager.cpp
@@ -90,7 +90,7 @@ bool DownloadManager::hasDownloadsLeft(T*& elementToCheck)
 {
     // Note: This code looks similar to numberOfDownloadsLeft() but does not require
     // to run through all downloads.
-    for (int i = 0, n = m_queue.size(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_queue.size(); i < n; ++i) {
         if (m_queue[i].getElement<T>() == elementToCheck) {
             return true;
         }
@@ -110,7 +110,7 @@ template<class T>
 int DownloadManager::numberOfDownloadsLeft(T*& elementToCheck)
 {
     int count = 0;
-    for (int i = 0, n = m_queue.size(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_queue.size(); i < n; ++i) {
         if (m_queue[i].getElement<T>() == elementToCheck) {
             ++count;
         }
@@ -309,7 +309,7 @@ bool DownloadManager::isDownloading() const
 
 int DownloadManager::downloadQueueSize()
 {
-    return m_queue.size() + m_currentReplies.size();
+    return qsizetype_to_int(m_queue.size() + m_currentReplies.size());
 }
 
 int DownloadManager::downloadsLeftForShow(TvShow* show)

--- a/src/globals/Helper.cpp
+++ b/src/globals/Helper.cpp
@@ -535,8 +535,8 @@ void applyEffect(QWidget* parent)
 
 qreal similarity(const QString& s1, const QString& s2)
 {
-    const int len1 = s1.length();
-    const int len2 = s2.length();
+    const elch_size_t len1 = s1.length();
+    const elch_size_t len2 = s2.length();
 
     if (s1 == s2) {
         return 1;
@@ -566,7 +566,7 @@ qreal similarity(const QString& s1, const QString& s2)
     }
 
     qreal dist = d[len1][len2];
-    return 1 - (dist / qMax(len1, len2));
+    return 1 - (dist / static_cast<qreal>(qMax(len1, len2)));
 }
 
 QMap<ColorLabel, QString> labels()

--- a/src/globals/ImageDialog.cpp
+++ b/src/globals/ImageDialog.cpp
@@ -302,8 +302,8 @@ void ImageDialog::startNextDownload()
 {
     qCDebug(generic) << "[ImageDialog] Start next download";
 
-    int nextIndex = -1;
-    for (int i = 0, n = m_elements.size(); i < n; i++) {
+    elch_size_t nextIndex = -1;
+    for (elch_size_t i = 0, n = m_elements.size(); i < n; i++) {
         if (!m_elements[i].downloaded) {
             nextIndex = i;
             break;
@@ -319,7 +319,7 @@ void ImageDialog::startNextDownload()
     QUrl url =
         m_elements[nextIndex].thumbUrl.isValid() ? m_elements[nextIndex].thumbUrl : m_elements[nextIndex].originalUrl;
 
-    m_currentDownloadIndex = nextIndex;
+    m_currentDownloadIndex = qsizetype_to_int(nextIndex);
     m_currentDownloadReply = network()->get(mediaelch::network::requestWithDefaults(url));
     connect(m_currentDownloadReply, &QNetworkReply::finished, this, &ImageDialog::downloadFinished);
 }
@@ -365,11 +365,11 @@ void ImageDialog::renderTable()
     ui->table->clearContents();
 
     for (int i = 0, n = ui->table->columnCount(); i < n; i++) {
-        ui->table->setColumnWidth(i, getColumnWidth());
+        ui->table->setColumnWidth(qsizetype_to_int(i), getColumnWidth());
     }
 
-    for (int i = 0, n = m_elements.size(); i < n; i++) {
-        int row = (i - (i % cols)) / cols;
+    for (int i = 0, n = qsizetype_to_int(m_elements.size()); i < n; i++) {
+        int row = qsizetype_to_int(i - (i % cols)) / cols;
         if (i % cols == 0) {
             ui->table->insertRow(row);
         }
@@ -522,7 +522,7 @@ void ImageDialog::chooseLocalImage()
 
     QFileInfo fi(fileName);
     Settings::instance()->setLastImagePath(mediaelch::DirectoryPath(fi.absoluteDir().canonicalPath()));
-    const int index = m_elements.size();
+    const elch_size_t index = m_elements.size();
 
     DownloadElement d;
     d.originalUrl = fileName;
@@ -561,7 +561,7 @@ void ImageDialog::onImageDropped(QUrl url)
 {
     qCDebug(generic) << "[ImageDialog] Dropped Image with url:" << url;
 
-    const int index = m_elements.size();
+    const elch_size_t index = m_elements.size();
 
     DownloadElement d;
     d.originalUrl = url;
@@ -801,7 +801,7 @@ void ImageDialog::onSearchFinished(QVector<ScraperSearchResult> results, mediael
     } else if (results.size() > 1) {
         // special case for 1 result  => load images automatically
         //                  0 results => message in center of dialog
-        showSuccess(tr("Found %n results", "", results.size()));
+        showSuccess(tr("Found %n results", "", qsizetype_to_int(results.size())));
     }
 
     for (const ScraperSearchResult& result : results) {

--- a/src/globals/Meta.h
+++ b/src/globals/Meta.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <QtGlobal>
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #    define ELCH_QHASH_RETURN_TYPE uint
@@ -16,6 +19,10 @@ using elch_size_t = qsizetype;
 
 #define ELCH_NODISCARD Q_REQUIRED_RESULT
 #define ELCH_DEPRECATED Q_DECL_DEPRECATED
+
+#define MediaElch_Expects(x) ((x) ? ((void)0) : throw std::runtime_error("MediaElch precondition failed (expects)"))
+#define MediaElch_Ensures(x) ((x) ? ((void)0) : throw std::runtime_error("MediaElch postcondition failed (ensures)"))
+#define MediaElch_Assert(x) ((x) ? ((void)0) : throw std::runtime_error("MediaElch assertion failed"))
 
 /// \brief Registers some common types using qRegisterMetaType
 /// \details Qt's queued connections require that types are registered using
@@ -121,6 +128,81 @@ auto makeDeleteLaterScope(T* ptr)
     return DeleteLaterScope<T>(ptr);
 }
 
-#define MediaElch_Expects(x) ((x) ? ((void)0) : throw std::runtime_error("MediaElch precondition failed (expects)"))
-#define MediaElch_Ensures(x) ((x) ? ((void)0) : throw std::runtime_error("MediaElch postcondition failed (ensures)"))
-#define MediaElch_Assert(x) ((x) ? ((void)0) : throw std::runtime_error("MediaElch assertion failed"))
+
+namespace detail {
+
+constexpr bool Signed = true;
+constexpr bool Unsigned = false;
+
+template<bool FromIsSigned, bool ToIsSigned, typename From, typename To>
+struct int_conversion
+{
+};
+
+template<typename From, typename To>
+struct int_conversion<Signed, Signed, From, To>
+{
+    static constexpr To convert(From from)
+    {
+        // TODO: No check if sizeof(To) >= sizeof(From)
+        MediaElch_Assert(from <= std::numeric_limits<To>::max());
+        MediaElch_Assert(from >= std::numeric_limits<To>::min());
+        return static_cast<To>(from);
+    }
+};
+
+template<typename From, typename To>
+struct int_conversion<Unsigned, Unsigned, From, To>
+{
+    static constexpr To convert(From from)
+    {
+        // TODO: No check if sizeof(To) >= sizeof(From)
+        MediaElch_Assert(from < std::numeric_limits<To>::max());
+        return static_cast<To>(from);
+    }
+};
+
+template<typename From, typename To>
+struct int_conversion<Unsigned, Signed, From, To>
+{
+    static constexpr To convert(From from)
+    {
+        // TODO: No check if sizeof(To) >= sizeof(From)
+        MediaElch_Assert(from <= std::numeric_limits<To>::max());
+        return static_cast<To>(from);
+    }
+};
+
+template<typename From, typename To>
+struct int_conversion<Signed, Unsigned, From, To>
+{
+    static constexpr To convert(From from)
+    {
+        MediaElch_Assert(from >= 0);
+        MediaElch_Assert(from <= std::numeric_limits<To>::max());
+        return static_cast<To>(from);
+    }
+};
+
+} // namespace detail
+
+template<typename To, typename From>
+constexpr To safe_int_cast(From from)
+{
+    static_assert(!std::is_same<From, To>::value, "Unnecessary int cast: Both types are the same");
+    static_assert(std::is_integral<From>::value, "safe_int_cast failed: From type is not integral");
+    static_assert(std::is_integral<To>::value, "safe_int_cast failed: To type is not integral");
+    return detail::int_conversion<std::is_signed<From>::value, std::is_signed<To>::value, From, To>::convert(from);
+}
+
+/// \brief Concerts qsizetype to int in a checked manner.
+/// \note  For Qt 5, the input value is returned as all return types of size()
+///        and count() return int as well.
+inline constexpr int qsizetype_to_int(elch_size_t size)
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    return size;
+#else
+    return safe_int_cast<int>(size);
+#endif
+}

--- a/src/globals/Random.cpp
+++ b/src/globals/Random.cpp
@@ -1,11 +1,15 @@
 #include "globals/Random.h"
 
+#include "globals/Meta.h"
+
 namespace mediaelch {
 
 unsigned randomUnsignedInt()
 {
 #if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
-    qsrand(QTime::currentTime().msec());
+    int time = QTime::currentTime().msec();
+    MediaElch_Assert(time >= 0);
+    qsrand(static_cast<unsigned>(time));
     return static_cast<unsigned>(qrand());
 #else
     return QRandomGenerator::global()->generate();

--- a/src/globals/TrailerDialog.cpp
+++ b/src/globals/TrailerDialog.cpp
@@ -4,6 +4,7 @@
 #include <QMessageBox>
 
 #include "globals/Manager.h"
+#include "globals/Meta.h"
 #include "network/NetworkRequest.h"
 #include "scrapers/trailer/TrailerProvider.h"
 
@@ -190,7 +191,7 @@ void TrailerDialog::showTrailers(QVector<TrailerResult> trailers)
     m_currentTrailers = trailers;
     bool hasPreview = false;
     bool hasLanguage = false;
-    for (int i = 0, n = trailers.size(); i < n; ++i) {
+    for (elch_size_t i = 0, n = trailers.size(); i < n; ++i) {
         TrailerResult trailer = trailers.at(i);
         int row = ui->trailers->rowCount();
         ui->trailers->insertRow(row);

--- a/src/image/ImageModel.cpp
+++ b/src/image/ImageModel.cpp
@@ -32,7 +32,7 @@ void ImageModel::clear()
 int ImageModel::rowCount(const QModelIndex& parent) const
 {
     Q_UNUSED(parent)
-    return m_images.count();
+    return qsizetype_to_int(m_images.count());
 }
 
 QVariant ImageModel::data(int row, const QString& roleName) const
@@ -78,7 +78,7 @@ void ImageModel::addImage(Image* image)
 
 void ImageModel::removeImage(Image* image)
 {
-    int row = m_images.indexOf(image);
+    int row = qsizetype_to_int(m_images.indexOf(image));
     if (row == -1) {
         return;
     }
@@ -184,7 +184,7 @@ bool ImageModel::setData(int row, const QVariant& value, int role)
 
 int ImageModel::rowById(int id) const
 {
-    for (int i = 0, n = m_images.count(); i < n; ++i) {
+    for (int i = 0, n = qsizetype_to_int(m_images.count()); i < n; ++i) {
         if (m_images.at(i)->imageId() == id) {
             return i;
         }

--- a/src/media_centers/KodiXml.cpp
+++ b/src/media_centers/KodiXml.cpp
@@ -466,7 +466,7 @@ void KodiXml::writeStreamDetails(QXmlStreamWriter& xml,
     }
     xml.writeEndElement();
 
-    for (int i = 0, n = streamDetails->audioDetails().count(); i < n; ++i) {
+    for (int i = 0, n = qsizetype_to_int(streamDetails->audioDetails().count()); i < n; ++i) {
         xml.writeStartElement("audio");
         QMapIterator<StreamDetails::AudioDetails, QString> itAudio(streamDetails->audioDetails().at(i));
         while (itAudio.hasNext()) {
@@ -479,7 +479,7 @@ void KodiXml::writeStreamDetails(QXmlStreamWriter& xml,
         xml.writeEndElement();
     }
 
-    for (int i = 0, n = streamDetails->subtitleDetails().count(); i < n; ++i) {
+    for (int i = 0, n = qsizetype_to_int(streamDetails->subtitleDetails().count()); i < n; ++i) {
         xml.writeStartElement("subtitle");
         QMapIterator<StreamDetails::SubtitleDetails, QString> itSubtitle(streamDetails->subtitleDetails().at(i));
         while (itSubtitle.hasNext()) {

--- a/src/movies/Movie.cpp
+++ b/src/movies/Movie.cpp
@@ -263,7 +263,7 @@ QStringList Movie::genres() const
 QVector<QString*> Movie::genresPointer()
 {
     QVector<QString*> genres;
-    for (int i = 0, n = m_genres.size(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_genres.size(); i < n; ++i) {
         genres.append(&m_genres[i]);
     }
     return genres;
@@ -290,7 +290,7 @@ QStringList Movie::countries() const
 QVector<QString*> Movie::countriesPointer()
 {
     QVector<QString*> countries;
-    for (int i = 0, n = m_countries.size(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_countries.size(); i < n; ++i) {
         countries.append(&m_countries[i]);
     }
     return countries;
@@ -317,7 +317,7 @@ QStringList Movie::studios() const
 QVector<QString*> Movie::studiosPointer()
 {
     QVector<QString*> studios;
-    for (int i = 0, n = m_studios.size(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_studios.size(); i < n; ++i) {
         studios.append(&m_studios[i]);
     }
     return studios;
@@ -868,7 +868,7 @@ void Movie::removeActor(Actor* actor)
  */
 void Movie::removeCountry(QString* country)
 {
-    for (int i = 0, n = m_countries.size(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_countries.size(); i < n; ++i) {
         if (&m_countries[i] == country) {
             m_countries.removeAt(i);
             break;
@@ -894,7 +894,7 @@ void Movie::removeCountry(QString country)
  */
 void Movie::removeGenre(QString* genre)
 {
-    for (int i = 0, n = m_genres.size(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_genres.size(); i < n; ++i) {
         if (&m_genres[i] == genre) {
             m_genres.removeAt(i);
             break;
@@ -920,7 +920,7 @@ void Movie::removeGenre(QString genre)
  */
 void Movie::removeStudio(QString* studio)
 {
-    for (int i = 0, n = m_studios.size(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_studios.size(); i < n; ++i) {
         if (&m_studios[i] == studio) {
             m_studios.removeAt(i);
             break;

--- a/src/movies/MovieController.cpp
+++ b/src/movies/MovieController.cpp
@@ -343,8 +343,8 @@ void MovieController::onFanartLoadDone(Movie* movie, QMap<ImageType, QVector<Pos
     }
 
     m_downloadsInProgress = !downloads.isEmpty();
-    m_downloadsSize = downloads.count();
-    m_downloadsLeft = downloads.count();
+    m_downloadsSize = qsizetype_to_int(downloads.count());
+    m_downloadsLeft = qsizetype_to_int(downloads.count());
     m_downloadManager->setDownloads(downloads);
 }
 

--- a/src/movies/MovieFilesOrganizer.cpp
+++ b/src/movies/MovieFilesOrganizer.cpp
@@ -30,14 +30,14 @@ void MovieFilesOrganizer::moveToDirs(mediaelch::DirectoryPath dir)
     fileSearcher->scanDir(path, path, contents, false, true);
     fileSearcher->deleteLater();
 
-    const int pos = path.lastIndexOf(QDir::separator());
+    const auto pos = path.lastIndexOf(QDir::separator());
     QString dirName = path.right(path.length() - pos - 1);
     QString fileName;
 
     NameFormatter::setExcludeWords(Settings::instance()->excludeWords());
 
     for (const QStringList& movie : asConst(contents)) {
-        const int movieIndex = movie.at(0).lastIndexOf(QDir::separator());
+        const auto movieIndex = movie.at(0).lastIndexOf(QDir::separator());
         if (!(movie.at(0).left(movieIndex).endsWith(dirName))) {
             qCDebug(generic) << "[MovieFilesOrganizer] skipping " << movie.at(0);
             continue;

--- a/src/movies/MovieModel.cpp
+++ b/src/movies/MovieModel.cpp
@@ -33,7 +33,7 @@ void MovieModel::addMovie(Movie* movie)
 
 void MovieModel::addMovies(const QVector<Movie*>& movies)
 {
-    beginInsertRows(QModelIndex(), rowCount(), rowCount() + movies.size() - 1);
+    beginInsertRows(QModelIndex(), rowCount(), rowCount() + qsizetype_to_int(movies.size()) - 1);
     m_movies.append(movies);
     for (Movie* movie : movies) {
         connect(movie, &Movie::sigChanged, this, &MovieModel::onMovieChanged, Qt::UniqueConnection);
@@ -48,7 +48,7 @@ void MovieModel::addMovies(const QVector<Movie*>& movies)
  */
 void MovieModel::onMovieChanged(Movie* movie)
 {
-    const QModelIndex index = createIndex(m_movies.indexOf(movie), 0);
+    const QModelIndex index = createIndex(qsizetype_to_int(m_movies.indexOf(movie)), 0);
     emit dataChanged(index, index);
 }
 
@@ -72,7 +72,7 @@ int MovieModel::rowCount(const QModelIndex& parent) const
         // Root has an invalid model index.
         return 0;
     }
-    return m_movies.size();
+    return qsizetype_to_int(m_movies.size());
 }
 
 int MovieModel::columnCount(const QModelIndex& parent) const
@@ -270,7 +270,7 @@ void MovieModel::clear()
     if (m_movies.isEmpty()) {
         return;
     }
-    beginRemoveRows(QModelIndex(), 0, m_movies.size() - 1);
+    beginRemoveRows(QModelIndex(), 0, qsizetype_to_int(m_movies.size()) - 1);
     for (Movie* movie : asConst(m_movies)) {
         movie->deleteLater();
     }

--- a/src/movies/file_searcher/MovieDirScan.cpp
+++ b/src/movies/file_searcher/MovieDirScan.cpp
@@ -97,7 +97,7 @@ void MovieDirScan::scanDir(QString startPath,
     QRegularExpression rx("([\\-_\\s\\.\\(\\)]+((a|b|c|d|e|f)|((part|cd|xvid)"
                           "[\\-_\\s\\.\\(\\)]*\\d+))[\\-_\\s\\.\\(\\)]+)",
         QRegularExpression::CaseInsensitiveOption);
-    for (int i = 0, n = files.size(); i < n; i++) {
+    for (elch_size_t i = 0, n = files.size(); i < n; i++) {
         if (m_aborted) {
             return;
         }
@@ -110,12 +110,12 @@ void MovieDirScan::scanDir(QString startPath,
 
         movieFiles << QDir::toNativeSeparators(path + QDir::separator() + file);
 
-        int pos = file.lastIndexOf(rx);
+        elch_size_t pos = file.lastIndexOf(rx);
         if (pos != -1) {
             QRegularExpressionMatch match = rx.match(file);
             QString left = file.left(pos);
             QString right = file.mid(pos + match.captured(0).size());
-            for (int x = 0; x < n; x++) {
+            for (elch_size_t x = 0; x < n; x++) {
                 QString subFile = files.at(x);
                 if (subFile != file) {
                     if (subFile.startsWith(left) && subFile.endsWith(right)) {

--- a/src/movies/file_searcher/MovieDirectorySearcher.cpp
+++ b/src/movies/file_searcher/MovieDirectorySearcher.cpp
@@ -88,7 +88,7 @@ void MovieDiskLoader::start()
     }
 
     m_processed = 0;
-    m_approxTotal = m_dir.separateFolders ? m_contents.size() : 0;
+    m_approxTotal = m_dir.separateFolders ? qsizetype_to_int(m_contents.size()) : 0;
     emit progress(this, m_processed, m_approxTotal);
 
     qCDebug(c_movie) << "[Movie] Creating movies for directory:" << QDir::toNativeSeparators(m_dir.path.path());

--- a/src/movies/file_searcher/MovieFileSearcher.cpp
+++ b/src/movies/file_searcher/MovieFileSearcher.cpp
@@ -139,7 +139,7 @@ void MovieFileSearcher::loadNext()
     SettingsDir dir = m_directoryQueue.dequeue();
 
     QString currentStatus = tr("Searching for movies...");
-    const size_t active =
+    const auto active =
         std::count_if(m_directories.cbegin(), m_directories.cend(), [](const SettingsDir& d) { return !d.disabled; });
     if (active > 1) {
         const auto finished = active - m_directoryQueue.size();

--- a/src/music/AlbumController.cpp
+++ b/src/music/AlbumController.cpp
@@ -233,8 +233,8 @@ void AlbumController::onFanartLoadDone(Album* album, QMap<ImageType, QVector<Pos
     }
 
     m_downloadsInProgress = !downloads.isEmpty();
-    m_downloadsSize = downloads.count();
-    m_downloadsLeft = downloads.count();
+    m_downloadsSize = qsizetype_to_int(downloads.count());
+    m_downloadsLeft = qsizetype_to_int(downloads.count());
     m_downloadManager->setDownloads(downloads);
 }
 

--- a/src/music/Artist.cpp
+++ b/src/music/Artist.cpp
@@ -484,7 +484,7 @@ void Artist::addDiscographyAlbum(DiscographyAlbum album)
 
 void Artist::removeDiscographyAlbum(DiscographyAlbum* album)
 {
-    for (int i = 0, n = m_discography.size(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_discography.size(); i < n; ++i) {
         if (&m_discography[i] == album) {
             m_discography.removeAt(i);
             break;

--- a/src/music/ArtistController.cpp
+++ b/src/music/ArtistController.cpp
@@ -226,7 +226,8 @@ void ArtistController::onFanartLoadDone(Artist* artist, QMap<ImageType, QVector<
         }
 
         if (it.key() == ImageType::ArtistExtraFanart) {
-            for (int i = 0, n = it.value().length(); i < n && i < Settings::instance()->extraFanartsMusicArtists();
+            for (elch_size_t i = 0, n = it.value().length();
+                 i < n && i < Settings::instance()->extraFanartsMusicArtists();
                  ++i) {
                 DownloadManagerElement d;
                 d.imageType = it.key();
@@ -254,8 +255,8 @@ void ArtistController::onFanartLoadDone(Artist* artist, QMap<ImageType, QVector<
     }
 
     m_downloadsInProgress = !downloads.isEmpty();
-    m_downloadsSize = downloads.count();
-    m_downloadsLeft = downloads.count();
+    m_downloadsSize = qsizetype_to_int(downloads.count());
+    m_downloadsLeft = qsizetype_to_int(downloads.count());
     m_downloadManager->setDownloads(downloads);
 }
 

--- a/src/music/MusicFileSearcher.cpp
+++ b/src/music/MusicFileSearcher.cpp
@@ -126,7 +126,7 @@ void MusicFileSearcher::reload(bool force)
     emit searchStarted(tr("Loading Music..."));
 
     int current = 0;
-    int max = artists.length() + albums.length() + artistsFromDb.length() + albumsFromDb.length();
+    int max = qsizetype_to_int(artists.length() + albums.length() + artistsFromDb.length() + albumsFromDb.length());
 
     Manager::instance()->database()->transaction();
     for (Artist* artist : artists) {

--- a/src/music/MusicModelItem.cpp
+++ b/src/music/MusicModelItem.cpp
@@ -20,14 +20,14 @@ MusicModelItem* MusicModelItem::child(int number)
 
 int MusicModelItem::childCount() const
 {
-    return m_childItems.count();
+    return qsizetype_to_int(m_childItems.count());
 }
 
 int MusicModelItem::childNumber() const
 {
     if (m_parentItem != nullptr) {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-        return m_parentItem->m_childItems.indexOf(const_cast<MusicModelItem*>(this));
+        return qsizetype_to_int(m_parentItem->m_childItems.indexOf(const_cast<MusicModelItem*>(this)));
     }
 
     return 0;

--- a/src/renamer/RenamerDialog.cpp
+++ b/src/renamer/RenamerDialog.cpp
@@ -53,11 +53,13 @@ int RenamerDialog::exec()
     const QString infoLabel = [&]() {
         switch (m_renameType) {
         case Renamer::RenameType::All: qCWarning(generic) << "Unknown Rename Type All"; return QString("");
-        case Renamer::RenameType::Concerts: return tr("%n concerts will be renamed", "", m_concerts.count());
-        case Renamer::RenameType::Movies: return tr("%n movies will be renamed", "", m_movies.count());
+        case Renamer::RenameType::Concerts:
+            return tr("%n concerts will be renamed", "", qsizetype_to_int(m_concerts.count()));
+        case Renamer::RenameType::Movies:
+            return tr("%n movies will be renamed", "", qsizetype_to_int(m_movies.count()));
         case Renamer::RenameType::TvShows:
-            return tr("%n TV shows and %1", "", m_shows.count())
-                .arg(tr("%n episodes will be renamed", "", m_episodes.count()));
+            return tr("%n TV shows and %1", "", qsizetype_to_int(m_shows.count()))
+                .arg(tr("%n episodes will be renamed", "", qsizetype_to_int(m_episodes.count())));
         }
         qCCritical(generic) << "[RenamerDialog] RenamerType: Missing case.";
         return QString("");

--- a/src/scrapers/image/FanartTv.cpp
+++ b/src/scrapers/image/FanartTv.cpp
@@ -834,7 +834,7 @@ void FanartTv::insertPoster(QVector<Poster>& posters, Poster b, QString language
     int lastInPreferredLang = -1;
     int lastHd = -1;
 
-    for (int i = 0, n = posters.count(); i < n; ++i) {
+    for (int i = 0, n = qsizetype_to_int(posters.count()); i < n; ++i) {
         if (posters[i].language == language && (posters[i].hint == "HD" || posters[i].hint == preferredDiscType)) {
             lastInPreferredLangAndHd = i;
         }

--- a/src/scrapers/movie/custom/CustomMovieScraper.cpp
+++ b/src/scrapers/movie/custom/CustomMovieScraper.cpp
@@ -258,7 +258,7 @@ void CustomMovieScraper::loadAllData(QHash<MovieScraper*, mediaelch::scraper::Mo
         scrapersWithIds.insert(scraper, MovieIdentifier(id));
     }
 
-    int loads = scrapersWithIds.count();
+    auto loads = scrapersWithIds.count();
     movie->controller()->setProperty("customMovieScraperLoads", loads);
     movie->controller()->setProperty("isCustomScraper", true);
 

--- a/src/scrapers/music/UniversalMusicScraper.cpp
+++ b/src/scrapers/music/UniversalMusicScraper.cpp
@@ -203,8 +203,8 @@ void UniversalMusicScraper::onArtistLoadFinished()
         return;
     }
 
-    int index = -1;
-    for (int i = 0, n = m_artistDownloads[artist].count(); i < n; ++i) {
+    elch_size_t index = -1;
+    for (elch_size_t i = 0, n = m_artistDownloads[artist].count(); i < n; ++i) {
         if (m_artistDownloads[artist][i].url == reply->url()) {
             index = i;
             break;
@@ -223,7 +223,7 @@ void UniversalMusicScraper::onArtistLoadFinished()
     m_artistDownloads[artist][index].downloaded = true;
 
     bool finished = true;
-    for (int i = 0, n = m_artistDownloads[artist].count(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_artistDownloads[artist].count(); i < n; ++i) {
         if (!m_artistDownloads[artist][i].downloaded) {
             finished = false;
             break;
@@ -473,8 +473,8 @@ void UniversalMusicScraper::onAlbumLoadFinished()
         return;
     }
 
-    int index = -1;
-    for (int i = 0, n = m_albumDownloads[album].count(); i < n; ++i) {
+    elch_size_t index = -1;
+    for (elch_size_t i = 0, n = m_albumDownloads[album].count(); i < n; ++i) {
         if (m_albumDownloads[album][i].url == reply->url()) {
             index = i;
             break;
@@ -492,7 +492,7 @@ void UniversalMusicScraper::onAlbumLoadFinished()
     m_albumDownloads[album][index].downloaded = true;
 
     bool finished = true;
-    for (int i = 0, n = m_albumDownloads[album].count(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_albumDownloads[album].count(); i < n; ++i) {
         if (!m_albumDownloads[album][i].downloaded) {
             finished = false;
             break;
@@ -673,7 +673,7 @@ bool UniversalMusicScraper::infosLeft(QSet<MusicScraperInfo> infos, Album* album
 
 bool UniversalMusicScraper::infosLeft(QSet<MusicScraperInfo> infos, Artist* artist)
 {
-    for (const auto info : infos) {
+    for (const auto info : asConst(infos)) {
         if (shouldLoad(info, infos, artist)) {
             return true;
         }

--- a/src/scrapers/tv_show/imdb/ImdbTvEpisodeParser.cpp
+++ b/src/scrapers/tv_show/imdb/ImdbTvEpisodeParser.cpp
@@ -248,7 +248,7 @@ void ImdbTvEpisodeParser::parseInfos(TvShowEpisode& episode, const QString& html
             // Most if not all episodes should have thumbs that are bigger than this.
             // This results in the followng postfix:
             const QString imdbThumbSizeSpec = QStringLiteral("._V1_UX400_CR0,0,400,225_AL_.jpg");
-            const int index = thumbUrlRaw.lastIndexOf("._V1");
+            const elch_size_t index = thumbUrlRaw.lastIndexOf("._V1");
             if (index > -1) {
                 thumbUrlRaw.truncate(index);
                 thumbUrlRaw.append(imdbThumbSizeSpec);

--- a/src/settings/DirectorySettings.cpp
+++ b/src/settings/DirectorySettings.cpp
@@ -31,7 +31,7 @@ void DirectorySettings::saveSettings()
 {
     const auto saveDirectory = [&](const char* settingsKey, QVector<SettingsDir>& directories) {
         m_settings->beginWriteArray(settingsKey);
-        const int size = directories.count();
+        const elch_size_t size = directories.count();
         for (int i = 0; i < size; ++i) {
             m_settings->setArrayIndex(i);
             m_settings->setValue("path", directories.at(i).path.path());
@@ -48,8 +48,8 @@ void DirectorySettings::saveSettings()
     saveDirectory("Directories/Music", m_musicDirectories);
 
     m_settings->beginWriteArray("Directories/TvShows");
-    for (int i = 0, n = m_tvShowDirectories.count(); i < n; ++i) {
-        m_settings->setArrayIndex(i);
+    for (elch_size_t i = 0, n = m_tvShowDirectories.count(); i < n; ++i) {
+        m_settings->setArrayIndex(qsizetype_to_int(i));
         m_settings->setValue("path", m_tvShowDirectories.at(i).path.path());
         m_settings->setValue("autoReload", m_tvShowDirectories.at(i).autoReload);
         m_settings->setValue("disabled", m_tvShowDirectories.at(i).disabled);

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -447,7 +447,7 @@ void Settings::saveSettings()
     settings()->setValue(KEY_SCRAPER_CURRENT_CONCERT_SCRAPER, m_currentConcertScraper);
 
     settings()->beginWriteArray(KEY_ALL_DATA_FILES);
-    for (int i = 0, n = m_dataFiles.count(); i < n; ++i) {
+    for (int i = 0, n = qsizetype_to_int(m_dataFiles.count()); i < n; ++i) {
         settings()->setArrayIndex(i);
         settings()->setValue("type", static_cast<int>(m_dataFiles.at(i).type()));
         settings()->setValue("fileName", m_dataFiles.at(i).fileName());

--- a/src/tv_shows/TvShow.cpp
+++ b/src/tv_shows/TvShow.cpp
@@ -186,7 +186,7 @@ void TvShow::addEpisode(TvShowEpisode* episode)
  */
 int TvShow::episodeCount() const
 {
-    return m_episodes.size();
+    return qsizetype_to_int(m_episodes.size());
 }
 
 /**
@@ -439,7 +439,7 @@ QStringList TvShow::genres() const
 QVector<QString*> TvShow::genresPointer()
 {
     QVector<QString*> genres;
-    for (int i = 0, n = m_genres.size(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_genres.size(); i < n; ++i) {
         genres.append(&m_genres[i]);
     }
     return genres;
@@ -677,7 +677,7 @@ const QMap<SeasonNumber, QVector<Poster>>& TvShow::allSeasonThumbs() const
 
 TvShowEpisode* TvShow::episode(SeasonNumber season, EpisodeNumber episode)
 {
-    for (int i = 0, n = m_episodes.count(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_episodes.count(); i < n; ++i) {
         if (m_episodes[i]->seasonNumber() == season && m_episodes[i]->episodeNumber() == episode) {
             return m_episodes[i];
         }
@@ -1420,7 +1420,7 @@ void TvShow::fillMissingEpisodes()
         }
 
         bool found = false;
-        for (int i = 0, n = m_episodes.count(); i < n; ++i) {
+        for (elch_size_t i = 0, n = m_episodes.count(); i < n; ++i) {
             if (m_episodes[i]->seasonNumber() == episode->seasonNumber()
                 && m_episodes[i]->episodeNumber() == episode->episodeNumber()) {
                 found = true;

--- a/src/tv_shows/TvShowEpisode.cpp
+++ b/src/tv_shows/TvShowEpisode.cpp
@@ -502,7 +502,7 @@ bool TvShowEpisode::hasChanged() const
 QVector<QString*> TvShowEpisode::writersPointer()
 {
     QVector<QString*> writers;
-    for (int i = 0, n = m_writers.size(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_writers.size(); i < n; ++i) {
         writers.append(&m_writers[i]);
     }
     return writers;
@@ -515,7 +515,7 @@ QVector<QString*> TvShowEpisode::writersPointer()
 QVector<QString*> TvShowEpisode::directorsPointer()
 {
     QVector<QString*> directors;
-    for (int i = 0, n = m_directors.size(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_directors.size(); i < n; ++i) {
         directors.append(&m_directors[i]);
     }
     return directors;
@@ -821,7 +821,7 @@ void TvShowEpisode::setStreamDetailsLoaded(bool loaded)
  */
 void TvShowEpisode::removeWriter(QString* writer)
 {
-    for (int i = 0, n = m_writers.size(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_writers.size(); i < n; ++i) {
         if (&m_writers[i] == writer) {
             m_writers.removeAt(i);
             break;
@@ -836,7 +836,7 @@ void TvShowEpisode::removeWriter(QString* writer)
  */
 void TvShowEpisode::removeDirector(QString* director)
 {
-    for (int i = 0, n = m_directors.size(); i < n; ++i) {
+    for (elch_size_t i = 0, n = m_directors.size(); i < n; ++i) {
         if (&m_directors[i] == director) {
             m_directors.removeAt(i);
             break;

--- a/src/tv_shows/TvShowFileSearcher.cpp
+++ b/src/tv_shows/TvShowFileSearcher.cpp
@@ -101,8 +101,8 @@ void TvShowFileSearcher::reloadEpisodes(const mediaelch::DirectoryPath& showDir)
 
     // get path
     mediaelch::DirectoryPath path;
-    int index = -1;
-    for (int i = 0, n = m_directories.count(); i < n; ++i) {
+    elch_size_t index = -1;
+    for (elch_size_t i = 0, n = m_directories.count(); i < n; ++i) {
         if (m_aborted) {
             return;
         }
@@ -128,7 +128,7 @@ void TvShowFileSearcher::reloadEpisodes(const mediaelch::DirectoryPath& showDir)
     emit currentDir(show->title());
 
     int episodeCounter = 0;
-    int episodeSum = contents.count();
+    int episodeSum = qsizetype_to_int(contents.count());
 
     QVector<TvShowEpisode*> episodes;
     for (const QStringList& files : contents) {
@@ -251,7 +251,7 @@ void TvShowFileSearcher::scanTvShowDir(const mediaelch::DirectoryPath& startPath
     files.sort();
 
     QRegularExpression rx("((?:part|cd)[\\s_]*)(\\d+)", QRegularExpression::CaseInsensitiveOption);
-    for (int i = 0, n = files.size(); i < n; i++) {
+    for (elch_size_t i = 0, n = files.size(); i < n; i++) {
         if (m_aborted) {
             return;
         }
@@ -265,7 +265,7 @@ void TvShowFileSearcher::scanTvShowDir(const mediaelch::DirectoryPath& startPath
         tvShowFiles << (path.toString() + '/' + file);
 
         QRegularExpressionMatch match = rx.match(file);
-        int pos = match.capturedStart(0);
+        elch_size_t pos = match.capturedStart(0);
         if (pos != -1) {
             QString left = file.left(pos) + match.captured(1);
             QString right = file.mid(pos + match.captured(1).size() + match.captured(2).size());
@@ -376,7 +376,7 @@ QVector<EpisodeNumber> TvShowFileSearcher::getEpisodeNumbers(QStringList files)
 
         QRegularExpressionMatchIterator matches = rx.globalMatch(filename);
 
-        int lastMatchEnd = -1;
+        elch_size_t lastMatchEnd = -1;
         while (matches.hasNext()) {
             QRegularExpressionMatch match = matches.next();
             // if between the last match and this one are more than five characters: break
@@ -489,7 +489,7 @@ void TvShowFileSearcher::setupShows(QMap<QString, QVector<QStringList>>& content
     QMapIterator<QString, QVector<QStringList>> it(contents);
     while (it.hasNext()) {
         it.next();
-        episodeSum += it.value().size();
+        episodeSum += qsizetype_to_int(it.value().size());
     }
     it.toFront();
 
@@ -503,8 +503,8 @@ void TvShowFileSearcher::setupShows(QMap<QString, QVector<QStringList>>& content
 
         // get path
         mediaelch::DirectoryPath path;
-        int index = -1;
-        for (int i = 0, n = m_directories.count(); i < n; ++i) {
+        elch_size_t index = -1;
+        for (elch_size_t i = 0, n = m_directories.count(); i < n; ++i) {
             if (it.key().startsWith(m_directories[i].path.path())) {
                 if (index == -1) {
                     index = i;

--- a/src/tv_shows/TvShowModel.cpp
+++ b/src/tv_shows/TvShowModel.cpp
@@ -64,7 +64,7 @@ int TvShowModel::columnCount(const QModelIndex& parent) const
     if (!parent.isValid()) {
         // the root item: columns for all children (TV shows)
         // each icon is a column + text
-        return m_icons.size() + 1;
+        return qsizetype_to_int(m_icons.size() + 1);
     }
     // All other items (season/episodes) only have one column
     return 1;
@@ -234,7 +234,7 @@ QModelIndex TvShowModel::index(int row, int column, const QModelIndex& parent) c
 
 void TvShowModel::appendShow(TvShow* show)
 {
-    const int size = m_rootItem.shows().size();
+    const int size = qsizetype_to_int(m_rootItem.shows().size());
 
     beginInsertRows(QModelIndex{}, size, size);
     {
@@ -316,7 +316,7 @@ int TvShowModel::rowCount(const QModelIndex& parent) const
 /// \brief Removes all children
 void TvShowModel::clear()
 {
-    const auto size = m_rootItem.shows().size();
+    const int size = qsizetype_to_int(m_rootItem.shows().size());
     if (size > 0) {
         beginRemoveRows(QModelIndex(), 0, size - 1);
         m_rootItem.removeChildren(0, size);

--- a/src/tv_shows/model/EpisodeModelItem.cpp
+++ b/src/tv_shows/model/EpisodeModelItem.cpp
@@ -20,7 +20,7 @@ TvShowBaseModelItem* EpisodeModelItem::parent() const
 int EpisodeModelItem::indexInParent() const
 {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    return m_parentItem.episodes().indexOf(const_cast<EpisodeModelItem*>(this));
+    return qsizetype_to_int(m_parentItem.episodes().indexOf(const_cast<EpisodeModelItem*>(this)));
 }
 
 TvShow* EpisodeModelItem::tvShow()

--- a/src/tv_shows/model/SeasonModelItem.cpp
+++ b/src/tv_shows/model/SeasonModelItem.cpp
@@ -22,7 +22,7 @@ TvShowBaseModelItem* SeasonModelItem::child(int number) const
 
 int SeasonModelItem::childCount() const
 {
-    return m_children.size();
+    return qsizetype_to_int(m_children.size());
 }
 
 /// \brief Returns a child or nullptr
@@ -44,7 +44,7 @@ const QList<EpisodeModelItem*>& SeasonModelItem::episodes() const
 int SeasonModelItem::indexInParent() const
 {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    return m_parentItem.seasons().indexOf(const_cast<SeasonModelItem*>(this));
+    return qsizetype_to_int(m_parentItem.seasons().indexOf(const_cast<SeasonModelItem*>(this)));
 }
 
 /// \brief Appends an episode to this model.

--- a/src/tv_shows/model/TvShowModelItem.cpp
+++ b/src/tv_shows/model/TvShowModelItem.cpp
@@ -25,7 +25,7 @@ TvShowBaseModelItem* TvShowModelItem::child(int number) const
 
 int TvShowModelItem::childCount() const
 {
-    return m_children.size();
+    return qsizetype_to_int(m_children.size());
 }
 
 bool TvShowModelItem::removeChildren(int position, int count)
@@ -50,7 +50,7 @@ TvShowBaseModelItem* TvShowModelItem::parent() const
 int TvShowModelItem::indexInParent() const
 {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    return m_parentItem.shows().indexOf(const_cast<TvShowModelItem*>(this));
+    return qsizetype_to_int(m_parentItem.shows().indexOf(const_cast<TvShowModelItem*>(this)));
 }
 
 TvShow* TvShowModelItem::tvShow()

--- a/src/tv_shows/model/TvShowRootModelItem.cpp
+++ b/src/tv_shows/model/TvShowRootModelItem.cpp
@@ -23,7 +23,7 @@ TvShowBaseModelItem* TvShowRootModelItem::child(int number) const
 
 int TvShowRootModelItem::childCount() const
 {
-    return m_children.size();
+    return qsizetype_to_int(m_children.size());
 }
 
 bool TvShowRootModelItem::removeChildren(int position, int count)

--- a/src/ui/concerts/ConcertInfoWidget.cpp
+++ b/src/ui/concerts/ConcertInfoWidget.cpp
@@ -107,7 +107,7 @@ void ConcertInfoWidget::updateConcertInfo()
     std::sort(certifications.begin(), certifications.end(), LocaleStringCompare());
     ui->certification->addItems(certifications);
     ui->certification->setCurrentIndex(
-        certifications.indexOf(m_concertController->concert()->certification().toString()));
+        qsizetype_to_int(certifications.indexOf(m_concertController->concert()->certification().toString())));
 
     ui->userRating->blockSignals(false);
     ui->runtime->blockSignals(false);

--- a/src/ui/concerts/ConcertSearchWidget.cpp
+++ b/src/ui/concerts/ConcertSearchWidget.cpp
@@ -138,7 +138,7 @@ void ConcertSearchWidget::onConcertResults(ConcertSearchJob* searchJob)
     }
 
     qCDebug(generic) << "[ConcertSearch] Result count:" << searchJob->results().count();
-    showSuccess(tr("Found %n results", "", searchJob->results().count()));
+    showSuccess(tr("Found %n results", "", qsizetype_to_int(searchJob->results().count())));
 
     for (const auto& result : searchJob->results()) {
         QString title;

--- a/src/ui/concerts/ConcertStreamDetailsWidget.cpp
+++ b/src/ui/concerts/ConcertStreamDetailsWidget.cpp
@@ -123,7 +123,7 @@ void ConcertStreamDetailsWidget::updateStreamDetails(bool reloadFromFile)
     m_streamDetailsSubtitles.clear();
 
     const auto audioDetails = streamDetails->audioDetails();
-    const int audioTracks = audioDetails.count();
+    const int audioTracks = qsizetype_to_int(audioDetails.count());
     for (int i = 0; i < audioTracks; ++i) {
         auto* label = new QLabel(tr("Track %1").arg(i + 1));
         ui->streamDetails->addWidget(label, 8 + i, 0);
@@ -158,7 +158,7 @@ void ConcertStreamDetailsWidget::updateStreamDetails(bool reloadFromFile)
         ui->streamDetails->addWidget(subtitleLabel, 8 + audioTracks, 0);
         m_streamDetailsWidgets << subtitleLabel;
 
-        for (int i = 0, n = streamDetails->subtitleDetails().count(); i < n; ++i) {
+        for (int i = 0, n = qsizetype_to_int(streamDetails->subtitleDetails().count()); i < n; ++i) {
             auto* trackLabel = new QLabel(tr("Track %1").arg(i + 1));
             ui->streamDetails->addWidget(trackLabel, 9 + audioTracks + i, 0);
             auto* edit1 =
@@ -230,12 +230,12 @@ void ConcertStreamDetailsWidget::onStreamDetailsEdited()
         VideoDetails::DurationInSeconds, QString::number(-ui->videoDuration->time().secsTo(QTime(0, 0))));
     details->setVideoDetail(VideoDetails::StereoMode, ui->stereoMode->currentData().toString());
 
-    for (int i = 0, n = m_streamDetailsAudio.count(); i < n; ++i) {
+    for (int i = 0, n = qsizetype_to_int(m_streamDetailsAudio.count()); i < n; ++i) {
         details->setAudioDetail(i, AudioDetails::Language, m_streamDetailsAudio[i][0]->text());
         details->setAudioDetail(i, AudioDetails::Codec, m_streamDetailsAudio[i][1]->text());
         details->setAudioDetail(i, AudioDetails::Channels, m_streamDetailsAudio[i][2]->text());
     }
-    for (int i = 0, n = m_streamDetailsSubtitles.count(); i < n; ++i) {
+    for (int i = 0, n = qsizetype_to_int(m_streamDetailsSubtitles.count()); i < n; ++i) {
         details->setSubtitleDetail(i, SubtitleDetails::Language, m_streamDetailsSubtitles[i][0]->text());
     }
 

--- a/src/ui/export/CsvExportDialog.cpp
+++ b/src/ui/export/CsvExportDialog.cpp
@@ -125,7 +125,7 @@ void CsvExportDialog::onExport()
         const QVector<Movie*>& movies = Manager::instance()->movieModel()->movies();
 
         int processedCount = 0;
-        ui->exportProgress->setRange(0, movies.size());
+        ui->exportProgress->setRange(0, qsizetype_to_int(movies.size()));
         ui->lblMessage->setStatusMessage(tr("Export movies..."));
 
         QFile file(exportFilePath(exportDir, "movies"));
@@ -142,7 +142,7 @@ void CsvExportDialog::onExport()
         const QVector<TvShow*>& tvShows = Manager::instance()->tvShowModel()->tvShows();
         if (ui->checkTvShows->isChecked()) {
             int processedCount = 0;
-            ui->exportProgress->setRange(0, tvShows.size());
+            ui->exportProgress->setRange(0, qsizetype_to_int(tvShows.size()));
             ui->lblMessage->setStatusMessage(tr("Export TV shows..."));
 
             QFile showFile(exportFilePath(exportDir, "tv_shows"));
@@ -156,7 +156,7 @@ void CsvExportDialog::onExport()
         }
         if (ui->checkTvEpisodes->isChecked()) {
             int processedCount = 0;
-            ui->exportProgress->setRange(0, tvShows.size());
+            ui->exportProgress->setRange(0, qsizetype_to_int(tvShows.size()));
             ui->lblMessage->setStatusMessage(tr("Export TV episodes..."));
 
             QFile episodeFile(exportFilePath(exportDir, "tv_episodes"));
@@ -174,7 +174,7 @@ void CsvExportDialog::onExport()
         const QVector<Concert*>& concerts = Manager::instance()->concertModel()->concerts();
 
         int processedCount = 0;
-        ui->exportProgress->setRange(0, concerts.size());
+        ui->exportProgress->setRange(0, qsizetype_to_int(concerts.size()));
         ui->lblMessage->setStatusMessage(tr("Export concerts..."));
 
         QFile episodeFile(exportFilePath(exportDir, "concerts"));
@@ -192,7 +192,7 @@ void CsvExportDialog::onExport()
         // Artists ----------------------------------------
         if (ui->checkMusicArtists->isChecked()) {
             int processedCount = 0;
-            ui->exportProgress->setRange(0, artists.size());
+            ui->exportProgress->setRange(0, qsizetype_to_int(artists.size()));
             ui->lblMessage->setStatusMessage(tr("Export artists..."));
 
             QFile episodeFile(exportFilePath(exportDir, "artists"));
@@ -207,7 +207,7 @@ void CsvExportDialog::onExport()
         // Albums ----------------------------------------
         if (ui->checkMusicAlbums->isChecked()) {
             int processedCount = 0;
-            ui->exportProgress->setRange(0, artists.size());
+            ui->exportProgress->setRange(0, qsizetype_to_int(artists.size()));
             ui->lblMessage->setStatusMessage(tr("Export albums..."));
 
             QFile episodeFile(exportFilePath(exportDir, "albums"));

--- a/src/ui/export/ExportDialog.cpp
+++ b/src/ui/export/ExportDialog.cpp
@@ -171,7 +171,7 @@ QVector<ExportTemplate::ExportSection> ExportDialog::sectionsToExport() const
 
 int ExportDialog::libraryItemCount(const QVector<ExportTemplate::ExportSection>& sections) const
 {
-    int itemsToExport = 0;
+    elch_size_t itemsToExport = 0;
     if (sections.contains(ExportTemplate::ExportSection::Concerts)) {
         itemsToExport += Manager::instance()->concertModel()->concerts().count();
     }
@@ -184,5 +184,5 @@ int ExportDialog::libraryItemCount(const QVector<ExportTemplate::ExportSection>&
             itemsToExport += show->episodeCount();
         }
     }
-    return itemsToExport;
+    return qsizetype_to_int(itemsToExport);
 }

--- a/src/ui/imports/DownloadsWidget.cpp
+++ b/src/ui/imports/DownloadsWidget.cpp
@@ -119,7 +119,8 @@ void DownloadsWidget::updatePackagesList(const QMap<QString, mediaelch::Download
 
         auto* item0 = new MyTableWidgetItem(it.value().baseName);
         item0->setData(Qt::UserRole, it.value().baseName);
-        auto* item1 = new MyTableWidgetItem(tr("%n files", "", files.length()), files.length());
+        auto* item1 = new MyTableWidgetItem(
+            tr("%n files", "", qsizetype_to_int(files.length())), qsizetype_to_int(files.length()));
         item1->setToolTip(files.join("\n"));
         ui->tablePackages->setItem(row, 0, item0);
         ui->tablePackages->setItem(row, 1, item1);
@@ -260,7 +261,8 @@ void DownloadsWidget::updateImportsList(const QMap<QString, mediaelch::DownloadF
         ui->tableImports->insertRow(row);
         auto* itemBaseName = new MyTableWidgetItem(it.value().baseName);
         itemBaseName->setData(Qt::UserRole, it.value().baseName);
-        auto* itemFileCount = new MyTableWidgetItem(tr("%n files", "", files.length()), files.length());
+        auto* itemFileCount = new MyTableWidgetItem(
+            tr("%n files", "", qsizetype_to_int(files.length())), qsizetype_to_int(files.length()));
         itemFileCount->setToolTip(files.join("\n"));
 
         ui->tableImports->setItem(row, 0, itemBaseName);
@@ -449,7 +451,7 @@ void DownloadsWidget::onChangeImportDetail(int currentIndex, QComboBox* box)
 
 int DownloadsWidget::hasNewItems()
 {
-    return m_imports.count() + m_packages.count();
+    return qsizetype_to_int(m_imports.count() + m_packages.count());
 }
 
 void DownloadsWidget::onImportWithMakeMkv()

--- a/src/ui/imports/ImportDialog.cpp
+++ b/src/ui/imports/ImportDialog.cpp
@@ -150,7 +150,7 @@ int ImportDialog::execTvShow(QString searchString, TvShow* tvShow)
     QString path;
     int index = -1;
     const QVector<SettingsDir>& dirs = Settings::instance()->directorySettings().tvShowDirectories();
-    for (int i = 0, n = dirs.count(); i < n; ++i) {
+    for (int i = 0, n = qsizetype_to_int(dirs.count()); i < n; ++i) {
         if (tvShow->dir().isParentFolderOf(mediaelch::DirectoryPath(dirs.at(i).path))) {
             if (index == -1 || dirs.at(index).path.path().length() < dirs.at(i).path.path().length()) {
                 index = i;
@@ -705,8 +705,9 @@ void ImportDialog::onMovingFilesFinished()
         m_concert = nullptr;
     }
 
-    Notificator::instance()->notify(
-        Notificator::Information, tr("Import finished"), tr("Import of %n files has finished", "", files().count()));
+    Notificator::instance()->notify(Notificator::Information,
+        tr("Import finished"),
+        tr("Import of %n files has finished", "", qsizetype_to_int(files().count())));
 
     ui->loading->setVisible(false);
     ui->badgeSuccess->setText(tr("Import has finished"));

--- a/src/ui/main/MyIconFont.cpp
+++ b/src/ui/main/MyIconFont.cpp
@@ -7,6 +7,7 @@
  * It has been renamed and adjusted to match another font than FontAwesome
  */
 
+#include "globals/Meta.h"
 #include "log/Log.h"
 
 #include <QFile>
@@ -56,7 +57,7 @@ public:
         painter->setPen(color);
 
         // add some 'padding' around the icon
-        float drawSize = rect.height() * options.value("scale-factor").toFloat();
+        double drawSize = static_cast<double>(rect.height()) * options.value("scale-factor").toDouble();
 
         painter->setFont(awesome->font(qRound(drawSize)));
         painter->drawText(rect, text, QTextOption(Qt::AlignCenter | Qt::AlignVCenter));
@@ -66,21 +67,21 @@ public:
 
         const float size = 0.6f;
         QRect starRect(rect.left() + 1,
-            qRound(rect.top() + rect.height() * (1 - size)) - 1,
-            qRound(rect.width() * size),
-            qRound(rect.height() * size));
+            qRound(static_cast<float>(rect.top()) + static_cast<float>(rect.height()) * (1 - size)) - 1,
+            qRound(static_cast<float>(rect.width()) * size),
+            qRound(static_cast<float>(rect.height()) * size));
         painter->setBrush(starColor);
         painter->setPen(starColor);
 
         // Font size depends on the number of digits
-        const int digits = marker.size();
-        drawSize = starRect.height() * options.value("scale-factor").toFloat();
+        const elch_size_t digits = marker.size();
+        drawSize = static_cast<double>(starRect.height()) * options.value("scale-factor").toDouble();
 #ifdef Q_OS_MAC
         drawSize *= 0.8;
 #else
-        drawSize *= 0.94f;
+        drawSize *= 0.94;
 #endif
-        drawSize = drawSize - (digits * 2.f + 2.f);
+        drawSize = drawSize - (static_cast<double>(digits) * 2. + 2.);
 
         QFont f;
         f.setPointSizeF(drawSize);
@@ -136,10 +137,10 @@ public:
         }
         painter->setPen(color);
 
-        float scale = 0.7f;
+        double scale = 0.7;
         QRect firstRect = rect;
-        firstRect.setWidth(static_cast<int>(rect.width() * scale));
-        firstRect.setHeight(static_cast<int>(rect.height() * scale));
+        firstRect.setWidth(static_cast<int>(static_cast<double>(rect.width()) * scale));
+        firstRect.setHeight(static_cast<int>(static_cast<double>(rect.height()) * scale));
 
         QRect secondRect = rect;
         secondRect.setTop(rect.top() + (rect.width() - firstRect.width()));
@@ -147,7 +148,7 @@ public:
         secondRect.setWidth(static_cast<int>(rect.width() * scale));
         secondRect.setHeight(static_cast<int>(rect.height() * scale));
 
-        int drawSize = qRound(firstRect.height() * options.value("scale-factor").toFloat());
+        const int drawSize = qRound(static_cast<double>(firstRect.height()) * options.value("scale-factor").toDouble());
 
         painter->setFont(awesome->font(drawSize));
         painter->drawText(firstRect, text, QTextOption(Qt::AlignCenter | Qt::AlignVCenter));
@@ -200,7 +201,7 @@ public:
         painter->setPen(color);
 
         // add some 'padding' around the icon
-        int drawSize = qRound(rect.height() * options.value("scale-factor").toFloat());
+        int drawSize = qRound(static_cast<double>(rect.height()) * options.value("scale-factor").toDouble());
 
         painter->setFont(awesome->font(drawSize));
         painter->drawText(rect, text, QTextOption(Qt::AlignCenter | Qt::AlignVCenter));

--- a/src/ui/main/QuickOpen.cpp
+++ b/src/ui/main/QuickOpen.cpp
@@ -194,7 +194,7 @@ void QuickOpen::updateViewGeometry()
     const QSize centralSize = parentWidget()->size();
 
     // width: 2.4 of editor, height: 1/2 of editor
-    const QSize viewMaxSize(centralSize.width() / 2.4, centralSize.height() / 2);
+    const QSize viewMaxSize(static_cast<int>(centralSize.width() / 2.4), static_cast<int>(centralSize.height() / 2.));
 
     // Position should be central over window
     const int xPos = std::max(0, (centralSize.width() - viewMaxSize.width()) / 2);

--- a/src/ui/media_centers/KodiSync.cpp
+++ b/src/ui/media_centers/KodiSync.cpp
@@ -363,8 +363,8 @@ void KodiSync::checkIfListsReady(Element element)
         setupItemsToRemove();
         if (!m_moviesToRemove.isEmpty() || !m_episodesToRemove.isEmpty() || !m_tvShowsToRemove.isEmpty()
             || !m_concertsToRemove.isEmpty()) {
-            ui->progressBar->setMaximum(m_moviesToRemove.count() + m_episodesToRemove.count()
-                                        + m_tvShowsToRemove.count() + m_concertsToRemove.count());
+            ui->progressBar->setMaximum(qsizetype_to_int(m_moviesToRemove.count() + m_episodesToRemove.count()
+                                                         + m_tvShowsToRemove.count() + m_concertsToRemove.count()));
             ui->progressBar->setValue(0);
             ui->progressBar->setVisible(true);
         }
@@ -496,8 +496,8 @@ void KodiSync::onRemoveFinished()
     }
 
     ui->progressBar->setValue(ui->progressBar->maximum()
-                              - (m_moviesToRemove.count() + m_episodesToRemove.count() + m_tvShowsToRemove.count()
-                                  + m_concertsToRemove.count()));
+                              - qsizetype_to_int(m_moviesToRemove.count() + m_episodesToRemove.count()
+                                                 + m_tvShowsToRemove.count() + m_concertsToRemove.count()));
     QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
 
     if (!m_moviesToRemove.isEmpty() || !m_concertsToRemove.isEmpty() || !m_tvShowsToRemove.isEmpty()

--- a/src/ui/movies/MovieDuplicates.cpp
+++ b/src/ui/movies/MovieDuplicates.cpp
@@ -71,7 +71,7 @@ void MovieDuplicates::detectDuplicates()
     m_duplicateMovies.clear();
 
     int counter = 0;
-    int movieCount = Manager::instance()->movieModel()->movies().count();
+    int movieCount = qsizetype_to_int(Manager::instance()->movieModel()->movies().count());
     NotificationBox::instance()->showProgressBar(
         tr("Detecting duplicate movies..."), Constants::MovieDuplicatesProgressMessageId);
     NotificationBox::instance()->progressBarProgress(0, movieCount, Constants::MovieDuplicatesProgressMessageId);

--- a/src/ui/movies/MovieFilesWidget.cpp
+++ b/src/ui/movies/MovieFilesWidget.cpp
@@ -502,7 +502,7 @@ void MovieFilesWidget::onLeftEdge(bool isEdge)
 
 void MovieFilesWidget::selectMovie(Movie* movie)
 {
-    int row = Manager::instance()->movieModel()->movies().indexOf(movie);
+    int row = qsizetype_to_int(Manager::instance()->movieModel()->movies().indexOf(movie));
     QModelIndex index = Manager::instance()->movieModel()->index(row, 0, QModelIndex());
     selectIndex(index);
 }

--- a/src/ui/movies/MovieMultiScrapeDialog.cpp
+++ b/src/ui/movies/MovieMultiScrapeDialog.cpp
@@ -151,14 +151,14 @@ void MovieMultiScrapeDialog::onStartScraping()
 
     ui->movieCounter->setText(QString("0/%1").arg(m_queue.count()));
     ui->movieCounter->setVisible(true);
-    ui->progressAll->setMaximum(m_movies.count());
+    ui->progressAll->setMaximum(qsizetype_to_int(m_movies.count()));
     scrapeNext();
 }
 
 void MovieMultiScrapeDialog::onScrapingFinished()
 {
     ui->movieCounter->setVisible(false);
-    int numberOfMovies = m_movies.count();
+    int numberOfMovies = qsizetype_to_int(m_movies.count());
     if (ui->chkOnlyImdb->isChecked()) {
         numberOfMovies = 0;
         for (Movie* movie : asConst(m_movies)) {
@@ -197,7 +197,7 @@ void MovieMultiScrapeDialog::scrapeNext()
     ui->movie->setText(m_currentMovie->name().trimmed());
     ui->movieCounter->setText(QString("%1/%2").arg(m_movies.count() - m_queue.count()).arg(m_movies.count()));
 
-    ui->progressAll->setValue(ui->progressAll->maximum() - m_queue.size() - 1);
+    ui->progressAll->setValue(ui->progressAll->maximum() - qsizetype_to_int(m_queue.size()) - 1);
     ui->progressMovie->setValue(0);
 
     if (ui->chkOnlyImdb->isChecked()

--- a/src/ui/movies/MovieSearchWidget.cpp
+++ b/src/ui/movies/MovieSearchWidget.cpp
@@ -170,7 +170,7 @@ void MovieSearchWidget::showResults(mediaelch::scraper::MovieSearchJob* searchJo
 
     } else {
         qCDebug(generic) << "[Search Results] Count: " << searchJob->results().size();
-        showSuccess(tr("Found %n results", "", searchJob->results().size()));
+        showSuccess(tr("Found %n results", "", qsizetype_to_int(searchJob->results().size())));
     }
 
     ui->comboScraper->setEnabled(m_customScraperIds.isEmpty());

--- a/src/ui/movies/MovieWidget.cpp
+++ b/src/ui/movies/MovieWidget.cpp
@@ -602,8 +602,9 @@ void MovieWidget::updateMovieInfo()
     std::sort(sets.begin(), sets.end(), LocaleStringCompare());
     ui->set->addItems(sets);
 
-    ui->certification->setCurrentIndex(certificationsSorted.indexOf(m_movie->certification().toString()));
-    ui->set->setCurrentIndex(sets.indexOf(m_movie->set().name));
+    ui->certification->setCurrentIndex(
+        qsizetype_to_int(certificationsSorted.indexOf(m_movie->certification().toString())));
+    ui->set->setCurrentIndex(qsizetype_to_int(sets.indexOf(m_movie->set().name)));
 
     ui->set->blockSignals(false);
     ui->certification->blockSignals(false);
@@ -773,7 +774,7 @@ void MovieWidget::updateStreamDetails(bool reloadFromFile)
     m_streamDetailsAudio.clear();
     m_streamDetailsSubtitles.clear();
 
-    int audioTracks = streamDetails->audioDetails().count();
+    int audioTracks = qsizetype_to_int(streamDetails->audioDetails().count());
     const auto audioDetails = streamDetails->audioDetails();
     for (int i = 0; i < audioTracks; ++i) {
         auto* label = new QLabel(tr("Track %1").arg(i + 1));
@@ -811,7 +812,7 @@ void MovieWidget::updateStreamDetails(bool reloadFromFile)
         ui->streamDetails->addWidget(subtitleLabel, 8 + audioTracks, 0);
         m_streamDetailsWidgets << subtitleLabel;
 
-        for (int i = 0, n = streamDetails->subtitleDetails().count(); i < n; ++i) {
+        for (int i = 0, n = qsizetype_to_int(streamDetails->subtitleDetails().count()); i < n; ++i) {
             auto* trackLabel = new QLabel(tr("Track %1").arg(i + 1));
             trackLabel->setAlignment(Qt::AlignVCenter | Qt::AlignRight);
             ui->streamDetails->addWidget(trackLabel, 9 + audioTracks + i, 0);
@@ -888,7 +889,7 @@ void MovieWidget::saveInformation()
     m_savingWidget->show();
     if (movies.count() > 1) {
         int counter = 0;
-        const int moviesToSave = movies.count();
+        const int moviesToSave = qsizetype_to_int(movies.count());
 
         NotificationBox::instance()->showProgressBar(tr("Saving movies..."), Constants::MovieWidgetProgressMessageId);
         NotificationBox::instance()->progressBarProgress(0, moviesToSave, Constants::MovieWidgetProgressMessageId);
@@ -1362,12 +1363,12 @@ void MovieWidget::onStreamDetailsEdited()
         QString("%1").arg(-ui->videoDuration->time().secsTo(QTime(0, 0))));
     details->setVideoDetail(StreamDetails::VideoDetails::StereoMode, ui->stereoMode->currentData().toString());
 
-    for (int i = 0, n = m_streamDetailsAudio.count(); i < n; ++i) {
+    for (int i = 0, n = qsizetype_to_int(m_streamDetailsAudio.count()); i < n; ++i) {
         details->setAudioDetail(i, StreamDetails::AudioDetails::Language, m_streamDetailsAudio[i][0]->text());
         details->setAudioDetail(i, StreamDetails::AudioDetails::Codec, m_streamDetailsAudio[i][1]->text());
         details->setAudioDetail(i, StreamDetails::AudioDetails::Channels, m_streamDetailsAudio[i][2]->text());
     }
-    for (int i = 0, n = m_streamDetailsSubtitles.count(); i < n; ++i) {
+    for (int i = 0, n = qsizetype_to_int(m_streamDetailsSubtitles.count()); i < n; ++i) {
         details->setSubtitleDetail(i, StreamDetails::SubtitleDetails::Language, m_streamDetailsSubtitles[i][0]->text());
     }
 

--- a/src/ui/music/MusicFilesWidget.cpp
+++ b/src/ui/music/MusicFilesWidget.cpp
@@ -145,16 +145,17 @@ void MusicFilesWidget::updateStatusLabel()
     if (m_proxyModel->filterRegularExpression().pattern().isEmpty()
         || m_proxyModel->filterRegularExpression().pattern() == "**") {
 #endif
-        int albumCount = 0;
+        elch_size_t albumCount = 0;
         const auto artists = Manager::instance()->musicModel()->artists();
         for (Artist* artist : artists) {
             albumCount += artist->albums().count();
         }
         ui->statusLabel->setText(
-            tr("%n artists", "", m_proxyModel->rowCount()) + ", " + tr("%n albums", "", albumCount));
+            tr("%n artists", "", m_proxyModel->rowCount()) + ", " + tr("%n albums", "", qsizetype_to_int(albumCount)));
     } else {
-        ui->statusLabel->setText(tr("%1 of %n artists", "", Manager::instance()->musicModel()->artists().count())
-                                     .arg(m_proxyModel->rowCount()));
+        ui->statusLabel->setText(
+            tr("%1 of %n artists", "", qsizetype_to_int(Manager::instance()->musicModel()->artists().count()))
+                .arg(m_proxyModel->rowCount()));
     }
 }
 

--- a/src/ui/music/MusicMultiScrapeDialog.cpp
+++ b/src/ui/music/MusicMultiScrapeDialog.cpp
@@ -194,7 +194,7 @@ void MusicMultiScrapeDialog::onStartScraping()
 
     ui->itemCounter->setText(QString("0/%1").arg(m_queue.count()));
     ui->itemCounter->setVisible(true);
-    ui->progressAll->setMaximum(m_queue.count());
+    ui->progressAll->setMaximum(qsizetype_to_int(m_queue.count()));
     scrapeNext();
 }
 
@@ -238,7 +238,7 @@ void MusicMultiScrapeDialog::scrapeNext()
     }
     ui->itemCounter->setText(
         QString("%1/%2").arg(ui->progressAll->maximum() - m_queue.count()).arg(ui->progressAll->maximum()));
-    ui->progressAll->setValue(ui->progressAll->maximum() - m_queue.size() - 1);
+    ui->progressAll->setValue(ui->progressAll->maximum() - qsizetype_to_int(m_queue.size()) - 1);
     ui->progressItem->setValue(0);
 
     if (m_currentAlbum != nullptr) {

--- a/src/ui/music/MusicWidget.cpp
+++ b/src/ui/music/MusicWidget.cpp
@@ -116,7 +116,7 @@ void MusicWidget::onSaveInformation()
         }
     }
 
-    int itemsToSave = artistsToSave.count() + albumsToSave.count();
+    int itemsToSave = qsizetype_to_int(artistsToSave.count() + albumsToSave.count());
     int itemsSaved = 0;
     NotificationBox::instance()->showProgressBar(
         tr("Saving changed Artists and Albums"), Constants::MusicWidgetSaveProgressMessageId);
@@ -156,7 +156,7 @@ void MusicWidget::onSaveAll()
         }
     }
 
-    int itemsToSave = artistsToSave.count() + albumsToSave.count();
+    int itemsToSave = qsizetype_to_int(artistsToSave.count() + albumsToSave.count());
     int itemsSaved = 0;
     NotificationBox::instance()->showProgressBar(
         tr("Saving changed Artists and Albums"), Constants::MusicWidgetSaveProgressMessageId);

--- a/src/ui/notifications/NotificationBox.cpp
+++ b/src/ui/notifications/NotificationBox.cpp
@@ -57,7 +57,7 @@ int NotificationBox::showMessage(QString message, NotificationType type, std::ch
 {
     m_msgCounter++;
     auto* msg = new Message(this);
-    msg->setMessage(message, timeout.count());
+    msg->setMessage(message, safe_int_cast<int>(timeout.count()));
     msg->setType(type);
     msg->setId(m_msgCounter);
     m_messages.append(msg);

--- a/src/ui/settings/GlobalSettingsWidget.cpp
+++ b/src/ui/settings/GlobalSettingsWidget.cpp
@@ -113,7 +113,7 @@ void GlobalSettingsWidget::loadSettings()
         addDir(downloadDirectories.at(i), SettingsDirType::Downloads);
     }
     QVector<SettingsDir> musicDirectories = m_settings->directorySettings().musicDirectories();
-    for (int i = 0, n = musicDirectories.count(); i < n; ++i) {
+    for (elch_size_t i = 0, n = musicDirectories.count(); i < n; ++i) {
         addDir(musicDirectories.at(i), SettingsDirType::Music);
     }
     dirListRowChanged(ui->dirs->currentRow());

--- a/src/ui/small_widgets/LoadingStreamDetails.cpp
+++ b/src/ui/small_widgets/LoadingStreamDetails.cpp
@@ -31,7 +31,7 @@ LoadingStreamDetails::~LoadingStreamDetails()
 
 void LoadingStreamDetails::loadMovies(QVector<Movie*> movies)
 {
-    ui->progressBar->setRange(0, movies.count());
+    ui->progressBar->setRange(0, qsizetype_to_int(movies.count()));
     ui->progressBar->setValue(0);
     ui->currentFile->clear();
     adjustSize();
@@ -50,7 +50,7 @@ void LoadingStreamDetails::loadMovies(QVector<Movie*> movies)
 
 void LoadingStreamDetails::loadConcerts(QVector<Concert*> concerts)
 {
-    ui->progressBar->setRange(0, concerts.count());
+    ui->progressBar->setRange(0, qsizetype_to_int(concerts.count()));
     ui->progressBar->setValue(0);
     ui->currentFile->clear();
     adjustSize();
@@ -67,7 +67,7 @@ void LoadingStreamDetails::loadConcerts(QVector<Concert*> concerts)
 
 void LoadingStreamDetails::loadTvShowEpisodes(QVector<TvShowEpisode*> episodes)
 {
-    ui->progressBar->setRange(0, episodes.count());
+    ui->progressBar->setRange(0, qsizetype_to_int(episodes.count()));
     ui->progressBar->setValue(0);
     ui->currentFile->clear();
     adjustSize();

--- a/src/ui/small_widgets/MediaFlags.cpp
+++ b/src/ui/small_widgets/MediaFlags.cpp
@@ -165,7 +165,7 @@ void MediaFlags::setupAudio(StreamDetails* streamDetails)
 void MediaFlags::setupChannels(StreamDetails* streamDetails)
 {
     int channels = -1;
-    for (int i = 0, n = streamDetails->audioDetails().count(); i < n; ++i) {
+    for (elch_size_t i = 0, n = streamDetails->audioDetails().count(); i < n; ++i) {
         if (streamDetails->audioDetails().at(i).value(StreamDetails::AudioDetails::Channels).toInt() > channels) {
             channels = streamDetails->audioDetails().at(i).value(StreamDetails::AudioDetails::Channels).toInt();
         }

--- a/src/ui/small_widgets/MyTableView.cpp
+++ b/src/ui/small_widgets/MyTableView.cpp
@@ -1,5 +1,6 @@
 #include "MyTableView.h"
 
+#include "globals/Meta.h"
 #include "log/Log.h"
 
 MyTableView::MyTableView(QWidget* parent) : QTableView(parent), m_searchOverlay{new SearchOverlay(this)}

--- a/src/ui/small_widgets/SlidingStackedWidget.cpp
+++ b/src/ui/small_widgets/SlidingStackedWidget.cpp
@@ -1,5 +1,6 @@
 #include "SlidingStackedWidget.h"
 
+#include "globals/Meta.h"
 #include <QHBoxLayout>
 
 SlidingStackedWidget::SlidingStackedWidget(QWidget* parent) :
@@ -197,7 +198,7 @@ void SlidingStackedWidget::collapse()
         widgetsToDelete.append(widget(i));
     }
 
-    setFixedWidth((frameRect().width() - ((m_widgets.count() - 1) * 24)) / m_widgets.count());
+    setFixedWidth(qsizetype_to_int((frameRect().width() - ((m_widgets.count() - 1) * 24)) / m_widgets.count()));
 
     for (QWidget* w : m_widgets) {
         addWidget(w);

--- a/src/ui/tv_show/TvShowFilesWidget.cpp
+++ b/src/ui/tv_show/TvShowFilesWidget.cpp
@@ -667,7 +667,7 @@ void TvShowFilesWidget::updateStatusLabel()
         ui->statusLabel->setText(tr("%n TV shows", "", rowCount) + ", " + tr("%n episodes", "", episodeCount));
 
     } else {
-        const int showCount = Manager::instance()->tvShowModel()->tvShows().count();
+        const int showCount = qsizetype_to_int(Manager::instance()->tvShowModel()->tvShows().count());
         ui->statusLabel->setText(tr("%1 of %n TV shows", "", showCount).arg(rowCount));
     }
 }

--- a/src/ui/tv_show/TvShowMultiScrapeDialog.cpp
+++ b/src/ui/tv_show/TvShowMultiScrapeDialog.cpp
@@ -301,7 +301,7 @@ void TvShowMultiScrapeDialog::onStartScraping()
 
     ui->itemCounter->setText(QStringLiteral("0/%1").arg(m_showQueue.count() + m_episodeQueue.count()));
     ui->itemCounter->setVisible(true);
-    ui->progressAll->setMaximum(m_showQueue.count() + m_episodeQueue.count());
+    ui->progressAll->setMaximum(qsizetype_to_int(m_showQueue.count() + m_episodeQueue.count()));
 
     logToUser(tr("Start scraping using \"%1\"").arg(m_currentScraper->meta().name));
 
@@ -332,10 +332,11 @@ void TvShowMultiScrapeDialog::scrapeNext()
         ui->title->setText(m_currentEpisode->title().trimmed());
     }
 
-    const int sum = m_shows.count() + m_episodes.count();
+    const int sum = qsizetype_to_int(m_shows.count() + m_episodes.count());
     ui->itemCounter->setText(QStringLiteral("%1/%2").arg(sum - m_showQueue.count() - m_episodeQueue.count()).arg(sum));
 
-    ui->progressAll->setValue(ui->progressAll->maximum() - m_showQueue.size() - m_episodeQueue.count() - 1);
+    ui->progressAll->setValue(
+        ui->progressAll->maximum() - qsizetype_to_int(m_showQueue.size() + m_episodeQueue.count()) - 1);
     ui->progressItem->setValue(0);
 
     // Check if the show/episode has an ID that suits the current scraper.
@@ -510,8 +511,8 @@ void TvShowMultiScrapeDialog::onScrapingFinished()
     logToUser(tr("Done."));
 
     ui->itemCounter->setVisible(false);
-    int numberOfShows = m_shows.count();
-    int numberOfEpisodes = m_episodes.count();
+    int numberOfShows = qsizetype_to_int(m_shows.count());
+    int numberOfEpisodes = qsizetype_to_int(m_episodes.count());
     if (ui->chkOnlyId->isChecked()) {
         numberOfShows = 0;
         numberOfEpisodes = 0;

--- a/src/ui/tv_show/TvShowSearchWidget.cpp
+++ b/src/ui/tv_show/TvShowSearchWidget.cpp
@@ -181,7 +181,7 @@ void TvShowSearchWidget::onShowResults(ShowSearchJob* searchJob)
     }
 
     qCDebug(generic) << "[TvShowSearch] Result count:" << searchJob->results().count();
-    showSuccess(tr("Found %n results", "", searchJob->results().count()));
+    showSuccess(tr("Found %n results", "", qsizetype_to_int(searchJob->results().count())));
 
     for (const auto& result : searchJob->results()) {
         QString title;

--- a/src/ui/tv_show/TvShowWidget.cpp
+++ b/src/ui/tv_show/TvShowWidget.cpp
@@ -151,13 +151,13 @@ void TvShowWidget::onSaveInformation()
         }
     }
 
-    const int itemsToSave = shows.count() + episodes.count();
+    const int itemsToSave = qsizetype_to_int(shows.count() + episodes.count());
     int itemsSaved = 0;
     NotificationBox::instance()->showProgressBar(
         tr("Saving changed TV Shows and Episodes"), Constants::TvShowWidgetSaveProgressMessageId);
     QApplication::processEvents();
 
-    for (int i = 0, n = shows.count(); i < n; ++i) {
+    for (elch_size_t i = 0, n = shows.count(); i < n; ++i) {
         itemsSaved++;
         if (shows.at(i)->hasChanged()) {
             shows.at(i)->saveData(Manager::instance()->mediaCenterInterfaceTvShow());
@@ -167,7 +167,7 @@ void TvShowWidget::onSaveInformation()
         }
     }
 
-    for (int i = 0, n = episodes.count(); i < n; ++i) {
+    for (elch_size_t i = 0, n = episodes.count(); i < n; ++i) {
         itemsSaved++;
         if (episodes.at(i)->hasChanged()) {
             episodes.at(i)->saveData(Manager::instance()->mediaCenterInterfaceTvShow());
@@ -190,11 +190,11 @@ void TvShowWidget::onSaveAll()
     QVector<TvShow*> shows = Manager::instance()->tvShowModel()->tvShows();
     int episodesToSave = 0;
     int episodesSaved = 0;
-    for (int i = 0, n = shows.count(); i < n; ++i) {
+    for (elch_size_t i = 0, n = shows.count(); i < n; ++i) {
         if (shows[i]->hasChanged()) {
             episodesToSave++;
         }
-        for (int x = 0, y = shows[i]->episodes().count(); x < y; ++x) {
+        for (int x = 0, y = qsizetype_to_int(shows[i]->episodes().count()); x < y; ++x) {
             if (shows[i]->episodes().at(x)->hasChanged()) {
                 episodesToSave++;
             }
@@ -206,7 +206,7 @@ void TvShowWidget::onSaveAll()
         tr("Saving changed TV Shows and Episodes"), Constants::TvShowWidgetSaveProgressMessageId);
     QApplication::processEvents();
 
-    for (int i = 0, n = shows.count(); i < n; ++i) {
+    for (elch_size_t i = 0, n = shows.count(); i < n; ++i) {
         if (shows[i]->hasChanged()) {
             qCDebug(generic) << "SAVING TV SHOW" << shows[i]->title();
             shows[i]->saveData(Manager::instance()->mediaCenterInterfaceTvShow());
@@ -214,7 +214,7 @@ void TvShowWidget::onSaveAll()
                 ++episodesSaved, episodesToSave, Constants::TvShowWidgetSaveProgressMessageId);
             QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
         }
-        for (int x = 0, y = shows[i]->episodes().count(); x < y; ++x) {
+        for (int x = 0, y = qsizetype_to_int(shows[i]->episodes().count()); x < y; ++x) {
             if (shows[i]->episodes().at(x)->hasChanged()) {
                 shows[i]->episodes().at(x)->saveData(Manager::instance()->mediaCenterInterfaceTvShow());
                 NotificationBox::instance()->progressBarProgress(

--- a/src/ui/tv_show/TvShowWidgetEpisode.cpp
+++ b/src/ui/tv_show/TvShowWidgetEpisode.cpp
@@ -429,7 +429,8 @@ void TvShowWidgetEpisode::updateEpisodeInfo()
         std::sort(certificationsSorted.begin(), certificationsSorted.end(), LocaleStringCompare());
         certificationsSorted.prepend(Certification::NoCertification.toString());
         ui->certification->addItems(certificationsSorted);
-        ui->certification->setCurrentIndex(certificationsSorted.indexOf(m_episode->certification().toString()));
+        ui->certification->setCurrentIndex(
+            qsizetype_to_int(certificationsSorted.indexOf(m_episode->certification().toString())));
 
     } else {
         ui->certification->addItem(m_episode->certification().toString());
@@ -519,7 +520,7 @@ void TvShowWidgetEpisode::updateStreamDetails(bool reloadFromFile)
     m_streamDetailsAudio.clear();
     m_streamDetailsSubtitles.clear();
 
-    int audioTracks = streamDetails->audioDetails().count();
+    int audioTracks = qsizetype_to_int(streamDetails->audioDetails().count());
     const auto audioDetails = streamDetails->audioDetails();
     for (int i = 0; i < audioTracks; ++i) {
         auto* label = new QLabel(tr("Track %1").arg(i + 1));
@@ -555,7 +556,7 @@ void TvShowWidgetEpisode::updateStreamDetails(bool reloadFromFile)
         ui->streamDetails->addWidget(subtitleLabel, 8 + audioTracks, 0);
         m_streamDetailsWidgets << subtitleLabel;
 
-        for (int i = 0, n = streamDetails->subtitleDetails().count(); i < n; ++i) {
+        for (int i = 0, n = qsizetype_to_int(streamDetails->subtitleDetails().count()); i < n; ++i) {
             auto* trackLabel = new QLabel(tr("Track %1").arg(i + 1));
             ui->streamDetails->addWidget(trackLabel, 9 + audioTracks + i, 0);
             auto* edit1 =
@@ -1047,12 +1048,12 @@ void TvShowWidgetEpisode::onStreamDetailsEdited()
         QString("%1").arg(-ui->videoDuration->time().secsTo(QTime(0, 0))));
     details->setVideoDetail(StreamDetails::VideoDetails::StereoMode, ui->stereoMode->currentData().toString());
 
-    for (int i = 0, n = m_streamDetailsAudio.count(); i < n; ++i) {
+    for (int i = 0, n = qsizetype_to_int(m_streamDetailsAudio.count()); i < n; ++i) {
         details->setAudioDetail(i, StreamDetails::AudioDetails::Language, m_streamDetailsAudio[i][0]->text());
         details->setAudioDetail(i, StreamDetails::AudioDetails::Codec, m_streamDetailsAudio[i][1]->text());
         details->setAudioDetail(i, StreamDetails::AudioDetails::Channels, m_streamDetailsAudio[i][2]->text());
     }
-    for (int i = 0, n = m_streamDetailsSubtitles.count(); i < n; ++i) {
+    for (int i = 0, n = qsizetype_to_int(m_streamDetailsSubtitles.count()); i < n; ++i) {
         details->setSubtitleDetail(i, StreamDetails::SubtitleDetails::Language, m_streamDetailsSubtitles[i][0]->text());
     }
 

--- a/src/ui/tv_show/TvShowWidgetTvShow.cpp
+++ b/src/ui/tv_show/TvShowWidgetTvShow.cpp
@@ -391,7 +391,8 @@ void TvShowWidgetTvShow::updateTvShowInfo()
     QStringList certificationsSorted = certifications.values();
     std::sort(certificationsSorted.begin(), certificationsSorted.end(), LocaleStringCompare());
     ui->certification->addItems(certificationsSorted);
-    ui->certification->setCurrentIndex(certificationsSorted.indexOf(m_show->certification().toString()));
+    ui->certification->setCurrentIndex(
+        qsizetype_to_int(certificationsSorted.indexOf(m_show->certification().toString())));
 
     // Images ---------------------------------------------------------
 
@@ -807,8 +808,8 @@ void TvShowWidgetTvShow::onDownloadsFinished(TvShow* show)
  */
 void TvShowWidgetTvShow::onDownloadsLeft(int left, DownloadManagerElement elem)
 {
-    emit sigDownloadsProgress(elem.show->actors().size() + elem.show->episodes().size() - left,
-        elem.show->actors().size() + elem.show->episodes().size(),
+    emit sigDownloadsProgress(qsizetype_to_int(elem.show->actors().size() + elem.show->episodes().size() - left),
+        qsizetype_to_int(elem.show->actors().size() + elem.show->episodes().size()),
         Constants::TvShowProgressMessageId + elem.show->showId());
 }
 

--- a/src/ui/tv_show/TvTunesDialog.cpp
+++ b/src/ui/tv_show/TvTunesDialog.cpp
@@ -135,7 +135,7 @@ void TvTunesDialog::onUpdateTime(qint64 currentTime)
 
     int position = 0;
     if (m_totalTime > 0) {
-        position = qRound((static_cast<float>(currentTime) / m_totalTime) * 100.0f);
+        position = qRound((static_cast<double>(currentTime) / static_cast<double>(m_totalTime)) * 100.0);
     }
     ui->seekSlider->setValue(position);
 }
@@ -216,7 +216,7 @@ void TvTunesDialog::downloadProgress(qint64 receivedBytes, qint64 totalBytes)
     ui->progressBar->setRange(0, 1000);
     ui->progressBar->setValue(static_cast<int>((received / total) * 1000));
 
-    double speed = received * 1000.0 / m_downloadTime.elapsed();
+    double speed = received * 1000.0 / static_cast<double>(m_downloadTime.elapsed());
     QString unit;
     if (speed < 1024) {
         unit = "bytes/sec";


### PR DESCRIPTION
This commit introduces new functions `qsizetype_to_int` and
`safe_int_cast` for integer conversion.  In Qt6, the type of `qsizetype`
changes from `int` to `long long int`.  And functions such as `size()`
no longer return `int`.  This resulted in hundreds of conversion
warnings for Qt6.  With this commit, `qsizetype_to_int` does a checked
conversion for Qt6, and simply returns the int in Qt5.

`elch_size_t` is used as `qsizetype` was introduced in Qt 5.10, but we
have to support earlier versions as well.

While most checks are probably not needed (e.g. we don't use more than
2^31 actors), they don't impact performance too much.  Better be safe
than sorry.


----------------

TODO:

- [x] check that each use of `qsizetype_to_int` is correct; currently a batch edited all files