### PR TITLE
[Renamer] Mark movie "changed" if subtitle was renamed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
  - Multi-Episode numbers such as `S01E01E02E03.mov` are now correctly identified (#1429)
  - UI: The "subtitle" column of movies is now also green if there are external subtitles (#1435)
+ - Renamer: If subtitles are renamed, movie is marked "changed" (#1432)
+   This is necessary to update the `<subtitle>` tag in the NFO file.
 
 ### Changes
 

--- a/data/i18n/MediaElch_bg.ts
+++ b/data/i18n/MediaElch_bg.ts
@@ -1126,7 +1126,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1137,6 +1136,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4375,57 +4379,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>Актьори</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>Допълнителни изображения</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>Допълнителни фанарти</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>Фанарт</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>Постер</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>Стрийм детайли</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>Трейлър</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation type="unfinished">Локален трейлър</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>Субтитри</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>Ключови думи</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6385,7 +6389,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6635,7 +6639,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>Преименувай</translation>
     </message>
@@ -6683,31 +6687,31 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/i18n/MediaElch_cs_CZ.ts
+++ b/data/i18n/MediaElch_cs_CZ.ts
@@ -1129,7 +1129,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1140,6 +1139,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4382,57 +4386,57 @@ operace zrušena.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>Herci</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>Extra arty</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>Extra fanarty</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>Plakát</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>Podrobnosti streamu</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>Upoutávka</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>Titulky</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>Tagy</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
@@ -6399,7 +6403,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6649,7 +6653,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>Přejmenovat</translation>
     </message>
@@ -6701,31 +6705,31 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/i18n/MediaElch_da.ts
+++ b/data/i18n/MediaElch_da.ts
@@ -1126,7 +1126,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1137,6 +1136,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4373,57 +4377,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6383,7 +6387,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6633,7 +6637,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6681,31 +6685,31 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/i18n/MediaElch_de.ts
+++ b/data/i18n/MediaElch_de.ts
@@ -1126,17 +1126,21 @@
         <translation>Streamdetails - Dauer (in Sekunden)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
-        <translation type="unfinished"></translation>
+        <translation>Streamdetails - Video Seitenverhältnis</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="318"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
+        <translation>Streamdetails - Video Breite</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1144,7 +1148,7 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="397"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="440"/>
         <source>Streamdetails - Video Height</source>
-        <translation type="unfinished"></translation>
+        <translation>Streamdetails - Video Höhe</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="320"/>
@@ -1158,7 +1162,7 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="399"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="442"/>
         <source>Streamdetails - Audio Language(s)</source>
-        <translation type="unfinished"></translation>
+        <translation>Streamdetails - Audio Sprache(n)</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="322"/>
@@ -4375,57 +4379,57 @@ Operation abgebrochen.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>Schauspieler</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>Extra Arts</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>Extra Fanarts</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>Streamdetails</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation>Lokaler Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>Untertitel</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>Tags</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
@@ -6386,7 +6390,7 @@ Wenn du bei TMDb nach einer ID suchen möchtest, stelle bitte &quot;id&quot; vor
         <translation>Invalider Wert für das XML-Tag:</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Verschiebe Datei&lt;/b&gt; &quot;%1&quot; nach &quot;%2&quot;
 </translation>
@@ -6637,7 +6641,7 @@ Wenn du bei TMDb nach einer ID suchen möchtest, stelle bitte &quot;id&quot; vor
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>Umbenennen</translation>
     </message>
@@ -6685,31 +6689,31 @@ Wenn du bei TMDb nach einer ID suchen möchtest, stelle bitte &quot;id&quot; vor
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Film&lt;/b&gt; &quot;%1&quot; wurde bearbeitet aber noch nicht gespeichert</translation>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation>&lt;b&gt;Film&lt;/b&gt; &quot;%1&quot; nicht umbenannt: Film wurde bearbeitet aber noch nicht gespeichert</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; wurde bearbeitet aber noch nicht gespeichert</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; nicht umbenannt: Episode wurde bearbeitet aber noch nicht gespeichert</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Serie&lt;/b&gt; &quot;%1&quot; wurde bearbeitet aber noch nicht gespeichert</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation>&lt;b&gt;Serie&lt;/b&gt; &quot;%1&quot; nicht umbenannt: Serie wurde bearbeitet aber noch nicht gespeichert</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Konzert&lt;/b&gt; &quot;%1&quot; wurde bearbeitet aber noch nicht gespeichert</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation>&lt;b&gt;Konzert&lt;/b&gt; &quot;%1&quot; nicht umbenannt: Konzert wurde bearbeitet aber noch nicht gespeichert</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation>Verzeichnis erstellen</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation>Verschieben</translation>
     </message>

--- a/data/i18n/MediaElch_en.ts
+++ b/data/i18n/MediaElch_en.ts
@@ -1126,7 +1126,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1137,6 +1136,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4373,57 +4377,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6383,7 +6387,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6633,7 +6637,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6681,31 +6685,31 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/i18n/MediaElch_en_US.ts
+++ b/data/i18n/MediaElch_en_US.ts
@@ -1115,7 +1115,6 @@
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1126,6 +1125,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
         <translation type="unfinished"/>
     </message>
     <message>
@@ -4350,57 +4354,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>Actors</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>Extra Arts</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>Extra Fanarts</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>Stream Details</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation>Local Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>Subtitles</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>Tags</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
@@ -6340,7 +6344,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</trans
         <translation>Invalid value for xml tag:</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</translation>
     </message>
@@ -6590,7 +6594,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</trans
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>Rename</translation>
     </message>
@@ -6626,31 +6630,31 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</trans
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</translation>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation>Create dir</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation>Move</translation>
     </message>
@@ -6685,11 +6689,6 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</trans
     <message>
         <location filename="../../src/renamer/RenamerPlaceholders.ui" line="756"/>
         <source>Season Name</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../../src/renamer/RenamerPlaceholders.ui" line="759"/>
-        <source>tvshow</source>
         <translation type="unfinished"/>
     </message>
     <message>
@@ -6783,11 +6782,6 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</trans
         <translation>Movie set name</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerPlaceholders.ui" line="253"/>
-        <source>&lt;seasonName&gt;</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
         <location filename="../../src/renamer/RenamerPlaceholders.ui" line="265"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
@@ -6796,11 +6790,6 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</trans
         <location filename="../../src/renamer/RenamerPlaceholders.ui" line="524"/>
         <source>Video Codec</source>
         <translation>Video Codec</translation>
-    </message>
-    <message>
-        <location filename="../../src/renamer/RenamerPlaceholders.ui" line="785"/>
-        <source>{seasonName}...{/seasonName}</source>
-        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/renamer/RenamerPlaceholders.ui" line="797"/>

--- a/data/i18n/MediaElch_es_ES.ts
+++ b/data/i18n/MediaElch_es_ES.ts
@@ -1126,7 +1126,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1137,6 +1136,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4374,57 +4378,57 @@ Operación cancelada.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>Actores</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>Artes extras</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>Fanart extras</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>Detalles del stream</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation>Trailer local</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>Subtítulos</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>Etiquetas</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6385,7 +6389,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Archivo movido&lt;/b&gt; &quot;%1&quot; a &quot;%2&quot;
 </translation>
@@ -6636,7 +6640,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>Renombrar</translation>
     </message>
@@ -6684,32 +6688,31 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Película&lt;/b&gt; &quot;%1&quot; ha sido editada pero no guardada</translation>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Episodio&lt;/b&gt; &quot;%1&quot; ha sido editado pero no salvado
-</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Serie&lt;/b&gt; &quot;%1&quot; ha sido editada pero no guardada</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Concierto&lt;/b&gt; &quot;%1&quot; ha sido editado pero no salvado</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation>Crear directorio</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>

--- a/data/i18n/MediaElch_et.ts
+++ b/data/i18n/MediaElch_et.ts
@@ -1115,7 +1115,6 @@
         <translation>Voo üksikasjad - kestus (sekundites)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1127,6 +1126,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
         <translation>Voo üksikasjad - video laius</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="319"/>
@@ -4350,57 +4354,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>Näitlejad</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>Lisapildid</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>Veel fännipilte</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>Fännipildid</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>Voo üksikasjad</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>Treiler</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation>Kohalik treiler</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>Subtiitrid</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>Sildid</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
@@ -6340,7 +6344,7 @@ Kui soovid otsida TMDb id-i järgi, lisa &quot;id&quot; eesliitena. </translatio
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Liiguta fail&lt;/b&gt; &quot;%1&quot; asukohta &quot;%2&quot;</translation>
     </message>
@@ -6590,7 +6594,7 @@ Kui soovid otsida TMDb id-i järgi, lisa &quot;id&quot; eesliitena. </translatio
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>Nimeta ümber</translation>
     </message>
@@ -6626,31 +6630,31 @@ Kui soovid otsida TMDb id-i järgi, lisa &quot;id&quot; eesliitena. </translatio
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Filmi&lt;/b&gt; &quot;%1&quot; on muudetud, aga mitte salvestatud</translation>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Episoodi&lt;/b&gt; &quot;%1&quot; on muudetud, aga mitte salvestatud</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Seriaali&lt;/b&gt; &quot;%1&quot; on muudetud, aga mitte salvestatud</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Kontserti&lt;/b&gt; &quot;%1&quot; on muudetud, aga mitte salvestatud</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation>Loo kataloog</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation>Liiguta</translation>
     </message>
@@ -6686,11 +6690,6 @@ Kui soovid otsida TMDb id-i järgi, lisa &quot;id&quot; eesliitena. </translatio
         <location filename="../../src/renamer/RenamerPlaceholders.ui" line="756"/>
         <source>Season Name</source>
         <translation>Hooaja nimi</translation>
-    </message>
-    <message>
-        <location filename="../../src/renamer/RenamerPlaceholders.ui" line="759"/>
-        <source>tvshow</source>
-        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/renamer/RenamerPlaceholders.ui" line="768"/>
@@ -6783,11 +6782,6 @@ Kui soovid otsida TMDb id-i järgi, lisa &quot;id&quot; eesliitena. </translatio
         <translation>Filmikomplekti nimi</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerPlaceholders.ui" line="253"/>
-        <source>&lt;seasonName&gt;</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
         <location filename="../../src/renamer/RenamerPlaceholders.ui" line="265"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
@@ -6796,11 +6790,6 @@ Kui soovid otsida TMDb id-i järgi, lisa &quot;id&quot; eesliitena. </translatio
         <location filename="../../src/renamer/RenamerPlaceholders.ui" line="524"/>
         <source>Video Codec</source>
         <translation>Videokoodek</translation>
-    </message>
-    <message>
-        <location filename="../../src/renamer/RenamerPlaceholders.ui" line="785"/>
-        <source>{seasonName}...{/seasonName}</source>
-        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/renamer/RenamerPlaceholders.ui" line="797"/>

--- a/data/i18n/MediaElch_fi.ts
+++ b/data/i18n/MediaElch_fi.ts
@@ -66,7 +66,7 @@
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="249"/>
         <source>Copy to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopioi leikepöydälle</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="273"/>
@@ -329,7 +329,7 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="48"/>
         <source>Play concert</source>
-        <translation type="unfinished"></translation>
+        <translation>Toista konsertti</translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="364"/>
@@ -562,14 +562,14 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="119"/>
         <source>Please insert a search string!</source>
-        <translation type="unfinished"></translation>
+        <translation>Syötä hakusana!</translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="141"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Löytyi %n tulos</numerusform>
+            <numerusform>Löytyi %n tulosta</numerusform>
         </translation>
     </message>
     <message>
@@ -915,23 +915,23 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="29"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="34"/>
         <source>Semicolon (;)</source>
-        <translation type="unfinished"></translation>
+        <translation>Puolipiste (;)</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="30"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="35"/>
         <source>Comma (,)</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilkku (,)</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="33"/>
         <source>Space</source>
-        <translation type="unfinished"></translation>
+        <translation>Välilyönti</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="36"/>
         <source>Minus (-)</source>
-        <translation type="unfinished"></translation>
+        <translation>Miinus (-)</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="51"/>
@@ -946,67 +946,67 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="113"/>
         <source>Export aborted. No directory was selected.</source>
-        <translation type="unfinished"></translation>
+        <translation>Vienti keskeytetty. Hakemistoa ei ole valittu.</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="129"/>
         <source>Export movies...</source>
-        <translation type="unfinished"></translation>
+        <translation>Vie elokuvat...</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="146"/>
         <source>Export TV shows...</source>
-        <translation type="unfinished"></translation>
+        <translation>Vie TV-sarjat...</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="160"/>
         <source>Export TV episodes...</source>
-        <translation type="unfinished"></translation>
+        <translation>Vie TV-jaksot...</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="178"/>
         <source>Export concerts...</source>
-        <translation type="unfinished"></translation>
+        <translation>Vie konsertit...</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="196"/>
         <source>Export artists...</source>
-        <translation type="unfinished"></translation>
+        <translation>Vie artistit...</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="211"/>
         <source>Export albums...</source>
-        <translation type="unfinished"></translation>
+        <translation>Vie albumit...</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="226"/>
         <source>Export completed in %1 seconds.</source>
-        <translation type="unfinished"></translation>
+        <translation>Vienti suoritettiin %1 sekunnissa.</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="289"/>
         <source>Movie - IMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - IMDb ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="290"/>
         <source>Movie - TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - TMDb ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="291"/>
         <source>Movie - Title</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Nimi</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="292"/>
         <source>Movie - Original Title</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Alkuperäinen nimi</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="293"/>
         <source>Movie - Sort Title</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Lajittelunimi</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="294"/>
@@ -1031,12 +1031,12 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="298"/>
         <source>Movie - IMDb Top 250</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - IMDb Top 250</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="299"/>
         <source>Movie - Release Date</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Julkaisupäivä</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="300"/>
@@ -1046,7 +1046,7 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="301"/>
         <source>Movie - Runtime in minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Kesto minuutteina</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="302"/>
@@ -1056,22 +1056,22 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="303"/>
         <source>Movie - Writers</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Käsikirjoittajat</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="304"/>
         <source>Movie - Director</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Ohjaaja</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="305"/>
         <source>Movie - Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Tyylilajit</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="306"/>
         <source>Movie - Countries</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Maat</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="307"/>
@@ -1081,42 +1081,42 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="308"/>
         <source>Movie - Tags</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Tunnisteet</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="309"/>
         <source>Movie - Trailers</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Trailerit</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="310"/>
         <source>Movie - Actors</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Näyttelijät</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="311"/>
         <source>Movie - Playcount</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Toistokerrat</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="312"/>
         <source>Movie - Last played</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Viimeksi toistettu</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="313"/>
         <source>Movie - Movie Set</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Elokuvakokoelma</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="314"/>
         <source>Movie - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Hakemisto</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="315"/>
         <source>Movie - Filename(s)</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuva - Tiedostonimet</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="316"/>
@@ -1126,7 +1126,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1137,6 +1136,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1185,51 +1189,51 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="340"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="375"/>
         <source>TV Show - TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarja - TMDb ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="341"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="374"/>
         <source>TV Show - IMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarja - IMDb ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="342"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="376"/>
         <source>TV Show - TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarja - TheTvDb ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="343"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="377"/>
         <source>TV Show - TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarja -  TVmaze ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="344"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="378"/>
         <source>TV Show - Title</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarja - Nimi</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="345"/>
         <source>TV Show - Sort Title</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarja - Lajittelunimi</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="346"/>
         <source>TV Show - Original Title</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarja - Alkuperäinen nimi</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="347"/>
         <source>TV Show - First Aired</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarja - Ensiesitys</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="348"/>
         <source>TV Show - network</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarja - Kanava</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="349"/>
@@ -1239,17 +1243,17 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="350"/>
         <source>TV Show - Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarja - Tyylilajit</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="351"/>
         <source>TV Show - Tags</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarja - Tunnisteet</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="352"/>
         <source>TV Show - Runtime</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarja - Kesto</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="353"/>
@@ -1259,7 +1263,7 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="354"/>
         <source>TV Show - IMDb Top 250</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarja - IMDb Top 250</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="355"/>
@@ -1269,7 +1273,7 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="356"/>
         <source>TV Show - Actors</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarja - Näyttelijät</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="357"/>
@@ -1279,47 +1283,47 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="358"/>
         <source>TV Show - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarja - Hakemisto</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="379"/>
         <source>Episode - Season</source>
-        <translation type="unfinished"></translation>
+        <translation>Jakso - Kausi</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="380"/>
         <source>Episode - Number</source>
-        <translation type="unfinished"></translation>
+        <translation>Jakso - Numero</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="381"/>
         <source>Episode - IMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Jakso - IMDb ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="382"/>
         <source>Episode - TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Jakso - TMDb ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="383"/>
         <source>Episode - TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Jakso - TheTvDb ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="384"/>
         <source>Episode - TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Jakso - TVmaze ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="385"/>
         <source>Episode - First Aired</source>
-        <translation type="unfinished"></translation>
+        <translation>Jakso - Ensiesitys</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="386"/>
         <source>Episode - Title</source>
-        <translation type="unfinished"></translation>
+        <translation>Jakso - Nimi</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="387"/>
@@ -1334,57 +1338,57 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="389"/>
         <source>Episode - Directors</source>
-        <translation type="unfinished"></translation>
+        <translation>Jakso - Ohjaajat</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="390"/>
         <source>Episode - Writers</source>
-        <translation type="unfinished"></translation>
+        <translation>Jakso - Käsikirjoittajat</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="391"/>
         <source>Episode - Actors</source>
-        <translation type="unfinished"></translation>
+        <translation>Jakso - Näyttelijät</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="392"/>
         <source>Episode - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Jakso - Hakemisto</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="393"/>
         <source>Episode - Filename(s)</source>
-        <translation type="unfinished"></translation>
+        <translation>Jakso - Tiedostonimet</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="417"/>
         <source>Concert - Title</source>
-        <translation type="unfinished"></translation>
+        <translation>Konsertti - Nimi</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="418"/>
         <source>Concert - TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Konsertti - TMDb ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="419"/>
         <source>Concert - IMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Konsertti - IMDb ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="420"/>
         <source>Concert - Original Title</source>
-        <translation type="unfinished"></translation>
+        <translation>Konsertti - Alkuperäinen nimi</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="421"/>
         <source>Concert - Artist</source>
-        <translation type="unfinished"></translation>
+        <translation>Konsertti - Artisti</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="422"/>
         <source>Concert - Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Konsertti - Albumi</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="423"/>
@@ -1404,7 +1408,7 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="426"/>
         <source>Concert - Release Date</source>
-        <translation type="unfinished"></translation>
+        <translation>Konsertti - Julkaisupäivä</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="427"/>
@@ -1414,7 +1418,7 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="428"/>
         <source>Concert - Runtime</source>
-        <translation type="unfinished"></translation>
+        <translation>Konsertti - Kesto</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="429"/>
@@ -1424,53 +1428,53 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="430"/>
         <source>Concert - Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>Konsertti - Tyylilajit</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="431"/>
         <source>Concert - Tags</source>
-        <translation type="unfinished"></translation>
+        <translation>Konsertti - Tunnisteet</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="432"/>
         <source>Concert - Trailer URL</source>
-        <translation type="unfinished"></translation>
+        <translation>Konsertti - Trailerin URL</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="433"/>
         <source>Concert - Playcount</source>
-        <translation type="unfinished"></translation>
+        <translation>Konsertti - Toistokerrat</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="434"/>
         <source>Concert - Last Played</source>
-        <translation type="unfinished"></translation>
+        <translation>Konsertti - Viimeksi toistettu</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="435"/>
         <source>Concert - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Konsertti - Hakemisto</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="436"/>
         <source>Concert - Filename(s)</source>
-        <translation type="unfinished"></translation>
+        <translation>Konsertti - Tiedostonimet</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="460"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="487"/>
         <source>Artist - Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Artisti - Nimi</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="461"/>
         <source>Artist - Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>Artisti - Tyylilajit</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="462"/>
         <source>Artist - Styles</source>
-        <translation type="unfinished"></translation>
+        <translation>Artisti - Tyylit</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="463"/>
@@ -1495,12 +1499,12 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="467"/>
         <source>Artist - Born</source>
-        <translation type="unfinished"></translation>
+        <translation>Artisti - Syntynyt</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="468"/>
         <source>Artist - Died</source>
-        <translation type="unfinished"></translation>
+        <translation>Artisti - Kuollut</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="469"/>
@@ -1510,37 +1514,37 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="470"/>
         <source>Artist - MusicBrainz ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Artisti - MusicBrainz ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="471"/>
         <source>Artist - AllMusic ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Artisti - AllMusic ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="472"/>
         <source>Artist - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Artisti - Hakemisto</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="488"/>
         <source>Album - Title</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi - Nimi</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="489"/>
         <source>Album - Artist Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi - Artistin nimi</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="490"/>
         <source>Album - Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi - Tyylilajit</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="491"/>
         <source>Album - Styles</source>
-        <translation type="unfinished"></translation>
+        <translation>Tyylit</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="492"/>
@@ -1555,7 +1559,7 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="494"/>
         <source>Album - Release Date</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi - Julkaisupäivä</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="495"/>
@@ -1570,37 +1574,37 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="497"/>
         <source>Album - Year</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi - Vuosi</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="498"/>
         <source>Album - MusicBrainz ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi - MusicBrainz ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="499"/>
         <source>Album - MusicBrainz ReleaseGroup ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi - MusicBrainz ReleaseGroup ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="500"/>
         <source>Album - AllMusic ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi - AllMusic ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="501"/>
         <source>Album - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi - Hakemisto</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="541"/>
         <source>Export failed. Could not write to CSV file.</source>
-        <translation type="unfinished"></translation>
+        <translation>Vienti epäonnistui. CSV-tiedostoon kirjoittaminen ei onnistunut.</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="531"/>
         <source>Export failed. File could not be opened for writing.</source>
-        <translation type="unfinished"></translation>
+        <translation>Vienti epäonnistui. Tiedostoa ei voitu avata kirjoitettavaksi.</translation>
     </message>
 </context>
 <context>
@@ -1613,7 +1617,7 @@
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="31"/>
         <source>TV show details</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarjan tiedot</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="53"/>
@@ -1630,7 +1634,7 @@
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="67"/>
         <source>Episode details</source>
-        <translation type="unfinished"></translation>
+        <translation>Jakson tiedot</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.cpp" line="148"/>
@@ -1699,9 +1703,9 @@
         <location filename="../../src/ui/imports/DownloadsWidget.cpp" line="123"/>
         <location filename="../../src/ui/imports/DownloadsWidget.cpp" line="265"/>
         <source>%n files</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n tiedosto</numerusform>
+            <numerusform>%n tiedostoa</numerusform>
         </translation>
     </message>
     <message>
@@ -1812,7 +1816,7 @@
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="58"/>
         <source>You need to select at least one media type to export.</source>
-        <translation type="unfinished"></translation>
+        <translation>Valitse vähintään yksi vietävä mediatyyppi.</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="68"/>
@@ -1822,7 +1826,7 @@
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="70"/>
         <source>Export aborted. No directory was selected.</source>
-        <translation type="unfinished"></translation>
+        <translation>Vienti keskeytetty. Hakemistoa ei ole valittu.</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="78"/>
@@ -1832,7 +1836,7 @@
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="95"/>
         <source>Export canceled.</source>
-        <translation type="unfinished"></translation>
+        <translation>Vienti peruutettu.</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="98"/>
@@ -1842,7 +1846,7 @@
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="145"/>
         <source>Selected theme not found! Try to restart MediaElch.</source>
-        <translation type="unfinished"></translation>
+        <translation>Valittua teemaa ei löytynyt! Kokeile käynnistää MediaElch uudelleen.</translation>
     </message>
 </context>
 <context>
@@ -2009,12 +2013,12 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="123"/>
         <source>Original Title contains &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Alkuperäinen nimi sisältää &quot;%1&quot;</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="138"/>
         <source>TMDb ID &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>TMDb ID &quot;%1&quot;</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="375"/>
@@ -2059,7 +2063,7 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="442"/>
         <source>IMDb</source>
-        <translation type="unfinished"></translation>
+        <translation>IMDb</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
@@ -2069,17 +2073,17 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="444"/>
         <source>Movie has no TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuvalla ei ole TMDb ID:tä</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="444"/>
         <source>No TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Ei TMDb ID:tä</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="444"/>
         <source>TMDb</source>
-        <translation type="unfinished"></translation>
+        <translation>TMDb</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
@@ -2783,12 +2787,12 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="77"/>
         <source>Disabled</source>
-        <translation type="unfinished"></translation>
+        <translation>Poistettu käytöstä</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="80"/>
         <source>Ignore this folder.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ohita tämä kansio.</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="90"/>
@@ -3011,9 +3015,9 @@ The directories containing your music must contain subdirectories for each artis
     <message numerus="yes">
         <location filename="../../src/globals/ImageDialog.cpp" line="804"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Löytyi %n tulos</numerusform>
+            <numerusform>Löytyi %n tulosta</numerusform>
         </translation>
     </message>
     <message>
@@ -3200,9 +3204,9 @@ The directories containing your music must contain subdirectories for each artis
     <message numerus="yes">
         <location filename="../../src/ui/imports/ImportDialog.cpp" line="711"/>
         <source>Import of %n files has finished</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n kuvan tuonti onnistui</numerusform>
+            <numerusform>%n kuvan tuonti onnistui</numerusform>
         </translation>
     </message>
     <message>
@@ -3532,17 +3536,17 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/data/Locale.cpp" line="43"/>
         <source>German (AT)</source>
-        <translation type="unfinished"></translation>
+        <translation>Saksa (AT)</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="44"/>
         <source>German (CH)</source>
-        <translation type="unfinished"></translation>
+        <translation>tSaksa (CH)</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="45"/>
         <source>German (DE)</source>
-        <translation type="unfinished"></translation>
+        <translation>SAKA (DE)</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="46"/>
@@ -3558,22 +3562,22 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/data/Locale.cpp" line="49"/>
         <source>English (Australia)</source>
-        <translation type="unfinished"></translation>
+        <translation>Englanti (Australia)</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="50"/>
         <source>English (Canada)</source>
-        <translation type="unfinished"></translation>
+        <translation>Englanti (Kanada)</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="51"/>
         <source>English (GB)</source>
-        <translation type="unfinished"></translation>
+        <translation>Englanti (GB)</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="52"/>
         <source>English (NZ)</source>
-        <translation type="unfinished"></translation>
+        <translation>Enkglanti (NZ)</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="53"/>
@@ -3583,7 +3587,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/data/Locale.cpp" line="54"/>
         <source>Esperanto</source>
-        <translation type="unfinished"></translation>
+        <translation>Espanja</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="55"/>
@@ -3599,7 +3603,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/data/Locale.cpp" line="58"/>
         <source>Estonian</source>
-        <translation type="unfinished"></translation>
+        <translation>Viro</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="59"/>
@@ -3961,32 +3965,32 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="58"/>
         <source>FAQ</source>
-        <translation type="unfinished"></translation>
+        <translation>UKK</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="59"/>
         <source>Troubleshooting</source>
-        <translation type="unfinished"></translation>
+        <translation>Vianmääritys</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="60"/>
         <source>Report Issue</source>
-        <translation type="unfinished"></translation>
+        <translation>Raportoi ongelma</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="62"/>
         <source>Release Notes</source>
-        <translation type="unfinished"></translation>
+        <translation>Julkaisutiedot</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="63"/>
         <source>Documentation</source>
-        <translation type="unfinished"></translation>
+        <translation>Dokumentaatio</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="64"/>
         <source>Blog</source>
-        <translation type="unfinished"></translation>
+        <translation>Blogi</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="65"/>
@@ -3996,7 +4000,7 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="67"/>
         <source>View License</source>
-        <translation type="unfinished"></translation>
+        <translation>Näytä lisenssi</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="346"/>
@@ -4332,14 +4336,14 @@ Toiminto peruutettu.</translation>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="86"/>
         <source>Play movie</source>
-        <translation type="unfinished"></translation>
+        <translation>Toista elokuva</translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="560"/>
         <source>%1 of %n movies</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%1 / %n elokuvasta</numerusform>
+            <numerusform>%1 / %n elokuvasta</numerusform>
         </translation>
     </message>
 </context>
@@ -4374,57 +4378,57 @@ Toiminto peruutettu.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>Näyttelijät</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>Lisätaiteet</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>Lisäfanitaide</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>Fanitaide</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>Juliste</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>Mediatiedot</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>Traileri</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation>Paikallinen traileri</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>Tekstitys</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>Tunnisteet</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
@@ -4579,7 +4583,7 @@ Toiminto peruutettu.</translation>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="366"/>
         <source>Update only movies with IMDb ID/TMDb Id</source>
-        <translation type="unfinished"></translation>
+        <translation>Päivitä vain elokuvat, joilla on IMDb ID/TMDb ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="381"/>
@@ -4789,9 +4793,9 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="173"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Löytyi %n tulos</numerusform>
+            <numerusform>Löytyi %n tulosta</numerusform>
         </translation>
     </message>
     <message>
@@ -6173,7 +6177,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="134"/>
         <source>Ctrl+R</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+R</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="141"/>
@@ -6361,7 +6365,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="12"/>
         <source>File not found:</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiedostoa ei löytynyt:</translation>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="13"/>
@@ -6384,7 +6388,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Siirrä tiedosto&lt;/b&gt; &quot;%1&quot; -&gt; &quot;%2&quot;</translation>
     </message>
@@ -6406,22 +6410,22 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="9"/>
         <source>Content not found</source>
-        <translation type="unfinished"></translation>
+        <translation>Sisältöä ei löytynyt</translation>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="10"/>
         <source>Remote connection timed out</source>
-        <translation type="unfinished"></translation>
+        <translation>Etäyhteys aikakatkaistiin</translation>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="11"/>
         <source>SSL handshake failed</source>
-        <translation type="unfinished"></translation>
+        <translation>SSL-kättely epäonnistui</translation>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="12"/>
         <source>Too many redirects</source>
-        <translation type="unfinished"></translation>
+        <translation>Liian monta uudelleenohjausta</translation>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="13"/>
@@ -6436,18 +6440,18 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="15"/>
         <source>Unknown network error</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuntematon verkkovirhe</translation>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="16"/>
         <source>Could not load the requested resource</source>
-        <translation type="unfinished"></translation>
+        <translation>Pyydetyn resurssin lataaminen epäonnistui</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="18"/>
         <location filename="../../src/scrapers/ScraperError.cpp" line="25"/>
         <source>Network Error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Verkkovirhe: %1</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="32"/>
@@ -6524,7 +6528,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/data/RatingModel.cpp" line="96"/>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation>Lähde</translation>
     </message>
     <message>
         <location filename="../../src/data/RatingModel.cpp" line="97"/>
@@ -6634,7 +6638,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>Nimeä uudelleen</translation>
     </message>
@@ -6646,33 +6650,33 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message numerus="yes">
         <location filename="../../src/renamer/RenamerDialog.cpp" line="57"/>
         <source>%n concerts will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n konsertti nimetään uudelleen</numerusform>
+            <numerusform>%n konserttia nimetään uudelleen</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/renamer/RenamerDialog.cpp" line="59"/>
         <source>%n movies will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n elokuvaa nimetään uudelleen</numerusform>
+            <numerusform>%n elokuva nimetään uudelleen</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/renamer/RenamerDialog.cpp" line="61"/>
         <source>%n TV shows and %1</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n TV-sarjaa ja %1</numerusform>
+            <numerusform>%n TV-sarja ja %1</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/renamer/RenamerDialog.cpp" line="62"/>
         <source>%n episodes will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n jaksoa nimetään uudelleen</numerusform>
+            <numerusform>%n jakso nimetään uudelleen</numerusform>
         </translation>
     </message>
     <message>
@@ -6682,31 +6686,31 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Elokuvaa&lt;/b&gt; &quot;%1&quot; on muokattu, mutta muutoksia ei ole tallennettu</translation>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Jaksoa&lt;/b&gt; &quot;%1&quot; on muokattu, mutta muutoksia ei ole tallennettu</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;TV-sarjaa&lt;/b&gt; &quot;%1&quot; on muokattu, mutta muutoksia ei ole tallennettu</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Konserttia&lt;/b&gt; &quot;%1&quot; on muokattu, mutta muutoksia ei ole tallennettu</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation>Luo hakemisto</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation>Siirrä</translation>
     </message>
@@ -6741,7 +6745,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/renamer/RenamerPlaceholders.ui" line="756"/>
         <source>Season Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuotantokauden nimi</translation>
     </message>
     <message>
         <location filename="../../src/renamer/RenamerPlaceholders.ui" line="768"/>
@@ -6791,7 +6795,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/renamer/RenamerPlaceholders.ui" line="241"/>
         <source>Director(s)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ohjaaja(t)</translation>
     </message>
     <message>
         <location filename="../../src/renamer/RenamerPlaceholders.ui" line="538"/>
@@ -6846,7 +6850,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/renamer/RenamerPlaceholders.ui" line="797"/>
         <source>Episode has a season name</source>
-        <translation type="unfinished"></translation>
+        <translation>Jaksolla on tuotantokauden nimi</translation>
     </message>
     <message>
         <location filename="../../src/renamer/RenamerPlaceholders.ui" line="101"/>
@@ -6963,12 +6967,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/globals/ScraperInfos.cpp" line="111"/>
         <source>Show Thumbnail</source>
-        <translation type="unfinished"></translation>
+        <translation>Näytä esikatselukuva</translation>
     </message>
     <message>
         <location filename="../../src/globals/ScraperInfos.cpp" line="112"/>
         <source>Season Thumbnail</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuotantokauden esikatselukuva</translation>
     </message>
     <message>
         <location filename="../../src/globals/ScraperInfos.cpp" line="113"/>
@@ -7524,7 +7528,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="110"/>
         <source>ID</source>
-        <translation type="unfinished"></translation>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="117"/>
@@ -7539,7 +7543,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="172"/>
         <source>Website</source>
-        <translation type="unfinished"></translation>
+        <translation>Verkkosivu</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="182"/>
@@ -7549,7 +7553,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="195"/>
         <source>Terms of Service</source>
-        <translation type="unfinished"></translation>
+        <translation>Käyttöehdot</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="202"/>
@@ -7559,7 +7563,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="215"/>
         <source>Privacy Policy</source>
-        <translation type="unfinished"></translation>
+        <translation>Yksityisyyskäytäntö</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="222"/>
@@ -7569,7 +7573,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="235"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Apua</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="242"/>
@@ -7589,17 +7593,17 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="265"/>
         <source>Default Language</source>
-        <translation type="unfinished"></translation>
+        <translation>Oletuskieli</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.cpp" line="111"/>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>Kyllä</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.cpp" line="111"/>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation>Ei</translation>
     </message>
 </context>
 <context>
@@ -7640,9 +7644,9 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="26"/>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="669"/>
         <source>%n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n TV-sarjaa</numerusform>
+            <numerusform>%n TV-sarja</numerusform>
         </translation>
     </message>
     <message>
@@ -7712,7 +7716,7 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="764"/>
         <source>Play episode</source>
-        <translation type="unfinished"></translation>
+        <translation>Toista jakso</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="781"/>
@@ -7885,7 +7889,7 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="46"/>
         <source>Show Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Näytä tiedot</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="148"/>
@@ -7923,7 +7927,7 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="350"/>
         <source>Episode Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Jakson tiedot</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="462"/>
@@ -8022,14 +8026,14 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="511"/>
         <source>Done.</source>
-        <translation type="unfinished"></translation>
+        <translation>Valmis.</translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="531"/>
         <source>%n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n TV-sarjaa</numerusform>
+            <numerusform>%n TV-sarja</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -8110,12 +8114,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="140"/>
         <source>Details to load</source>
-        <translation type="unfinished"></translation>
+        <translation>Ladattavat tiedot</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="151"/>
         <source>Show Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Näytä tiedot</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="170"/>
@@ -8239,7 +8243,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="448"/>
         <source>Episode Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Jakson tiedot</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="534"/>
@@ -8299,14 +8303,14 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="161"/>
         <source>Please insert a search string!</source>
-        <translation type="unfinished"></translation>
+        <translation>Syötä hakusana!</translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="184"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Löytyi %n tulos</numerusform>
+            <numerusform>Löytyi %n tulosta</numerusform>
         </translation>
     </message>
     <message>
@@ -8556,7 +8560,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="474"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation>TVmaze ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="545"/>
@@ -8813,7 +8817,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="146"/>
         <source>Season Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuotantokauden nimi</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="168"/>
@@ -8893,7 +8897,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="205"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation>TVmaze ID</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="239"/>
@@ -9326,7 +9330,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/movies/file_searcher/MovieDirectorySearcher.cpp" line="369"/>
         <source>Storing movies in database...</source>
-        <translation type="unfinished"></translation>
+        <translation>Tallennetaan elokuvia tietokantaan...</translation>
     </message>
 </context>
 <context>
@@ -9339,7 +9343,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/movies/file_searcher/MovieFileSearcher.cpp" line="141"/>
         <source>Searching for movies...</source>
-        <translation type="unfinished"></translation>
+        <translation>Etsitään elokuvia...</translation>
     </message>
 </context>
 <context>
@@ -9546,12 +9550,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="357"/>
         <source>Movie not found on Fanart.tv</source>
-        <translation type="unfinished"></translation>
+        <translation>Elokuvaa ei löytnyt Fanart.tv:stä</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="567"/>
         <source>TV show not found on Fanart.tv</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarjaa ei löytnyt Fanart.tv:stä</translation>
     </message>
 </context>
 <context>
@@ -9619,7 +9623,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvSeasonScrapeJob.cpp" line="24"/>
         <source>Show is missing an IMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarjalta puuttuu IMDb ID</translation>
     </message>
 </context>
 <context>
@@ -9645,7 +9649,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowScrapeJob.cpp" line="33"/>
         <source>Show is missing an IMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarjalta puuttuu IMDb ID</translation>
     </message>
 </context>
 <context>
@@ -9706,7 +9710,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing a TheTvDb id</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarjalta puuttuu TheTvDb ID</translation>
     </message>
 </context>
 <context>
@@ -9714,7 +9718,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbShowScrapeJob.cpp" line="45"/>
         <source>Show is missing a TheTvDb id</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarjalta puuttuu TheTvDb ID</translation>
     </message>
 </context>
 <context>
@@ -9914,7 +9918,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvSeasonScrapeJob.cpp" line="24"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarjalta puuttuu TMDb ID</translation>
     </message>
 </context>
 <context>
@@ -9935,7 +9939,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowScrapeJob.cpp" line="22"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarjalta puuttuu TMDb ID</translation>
     </message>
 </context>
 <context>
@@ -9964,7 +9968,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeSeasonScrapeJob.cpp" line="24"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarjalta puuttuu TMDb ID</translation>
     </message>
 </context>
 <context>
@@ -9972,7 +9976,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeShowScrapeJob.cpp" line="28"/>
         <source>TV show is missing a TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation>TV-sarjalta puuttuu TVmaze ID</translation>
     </message>
 </context>
 <context>
@@ -10060,7 +10064,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="45"/>
         <source>MusicBrainz</source>
-        <translation type="unfinished"></translation>
+        <translation>MusicBrainz</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="46"/>

--- a/data/i18n/MediaElch_fr.ts
+++ b/data/i18n/MediaElch_fr.ts
@@ -1126,7 +1126,6 @@
         <translation>Détails de flux - Durée (en secondes)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1138,6 +1137,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
         <translation>Détails de flux - Largeur de la Vidéo</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="319"/>
@@ -4376,57 +4380,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>Acteurs</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>Extra Arts</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>Extra Fanarts</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>Affiche</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>Détails de flux</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>Bande-annonce</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation>Bande-annonce locale</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>Sous-titres</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>Mots-clés</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation>ID IMDb</translation>
     </message>
@@ -6389,7 +6393,7 @@ Vérifiez les paramètres si vous avez déjà stocké vos films dans des dossier
         <translation>Valeur non valide pour la balise xml:</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Déplacer le fichier&lt;/b&gt; &quot;%1&quot; vers &quot;%2&quot;</translation>
     </message>
@@ -6639,7 +6643,7 @@ Vérifiez les paramètres si vous avez déjà stocké vos films dans des dossier
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>Renommer</translation>
     </message>
@@ -6687,31 +6691,31 @@ Vérifiez les paramètres si vous avez déjà stocké vos films dans des dossier
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Film&lt;/b&gt; &quot;%1&quot; modifié mais non enregistré</translation>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Épisode&lt;/b&gt; &quot;%1&quot; modifié mais non enregistré</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Série TV&lt;/b&gt; &quot;%1&quot; modifiée mais non enregistrée</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; modifié mais non enregistré</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation>Créer le répertoire</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation>Déplacer</translation>
     </message>

--- a/data/i18n/MediaElch_it.ts
+++ b/data/i18n/MediaElch_it.ts
@@ -1126,7 +1126,6 @@
         <translation>Dettagli stream - Durata (in secondi)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1138,6 +1137,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
         <translation>Dettagli stream - Larghezza video</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="319"/>
@@ -4376,57 +4380,57 @@ Operazione cancellata</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>Attori</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>Extra Art</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>Fanart Extra</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>Dettagli Stream</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation>Trailer locale</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>Sottotitoli</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>Tag</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
@@ -6387,7 +6391,7 @@ Se vuoi cercare per un ID di TMDb inizia la stringa con &quot;id&quot;.</transla
         <translation>Valore non valido per il tag xml:</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Muovi il File&lt;/b&gt; da &quot;%1&quot; a &quot;%2&quot;</translation>
     </message>
@@ -6637,7 +6641,7 @@ Se vuoi cercare per un ID di TMDb inizia la stringa con &quot;id&quot;.</transla
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>Rinomina</translation>
     </message>
@@ -6685,31 +6689,31 @@ Se vuoi cercare per un ID di TMDb inizia la stringa con &quot;id&quot;.</transla
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Film&lt;/b&gt; &quot;%1&quot; è stato modificato ma non è stato salvato</translation>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Episodio&lt;/b&gt; &quot;%1&quot; è stato modificato ma non è stato salvato</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Serie TV&lt;/b&gt; &quot;%1&quot; è stata modificata ma non è stata salvata</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Concerto&lt;/b&gt; &quot;%1&quot; è stato modificato ma non è stato salvato</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation>Crea cartella</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation>Sposta</translation>
     </message>

--- a/data/i18n/MediaElch_ja.ts
+++ b/data/i18n/MediaElch_ja.ts
@@ -1123,7 +1123,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1134,6 +1133,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4365,57 +4369,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6368,7 +6372,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6618,7 +6622,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6662,31 +6666,31 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/i18n/MediaElch_ko.ts
+++ b/data/i18n/MediaElch_ko.ts
@@ -1123,7 +1123,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1134,6 +1133,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4366,57 +4370,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>배우</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>추가 아트</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>추가 팬아트</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>팬아트</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>포스터</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>스트림 정보</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>예고편</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation>로컬 예고편</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>자막</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>태그</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6369,7 +6373,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6619,7 +6623,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>이름 변경</translation>
     </message>
@@ -6663,31 +6667,31 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/i18n/MediaElch_nl_NL.ts
+++ b/data/i18n/MediaElch_nl_NL.ts
@@ -1126,7 +1126,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1137,6 +1136,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4374,57 +4378,57 @@ Opdracht geannuleerd.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>Acteurs</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>Extra Arts</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>Extra Fanarts</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>Stream Details</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation>Lokale Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>Ondertitels</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>Tags</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation>IMDB ID</translation>
     </message>
@@ -6384,7 +6388,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6634,7 +6638,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>Hernoemen</translation>
     </message>
@@ -6682,31 +6686,31 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Film &lt;/b&gt; &quot;%1&quot; werd aangepast maar is niet bewaard</translation>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; werd aangepast maar werd niet bewaard.</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; werd aangepast maar werd niet bewaard.</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; werd aangepast maar werd niet bewaard.</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation>Maak folder</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation>Verplaats</translation>
     </message>

--- a/data/i18n/MediaElch_no.ts
+++ b/data/i18n/MediaElch_no.ts
@@ -1126,7 +1126,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1137,6 +1136,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4374,57 +4378,57 @@ Operasjon kansellert.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>Skuespillere</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>Ekstra arts</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>Ekstra fanarts</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>Stream detaljer</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation type="unfinished">Lokale Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>Undertekster</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>Tags</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6384,7 +6388,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6634,7 +6638,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>Endre navn</translation>
     </message>
@@ -6682,31 +6686,31 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/i18n/MediaElch_pl.ts
+++ b/data/i18n/MediaElch_pl.ts
@@ -1129,7 +1129,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1140,6 +1139,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4383,57 +4387,57 @@ Operacja anulowana.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>Obsada</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>Dodatkowe grafiki</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>Fototapety</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>Fotoapeta</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>Plakat</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>Ścieżki</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>Zwiastun</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation>Lokalny zwiastun</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>Napisy</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>Znaczniki</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation>Identyfikator IMDb</translation>
     </message>
@@ -6400,7 +6404,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Przenieś plik&lt;/b&gt; z &quot;%1&quot; do &quot;%2&quot;</translation>
     </message>
@@ -6650,7 +6654,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>Uruchom</translation>
     </message>
@@ -6702,31 +6706,31 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Film&lt;/b&gt; &quot;%1&quot; został zmieniony, ale zmiany nie zostały zapisane.</translation>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Odcinek&lt;/b&gt; &quot;%1&quot; został zmieniony, ale zmiany nie zostały zapisane.</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Serial&lt;/b&gt; &quot;%1&quot; został zmieniony, ale zmiany nie zostały zapisane.</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Koncert&lt;/b&gt; &quot;%1&quot; został zmieniony, ale zmiany nie zostały zapisane.</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation>Utwórz folder</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation>Przenieś</translation>
     </message>

--- a/data/i18n/MediaElch_pt_BR.ts
+++ b/data/i18n/MediaElch_pt_BR.ts
@@ -1132,7 +1132,6 @@ Por exemplo:  &lt;baseFileName&gt;-poster.jpg,folder.jpg</translation>
         <translation>Streamdetails - Duração (Em Segundos)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1144,6 +1143,11 @@ Por exemplo:  &lt;baseFileName&gt;-poster.jpg,folder.jpg</translation>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
         <translation>Mídia - Vídeo Largura</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="319"/>
@@ -4395,57 +4399,57 @@ Operação Cancelada.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>Elenco</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>Artes Extras</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>Extra Fanarts</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>Dados de Mídia</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation>Trailer Local</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>Legendas</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>Etiquetas</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation>IMDB ID</translation>
     </message>
@@ -6413,7 +6417,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <translation>Valor inválido para Tag xml:</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Mover Arquivo&lt;/b&gt; &quot;%1&quot; para &quot;%2&quot;</translation>
     </message>
@@ -6663,7 +6667,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>Renomear</translation>
     </message>
@@ -6711,31 +6715,31 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Filme&lt;/b&gt; &quot;%1&quot; foi editado mas não foi salvo</translation>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Episódio&lt;/b&gt; &quot;%1&quot; foi editado mas não foi salvo</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Série&lt;/b&gt; &quot;%1&quot; foi editado mas não foi salvo</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Concerto&lt;/b&gt; &quot;%1&quot; foi editado mas não foi salvo</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation>Criar dir</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>

--- a/data/i18n/MediaElch_pt_PT.ts
+++ b/data/i18n/MediaElch_pt_PT.ts
@@ -1126,7 +1126,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1137,6 +1136,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4376,57 +4380,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>Atores</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>Arts extras</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>Fanarts extra</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>Cartaz</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>Detalhes da pista</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation>Trailer local</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>Legendas</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>Etiquetas</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation>Identificador do IMDb</translation>
     </message>
@@ -6388,7 +6392,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Mover Ficheiro&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</translation>
     </message>
@@ -6638,7 +6642,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>Alterar nome</translation>
     </message>
@@ -6686,31 +6690,31 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>O &lt;b&gt;filme&lt;/b&gt; &quot;%1&quot; foi editado mas não foi guardado</translation>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Episódio&lt;/b&gt; &quot;%1&quot; foi editado mas não foi guardado</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Série de TV&lt;/b&gt; &quot;%1&quot; foi editada mas não foi guardada</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Concerto&lt;/b&gt; &quot;%1&quot; foi editado mas não foi guardado</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation>Criar pasta</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>

--- a/data/i18n/MediaElch_ru.ts
+++ b/data/i18n/MediaElch_ru.ts
@@ -1131,7 +1131,6 @@
         <translation>Информация о потоке - Продолжительность (в секундах)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1143,6 +1142,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
         <translation>Информация о потоке - Ширина видео</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="319"/>
@@ -4388,57 +4392,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>Актёры</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>Дополнительные обложки</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>Фан-арты</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>Фон</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>Постер</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>Информация о потоке</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>Трейлер</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation>Локальный трейлер</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>Субтитры</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>Теги</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
@@ -6410,7 +6414,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation>Недопустимое значение для XML-тега:</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Файл фильма&lt;/b&gt; &quot;%1&quot; в &quot;%2&quot;</translation>
     </message>
@@ -6660,7 +6664,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>Переименовать</translation>
     </message>
@@ -6712,31 +6716,31 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Фильм&lt;/b&gt; &quot;%1&quot; был изменён, но не сохранён</translation>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Серия&lt;/b&gt; &quot;%1&quot; была изменена, но не сохранена</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Сериал&lt;/b&gt; &quot;%1&quot; был изменён, но не сохранён</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;Концерт&lt;/b&gt; &quot;%1&quot; был изменён, но не сохранён</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation>Создать папку</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation>Переместить</translation>
     </message>

--- a/data/i18n/MediaElch_sv.ts
+++ b/data/i18n/MediaElch_sv.ts
@@ -1126,7 +1126,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1137,6 +1136,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4374,57 +4378,57 @@ Processen avbruten.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>Skådespelare</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>Extra Art</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>Extra Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>Ströminfo</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation type="unfinished">Lokal Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>Undertexter</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>Taggar</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6384,7 +6388,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6634,7 +6638,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>Ändra namn</translation>
     </message>
@@ -6682,31 +6686,31 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/i18n/MediaElch_zh_CN.ts
+++ b/data/i18n/MediaElch_zh_CN.ts
@@ -1123,7 +1123,6 @@
         <translation>视频压制编码信息 - 时长（以秒为单位）</translation>
     </message>
     <message>
-        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Streamdetails - Video Aspect</source>
@@ -1135,6 +1134,11 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Streamdetails - Video Width</source>
         <translation>视频压制编码信息 - 视频宽度</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
+        <source>Streamdetails - Video Aspect Ratio</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="319"/>
@@ -4370,57 +4374,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="326"/>
         <source>Actors</source>
         <translation>演员</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="327"/>
         <source>Extra Arts</source>
         <translation>额外的艺术图</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="328"/>
         <source>Extra Fanarts</source>
         <translation>其他剧照</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="329"/>
         <source>Fanart</source>
         <translation>剧照</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="330"/>
         <source>Poster</source>
         <translation>海报</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="331"/>
         <source>Stream Details</source>
         <translation>视频压制编码信息</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="332"/>
         <source>Trailer</source>
         <translation>预告片</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="333"/>
         <source>Local Trailer</source>
         <translation>本地预告片</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="334"/>
         <source>Subtitles</source>
         <translation>字幕</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="335"/>
         <source>Tags</source>
         <translation>标签</translation>
     </message>
     <message>
-        <location filename="../../src/movies/MovieModel.cpp" line="337"/>
+        <location filename="../../src/movies/MovieModel.cpp" line="336"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
@@ -6381,7 +6385,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation>xml标记的值无效：</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="328"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="341"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;移动文件&lt;/b&gt; &quot;%1&quot; 改为 &quot;%2&quot;</translation>
     </message>
@@ -6631,7 +6635,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.ui" line="312"/>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="362"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="366"/>
         <source>Rename</source>
         <translation>更名</translation>
     </message>
@@ -6675,31 +6679,31 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/renamer/RenamerDialog.cpp" line="237"/>
-        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;电影&lt;/ b&gt;“％1”已编辑，但未保存</translation>
+        <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="265"/>
-        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;剧集&lt;/ b&gt;“％1”已编辑，但未保存</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="266"/>
+        <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="289"/>
-        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;电视节目&lt;/ b&gt;“％1”已编辑，但未保存</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="291"/>
+        <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="341"/>
-        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; has been edited but is not saved</source>
-        <translation>&lt;b&gt;音乐会&lt;/ b&gt;“％1”已编辑，但未保存</translation>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="344"/>
+        <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="360"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="364"/>
         <source>Create dir</source>
         <translation>创建目录</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/RenamerDialog.cpp" line="361"/>
+        <location filename="../../src/renamer/RenamerDialog.cpp" line="365"/>
         <source>Move</source>
         <translation>移动</translation>
     </message>

--- a/src/concerts/Concert.cpp
+++ b/src/concerts/Concert.cpp
@@ -19,11 +19,8 @@ using namespace std::chrono_literals;
 Concert::Concert(const mediaelch::FileList& files, QObject* parent) :
     QObject(parent),
     m_controller{new ConcertController(this)},
-
     m_hasChanged{false},
-
     m_inSeparateFolder{false},
-    m_streamDetailsLoaded{false},
     m_syncNeeded{false},
     m_hasExtraFanarts{false}
 {
@@ -358,11 +355,10 @@ QString Concert::folderName() const
  * \property Concert::streamDetailsLoaded
  * \brief Holds if the stream details were loaded
  * \return True if the stream details were loaded
- * \see Concert::setStreamDetailsLoaded
  */
 bool Concert::streamDetailsLoaded() const
 {
-    return m_streamDetailsLoaded;
+    return m_concert.streamDetails->hasLoaded();
 }
 
 bool Concert::watched() const
@@ -726,15 +722,6 @@ void Concert::setImdbId(ImdbId id)
 {
     m_concert.imdbId = std::move(id);
     setChanged(true);
-}
-
-/**
- * \brief Sets if the stream details were loaded
- * \see Concert::streamDetailsLoaded
- */
-void Concert::setStreamDetailsLoaded(bool loaded)
-{
-    m_streamDetailsLoaded = loaded;
 }
 
 /**

--- a/src/concerts/Concert.h
+++ b/src/concerts/Concert.h
@@ -147,7 +147,6 @@ public:
     void setMediaCenterId(int mediaCenterId);
     void setTmdbId(TmdbId id);
     void setImdbId(ImdbId id);
-    void setStreamDetailsLoaded(bool loaded);
     void setNfoContent(QString content);
     void setDatabaseId(int id);
     void setSyncNeeded(bool syncNeeded);
@@ -202,7 +201,6 @@ private:
     bool m_downloadsInProgress = false;
     bool m_inSeparateFolder;
     QSet<ConcertScraperInfo> m_infosToLoad;
-    bool m_streamDetailsLoaded;
     QString m_nfoContent;
     bool m_syncNeeded;
     QVector<ScraperData> m_loadsLeft;

--- a/src/concerts/ConcertController.cpp
+++ b/src/concerts/ConcertController.cpp
@@ -140,7 +140,6 @@ bool ConcertController::loadStreamDetailsFromFile()
     seconds runtime(
         m_concert->streamDetails()->videoDetails().value(StreamDetails::VideoDetails::DurationInSeconds).toInt());
     m_concert->setRuntime(duration_cast<minutes>(runtime));
-    m_concert->setStreamDetailsLoaded(true);
     m_concert->setChanged(true);
     return true;
 }

--- a/src/data/StreamDetails.cpp
+++ b/src/data/StreamDetails.cpp
@@ -67,6 +67,7 @@ void StreamDetails::clear()
 
 bool StreamDetails::loadStreamDetails()
 {
+    m_hasLoadedStreamDetails = true;
     if (m_files.isEmpty()) {
         return false;
     }
@@ -107,6 +108,21 @@ bool StreamDetails::loadStreamDetails()
     }
 
     return loadWithLibrary();
+}
+
+void StreamDetails::setLoaded(bool loaded)
+{
+    m_hasLoadedStreamDetails = loaded;
+}
+
+void StreamDetails::setFilesWithoutReloading(mediaelch::FileList files)
+{
+    m_files = std::move(files);
+}
+
+bool StreamDetails::hasLoaded() const
+{
+    return m_hasLoadedStreamDetails;
 }
 
 bool StreamDetails::loadWithLibrary()

--- a/src/data/StreamDetails.h
+++ b/src/data/StreamDetails.h
@@ -41,6 +41,15 @@ public:
 
     /// \brief Loads stream details from the file. Returns true if successful.
     ELCH_NODISCARD bool loadStreamDetails();
+    /// \brief Indicates whether the stream details were loaded at least once.
+    /// \details Returns true, f the stream details were either loaded through
+    ///          \see loadStreamDetails or if set through \see setLoaded.
+    ELCH_NODISCARD bool hasLoaded() const;
+    /// \brief Explicitly state that the streamdetails were loaded, e.g. through reading the NFO file.
+    void setLoaded(bool loaded);
+    /// \brief Set the list of files without reloading/changing the current streamdetails.
+    /// \details Useful if files were renamed, but their contents did not change.
+    void setFilesWithoutReloading(mediaelch::FileList files);
 
     void setVideoDetail(VideoDetails key, QString value);
     void setAudioDetail(int streamNumber, AudioDetails key, QString value);
@@ -76,4 +85,6 @@ private:
     QStringList m_hdAudioCodecs;
     QStringList m_normalAudioCodecs;
     QStringList m_sdAudioCodecs;
+
+    bool m_hasLoadedStreamDetails{false};
 };

--- a/src/media_centers/KodiXml.h
+++ b/src/media_centers/KodiXml.h
@@ -114,7 +114,7 @@ private:
     QByteArray getArtistXml(Artist* artist);
     QByteArray getAlbumXml(Album* album);
     bool loadStreamDetails(StreamDetails* streamDetails, QDomDocument domDoc);
-    void loadStreamDetails(StreamDetails* streamDetails, QDomElement elem);
+    bool loadStreamDetails(StreamDetails* streamDetails, QDomElement elem);
     bool saveFile(QString filename, QByteArray data);
     mediaelch::DirectoryPath getPath(const Movie* movie);
     mediaelch::DirectoryPath getPath(const Concert* concert);

--- a/src/media_centers/kodi/ConcertXmlReader.cpp
+++ b/src/media_centers/kodi/ConcertXmlReader.cpp
@@ -273,7 +273,7 @@ void ConcertXmlReader::parseStreamDetails(QXmlStreamReader& reader)
         }
     }
 
-    m_concert.setStreamDetailsLoaded(true);
+    m_concert.streamDetails()->setLoaded(true);
 }
 
 void ConcertXmlReader::parseVideoStreamDetails(QXmlStreamReader& reader, StreamDetails* streamDetails)

--- a/src/movies/Movie.cpp
+++ b/src/movies/Movie.cpp
@@ -22,7 +22,6 @@ Movie::Movie(QStringList files, QObject* parent) :
     m_controller{new MovieController(this)},
     m_movieImages(*this),
     m_runtime{0min},
-
     m_streamDetails{nullptr},
     m_discType{DiscType::Single},
     m_label{ColorLabel::NoLabel}
@@ -45,9 +44,10 @@ void Movie::setFiles(const mediaelch::FileList& files)
     }
     m_files = files;
     if (m_streamDetails != nullptr) {
-        m_streamDetails->deleteLater();
+        m_streamDetails->setFilesWithoutReloading(m_files);
+    } else {
+        m_streamDetails = new StreamDetails(this, files);
     }
-    m_streamDetails = new StreamDetails(this, files);
 }
 
 MovieController* Movie::controller() const
@@ -438,11 +438,10 @@ bool Movie::hasChanged() const
  * \property Movie::streamDetailsLoaded
  * \brief Holds if the stream details were loaded
  * \return True if the stream details were loaded
- * \see Movie::setStreamDetailsLoaded
  */
 bool Movie::streamDetailsLoaded() const
 {
-    return m_streamDetailsLoaded;
+    return m_streamDetails != nullptr && m_streamDetails->hasLoaded();
 }
 
 /**
@@ -731,15 +730,6 @@ void Movie::setChanged(bool changed)
 {
     m_hasChanged = changed;
     emit sigChanged(this);
-}
-
-/**
- * \brief Sets if the stream details were loaded
- * \see Movie::streamDetailsLoaded
- */
-void Movie::setStreamDetailsLoaded(bool loaded)
-{
-    m_streamDetailsLoaded = loaded;
 }
 
 /**

--- a/src/movies/Movie.cpp
+++ b/src/movies/Movie.cpp
@@ -1041,11 +1041,6 @@ QVector<Subtitle*> Movie::subtitles() const
     return m_subtitles;
 }
 
-void Movie::setSubtitles(const QVector<Subtitle*>& subtitles)
-{
-    m_subtitles = subtitles;
-    setChanged(true);
-}
 
 void Movie::addSubtitle(Subtitle* subtitle, bool fromLoad)
 {

--- a/src/movies/Movie.h
+++ b/src/movies/Movie.h
@@ -128,7 +128,6 @@ public:
     void setDownloadsSize(int downloadsSize);
     void setInSeparateFolder(bool inSepFolder);
     void setMediaCenterId(int mediaCenterId);
-    void setStreamDetailsLoaded(bool loaded);
     void setFileLastModified(QDateTime modified);
     void setNfoContent(QString content);
     void setDatabaseId(int id);
@@ -207,7 +206,6 @@ private:
     bool m_hasChanged = false;
     bool m_inSeparateFolder = false;
     bool m_syncNeeded = false;
-    bool m_streamDetailsLoaded = false;
     bool m_hasDuplicates = false;
     StreamDetails* m_streamDetails;
     QDateTime m_fileLastModified;

--- a/src/movies/Movie.h
+++ b/src/movies/Movie.h
@@ -156,7 +156,6 @@ public:
     /// \brief Whether there are external subtitles or streamdetails subtitles.
     bool hasSubtitles() const;
     QVector<Subtitle*> subtitles() const;
-    void setSubtitles(const QVector<Subtitle*>& subtitles);
     void addSubtitle(Subtitle* subtitle, bool fromLoad = false);
 
     bool isDuplicate(Movie* movie) const;

--- a/src/movies/MovieController.cpp
+++ b/src/movies/MovieController.cpp
@@ -182,7 +182,6 @@ bool MovieController::loadStreamDetailsFromFile()
     if (runtime > 0s) {
         m_movie->setRuntime(duration_cast<minutes>(runtime));
     }
-    m_movie->setStreamDetailsLoaded(true);
     m_movie->setChanged(true);
     return true;
 }

--- a/src/renamer/RenamerDialog.cpp
+++ b/src/renamer/RenamerDialog.cpp
@@ -234,7 +234,8 @@ void RenamerDialog::renameMovies(QVector<Movie*> movies, const RenamerConfig& co
             continue;
         }
         if (movie->hasChanged()) {
-            ui->results->append(tr("<b>Movie</b> \"%1\" has been edited but is not saved").arg(movie->name()));
+            ui->results->append(tr("<b>Movie</b> \"%1\" not renamed: It has been edited but is not saved")
+                                    .arg(movie->name()));
             continue;
         }
 
@@ -262,7 +263,8 @@ void RenamerDialog::renameEpisodes(QVector<TvShowEpisode*> episodes, const Renam
             continue;
         }
         if (episode->hasChanged()) {
-            ui->results->append(tr("<b>Episode</b> \"%1\" has been edited but is not saved").arg(episode->title()));
+            ui->results->append(tr("<b>Episode</b> \"%1\" not renamed: It has been edited but is not saved")
+                                    .arg(episode->title()));
             continue;
         }
 
@@ -286,7 +288,8 @@ void RenamerDialog::renameShows(QVector<TvShow*> shows,
 
     for (TvShow* show : shows) {
         if (show->hasChanged()) {
-            ui->results->append(tr("<b>TV Show</b> \"%1\" has been edited but is not saved").arg(show->title()));
+            ui->results->append(tr("<b>TV Show</b> \"%1\" not renamed: It has been edited but is not saved")
+                                    .arg(show->title()));
             continue;
         }
 
@@ -338,7 +341,8 @@ void RenamerDialog::renameConcerts(QVector<Concert*> concerts, const RenamerConf
             continue;
         }
         if (concert->hasChanged()) {
-            ui->results->append(tr("<b>Concert</b> \"%1\" has been edited but is not saved").arg(concert->title()));
+            ui->results->append(tr("<b>Concert</b> \"%1\" not renamed: It has been edited but is not saved")
+                                    .arg(concert->title()));
             continue;
         }
 

--- a/src/renamer/RenamerDialog.cpp
+++ b/src/renamer/RenamerDialog.cpp
@@ -234,8 +234,8 @@ void RenamerDialog::renameMovies(QVector<Movie*> movies, const RenamerConfig& co
             continue;
         }
         if (movie->hasChanged()) {
-            ui->results->append(tr("<b>Movie</b> \"%1\" not renamed: It has been edited but is not saved")
-                                    .arg(movie->name()));
+            ui->results->append(
+                tr("<b>Movie</b> \"%1\" not renamed: It has been edited but is not saved").arg(movie->name()));
             continue;
         }
 
@@ -263,8 +263,8 @@ void RenamerDialog::renameEpisodes(QVector<TvShowEpisode*> episodes, const Renam
             continue;
         }
         if (episode->hasChanged()) {
-            ui->results->append(tr("<b>Episode</b> \"%1\" not renamed: It has been edited but is not saved")
-                                    .arg(episode->title()));
+            ui->results->append(
+                tr("<b>Episode</b> \"%1\" not renamed: It has been edited but is not saved").arg(episode->title()));
             continue;
         }
 
@@ -288,8 +288,8 @@ void RenamerDialog::renameShows(QVector<TvShow*> shows,
 
     for (TvShow* show : shows) {
         if (show->hasChanged()) {
-            ui->results->append(tr("<b>TV Show</b> \"%1\" not renamed: It has been edited but is not saved")
-                                    .arg(show->title()));
+            ui->results->append(
+                tr("<b>TV Show</b> \"%1\" not renamed: It has been edited but is not saved").arg(show->title()));
             continue;
         }
 
@@ -341,8 +341,8 @@ void RenamerDialog::renameConcerts(QVector<Concert*> concerts, const RenamerConf
             continue;
         }
         if (concert->hasChanged()) {
-            ui->results->append(tr("<b>Concert</b> \"%1\" not renamed: It has been edited but is not saved")
-                                    .arg(concert->title()));
+            ui->results->append(
+                tr("<b>Concert</b> \"%1\" not renamed: It has been edited but is not saved").arg(concert->title()));
             continue;
         }
 

--- a/src/tv_shows/TvShowEpisode.cpp
+++ b/src/tv_shows/TvShowEpisode.cpp
@@ -161,7 +161,6 @@ bool TvShowEpisode::loadStreamDetailsFromFile()
 {
     const bool success = m_streamDetails->loadStreamDetails();
     if (success) {
-        setStreamDetailsLoaded(true);
         setChanged(true);
     }
     return success;
@@ -543,11 +542,10 @@ int TvShowEpisode::episodeId() const
  * \property TvShowEpisode::streamDetailsLoaded
  * \brief Holds if the stream details were loaded
  * \return True if the stream details were loaded
- * \see TvShowEpisode::setStreamDetailsLoaded
  */
 bool TvShowEpisode::streamDetailsLoaded() const
 {
-    return m_streamDetailsLoaded;
+    return m_streamDetails->hasLoaded();
 }
 
 /**
@@ -815,15 +813,6 @@ void TvShowEpisode::setChanged(bool changed)
 void TvShowEpisode::setModelItem(EpisodeModelItem* item)
 {
     m_modelItem = item;
-}
-
-/**
- * \brief Sets if the stream details were loaded
- * \see TvShowEpisode::streamDetailsLoaded
- */
-void TvShowEpisode::setStreamDetailsLoaded(bool loaded)
-{
-    m_streamDetailsLoaded = loaded;
 }
 
 /*** REMOVER ***/

--- a/src/tv_shows/TvShowEpisode.h
+++ b/src/tv_shows/TvShowEpisode.h
@@ -121,7 +121,6 @@ public:
     void setInfosLoaded(bool loaded);
     void setChanged(bool changed);
     void setModelItem(EpisodeModelItem* item);
-    void setStreamDetailsLoaded(bool loaded);
     void setNfoContent(QString content);
     void setDatabaseId(int id);
     void setSyncNeeded(bool syncNeeded);
@@ -206,7 +205,6 @@ private:
     bool m_infoFromNfoLoaded = false;
     bool m_hasChanged = false;
     int m_episodeId = -1;
-    bool m_streamDetailsLoaded = false;
     StreamDetails* m_streamDetails = nullptr;
     QString m_nfoContent;
     int m_databaseId = -1;

--- a/src/ui/export/CsvExportDialog.cpp
+++ b/src/ui/export/CsvExportDialog.cpp
@@ -314,7 +314,7 @@ void CsvExportDialog::initializeItems()
         addField(Field::Directory, tr("Movie - Directory"));
         addField(Field::Filenames, tr("Movie - Filename(s)"));
         addField(Field::StreamDetails_Video_DurationInSeconds, tr("Streamdetails - Duration (in seconds)"));
-        addField(Field::StreamDetails_Video_Aspect, tr("Streamdetails - Video Aspect"));
+        addField(Field::StreamDetails_Video_Aspect, tr("Streamdetails - Video Aspect Ratio"));
         addField(Field::StreamDetails_Video_Width, tr("Streamdetails - Video Width"));
         addField(Field::StreamDetails_Video_Height, tr("Streamdetails - Video Height"));
         addField(Field::StreamDetails_Video_Codec, tr("Streamdetails - Video Codec"));


### PR DESCRIPTION
Fix #1432

------------

[StreamDetails] Refactor "hasStreamDetails" handling

This commit refactors the stream details handling a bit. Previously,
we used a member variable for `streamDetailsLoaded()` that tracked
whether stream details were loaded.  However, this was not reliably
set throughout our code base.  We now simply use the StreamDetails
class for tracking this state.

------------

[Renamer] Mark movie "changed" if subtitle was renamed

If a movie's subtitles are renamed, the movie must be marked as
"changed" or otherwise the `<subtitle>` tag in its NFO file won't be
updated, or rather: The user won't notice that the tag is not updated.