### PR TITLE
[Music Scrapers] Correctly decode / remove HTML entities / tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
  - AEBN scraper now loads movies again (#1325)  
    v2.8.8 introduced a bug where the movie ID was parsed incorrectly and the
    scraping failed with a network error.
+ - Music scrapers now correctly remove HTML entities such as `&amp;` from texts
+   such as biographies and reviews.
 
 ### Changes
 

--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -134,6 +134,7 @@ SOURCES += src/main.cpp \
     src/network/NetworkRequest.cpp \
     src/network/NetworkManager.cpp \
     src/scrapers/ScraperError.cpp \
+    src/scrapers/ScraperUtils.cpp \
     src/scrapers/imdb/ImdbReferencePage.cpp \
     src/scrapers/music/AllMusic.cpp \
     src/scrapers/music/Discogs.cpp \
@@ -471,6 +472,7 @@ HEADERS  += Version.h \
     src/network/NetworkRequest.h \
     src/network/NetworkManager.h \
     src/scrapers/ScraperError.h \
+    src/scrapers/ScraperUtils.h \
     src/scrapers/imdb/ImdbReferencePage.h \
     src/scrapers/music/AllMusic.h \
     src/scrapers/music/Discogs.h \

--- a/src/scrapers/CMakeLists.txt
+++ b/src/scrapers/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(
   # Sources
   ScraperInterface.cpp
   ScraperError.cpp
+  ScraperUtils.cpp
   concert/ConcertIdentifier.cpp
   concert/ConcertScraper.cpp
   concert/ConcertSearchJob.cpp

--- a/src/scrapers/ScraperUtils.cpp
+++ b/src/scrapers/ScraperUtils.cpp
@@ -1,0 +1,10 @@
+#include "scrapers/ScraperUtils.h"
+
+#include <QTextDocument>
+
+QString removeHtmlEntities(QString str)
+{
+    QTextDocument doc;
+    doc.setHtml(std::move(str));
+    return doc.toPlainText();
+}

--- a/src/scrapers/ScraperUtils.cpp
+++ b/src/scrapers/ScraperUtils.cpp
@@ -6,5 +6,5 @@ QString removeHtmlEntities(QString str)
 {
     QTextDocument doc;
     doc.setHtml(std::move(str));
-    return doc.toPlainText();
+    return doc.toPlainText().trimmed();
 }

--- a/src/scrapers/ScraperUtils.h
+++ b/src/scrapers/ScraperUtils.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <QString>
+
+QString removeHtmlEntities(QString str);

--- a/src/scrapers/imdb/ImdbReferencePage.cpp
+++ b/src/scrapers/imdb/ImdbReferencePage.cpp
@@ -2,6 +2,7 @@
 
 #include "globals/Helper.h"
 #include "movies/Movie.h"
+#include "scrapers/ScraperUtils.h"
 
 #include <QDate>
 #include <QRegularExpression>
@@ -295,14 +296,6 @@ void ImdbReferencePage::extractCountries(Movie* movie, const QString& html)
         }
     }
 }
-
-QString ImdbReferencePage::removeHtmlEntities(QString str)
-{
-    QTextDocument doc;
-    doc.setHtml(std::move(str));
-    return doc.toPlainText();
-}
-
 
 } // namespace scraper
 } // namespace mediaelch

--- a/src/scrapers/imdb/ImdbReferencePage.h
+++ b/src/scrapers/imdb/ImdbReferencePage.h
@@ -28,8 +28,6 @@ public:
     static void extractTaglines(Movie* movie, const QString& html);
     static void extractTags(Movie* movie, const QString& html);
     static void extractCountries(Movie* movie, const QString& html);
-
-    static QString removeHtmlEntities(QString str);
 };
 
 } // namespace scraper

--- a/src/scrapers/music/AllMusic.cpp
+++ b/src/scrapers/music/AllMusic.cpp
@@ -2,6 +2,7 @@
 
 #include "music/Album.h"
 #include "music/Artist.h"
+#include "scrapers/ScraperUtils.h"
 #include "scrapers/music/UniversalMusicScraper.h"
 
 #include <QJsonArray>
@@ -47,10 +48,10 @@ void AllMusic::parseAndAssignAlbum(const QString& html, Album* album, QSet<Music
         rx.setPattern(R"(<h2 class="album-name" itemprop="name">[\n\s]*(.*)[\n\s]*</h2>)");
         match = rx.match(html);
         if (match.hasMatch()) {
-            album->setTitle(trim(match.captured(1)));
+            album->setTitle(removeHtmlEntities(match.captured(1)));
 
         } else if (useJson) {
-            const QString name = trim(doc.value("name").toString());
+            const QString name = removeHtmlEntities(doc.value("name").toString());
             if (!name.isEmpty()) {
                 album->setTitle(name);
             }
@@ -61,13 +62,13 @@ void AllMusic::parseAndAssignAlbum(const QString& html, Album* album, QSet<Music
         rx.setPattern(R"(<h3 class="album-artist"[^>]*>[\n\s]*<span itemprop="name">[\n\s]*<a [^>]*>(.*)</a>)");
         match = rx.match(html);
         if (match.hasMatch()) {
-            album->setArtist(trim(match.captured(1)));
+            album->setArtist(removeHtmlEntities(match.captured(1)));
 
         } else if (useJson) {
             QStringList artists;
             const QJsonArray artistArray = doc.value("byArtist").toArray();
             for (const QJsonValue& value : artistArray) {
-                const QString name = trim(value.toObject().value("name").toString());
+                const QString name = removeHtmlEntities(value.toObject().value("name").toString());
                 if (!name.isEmpty()) {
                     artists.append(name);
                 }
@@ -83,13 +84,12 @@ void AllMusic::parseAndAssignAlbum(const QString& html, Album* album, QSet<Music
         match = rx.match(html);
         if (match.hasMatch()) {
             QString review = match.captured(1);
-            review.remove(QRegularExpression("<[^>]*>"));
-            album->setReview(trim(review));
+            album->setReview(removeHtmlEntities(review));
 
         } else if (useJson) {
-            const QString review = trim(doc.value("review").toObject().value("reviewBody").toString());
+            const QString review = removeHtmlEntities(doc.value("review").toObject().value("reviewBody").toString());
             if (!review.isEmpty()) {
-                album->setReview(review);
+                album->setReview(removeHtmlEntities(review));
             }
         }
     }
@@ -98,7 +98,7 @@ void AllMusic::parseAndAssignAlbum(const QString& html, Album* album, QSet<Music
         rx.setPattern(R"(<h4>[\n\s]*Release Date[\n\s]*</h4>[\n\s]*<span>(.*)</span>)");
         match = rx.match(html);
         if (match.hasMatch()) {
-            album->setReleaseDate(trim(match.captured(1)));
+            album->setReleaseDate(removeHtmlEntities(match.captured(1)));
         }
     }
 
@@ -128,7 +128,7 @@ void AllMusic::parseAndAssignAlbum(const QString& html, Album* album, QSet<Music
 
             QRegularExpressionMatchIterator matches = rx.globalMatch(genres);
             while (matches.hasNext()) {
-                album->addGenre(trim(matches.next().captured(1)));
+                album->addGenre(removeHtmlEntities(matches.next().captured(1)));
             }
         }
     }
@@ -142,7 +142,7 @@ void AllMusic::parseAndAssignAlbum(const QString& html, Album* album, QSet<Music
 
             QRegularExpressionMatchIterator matches = rx.globalMatch(styles);
             while (matches.hasNext()) {
-                album->addStyle(trim(matches.next().captured(1)));
+                album->addStyle(removeHtmlEntities(matches.next().captured(1)));
             }
         }
     }
@@ -156,7 +156,7 @@ void AllMusic::parseAndAssignAlbum(const QString& html, Album* album, QSet<Music
 
             QRegularExpressionMatchIterator matches = rx.globalMatch(moods);
             while (matches.hasNext()) {
-                album->addMood(trim(matches.next().captured(1)));
+                album->addMood(removeHtmlEntities(matches.next().captured(1)));
             }
         }
     }
@@ -172,7 +172,7 @@ void AllMusic::parseAndAssignArtist(const QString& html, Artist* artist, QSet<Mu
         rx.setPattern(R"(<h2 class="artist-name" itemprop="name">[\n\s]*(.*)[\n\s]*</h2>)");
         match = rx.match(html);
         if (match.hasMatch()) {
-            artist->setName(trim(match.captured(1)));
+            artist->setName(removeHtmlEntities(match.captured(1)));
         }
     }
 
@@ -180,7 +180,7 @@ void AllMusic::parseAndAssignArtist(const QString& html, Artist* artist, QSet<Mu
         rx.setPattern("<h4>Active</h4>[\\n\\s]*<div>(.*)</div>");
         match = rx.match(html);
         if (match.hasMatch()) {
-            artist->setYearsActive(trim(match.captured(1)));
+            artist->setYearsActive(removeHtmlEntities(match.captured(1)));
         }
     }
 
@@ -189,9 +189,7 @@ void AllMusic::parseAndAssignArtist(const QString& html, Artist* artist, QSet<Mu
         match = rx.match(html);
         if (match.hasMatch()) {
             QString formed = match.captured(1);
-            // Remove all HTML elements, e.g. <a href="..."></a>
-            formed.remove(QRegularExpression("<.+?>"));
-            artist->setFormed(trim(formed));
+            artist->setFormed(removeHtmlEntities(formed));
         }
     }
 
@@ -199,7 +197,7 @@ void AllMusic::parseAndAssignArtist(const QString& html, Artist* artist, QSet<Mu
         rx.setPattern(R"(<h4>[\n\s]*Born[\n\s]*</h4>[\n\s]*<div>(.*)</div>)");
         match = rx.match(html);
         if (match.hasMatch()) {
-            artist->setBorn(trim(match.captured(1)));
+            artist->setBorn(removeHtmlEntities(match.captured(1)));
         }
     }
 
@@ -207,7 +205,7 @@ void AllMusic::parseAndAssignArtist(const QString& html, Artist* artist, QSet<Mu
         rx.setPattern(R"(<h4>[\n\s]*Died[\n\s]*</h4>[\n\s]*<div>(.*)</div>)");
         match = rx.match(html);
         if (match.hasMatch()) {
-            artist->setDied(trim(match.captured(1)));
+            artist->setDied(removeHtmlEntities(match.captured(1)));
         }
     }
 
@@ -215,7 +213,7 @@ void AllMusic::parseAndAssignArtist(const QString& html, Artist* artist, QSet<Mu
         rx.setPattern(R"(<h4>[\n\s]*Disbanded[\n\s]*</h4>[\n\s]*<div>(.*)</div>)");
         match = rx.match(html);
         if (match.hasMatch()) {
-            artist->setDisbanded(trim(match.captured(1)));
+            artist->setDisbanded(removeHtmlEntities(match.captured(1)));
         }
     }
 
@@ -228,7 +226,7 @@ void AllMusic::parseAndAssignArtist(const QString& html, Artist* artist, QSet<Mu
 
             QRegularExpressionMatchIterator matches = rx.globalMatch(genres);
             while (matches.hasNext()) {
-                artist->addGenre(trim(matches.next().captured(1)));
+                artist->addGenre(removeHtmlEntities(matches.next().captured(1)));
             }
         }
     }
@@ -242,7 +240,7 @@ void AllMusic::parseAndAssignArtist(const QString& html, Artist* artist, QSet<Mu
 
             QRegularExpressionMatchIterator matches = rx.globalMatch(styles);
             while (matches.hasNext()) {
-                artist->addStyle(trim(matches.next().captured(1)));
+                artist->addStyle(removeHtmlEntities(matches.next().captured(1)));
             }
         }
     }
@@ -256,7 +254,7 @@ void AllMusic::parseAndAssignArtist(const QString& html, Artist* artist, QSet<Mu
 
             QRegularExpressionMatchIterator matches = rx.globalMatch(moods);
             while (matches.hasNext()) {
-                artist->addMood(trim(matches.next().captured(1)));
+                artist->addMood(removeHtmlEntities(matches.next().captured(1)));
             }
         }
     }
@@ -271,8 +269,7 @@ void AllMusic::parseAndAssignArtistBiography(const QString& html, Artist* artist
         QRegularExpressionMatch match = rx.match(html);
         if (match.hasMatch()) {
             QString biography = match.captured(1);
-            biography.remove(QRegularExpression("<[^>]*>"));
-            artist->setBiography(trim(biography));
+            artist->setBiography(removeHtmlEntities(biography));
         }
     }
 }
@@ -291,18 +288,13 @@ void AllMusic::parseAndAssignArtistDiscography(const QString& html, Artist* arti
             QRegularExpressionMatch match = matches.next();
 
             DiscographyAlbum a;
-            a.title = trim(match.captured(2));
-            a.year = trim(match.captured(1));
+            a.title = removeHtmlEntities(match.captured(2));
+            a.year = removeHtmlEntities(match.captured(1));
             if (!a.title.isEmpty() || !a.year.isEmpty()) {
                 artist->addDiscographyAlbum(a);
             }
         }
     }
-}
-
-QString AllMusic::trim(QString text)
-{
-    return text.replace(QRegularExpression("\\s\\s+"), " ").trimmed();
 }
 
 } // namespace scraper

--- a/src/scrapers/music/AllMusic.h
+++ b/src/scrapers/music/AllMusic.h
@@ -47,9 +47,6 @@ public:
     void parseAndAssignArtist(const QString& html, Artist* artist, QSet<MusicScraperInfo> infos);
     void parseAndAssignArtistBiography(const QString& html, Artist* artist, QSet<MusicScraperInfo> infos);
     void parseAndAssignArtistDiscography(const QString& html, Artist* artist, QSet<MusicScraperInfo> infos);
-
-private:
-    QString trim(QString text);
 };
 
 } // namespace scraper

--- a/src/scrapers/music/Discogs.cpp
+++ b/src/scrapers/music/Discogs.cpp
@@ -2,6 +2,7 @@
 
 #include "music/Album.h"
 #include "music/Artist.h"
+#include "scrapers/ScraperUtils.h"
 #include "scrapers/music/UniversalMusicScraper.h"
 
 #include <QRegularExpression>
@@ -23,7 +24,7 @@ void Discogs::parseAndAssignArtist(const QString& html, Artist* artist, QSet<Mus
         rx.setPattern(R"(<div class="body">[\n\s]*<h1 class="hide_desktop">(.*)</h1>)");
         match = rx.match(html);
         if (match.hasMatch()) {
-            artist->setName(trim(match.captured(1)));
+            artist->setName(removeHtmlEntities(match.captured(1)));
         }
     }
 
@@ -31,7 +32,7 @@ void Discogs::parseAndAssignArtist(const QString& html, Artist* artist, QSet<Mus
         rx.setPattern(R"(<div [^>]* id="profile">[\n\s]*(.*)[\n\s]*</div>)");
         match = rx.match(html);
         if (match.hasMatch()) {
-            artist->setBiography(trim(match.captured(1)));
+            artist->setBiography(removeHtmlEntities(match.captured(1)));
         }
     }
 
@@ -53,13 +54,13 @@ void Discogs::parseAndAssignArtist(const QString& html, Artist* artist, QSet<Mus
                 DiscographyAlbum a;
                 match = rx2.match(str);
                 if (match.hasMatch()) {
-                    a.title = trim(match.captured(1));
+                    a.title = removeHtmlEntities(match.captured(1));
                 }
 
                 rx2.setPattern(R"(<td class="year has_header" data\-header="Year: ">(.*)</td>)");
                 match = rx2.match(str);
                 if (match.hasMatch()) {
-                    a.year = trim(match.captured(1));
+                    a.year = removeHtmlEntities(match.captured(1));
                 }
 
                 if (a.title != "" || a.year != "") {
@@ -81,7 +82,7 @@ void Discogs::parseAndAssignAlbum(const QString& html, Album* album, QSet<MusicS
                       "itemprop=\"name\" title=\"(.*)\" >");
         match = rx.match(html);
         if (match.hasMatch()) {
-            album->setArtist(trim(match.captured(1)));
+            album->setArtist(removeHtmlEntities(match.captured(1)));
         }
     }
 
@@ -89,7 +90,7 @@ void Discogs::parseAndAssignAlbum(const QString& html, Album* album, QSet<MusicS
         rx.setPattern(R"(<span itemprop="name">[\n\s]*(.*)[\n\s]*</span>)");
         match = rx.match(html);
         if (match.hasMatch()) {
-            album->setTitle(trim(match.captured(1)));
+            album->setTitle(removeHtmlEntities(match.captured(1)));
         }
     }
 
@@ -102,7 +103,7 @@ void Discogs::parseAndAssignAlbum(const QString& html, Album* album, QSet<MusicS
 
             QRegularExpressionMatchIterator matches = rx.globalMatch(genres);
             while (matches.hasNext()) {
-                album->addGenre(trim(matches.next().captured(1)));
+                album->addGenre(removeHtmlEntities(matches.next().captured(1)));
             }
         }
     }
@@ -116,7 +117,7 @@ void Discogs::parseAndAssignAlbum(const QString& html, Album* album, QSet<MusicS
 
             QRegularExpressionMatchIterator matches = rx.globalMatch(styles);
             while (matches.hasNext()) {
-                album->addStyle(trim(matches.next().captured(1)));
+                album->addStyle(removeHtmlEntities(matches.next().captured(1)));
             }
         }
     }
@@ -126,14 +127,9 @@ void Discogs::parseAndAssignAlbum(const QString& html, Album* album, QSet<MusicS
                       "href=\"[^\"]*\">(.*)</a>[\\n\\s]*</div>");
         match = rx.match(html);
         if (match.hasMatch()) {
-            album->setYear(trim(match.captured(1)).toInt());
+            album->setYear(removeHtmlEntities(match.captured(1)).toInt());
         }
     }
-}
-
-QString Discogs::trim(QString text)
-{
-    return text.replace(QRegularExpression("\\s\\s+"), " ").trimmed();
 }
 
 } // namespace scraper

--- a/src/scrapers/music/Discogs.h
+++ b/src/scrapers/music/Discogs.h
@@ -20,9 +20,6 @@ public:
 public:
     void parseAndAssignArtist(const QString& html, Artist* artist, QSet<MusicScraperInfo> infos);
     void parseAndAssignAlbum(const QString& html, Album* album, QSet<MusicScraperInfo> infos);
-
-private:
-    QString trim(QString text);
 };
 
 } // namespace scraper

--- a/src/scrapers/music/MusicBrainz.cpp
+++ b/src/scrapers/music/MusicBrainz.cpp
@@ -4,6 +4,7 @@
 #include "log/Log.h"
 #include "music/Album.h"
 #include "network/NetworkRequest.h"
+#include "scrapers/ScraperUtils.h"
 #include "scrapers/music/UniversalMusicScraper.h"
 
 #include <QDomDocument>
@@ -199,7 +200,7 @@ void MusicBrainz::parseAndAssignArtist(const QString& data, Artist* artist, QSet
 
     QString biography = json.object()["wikipediaExtract"].toObject()["content"].toString();
     if (!biography.isEmpty()) {
-        artist->setBiography(replaceCommonHtmlTags(biography));
+        artist->setBiography(removeHtmlEntities(biography));
     }
 }
 
@@ -225,19 +226,6 @@ QPair<AllMusicId, QString> MusicBrainz::extractAllMusicIdAndDiscogsUrl(const QSt
         }
     }
     return {allMusicId, discogsUrl};
-}
-
-QString MusicBrainz::replaceCommonHtmlTags(QString text) const
-{
-    text.remove(QRegularExpression("<[apubi][^>]*?>"));
-    text.remove(QRegularExpression("</[aubi]>"));
-    text.remove("<small>");
-    text.remove("</small>");
-    text.remove(QRegularExpression("<span[^>]*?>"));
-    text.remove("</span>");
-
-    text.replace("</p>", " ");
-    return text;
 }
 
 } // namespace scraper

--- a/src/scrapers/music/MusicBrainz.h
+++ b/src/scrapers/music/MusicBrainz.h
@@ -58,9 +58,6 @@ public:
 
 public:
     static QPair<AllMusicId, QString> extractAllMusicIdAndDiscogsUrl(const QString& xml);
-
-private:
-    QString replaceCommonHtmlTags(QString text) const;
 };
 
 } // namespace scraper

--- a/src/scrapers/tv_show/imdb/ImdbTvEpisodeParser.cpp
+++ b/src/scrapers/tv_show/imdb/ImdbTvEpisodeParser.cpp
@@ -2,6 +2,7 @@
 
 #include "globals/Helper.h"
 #include "globals/Poster.h"
+#include "scrapers/ScraperUtils.h"
 #include "scrapers/imdb/ImdbReferencePage.h"
 #include "tv_shows/TvDbId.h"
 #include "tv_shows/TvShowEpisode.h"
@@ -169,27 +170,26 @@ void ImdbTvEpisodeParser::parseInfos(TvShowEpisode& episode, const QString& html
     rx.setPattern("<p itemprop=\"description\">(.*)</p>");
     match = rx.match(html);
     if (match.hasMatch()) {
-        QString outline = match.captured(1).remove(QRegularExpression("<[^>]*>"));
+        QString outline = match.captured(1);
         outline = outline.remove("See full summary&nbsp;&raquo;").trimmed();
-        episode.setOverview(outline);
+        episode.setOverview(removeHtmlEntities(outline));
     }
 
     // --------------------------------------
     rx.setPattern(R"(<div class="summary_text">(.*)</div>)");
     match = rx.match(html);
     if (match.hasMatch()) {
-        QString outline = match.captured(1).remove(QRegularExpression("<[^>]*>"));
+        QString outline = match.captured(1);
         outline = outline.remove("See full summary&nbsp;&raquo;").trimmed();
-        episode.setOverview(outline);
+        episode.setOverview(removeHtmlEntities(outline));
     }
     // --------------------------------------
 
     rx.setPattern(R"(<h2>Storyline</h2>\n +\n +<div class="inline canwrap">\n +<p>\n +<span>(.*)</span>)");
     match = rx.match(html);
     if (match.hasMatch()) {
-        QString overview = match.captured(1).trimmed();
-        overview.remove(QRegularExpression("<[^>]*>"));
-        episode.setOverview(overview.trimmed());
+        QString overview = removeHtmlEntities(match.captured(1));
+        episode.setOverview(overview);
     }
     // --------------------------------------
 

--- a/src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp
+++ b/src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp
@@ -2,6 +2,7 @@
 
 #include "log/Log.h"
 #include "scrapers/ScraperInterface.h"
+#include "scrapers/ScraperUtils.h"
 #include "tv_shows/TvShow.h"
 
 #include <QDate>
@@ -122,14 +123,6 @@ std::chrono::minutes ImdbTvShowParser::extractRuntime(const QString& html)
 
     return std::chrono::minutes(match.captured(1).toInt());
 }
-
-QString ImdbTvShowParser::removeHtmlEntities(QString str) const
-{
-    QTextDocument doc;
-    doc.setHtml(std::move(str));
-    return doc.toPlainText();
-}
-
 
 } // namespace scraper
 } // namespace mediaelch

--- a/src/scrapers/tv_show/imdb/ImdbTvShowParser.h
+++ b/src/scrapers/tv_show/imdb/ImdbTvShowParser.h
@@ -27,7 +27,6 @@ private:
 
     QJsonDocument extractMetaJson(const QString& html);
     std::chrono::minutes extractRuntime(const QString& html);
-    QString removeHtmlEntities(QString str) const;
 
 private:
     TvShow& m_show;


### PR DESCRIPTION
This commit fixes some music scrapers where the contents, e.g, review
and biography, were not correctly decoded and still contained HTML
entities such as `&amp;`.