### PR TITLE
[Movies] Fix double loading images; incorrect image matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
- - Movies: Downloading multiple movies (and their fanart) crashed MediaElch (#1408)
+ - Movies: Downloading multiple movies (and their fanart) crashed MediaElch or could lead to mixed up fanart/images (#1408, #1409)
  - TV Shows: When selecting TV shows/seasons/episodes on Linux, the background
    was just white (#1412)
  - UI: Fix spacing for checkboxes in movie search window
@@ -21,6 +21,7 @@
 
  - If streamdetails can't be loaded (e.g. because libmediainfo is missing), a click on the button
    "Reload Streamdetails" will now tell your (#1414)
+ - More default sort tokens for other languages were added (#1421)
 
 ### Removed
 

--- a/src/globals/DownloadManager.h
+++ b/src/globals/DownloadManager.h
@@ -79,6 +79,8 @@ private:
     mediaelch::network::NetworkManager* network();
     static bool isLocalFile(const QUrl& url);
 
+    void logCurrentDownloads() const;
+
     QVector<QNetworkReply*> m_currentReplies;
     QQueue<DownloadManagerElement> m_queue;
 

--- a/src/globals/DownloadManagerElement.cpp
+++ b/src/globals/DownloadManagerElement.cpp
@@ -9,3 +9,9 @@ template<> Movie*         DownloadManagerElement::getElement() { return movie;  
 template<> TvShow*        DownloadManagerElement::getElement() { return show;    }
 template<> TvShowEpisode* DownloadManagerElement::getElement() { return episode; }
 // clang-format on
+
+QDebug operator<<(QDebug dbg, const DownloadManagerElement& element)
+{
+    dbg << "DownloadManagerElement(" << element.url << ")";
+    return dbg;
+}

--- a/src/globals/DownloadManagerElement.h
+++ b/src/globals/DownloadManagerElement.h
@@ -4,6 +4,8 @@
 #include "globals/Globals.h"
 #include "tv_shows/SeasonNumber.h"
 
+#include <QDebug>
+
 class Album;
 class Artist;
 class Concert;
@@ -40,3 +42,5 @@ public:
 
 // required for QVariant
 Q_DECLARE_METATYPE(DownloadManagerElement)
+
+QDebug operator<<(QDebug dbg, const DownloadManagerElement& element);

--- a/src/movies/MovieController.h
+++ b/src/movies/MovieController.h
@@ -93,9 +93,7 @@ private:
     bool m_infoFromNfoLoaded;
     QSet<MovieScraperInfo> m_infosToLoad;
     DownloadManager* m_downloadManager;
-    bool m_downloadsInProgress = false;
     int m_downloadsSize = 0;
-    int m_downloadsLeft = 0;
     QVector<ScraperData> m_loadsLeft;
     bool m_loadDoneFired = 0;
     bool m_forceFanartBackdrop;

--- a/src/scrapers/image/FanartTv.cpp
+++ b/src/scrapers/image/FanartTv.cpp
@@ -376,6 +376,7 @@ void FanartTv::onLoadAllMovieDataFinished()
 
     if (reply->error() != QNetworkReply::NoError) {
         emit sigMovieImagesLoaded(movie, {});
+        return;
     }
 
     QMap<ImageType, QVector<Poster>> posters;
@@ -399,6 +400,7 @@ void FanartTv::onLoadAllConcertDataFinished()
 
     if (reply->error() != QNetworkReply::NoError) {
         emit sigConcertImagesLoaded(concert, {});
+        return;
     }
 
     QMap<ImageType, QVector<Poster>> posters;

--- a/src/ui/media_centers/KodiSync.cpp
+++ b/src/ui/media_centers/KodiSync.cpp
@@ -239,19 +239,20 @@ void KodiSync::onMovieListFinished()
 
     if (reply->error() != QNetworkReply::NoError) {
         QMessageBox::warning(this, tr("Network error"), reply->errorString());
-    }
 
-    QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
-    QJsonObject obj = doc.object();
-    QMapIterator<QString, QVariant> it(obj.value("result").toObject().toVariantMap());
-    while (it.hasNext()) {
-        it.next();
-        if (it.key() == "movies" && !it.value().toList().isEmpty()) {
-            for (const QVariant& var : it.value().toList()) {
-                if (var.toMap().value("movieid").toInt() == 0) {
-                    continue;
+    } else {
+        QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+        QJsonObject obj = doc.object();
+        QMapIterator<QString, QVariant> it(obj.value("result").toObject().toVariantMap());
+        while (it.hasNext()) {
+            it.next();
+            if (it.key() == "movies" && !it.value().toList().isEmpty()) {
+                for (const QVariant& var : it.value().toList()) {
+                    if (var.toMap().value("movieid").toInt() == 0) {
+                        continue;
+                    }
+                    m_xbmcMovies.insert(var.toMap().value("movieid").toInt(), parseXbmcDataFromMap(var.toMap()));
                 }
-                m_xbmcMovies.insert(var.toMap().value("movieid").toInt(), parseXbmcDataFromMap(var.toMap()));
             }
         }
     }
@@ -269,19 +270,20 @@ void KodiSync::onConcertListFinished()
 
     if (reply->error() != QNetworkReply::NoError) {
         QMessageBox::warning(this, tr("Network error"), reply->errorString());
-    }
 
-    QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
-    QJsonObject obj = doc.object();
-    QMapIterator<QString, QVariant> it(obj.value("result").toObject().toVariantMap());
-    while (it.hasNext()) {
-        it.next();
-        if (it.key() == "musicvideos" && !it.value().toList().isEmpty()) {
-            for (const QVariant& var : it.value().toList()) {
-                if (var.toMap().value("musicvideoid").toInt() == 0) {
-                    continue;
+    } else {
+        QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+        QJsonObject obj = doc.object();
+        QMapIterator<QString, QVariant> it(obj.value("result").toObject().toVariantMap());
+        while (it.hasNext()) {
+            it.next();
+            if (it.key() == "musicvideos" && !it.value().toList().isEmpty()) {
+                for (const QVariant& var : it.value().toList()) {
+                    if (var.toMap().value("musicvideoid").toInt() == 0) {
+                        continue;
+                    }
+                    m_xbmcConcerts.insert(var.toMap().value("musicvideoid").toInt(), parseXbmcDataFromMap(var.toMap()));
                 }
-                m_xbmcConcerts.insert(var.toMap().value("musicvideoid").toInt(), parseXbmcDataFromMap(var.toMap()));
             }
         }
     }
@@ -299,19 +301,20 @@ void KodiSync::onTvShowListFinished()
 
     if (reply->error() != QNetworkReply::NoError) {
         QMessageBox::warning(this, tr("Network error"), reply->errorString());
-    }
 
-    QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
-    QJsonObject obj = doc.object();
-    QMapIterator<QString, QVariant> it(obj.value("result").toObject().toVariantMap());
-    while (it.hasNext()) {
-        it.next();
-        if (it.key() == "tvshows" && !it.value().toList().isEmpty()) {
-            for (const QVariant& var : it.value().toList()) {
-                if (var.toMap().value("tvshowid").toInt() == 0) {
-                    continue;
+    } else {
+        QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+        QJsonObject obj = doc.object();
+        QMapIterator<QString, QVariant> it(obj.value("result").toObject().toVariantMap());
+        while (it.hasNext()) {
+            it.next();
+            if (it.key() == "tvshows" && !it.value().toList().isEmpty()) {
+                for (const QVariant& var : it.value().toList()) {
+                    if (var.toMap().value("tvshowid").toInt() == 0) {
+                        continue;
+                    }
+                    m_xbmcShows.insert(var.toMap().value("tvshowid").toInt(), parseXbmcDataFromMap(var.toMap()));
                 }
-                m_xbmcShows.insert(var.toMap().value("tvshowid").toInt(), parseXbmcDataFromMap(var.toMap()));
             }
         }
     }
@@ -329,19 +332,20 @@ void KodiSync::onEpisodeListFinished()
 
     if (reply->error() != QNetworkReply::NoError) {
         QMessageBox::warning(this, tr("Network error"), reply->errorString());
-    }
 
-    QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
-    QJsonObject obj = doc.object();
-    QMapIterator<QString, QVariant> it(obj.value("result").toObject().toVariantMap());
-    while (it.hasNext()) {
-        it.next();
-        if (it.key() == "episodes" && !it.value().toList().isEmpty()) {
-            for (const QVariant& var : it.value().toList()) {
-                if (var.toMap().value("episodeid").toInt() == 0) {
-                    continue;
+    } else {
+        QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+        QJsonObject obj = doc.object();
+        QMapIterator<QString, QVariant> it(obj.value("result").toObject().toVariantMap());
+        while (it.hasNext()) {
+            it.next();
+            if (it.key() == "episodes" && !it.value().toList().isEmpty()) {
+                for (const QVariant& var : it.value().toList()) {
+                    if (var.toMap().value("episodeid").toInt() == 0) {
+                        continue;
+                    }
+                    m_xbmcEpisodes.insert(var.toMap().value("episodeid").toInt(), parseXbmcDataFromMap(var.toMap()));
                 }
-                m_xbmcEpisodes.insert(var.toMap().value("episodeid").toInt(), parseXbmcDataFromMap(var.toMap()));
             }
         }
     }

--- a/src/ui/movies/MovieMultiScrapeDialog.h
+++ b/src/ui/movies/MovieMultiScrapeDialog.h
@@ -18,6 +18,7 @@ class MovieSearchJob;
 }
 } // namespace mediaelch
 
+/// \brief Dialog for scraping multiple movies at once.
 class MovieMultiScrapeDialog : public QDialog
 {
     Q_OBJECT
@@ -26,6 +27,7 @@ public:
     explicit MovieMultiScrapeDialog(QWidget* parent = nullptr);
     ~MovieMultiScrapeDialog() override;
 
+    /// \brief Set the movies that should be scraped.
     void setMovies(QVector<Movie*> movies);
 
 public slots:
@@ -54,6 +56,7 @@ private:
     bool m_isTmdb = false;
     bool m_executed = false;
     QSet<MovieScraperInfo> m_infosToLoad;
+
     void loadMovieData(Movie* movie, ImdbId id);
     void loadMovieData(Movie* movie, TmdbId id);
     bool isExecuted() const;

--- a/src/ui/movies/MovieWidget.cpp
+++ b/src/ui/movies/MovieWidget.cpp
@@ -470,8 +470,12 @@ void MovieWidget::onInfoLoadDone(Movie* movie)
 
 void MovieWidget::onLoadDone(Movie* movie)
 {
+    if (m_movie == nullptr) {
+        return;
+    }
+    // This signal is only used to hide the progress bar.
     emit actorDownloadFinished(Constants::MovieProgressMessageId + movie->movieId());
-    if (m_movie == nullptr || m_movie != movie) {
+    if (m_movie != movie) {
         return;
     }
     setEnabledTrue();


### PR DESCRIPTION
This commit fixes some issues with the download manager.  Some signals
were emitted twice, the logging for running downloads was improved and
overall movie-image mismatches were fixed.

--------------

Fix  #1409