### PR TITLE
[StreamDetails] Don't override details if MediaInfoDll is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 
 ### Added
 
- - *tbd*
+ - If streamdetails can't be loaded (e.g. because libmediainfo is missing), a click on the button
+   "Reload Streamdetails" will now tell your (#1414)
 
 ### Removed
 

--- a/src/concerts/ConcertController.h
+++ b/src/concerts/ConcertController.h
@@ -29,7 +29,9 @@ public:
     bool saveData(MediaCenterInterface* mediaCenterInterface);
     bool loadData(MediaCenterInterface* mediaCenterInterface, bool force = false, bool reloadFromNfo = true);
     void loadData(TmdbId id, mediaelch::scraper::ConcertScraper* scraperInterface, QSet<ConcertScraperInfo> infos);
-    void loadStreamDetailsFromFile();
+
+    ELCH_NODISCARD bool loadStreamDetailsFromFile();
+
     void scraperLoadDone(mediaelch::scraper::ConcertScraper* scraper);
     QSet<ConcertScraperInfo> infosToLoad();
     bool infoLoaded() const;

--- a/src/data/MediaInfoFile.cpp
+++ b/src/data/MediaInfoFile.cpp
@@ -15,18 +15,34 @@
 MediaInfoFile::MediaInfoFile(const QString& filepath) : m_mediaInfo{std::make_unique<MediaInfoDLL::MediaInfo>()}
 {
     // VERSION;APP_NAME;APP_VERSION"
-    m_mediaInfo->Option(__T("Info_Version"), __T("20.03;MediaElch;2.6"));
+    m_mediaInfo->Option(__T("Info_Version"), __T("20.03;MediaElch;2.8"));
     m_mediaInfo->Option(__T("Internet"), __T("no"));
     m_mediaInfo->Option(__T("Complete"), __T("1"));
     m_mediaInfo->Open(QString2MI(filepath));
-    if (!m_mediaInfo->IsReady()) {
+
+    m_isReady = m_mediaInfo->IsReady();
+    if (!m_isReady) {
         qCCritical(generic) << "[MediaInfo] Unable to load libmediainfo!";
     }
 }
 
 MediaInfoFile::~MediaInfoFile()
 {
+    m_isReady = false;
     m_mediaInfo->Close();
+}
+
+bool MediaInfoFile::hasMediaInfo()
+{
+    if (MediaInfoDLL_IsLoaded() > 0)
+        return true;
+    MediaInfoDLL_Load();
+    return MediaInfoDLL_IsLoaded() > 0;
+}
+
+bool MediaInfoFile::isReady() const
+{
+    return m_isReady;
 }
 
 int MediaInfoFile::subtitleCount() const

--- a/src/data/MediaInfoFile.h
+++ b/src/data/MediaInfoFile.h
@@ -50,6 +50,10 @@ public:
     MediaInfoFile(const QString& filepath);
     ~MediaInfoFile();
 
+    static bool hasMediaInfo();
+
+    bool isReady() const;
+
     int subtitleCount() const;
     int videoStreamCount() const;
     int audioStreamCount() const;
@@ -83,4 +87,5 @@ private:
     // We don't want the MediaInfoLib include here so we avoid it by
     // using the forward declaration of the class MediaInfo
     std::unique_ptr<MediaInfoDLL::MediaInfo> m_mediaInfo;
+    bool m_isReady = false;
 };

--- a/src/data/StreamDetails.h
+++ b/src/data/StreamDetails.h
@@ -39,7 +39,9 @@ public:
     static QString detailToString(AudioDetails details);
     static QString detailToString(SubtitleDetails details);
 
-    void loadStreamDetails();
+    /// \brief Loads stream details from the file. Returns true if successful.
+    ELCH_NODISCARD bool loadStreamDetails();
+
     void setVideoDetail(VideoDetails key, QString value);
     void setAudioDetail(int streamNumber, AudioDetails key, QString value);
     void setSubtitleDetail(int streamNumber, SubtitleDetails key, QString value);
@@ -62,7 +64,7 @@ public:
     QStringList allSubtitleLanguages() const;
 
 private:
-    void loadWithLibrary();
+    bool loadWithLibrary();
 
     mediaelch::FileList m_files;
     QMap<VideoDetails, QString> m_videoDetails;

--- a/src/image/ImageCapture.cpp
+++ b/src/image/ImageCapture.cpp
@@ -22,11 +22,13 @@ bool ImageCapture::captureImage(FilePath file,
     bool cropFromCenter)
 {
     if (streamDetails->videoDetails().value(StreamDetails::VideoDetails::DurationInSeconds, nullptr) == nullptr) {
-        streamDetails->loadStreamDetails();
-    }
-    if (streamDetails->videoDetails().value(StreamDetails::VideoDetails::DurationInSeconds, nullptr) == nullptr) {
-        NotificationBox::instance()->showError(tr("Could not get duration of file"));
-        return false;
+        const bool success = streamDetails->loadStreamDetails();
+
+        if (!success || //
+            streamDetails->videoDetails().value(StreamDetails::VideoDetails::DurationInSeconds, nullptr) == nullptr) {
+            NotificationBox::instance()->showError(tr("Could not get duration of file"));
+            return false;
+        }
     }
 
 #ifdef Q_OS_OSX

--- a/src/movies/MovieController.h
+++ b/src/movies/MovieController.h
@@ -46,7 +46,7 @@ public:
         mediaelch::scraper::MovieScraper* scraperInterface,
         QSet<MovieScraperInfo> infos);
 
-    void loadStreamDetailsFromFile();
+    ELCH_NODISCARD bool loadStreamDetailsFromFile();
 
     /// \brief Called when a ScraperInterface has finished loading
     ///        Emits the loaded signal

--- a/src/tv_shows/TvShowEpisode.cpp
+++ b/src/tv_shows/TvShowEpisode.cpp
@@ -157,14 +157,14 @@ bool TvShowEpisode::loadData(MediaCenterInterface* mediaCenterInterface, bool re
     return infoLoaded;
 }
 
-/**
- * \brief Tries to load streamdetails from the file
- */
-void TvShowEpisode::loadStreamDetailsFromFile()
+bool TvShowEpisode::loadStreamDetailsFromFile()
 {
-    m_streamDetails->loadStreamDetails();
-    setStreamDetailsLoaded(true);
-    setChanged(true);
+    const bool success = m_streamDetails->loadStreamDetails();
+    if (success) {
+        setStreamDetailsLoaded(true);
+        setChanged(true);
+    }
+    return success;
 }
 
 /**
@@ -175,10 +175,14 @@ void TvShowEpisode::loadStreamDetailsFromFile()
 bool TvShowEpisode::saveData(MediaCenterInterface* mediaCenterInterface)
 {
     if (!streamDetailsLoaded() && Settings::instance()->autoLoadStreamDetails()) {
-        loadStreamDetailsFromFile();
+        const bool success = loadStreamDetailsFromFile();
+        if (!success) {
+            // TODO: Tell the user that it failed
+            qCDebug(generic) << "[TvShowEpisode] Could not load stream details for episode with ID=" << m_episodeId;
+        }
     }
     bool saved = mediaCenterInterface->saveTvShowEpisode(this);
-    qCDebug(generic) << "Saving episode" << (saved ? "successful" : "not successful");
+    qCDebug(generic) << "[TvShowEpisode] Saving episode" << (saved ? "successful" : "not successful");
     if (!m_infoLoaded) {
         m_infoLoaded = saved;
     }

--- a/src/tv_shows/TvShowEpisode.h
+++ b/src/tv_shows/TvShowEpisode.h
@@ -144,7 +144,10 @@ public:
         const mediaelch::scraper::ShowIdentifier& showIdentifier,
         SeasonOrder order,
         const QSet<EpisodeScraperInfo>& infosToLoad);
-    void loadStreamDetailsFromFile();
+
+    /// \brief Tries to load streamdetails from the file
+    ELCH_NODISCARD bool loadStreamDetailsFromFile();
+
     void clearImages();
     QSet<EpisodeScraperInfo> infosToLoad();
 

--- a/src/ui/concerts/ConcertFilesWidget.cpp
+++ b/src/ui/concerts/ConcertFilesWidget.cpp
@@ -156,7 +156,7 @@ void ConcertFilesWidget::loadStreamDetails()
         concerts.append(concert);
     }
     if (concerts.count() == 1) {
-        concerts.at(0)->controller()->loadStreamDetailsFromFile();
+        Q_UNUSED(concerts.at(0)->controller()->loadStreamDetailsFromFile());
         concerts.at(0)->setChanged(true);
     } else {
         auto* loader = new LoadingStreamDetails(this);

--- a/src/ui/concerts/ConcertStreamDetailsWidget.h
+++ b/src/ui/concerts/ConcertStreamDetailsWidget.h
@@ -30,10 +30,13 @@ signals:
     void runtimeChanged(std::chrono::minutes);
 
 private slots:
+    /// \brief Forces a reload of stream details
     void onReloadStreamDetails();
 
     void onStreamDetailsEdited();
-    void updateStreamDetails(bool reloadFromFile = false);
+    /// \brief Fills the widget with streamdetails
+    /// \param reloadFromFile If true, re-set the duration (non-streamdetails property)
+    void updateStreamDetails(bool reloadedFromFile = false);
 
 private:
     std::unique_ptr<Ui::ConcertStreamDetailsWidget> ui;

--- a/src/ui/concerts/ConcertStreamDetailsWidget.ui
+++ b/src/ui/concerts/ConcertStreamDetailsWidget.ui
@@ -69,7 +69,6 @@
       <widget class="QLabel" name="label_27">
        <property name="font">
         <font>
-         <weight>75</weight>
          <bold>true</bold>
         </font>
        </property>
@@ -85,7 +84,6 @@
       <widget class="QLabel" name="labelStreamDetailsAudio">
        <property name="font">
         <font>
-         <weight>75</weight>
          <bold>true</bold>
         </font>
        </property>
@@ -219,6 +217,13 @@
        </property>
        <property name="dropShadow" stdset="0">
         <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblReloadStreamDetailsError">
+       <property name="text">
+        <string notr="true">Error</string>
        </property>
       </widget>
      </item>

--- a/src/ui/concerts/ConcertWidget.cpp
+++ b/src/ui/concerts/ConcertWidget.cpp
@@ -229,13 +229,15 @@ void ConcertWidget::setConcert(Concert* concert)
     concert->controller()->loadData(Manager::instance()->mediaCenterInterfaceConcert());
     m_concert = concert;
     if (!concert->streamDetailsLoaded() && Settings::instance()->autoLoadStreamDetails()) {
-        concert->controller()->loadStreamDetailsFromFile();
-        const auto videoDetails = concert->streamDetails()->videoDetails();
-        if (concert->streamDetailsLoaded()
-            && videoDetails.value(StreamDetails::VideoDetails::DurationInSeconds).toInt() != 0) {
-            using namespace std::chrono;
-            seconds runtime{videoDetails.value(StreamDetails::VideoDetails::DurationInSeconds).toInt()};
-            concert->setRuntime(duration_cast<minutes>(runtime));
+        const bool success = concert->controller()->loadStreamDetailsFromFile();
+        if (success) {
+            const auto videoDetails = concert->streamDetails()->videoDetails();
+            if (concert->streamDetailsLoaded()
+                && videoDetails.value(StreamDetails::VideoDetails::DurationInSeconds).toInt() != 0) {
+                using namespace std::chrono;
+                seconds runtime{videoDetails.value(StreamDetails::VideoDetails::DurationInSeconds).toInt()};
+                concert->setRuntime(duration_cast<minutes>(runtime));
+            }
         }
     }
     updateConcertInfo();

--- a/src/ui/imports/ImportDialog.cpp
+++ b/src/ui/imports/ImportDialog.cpp
@@ -661,7 +661,7 @@ void ImportDialog::onMovingFilesFinished()
         if (!m_newFiles.isEmpty()) {
             m_movie->setFileLastModified(QFileInfo(m_newFiles.first()).lastModified());
         }
-        m_movie->controller()->loadStreamDetailsFromFile();
+        Q_UNUSED(m_movie->controller()->loadStreamDetailsFromFile());
         m_movie->controller()->saveData(Manager::instance()->mediaCenterInterface());
         m_movie->controller()->loadData(Manager::instance()->mediaCenterInterface());
         Manager::instance()->database()->addMovie(m_movie, mediaelch::DirectoryPath(importDir()));
@@ -675,7 +675,7 @@ void ImportDialog::onMovingFilesFinished()
         }
 
         m_episode->setFiles(m_newFiles);
-        m_episode->loadStreamDetailsFromFile();
+        Q_UNUSED(m_episode->loadStreamDetailsFromFile());
         m_show->addEpisode(m_episode);
         m_episode->saveData(Manager::instance()->mediaCenterInterfaceTvShow());
         m_episode->loadData(Manager::instance()->mediaCenterInterfaceTvShow(), true, false);
@@ -697,7 +697,7 @@ void ImportDialog::onMovingFilesFinished()
 
     } else if (m_type == "concert") {
         m_concert->setFiles(m_newFiles);
-        m_concert->controller()->loadStreamDetailsFromFile();
+        Q_UNUSED(m_concert->controller()->loadStreamDetailsFromFile());
         m_concert->controller()->saveData(Manager::instance()->mediaCenterInterface());
         m_concert->controller()->loadData(Manager::instance()->mediaCenterInterface());
         Manager::instance()->database()->add(m_concert, mediaelch::DirectoryPath(importDir()));

--- a/src/ui/imports/MakeMkvDialog.cpp
+++ b/src/ui/imports/MakeMkvDialog.cpp
@@ -376,7 +376,7 @@ void MakeMkvDialog::importFinished()
     if (!m_movie->files().isEmpty()) {
         m_movie->setFileLastModified(QFileInfo(m_movie->files().first().toString()).lastModified());
     }
-    m_movie->controller()->loadStreamDetailsFromFile();
+    Q_UNUSED(m_movie->controller()->loadStreamDetailsFromFile());
     m_movie->controller()->saveData(Manager::instance()->mediaCenterInterface());
     m_movie->controller()->loadData(Manager::instance()->mediaCenterInterface());
     Manager::instance()->database()->addMovie(m_movie, mediaelch::DirectoryPath(ui->comboImportDir->currentText()));

--- a/src/ui/movies/MovieFilesWidget.cpp
+++ b/src/ui/movies/MovieFilesWidget.cpp
@@ -234,9 +234,10 @@ void MovieFilesWidget::loadStreamDetails()
         movies.append(movie);
     }
     if (movies.count() == 1) {
-        movies.at(0)->controller()->loadStreamDetailsFromFile();
+        Q_UNUSED(movies.at(0)->controller()->loadStreamDetailsFromFile());
         movies.at(0)->setChanged(true);
     } else {
+        // TODO: Check if MediaInfo is available
         auto* loader = new LoadingStreamDetails(this);
         loader->loadMovies(movies);
         delete loader;
@@ -486,7 +487,8 @@ void MovieFilesWidget::renewModel()
     for (int i = 1, n = ui->files->model()->columnCount(); i < n; ++i) {
         ui->files->setColumnHidden(i, true);
     }
-    for (const MediaStatusColumn& column : Settings::instance()->mediaStatusColumns()) {
+    const auto columns = Settings::instance()->mediaStatusColumns();
+    for (const MediaStatusColumn& column : columns) {
         ui->files->setColumnHidden(MovieModel::mediaStatusToColumn(column), false);
     }
 }

--- a/src/ui/movies/MovieWidget.h
+++ b/src/ui/movies/MovieWidget.h
@@ -103,8 +103,11 @@ private slots:
 
     void onSubtitleEdited(QTableWidgetItem* item);
     void onStreamDetailsEdited();
-    void onReloadStreamDetails();
-    void updateStreamDetails(bool reloadFromFile = false);
+    /// \brief Forces a reload of stream details
+    void onClickReloadStreamDetails();
+    /// \brief Fills the widget with streamdetails
+    /// \param reloadFromFile If true, re-set the duration (non-streamdetails property)
+    void updateStreamDetails(bool reloadedFromFile = false);
     void onDownloadTrailer();
     void onInsertYoutubeLink();
     void onPlayLocalTrailer();

--- a/src/ui/movies/MovieWidget.ui
+++ b/src/ui/movies/MovieWidget.ui
@@ -68,7 +68,6 @@
       <widget class="QLabel" name="movieName">
        <property name="font">
         <font>
-         <family>Helvetica Neue</family>
          <pointsize>22</pointsize>
         </font>
        </property>
@@ -727,9 +726,7 @@
               <item>
                <widget class="QLabel" name="label_16">
                 <property name="font">
-                 <font>
-                  <family>Helvetica Neue</family>
-                 </font>
+                 <font/>
                 </property>
                 <property name="text">
                  <string>Hint: Closed images will be deleted on save.</string>
@@ -843,7 +840,6 @@
                <widget class="QLabel" name="labelStreamDetailsAudio">
                 <property name="font">
                  <font>
-                  <weight>75</weight>
                   <bold>true</bold>
                  </font>
                 </property>
@@ -859,7 +855,6 @@
                <widget class="QLabel" name="label_27">
                 <property name="font">
                  <font>
-                  <weight>75</weight>
                   <bold>true</bold>
                  </font>
                 </property>
@@ -987,6 +982,16 @@
                </widget>
               </item>
               <item>
+               <widget class="QLabel" name="lblReloadStreamDetailsError">
+                <property name="text">
+                 <string notr="true">Error</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::PlainText</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
                <spacer name="horizontalSpacer_9">
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
@@ -1021,7 +1026,6 @@
              <widget class="QLabel" name="label_14">
               <property name="font">
                <font>
-                <weight>75</weight>
                 <bold>true</bold>
                </font>
               </property>

--- a/src/ui/small_widgets/LoadingStreamDetails.cpp
+++ b/src/ui/small_widgets/LoadingStreamDetails.cpp
@@ -38,8 +38,10 @@ void LoadingStreamDetails::loadMovies(QVector<Movie*> movies)
     show();
     for (Movie* movie : movies) {
         movie->blockSignals(true);
-        movie->controller()->loadStreamDetailsFromFile();
-        movie->setChanged(true);
+        const bool success = movie->controller()->loadStreamDetailsFromFile();
+        if (success) {
+            movie->setChanged(true);
+        }
         movie->blockSignals(false);
         ui->progressBar->setValue(ui->progressBar->value() + 1);
         ui->currentFile->setText(movie->name());
@@ -56,8 +58,10 @@ void LoadingStreamDetails::loadConcerts(QVector<Concert*> concerts)
     adjustSize();
     show();
     for (Concert* concert : concerts) {
-        concert->controller()->loadStreamDetailsFromFile();
-        concert->setChanged(true);
+        const bool success = concert->controller()->loadStreamDetailsFromFile();
+        if (success) {
+            concert->setChanged(true);
+        }
         ui->progressBar->setValue(ui->progressBar->value() + 1);
         ui->currentFile->setText(concert->title());
         QApplication::processEvents();
@@ -73,8 +77,10 @@ void LoadingStreamDetails::loadTvShowEpisodes(QVector<TvShowEpisode*> episodes)
     adjustSize();
     show();
     for (TvShowEpisode* episode : episodes) {
-        episode->loadStreamDetailsFromFile();
-        episode->setChanged(true);
+        const bool success = episode->loadStreamDetailsFromFile();
+        if (success) {
+            episode->setChanged(true);
+        }
         ui->progressBar->setValue(ui->progressBar->value() + 1);
         ui->currentFile->setText(episode->title());
         QApplication::processEvents();

--- a/src/ui/tv_show/TvShowFilesWidget.cpp
+++ b/src/ui/tv_show/TvShowFilesWidget.cpp
@@ -300,7 +300,9 @@ void TvShowFilesWidget::loadStreamDetails()
     });
 
     if (episodes.count() == 1) {
-        episodes.at(0)->loadStreamDetailsFromFile();
+        // Load stream details, but ignore if failed
+        // TODO: Let user know
+        Q_UNUSED(episodes.at(0)->loadStreamDetailsFromFile());
         episodes.at(0)->setChanged(true);
 
     } else {

--- a/src/ui/tv_show/TvShowWidgetEpisode.h
+++ b/src/ui/tv_show/TvShowWidgetEpisode.h
@@ -68,8 +68,13 @@ private slots:
     void onDirectorEdited(QTableWidgetItem* item);
     void onWriterEdited(QTableWidgetItem* item);
     void onStreamDetailsEdited();
+
+    /// \brief Forces a reload of stream details
     void onReloadStreamDetails();
-    void updateStreamDetails(bool reloadFromFile = false);
+
+    /// \brief Fills the widget with streamdetails
+    /// \param reloadFromFile If true, re-set the duration (non-streamdetails property)
+    void updateStreamDetails(bool reloadedFromFile = false);
 
     void onAddTag(QString tag);
     void onRemoveTag(QString tag);

--- a/src/ui/tv_show/TvShowWidgetEpisode.ui
+++ b/src/ui/tv_show/TvShowWidgetEpisode.ui
@@ -75,7 +75,6 @@
           <widget class="QLabel" name="episodeName">
            <property name="font">
             <font>
-             <family>Helvetica Neue</family>
              <pointsize>22</pointsize>
             </font>
            </property>
@@ -993,7 +992,6 @@
              <widget class="QLabel" name="labelStreamDetailsAudio">
               <property name="font">
                <font>
-                <weight>75</weight>
                 <bold>true</bold>
                </font>
               </property>
@@ -1109,7 +1107,6 @@
              <widget class="QLabel" name="label_27">
               <property name="font">
                <font>
-                <weight>75</weight>
                 <bold>true</bold>
                </font>
               </property>
@@ -1163,6 +1160,13 @@
               </property>
               <property name="dropShadow" stdset="0">
                <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="lblReloadStreamDetailsError">
+              <property name="text">
+               <string notr="true">Error</string>
               </property>
              </widget>
             </item>
@@ -1302,9 +1306,10 @@
    <header>ui/small_widgets/ClosableImage.h</header>
   </customwidget>
   <customwidget>
-   <class>MyLabel</class>
-   <extends>QLabel</extends>
-   <header>ui/small_widgets/MyLabel.h</header>
+   <class>RatingsWidget</class>
+   <extends>QWidget</extends>
+   <header>ui/small_widgets/RatingsWidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>MediaFlags</class>
@@ -1313,10 +1318,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>RatingsWidget</class>
-   <extends>QWidget</extends>
-   <header>ui/small_widgets/RatingsWidget.h</header>
-   <container>1</container>
+   <class>MyLabel</class>
+   <extends>QLabel</extends>
+   <header>ui/small_widgets/MyLabel.h</header>
   </customwidget>
   <customwidget>
    <class>MySpinBox</class>


### PR DESCRIPTION
Fix #1414

------------

TODO:

- [x] Test properly
- [ ] ~~Make "load stream details" button un-clickable if MediaInfo is not found~~ (now just a message)
- [x] Properly show error message if stream details can not be loaded