### PR TITLE
[Renamer/Import] Interchange originalTitle on replace

### DIFF
--- a/src/renamer/MovieRenamer.cpp
+++ b/src/renamer/MovieRenamer.cpp
@@ -240,7 +240,7 @@ MovieRenamer::RenameError MovieRenamer::renameMovie(Movie& movie)
     if (m_config.renameDirectories && movie.inSeparateFolder()) {
         Renamer::replace(newFolderName, "title", movie.name());
         Renamer::replace(newFolderName, "extension", extension);
-        Renamer::replace(newFolderName, "originalTitle", movie.originalName());
+        Renamer::replace(newFolderName, "originalTitle", movie.originalName().isEmpty() ? movie.name() : movie.originalName());
         Renamer::replace(newFolderName, "sortTitle", movie.sortTitle());
         // TODO: Let the user decide whether only the first should be used or
         //       if a space should be the separator.

--- a/src/ui/imports/DownloadsWidget.cpp
+++ b/src/ui/imports/DownloadsWidget.cpp
@@ -479,13 +479,9 @@ void DownloadsWidget::onScanFinished(mediaelch::DownloadFileSearcher* searcher)
     const auto packages = searcher->packages();
     const auto imports = searcher->imports();
 
-    if (!packages.isEmpty()) {
-        updatePackagesList(packages);
-    }
-
-    if (!imports.isEmpty()) {
-        updateImportsList(imports);
-    }
+    // always update!
+    updatePackagesList(packages);
+    updateImportsList(imports);
 
     // Delete only after we have used it's members because "searcher" lives in another
     // thread, calling deleteLater() deletes it likely immediately.

--- a/src/ui/imports/ImportDialog.cpp
+++ b/src/ui/imports/ImportDialog.cpp
@@ -466,7 +466,7 @@ void ImportDialog::onImport()
         if (m_separateFolders) {
             QString newFolderName = ui->directoryNaming->text();
             Renamer::replace(newFolderName, "title", m_movie->name());
-            Renamer::replace(newFolderName, "originalTitle", m_movie->originalName());
+            Renamer::replace(newFolderName, "originalTitle", m_movie->originalName().isEmpty() ? m_movie->name() : m_movie->originalName());
             Renamer::replace(newFolderName, "sortTitle", m_movie->sortTitle());
             Renamer::replace(newFolderName, "year", m_movie->released().toString("yyyy"));
             Renamer::replace(newFolderName,


### PR DESCRIPTION
When originalTitle is empty fall back to title for the placeholder replacement.
Otherwise you can't rely on renaming to <originalTitle>; biggest problem on direct
Bulk Importing Files.

Additional *always* update the lists after import