### PR TITLE
[Episodes] Match multi-episode names such as `S01E01E02E03`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
- - *tbd*
+ - Multi-Episode numbers such as `S01E01E02E03.mov` are now correctly identified (#1429)
 
 ### Changes
 

--- a/src/tv_shows/TvShowFileSearcher.cpp
+++ b/src/tv_shows/TvShowFileSearcher.cpp
@@ -388,15 +388,16 @@ QVector<EpisodeNumber> TvShowFileSearcher::getEpisodeNumbers(QStringList files)
             lastMatchEnd = match.capturedEnd(0);
         }
 
-        // Pattern matched
+        // Pattern did not match
         if (episodes.isEmpty()) {
             return false;
         }
 
         // The one episode we found could actually be a multi-episode file.
-        // For example: S01E01E02
+        // To avoid false positives, we use a positive lookahead.
+        // For example: "S01E01E02E03 - Name.mov"
         if (episodes.count() == 1) {
-            rx.setPattern(R"([-_EeXx]+([0-9]+)($|[\-\._\sE]))");
+            rx.setPattern(R"([-_EeXx]+(\d+)(?=$|[ -._sEeXx]))");
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
             matches = rx.globalMatch(

--- a/test/unit/tv_shows/testTvShowFileSearcher.cpp
+++ b/test/unit/tv_shows/testTvShowFileSearcher.cpp
@@ -66,8 +66,10 @@ TEST_CASE("TvShowFileSearcher parses season and episode data", "[show][utils]")
         CHECK(getEpisodeNumbers("dir/S01E14-S01E115.mov") == episodeList({14, 115}));
         CHECK(getEpisodeNumbers("dir/S01E004-S01E005.mov") == episodeList({4, 5}));
         CHECK(getEpisodeNumbers("dir/S01E004-S01E005-S01E15.mov") == episodeList({4, 5, 15}));
+        CHECK(getEpisodeNumbers("dir/S01E02E03E04E06.mov") == episodeList({2, 3, 4, 6}));
 
-        CHECK(getEpisodeNumbers("dir/Name_S01E4-S01E5.mov") == episodeList({4, 5}));
+        // Note: No episode ranges.
+        CHECK(getEpisodeNumbers("dir/Name_S01E4-S01E6.mov") == episodeList({4, 6}));
         CHECK(getEpisodeNumbers("dir/S01E4 Name with space S01E05 Second name.mov") == episodeList({4, 5}));
         CHECK(getEpisodeNumbers("dir/S01E14-S01E115 - Some name.mov") == episodeList({14, 115}));
         CHECK(getEpisodeNumbers("dir/S01E004.S01E005-Another-Title.mov") == episodeList({4, 5}));


### PR DESCRIPTION
This commit fixes our episode number matching.  Because we used a
capturing group instead of a positive lookahead, `S01E01E02E03` was
not correctly identified, because one `E` was matched for the previous
episode number.

------------

Fix #1429