### PR TITLE
Add more languages to the sort tokens

### DIFF
--- a/docs/advancedsettings.xml
+++ b/docs/advancedsettings.xml
@@ -71,16 +71,49 @@
         ("The Movie" -> "Movie, The").
     -->
     <sorttokens>
-        <token>Der</token>
-        <token>Die</token>
-        <token>Das</token>
-        <token>The</token>
-        <token>Le</token>
-        <token>La</token>
-        <token>Les</token>
-        <token>Un</token>
-        <token>Une</token>
-        <token>Des</token>
+		<!-- English -->
+		<token>The</token>
+		<token>A</token>
+		<token>An</token>
+		<!-- German -->
+		<token>Der</token>
+		<token>Die</token>
+		<token>Das</token>
+		<token>Des</token>
+		<token>Dem</token>
+		<token>Den</token>
+        <token>Ein</token>
+		<token>Eine</token>
+		<token>Einer</token>
+		<token>Eines</token>
+		<token>Einem</token>
+		<token>Einen</token>
+		<!-- French -->
+		<token>Le</token>
+		<token>La</token>
+		<token>Les</token>
+		<token>Un</token>
+		<token>Une</token>
+		<token>Des</token>
+		<!-- Spanish -->
+		<token>El</token>
+		<token>La</token>
+		<token>Lo</token>
+		<token>Los</token>
+		<token>Las</token>
+		<token>Un</token>
+		<token>Una</token>
+		<token>Unos</token>
+		<token>Unas</token>
+		<!-- Portuguese -->
+		<token>O</token>
+		<token>A</token>
+		<token>Os</token>
+		<token>As</token>
+		<token>Um</token>
+		<token>Uma</token>
+		<token>Uns</token>
+		<token>Umas</token>
     </sorttokens>
 
     <!--

--- a/docs/advancedsettings.xml
+++ b/docs/advancedsettings.xml
@@ -71,49 +71,49 @@
         ("The Movie" -> "Movie, The").
     -->
     <sorttokens>
-		<!-- English -->
-		<token>The</token>
-		<token>A</token>
-		<token>An</token>
-		<!-- German -->
-		<token>Der</token>
-		<token>Die</token>
-		<token>Das</token>
-		<token>Des</token>
-		<token>Dem</token>
-		<token>Den</token>
+        <!-- English -->
+        <token>The</token>
+        <token>A</token>
+        <token>An</token>
+        <!-- German -->
+        <token>Der</token>
+        <token>Die</token>
+        <token>Das</token>
+        <token>Des</token>
+        <token>Dem</token>
+        <token>Den</token>
         <token>Ein</token>
-		<token>Eine</token>
-		<token>Einer</token>
-		<token>Eines</token>
-		<token>Einem</token>
-		<token>Einen</token>
-		<!-- French -->
-		<token>Le</token>
-		<token>La</token>
-		<token>Les</token>
-		<token>Un</token>
-		<token>Une</token>
-		<token>Des</token>
-		<!-- Spanish -->
-		<token>El</token>
-		<token>La</token>
-		<token>Lo</token>
-		<token>Los</token>
-		<token>Las</token>
-		<token>Un</token>
-		<token>Una</token>
-		<token>Unos</token>
-		<token>Unas</token>
-		<!-- Portuguese -->
-		<token>O</token>
-		<token>A</token>
-		<token>Os</token>
-		<token>As</token>
-		<token>Um</token>
-		<token>Uma</token>
-		<token>Uns</token>
-		<token>Umas</token>
+        <token>Eine</token>
+        <token>Einer</token>
+        <token>Eines</token>
+        <token>Einem</token>
+        <token>Einen</token>
+        <!-- French -->
+        <token>Le</token>
+        <token>La</token>
+        <token>Les</token>
+        <token>Un</token>
+        <token>Une</token>
+        <token>Des</token>
+        <!-- Spanish -->
+        <token>El</token>
+        <token>La</token>
+        <token>Lo</token>
+        <token>Los</token>
+        <token>Las</token>
+        <token>Un</token>
+        <token>Una</token>
+        <token>Unos</token>
+        <token>Unas</token>
+        <!-- Portuguese -->
+        <token>O</token>
+        <token>A</token>
+        <token>Os</token>
+        <token>As</token>
+        <token>Um</token>
+        <token>Uma</token>
+        <token>Uns</token>
+        <token>Umas</token>
     </sorttokens>
 
     <!--

--- a/src/settings/AdvancedSettings.cpp
+++ b/src/settings/AdvancedSettings.cpp
@@ -8,7 +8,49 @@
 AdvancedSettings::AdvancedSettings()
 {
     m_locale = QLocale::system();
-    m_sortTokens = QStringList{"Der", "Die", "Das", "The", "Le", "La", "Les", "Un", "Une", "Des"};
+    m_sortTokens = QStringList{// English
+        "The",
+        "A",
+        "An",
+        // German
+        "Der",
+        "Die",
+        "Das",
+        "Des",
+        "Dem",
+        "Den",
+        "Ein",
+        "Eine",
+        "Einer",
+        "Eines",
+        "Einem",
+        "Einen",
+        // French
+        "Le",
+        "La",
+        "Les",
+        "Un",
+        "Une",
+        "Des",
+        // Spanish
+        "El",
+        "La",
+        "Lo",
+        "Los",
+        "Las",
+        "Un",
+        "Una",
+        "Unos",
+        "Unas",
+        // Portuguese -->
+        "O",
+        "A",
+        "Os",
+        "As",
+        "Um",
+        "Uma",
+        "Uns",
+        "Umas"};
 
     m_audioCodecMappings.insert("mpa1l2", "mp2");
     m_audioCodecMappings.insert("mpa1l3", "mp3");


### PR DESCRIPTION
Sourced from here: https://en.wikipedia.org/wiki/Article_(grammar)#Tables 

Going over the list and including the rest (without major coflicts) is left as an exercise to the reader.

This is *much* more complex than this simple feature can handle, but these should cover [~2 billion people](https://en.wikipedia.org/wiki/List_of_languages_by_total_number_of_speakers).