### PR TITLE
[ExportTheme] Allow multiple `<author>` tags in `metadata.xml`

### DIFF
--- a/src/export/ExportTemplate.cpp
+++ b/src/export/ExportTemplate.cpp
@@ -10,14 +10,19 @@ ExportTemplate::ExportTemplate(QObject* parent) : QObject(parent)
 {
 }
 
-void ExportTemplate::setAuthor(QString author)
+void ExportTemplate::setAuthors(QStringList authors)
 {
-    m_author = author;
+    m_authors = std::move(authors);
 }
 
-const QString& ExportTemplate::author() const
+void ExportTemplate::addAuthor(QString author)
 {
-    return m_author;
+    m_authors.append(std::move(author));
+}
+
+const QStringList& ExportTemplate::authors() const
+{
+    return m_authors;
 }
 
 void ExportTemplate::addDescription(QString language, QString description)
@@ -328,7 +333,7 @@ QDebug operator<<(QDebug dbg, const ExportTemplate& exportTemplate)
     out.append("Export Template").append(nl);
     out.append(QString("  Name:             ").append(exportTemplate.name()).append(nl));
     out.append(QString("  Identifier:       ").append(exportTemplate.identifier()).append(nl));
-    out.append(QString("  Author:           ").append(exportTemplate.author()).append(nl));
+    out.append(QString("  Authors:           ").append(exportTemplate.authors().join(" and ")).append(nl));
     out.append(QString("  Version:          ").append(exportTemplate.version()).append(nl));
     out.append(QString("  Remote Version:   ").append(exportTemplate.remoteVersion()).append(nl));
     out.append(QString("  Remote File:      ").append(exportTemplate.remoteFile()).append(nl));

--- a/src/export/ExportTemplate.h
+++ b/src/export/ExportTemplate.h
@@ -6,6 +6,7 @@
 
 #include <QObject>
 #include <QString>
+#include <QStringList>
 #include <QVector>
 
 /// Represents different template engines. Future releases may introduce
@@ -37,7 +38,7 @@ public:
     const QString& identifier() const;
     const QString& name() const;
     const QString& website() const;
-    const QString& author() const;
+    const QStringList& authors() const;
     QString description() const;
     ExportEngine templateEngine() const;
     const QString& version() const;
@@ -58,7 +59,8 @@ public:
     void setIdentifier(QString identifier);
     void setName(QString name);
     void setWebsite(QString website);
-    void setAuthor(QString author);
+    void setAuthors(QStringList authors);
+    void addAuthor(QString author);
     void setRemoteFile(QString remoteFile);
     void setRemoteFileChecksum(QString checksum);
     void addDescription(QString language, QString description);
@@ -80,7 +82,7 @@ private:
     QString m_identifier;
     QString m_name;
     QString m_website;
-    QString m_author;
+    QStringList m_authors;
     QString m_remoteFile;
     QString m_remoteFileChecksum;
     QMap<QString, QString> m_description;

--- a/src/export/ExportTemplateLoader.h
+++ b/src/export/ExportTemplateLoader.h
@@ -44,3 +44,11 @@ private:
     bool removeDir(const QString& dirName);
     QVector<ExportTemplate*> mergeTemplates(QVector<ExportTemplate*> local, QVector<ExportTemplate*> remote);
 };
+
+namespace mediaelch {
+namespace exports {
+
+ExportTemplate* parseTemplate(QXmlStreamReader& xml, QObject* parent);
+
+}
+} // namespace mediaelch

--- a/src/ui/settings/ExportTemplateWidget.cpp
+++ b/src/ui/settings/ExportTemplateWidget.cpp
@@ -22,7 +22,7 @@ ExportTemplateWidget::~ExportTemplateWidget()
 void ExportTemplateWidget::setExportTemplate(ExportTemplate* exportTemplate)
 {
     m_exportTemplate = exportTemplate;
-    ui->author->setText(tr("by %1").arg(exportTemplate->author()));
+    ui->authors->setText(tr("by %1").arg(exportTemplate->authors().join(" and ")));
     ui->name->setText(exportTemplate->name());
     if (!exportTemplate->website().isEmpty()) {
         ui->website->setText(exportTemplate->website());

--- a/src/ui/settings/ExportTemplateWidget.ui
+++ b/src/ui/settings/ExportTemplateWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>670</width>
-    <height>82</height>
+    <height>88</height>
    </rect>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,0">
@@ -45,9 +45,9 @@
         </widget>
        </item>
        <item>
-        <widget class="QLabel" name="author">
+        <widget class="QLabel" name="authors">
          <property name="text">
-          <string notr="true">Author</string>
+          <string notr="true">Authors</string>
          </property>
         </widget>
        </item>

--- a/test/integration/export/testSimpleExport.cpp
+++ b/test/integration/export/testSimpleExport.cpp
@@ -40,7 +40,7 @@ TEST_CASE("Simple HTML export", "[export][simple]")
 {
     ExportTemplate exportTemplate;
     exportTemplate.setName("Test Template");
-    exportTemplate.setAuthor("MediaElch authors");
+    exportTemplate.setAuthors({"MediaElch authors"});
     exportTemplate.setTemplateEngine(ExportEngine::Simple);
     exportTemplate.setRemote(false);
     exportTemplate.setVersion("0.0.1");

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(
     data/testLocale.cpp
     data/testTmdbId.cpp
     data/testCertification.cpp
+    export/test.ExportTemplateLoader.cpp
     file/testNameFormatter.cpp
     file/testStackedBaseName.cpp
     globals/testVersionInfo.cpp

--- a/test/unit/export/test.ExportTemplateLoader.cpp
+++ b/test/unit/export/test.ExportTemplateLoader.cpp
@@ -1,0 +1,50 @@
+#include "test/test_helpers.h"
+
+#include "src/export/ExportTemplateLoader.h"
+
+
+TEST_CASE("ExportTemplateLoader", "[export]")
+{
+    SECTION("parses metadata.xml")
+    {
+        QString metadataXml = R"xml(<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+            <metadata>
+                <name>MediaElch</name>
+                <identifier>mediaelch-default</identifier>
+                <website>https://github.com/mediaelch/mediaelch-theme-default</website>
+                <description>Default Theme</description>
+                <description lang="de">MediaElch Standard Theme</description>
+                <author>Daniel Kabel</author>
+                <author>Andre Meyering</author>
+                <version>1.2.3</version>
+                <mediaelch-min>2.6.8</mediaelch-min>
+                <mediaelch-max>3.1.2</mediaelch-max>
+                <engine>simple</engine>
+                <supports>
+                    <section>movies</section>
+                    <section>tvshows</section>
+                    <section>concerts</section>
+                </supports>
+            </metadata>
+        )xml";
+
+        QXmlStreamReader xml(metadataXml);
+        std::unique_ptr<ExportTemplate> meta{mediaelch::exports::parseTemplate(xml, nullptr)};
+
+        CHECK(meta->name() == "MediaElch");
+        CHECK(meta->identifier() == "mediaelch-default");
+        CHECK(meta->website() == "https://github.com/mediaelch/mediaelch-theme-default");
+        CHECK(meta->descriptions()
+              == QMap<QString, QString>{//
+                  {"", "Default Theme"},
+                  {"de", "MediaElch Standard Theme"}});
+        CHECK(meta->authors() == QStringList{"Daniel Kabel", "Andre Meyering"});
+        CHECK(meta->templateEngine() == ExportEngine::Simple);
+        CHECK(meta->mediaElchVersionMin() == mediaelch::VersionInfo("2.6.8"));
+        CHECK(meta->mediaElchVersionMax() == mediaelch::VersionInfo("3.1.2"));
+        CHECK(meta->exportSections()
+              == QVector<ExportTemplate::ExportSection>{ExportTemplate::ExportSection::Movies,
+                  ExportTemplate::ExportSection::TvShows,
+                  ExportTemplate::ExportSection::Concerts});
+    }
+}


### PR DESCRIPTION
This commit makes it possible to write multiple `<author>` tags in
an export theme's `metadata.xml`.  Furthermore, tests were added.

----------------

Fix #1364