### PR TITLE
[UI TvShow] Fix white background on selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Bugfixes
 
  - Movies: Downloading multiple movies (and their fanart) crashed MediaElch (#1408)
+ - TV Shows: When selecting TV shows/seasons/episodes on Linux, the background
+   was just white (#1412)
 
 ### Changes
 

--- a/src/ui/small_widgets/TvShowTreeView.cpp
+++ b/src/ui/small_widgets/TvShowTreeView.cpp
@@ -225,14 +225,19 @@ void TvShowTreeView::drawRowBackground(QPainter* painter,
 
     if (selectionModel()->isSelected(index)) {
         optionClone.state |= QStyle::State_Selected;
-#ifdef Q_OS_WIN
+        // TODO:
+        //   See bug #1412
+        //   The stylesheet is not properly used in this tree view.  Because of that, the background stayed white.
+        //   Look how Qt does it: qtbase/src/widget/itemsviews/qtreeview.cpp (QTreeView::drawRow)
+        //   Also check if this ifdef for Windows was necessary.
+        // #ifdef Q_OS_WIN
         const QColor blue(27, 106, 165);
         QPen pen(blue);
         pen.setWidth(0);
         painter->setPen(pen);
         painter->setBrush(QBrush(blue));
         painter->drawRect(optionClone.rect);
-#endif
+        // #endif
     }
 
     style()->drawPrimitive(QStyle::PE_PanelItemViewRow, &option, painter, this);


### PR DESCRIPTION
This commit fixes the white background when a TV show / season /
episode was selected.

There is still a TODO open, see inline comments of the diff.


-------------------

Before:
![Screenshot_20220219_180104](https://user-images.githubusercontent.com/1667306/154811786-e24f7191-5ae4-4784-8a7c-f9dafb57317e.png)


After:
![Screenshot_20220219_182044](https://user-images.githubusercontent.com/1667306/154811790-0fcb43d7-8fde-4873-a066-0a581e02c9e2.png)


-------------------

Fix  #1412