### PR TITLE
[DownloadManager] Correctly abort downloads to avoid crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
- - *tbd*
+ - Movies: Downloading multiple movies (and their fanart) crashed MediaElch (#1408)
 
 ### Changes
 

--- a/src/movies/MovieController.cpp
+++ b/src/movies/MovieController.cpp
@@ -351,6 +351,11 @@ void MovieController::onFanartLoadDone(Movie* movie, QMap<ImageType, QVector<Pos
         emit sigLoadImagesStarted(m_movie);
     }
 
+    if (m_downloadsInProgress) {
+        // TODO: This could mean that art is downloaded for the wrong movie.
+        //       I need to look at ImageProvider::sigMovieImagesLoaded
+        qCCritical(generic) << "[MovieController] Download is already in progress!";
+    }
     m_downloadsInProgress = !downloads.isEmpty();
     m_downloadsSize = qsizetype_to_int(downloads.count());
     m_downloadsLeft = qsizetype_to_int(downloads.count());


### PR DESCRIPTION
MediaElch would crash if I downloaded more than 10 or 20 movies at once.
This happened because running downloads were not aborted properly.

I still need to investigate why this even happens: There may be a
mismatch between movies in the Image provider, i.e. the callback for
the wrong movie is called.

---------------

Fix #1408