### PR TITLE
Change outdated ffmpeg switch

### DIFF
--- a/src/image/ImageCapture.cpp
+++ b/src/image/ImageCapture.cpp
@@ -61,7 +61,7 @@ bool ImageCapture::captureImage(FilePath file,
 
     ffmpeg.start(ffmpegbin,
         QStringList() << "-y"
-                      << "-ss" << timeCode << "-i" << file.toNativePathString() << "-vframes"
+                      << "-ss" << timeCode << "-i" << file.toNativePathString() << "-frames:v"
                       << "1"
                       << "-q:v"
                       << "2"


### PR DESCRIPTION
ffmpeg -vframes switch is outdated and will likely stop working some time in the future
See https://ffmpeg.org/ffmpeg.html
"-vframes number (output) - Set the number of video frames to output. This is an obsolete alias for -frames:v, which you should use instead."

I found this by accident as I was having a look at the code to grab screenshots because I was trying to figure out whether I could make a mini ffmpeg build for a docker image. I didn't get far with that pursuit, but every example I found about grabbing frames had -frames:v instead of -vframes, so I looked at the documentation and found the above page.

You might want to check that it still works with this change as I have not built it with this change, but it seems simple enough.