### PR TITLE
[UI] Movie also has subtitles if there are external subtitles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfixes
 
  - Multi-Episode numbers such as `S01E01E02E03.mov` are now correctly identified (#1429)
+ - UI: The "subtitle" column of movies is now also green if there are external subtitles (#1435)
 
 ### Changes
 

--- a/src/movies/Movie.cpp
+++ b/src/movies/Movie.cpp
@@ -1041,6 +1041,11 @@ QVector<ImageType> Movie::imageTypes()
         ImageType::MovieBackdrop};
 }
 
+bool Movie::hasSubtitles() const
+{
+    return !m_subtitles.isEmpty() || (streamDetailsLoaded() && m_streamDetails->hasSubtitles());
+}
+
 QVector<Subtitle*> Movie::subtitles() const
 {
     return m_subtitles;

--- a/src/movies/Movie.h
+++ b/src/movies/Movie.h
@@ -154,6 +154,8 @@ public:
     static bool lessThan(Movie* a, Movie* b);
     static QVector<ImageType> imageTypes();
 
+    /// \brief Whether there are external subtitles or streamdetails subtitles.
+    bool hasSubtitles() const;
     QVector<Subtitle*> subtitles() const;
     void setSubtitles(const QVector<Subtitle*>& subtitles);
     void addSubtitle(Subtitle* subtitle, bool fromLoad = false);

--- a/src/movies/MovieModel.cpp
+++ b/src/movies/MovieModel.cpp
@@ -180,8 +180,7 @@ QVariant MovieModel::data(const QModelIndex& index, int role) const
             icon = "filmgrain";
             break;
         case MediaStatusColumn::Subtitles:
-            color = (movie->streamDetailsLoaded() && movie->streamDetails()->hasSubtitles()) ? MediaStatusState::GREEN
-                                                                                             : MediaStatusState::RED;
+            color = movie->hasSubtitles() ? MediaStatusState::GREEN : MediaStatusState::RED;
             icon = "add-subtitle";
             break;
         case MediaStatusColumn::Tags:


### PR DESCRIPTION
Previous to this commit, the UI column "subtitles" was only green if
there were subtitles embedded in stream details.

This is no longer the case. We now also check if the movie has external
subtitles, such as `*.srt` files.