### PR TITLE
[Concert] Fix use-after-free when reloading concerts

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -41,3 +41,5 @@ jobs:
           VALIDATE_JSCPD: false
           # cpplint uses another code style and not the one from clang-format
           VALIDATE_CPP: false
+          # textlint: No easy way to add custom words
+          VALIDATE_NATURAL_LANGUAGE: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
    such as biographies and reviews.
  - AllMusic scrapes artist's biographies again (#1379)
  - Discogs scrapes years correctly again for Non-English users (#1379)
+ - A crash when concerts were reloaded was fixed (#1335)
 
 ### Changes
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -20,6 +20,7 @@
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_LINKER": "mold",
                 "ENABLE_TESTS": "ON",
                 "ENABLE_COLOR_OUTPUT": "ON",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",

--- a/src/scrapers/tv_show/tmdb/TmdbTvShowParser.h
+++ b/src/scrapers/tv_show/tmdb/TmdbTvShowParser.h
@@ -8,9 +8,11 @@
 #include <chrono>
 
 class TvShow;
-struct ScraperError;
 
 namespace mediaelch {
+
+struct ScraperError;
+
 namespace scraper {
 
 class TmdbApi;

--- a/src/ui/concerts/ConcertFilesWidget.cpp
+++ b/src/ui/concerts/ConcertFilesWidget.cpp
@@ -224,7 +224,7 @@ void ConcertFilesWidget::openNfo()
 void ConcertFilesWidget::itemActivated(QModelIndex index, QModelIndex previous)
 {
     if (!index.isValid()) {
-        qCDebug(generic) << "Index is invalid";
+        qCWarning(generic) << "[ConcertFilesWidget] Concert index is invalid!";
         m_lastConcert = nullptr;
         emit noConcertSelected();
         return;

--- a/src/ui/concerts/ConcertInfoWidget.cpp
+++ b/src/ui/concerts/ConcertInfoWidget.cpp
@@ -52,17 +52,16 @@ ConcertInfoWidget::ConcertInfoWidget(QWidget* parent) : QWidget(parent), ui(std:
 // complete type of UI::ConcertInfoWidget
 ConcertInfoWidget::~ConcertInfoWidget() = default;
 
-void ConcertInfoWidget::setConcertController(ConcertController* controller)
+void ConcertInfoWidget::updateConcert(ConcertController* controller)
 {
-    m_concertController = controller;
-}
+    clear();
 
-void ConcertInfoWidget::updateConcertInfo()
-{
-    if ((m_concertController == nullptr) || (m_concertController->concert() == nullptr)) {
-        qCDebug(generic) << "My concert is invalid";
+    if ((controller == nullptr) || (controller->concert() == nullptr)) {
+        qCWarning(generic) << "[ConcertInfoWidget] New concert is invalid";
         return;
     }
+
+    m_concertController = controller;
 
     ui->userRating->blockSignals(true);
     ui->runtime->blockSignals(true);
@@ -71,8 +70,6 @@ void ConcertInfoWidget::updateConcertInfo()
     ui->released->blockSignals(true);
     ui->lastPlayed->blockSignals(true);
     ui->overview->blockSignals(true);
-
-    clear();
 
     const QStringList nativeFileList = m_concertController->concert()->files().toNativeStringList();
     ui->files->setText(nativeFileList.join(", "));
@@ -99,7 +96,8 @@ void ConcertInfoWidget::updateConcertInfo()
 
     QStringList certifications;
     certifications.append("");
-    for (const Concert* concert : Manager::instance()->concertModel()->concerts()) {
+    const auto concerts = Manager::instance()->concertModel()->concerts();
+    for (const Concert* concert : concerts) {
         if (!certifications.contains(concert->certification().toString()) && concert->certification().isValid()) {
             certifications.append(concert->certification().toString());
         }
@@ -125,6 +123,7 @@ void ConcertInfoWidget::setRuntime(std::chrono::minutes runtime)
 
 void ConcertInfoWidget::clear()
 {
+    m_concertController = nullptr;
     ui->certification->clear();
     ui->files->clear();
     ui->title->clear();

--- a/src/ui/concerts/ConcertInfoWidget.h
+++ b/src/ui/concerts/ConcertInfoWidget.h
@@ -27,8 +27,9 @@ public:
     explicit ConcertInfoWidget(QWidget* parent = nullptr);
     ~ConcertInfoWidget() override;
 
-    void setConcertController(ConcertController* controller);
-    void updateConcertInfo();
+    void updateConcert(ConcertController* controller);
+    /// \brief Clear the widget and remove all references to current concert.
+    void clear();
 
     void setRuntime(std::chrono::minutes runtime);
 
@@ -57,8 +58,6 @@ private slots:
     void onOverviewChange();
 
 private:
-    void clear();
-
     std::unique_ptr<Ui::ConcertInfoWidget> ui;
     QPointer<ConcertController> m_concertController = nullptr;
 };

--- a/src/ui/concerts/ConcertStreamDetailsWidget.cpp
+++ b/src/ui/concerts/ConcertStreamDetailsWidget.cpp
@@ -35,18 +35,17 @@ ConcertStreamDetailsWidget::ConcertStreamDetailsWidget(QWidget* parent) :
     helper::fillStereoModeCombo(ui->stereoMode);
 }
 
-void ConcertStreamDetailsWidget::setConcertController(ConcertController* controller)
+void ConcertStreamDetailsWidget::updateConcert(ConcertController* controller)
 {
-    m_concertController = controller;
-}
+    clear();
 
-void ConcertStreamDetailsWidget::updateConcertInfo()
-{
-    if ((m_concertController == nullptr) || (m_concertController->concert() == nullptr)) {
-        qCDebug(generic) << "My concert is invalid";
+    if ((controller == nullptr) || (controller->concert() == nullptr)) {
+        qCWarning(generic) << "[ConcertStreamDetailsWidget] New concert is invalid";
         return;
     }
-    clear();
+
+    m_concertController = controller;
+
     updateStreamDetails();
     ui->videoAspectRatio->setEnabled(m_concertController->concert()->streamDetailsLoaded());
     ui->videoCodec->setEnabled(m_concertController->concert()->streamDetailsLoaded());

--- a/src/ui/concerts/ConcertStreamDetailsWidget.h
+++ b/src/ui/concerts/ConcertStreamDetailsWidget.h
@@ -21,8 +21,9 @@ public:
     explicit ConcertStreamDetailsWidget(QWidget* parent = nullptr);
     ~ConcertStreamDetailsWidget() override;
 
-    void setConcertController(ConcertController* controller);
-    void updateConcertInfo();
+    void updateConcert(ConcertController* controller);
+    /// \brief Clear the widget and remove all references to current concert.
+    void clear();
 
 signals:
     void streamDetailsChanged();
@@ -35,8 +36,6 @@ private slots:
     void updateStreamDetails(bool reloadFromFile = false);
 
 private:
-    void clear();
-
     std::unique_ptr<Ui::ConcertStreamDetailsWidget> ui;
     QPointer<ConcertController> m_concertController = nullptr;
     QVector<QWidget*> m_streamDetailsWidgets;

--- a/src/ui/concerts/ConcertWidget.cpp
+++ b/src/ui/concerts/ConcertWidget.cpp
@@ -157,11 +157,11 @@ void ConcertWidget::setBigWindow(bool bigWindow)
     }
 }
 
-/**
- * \brief Clears all contents of the widget
- */
 void ConcertWidget::clear()
 {
+    ui->concertInfo->clear();
+    ui->concertStreamdetails->clear();
+
     ui->concertName->clear();
 
     ui->poster->clear();
@@ -238,8 +238,6 @@ void ConcertWidget::setConcert(Concert* concert)
             concert->setRuntime(duration_cast<minutes>(runtime));
         }
     }
-    ui->concertInfo->setConcertController(concert->controller());
-    ui->concertStreamdetails->setConcertController(concert->controller());
     updateConcertInfo();
 
     // clang-format off
@@ -363,20 +361,17 @@ void ConcertWidget::onDownloadProgress(Concert* concert, int current, int maximu
 }
 
 
-/**
- * \brief Updates the contents of the widget with the current concert infos
- */
 void ConcertWidget::updateConcertInfo()
 {
+    clear();
+
     if (m_concert == nullptr) {
         qCWarning(generic) << "[ConcertWidget] Concert is invalid; can't update";
         return;
     }
 
-    clear();
-
-    ui->concertInfo->updateConcertInfo();
-    ui->concertStreamdetails->updateConcertInfo();
+    ui->concertInfo->updateConcert(m_concert->controller());
+    ui->concertStreamdetails->updateConcert(m_concert->controller());
 
     ui->concertName->setText(m_concert->title());
 

--- a/src/ui/concerts/ConcertWidget.h
+++ b/src/ui/concerts/ConcertWidget.h
@@ -36,6 +36,7 @@ public slots:
     void setEnabledTrue(Concert* concert = nullptr);
     void setDisabledTrue();
     void setBigWindow(bool bigWindow);
+    /// \brief Updates the contents of the widget with the current concert infos.
     void updateConcertInfo();
 
 protected:


### PR DESCRIPTION
Fix  #1335

------------------

There was a use-after-free bug in MediaElch where it would crash if a
concert was selected that has ratings and then "reload" was pressed.

Why did it crash? Because the old concert was deleted, but we still held
the reference to it in the info widget. While clear() was called, we did
not reset the reference.