### PR TITLE
[UI] Use QComboBox for PlaceholderLineEdit to provide default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
  - Multi-Episode numbers such as `S01E01E02E03.mov` are now correctly identified (#1429)
  - UI: The "subtitle" column of movies is now also green if there are external subtitles (#1435)
- - Renamer: If subtitles are renamed, movie is marked "changed" (#1432)
+ - Renamer: If subtitles are renamed, movie is marked "changed" (#1432)  
    This is necessary to update the `<subtitle>` tag in the NFO file.
 
 ### Changes
@@ -19,7 +19,8 @@
 
 ### Added
 
- - *tbd*
+ - Renamer: Placeholder input fields now provide examples through a drop-down menu (#657)  
+   Only few are shown by default.  If you want more, let us know by opening an issue on GitHub.
 
 ### Removed
 

--- a/src/concerts/Concert.cpp
+++ b/src/concerts/Concert.cpp
@@ -17,12 +17,7 @@ using namespace std::chrono_literals;
  * \param files List of files for this concert
  */
 Concert::Concert(const mediaelch::FileList& files, QObject* parent) :
-    QObject(parent),
-    m_controller{new ConcertController(this)},
-    m_hasChanged{false},
-    m_inSeparateFolder{false},
-    m_syncNeeded{false},
-    m_hasExtraFanarts{false}
+    QObject(parent), m_controller{new ConcertController(this)}
 {
     moveToThread(QApplication::instance()->thread());
     static int s_idCounter = 0;

--- a/src/concerts/Concert.h
+++ b/src/concerts/Concert.h
@@ -197,19 +197,20 @@ private:
     QString m_folderName;
 
     int m_downloadsSize = 0;
-    bool m_hasChanged;
-    bool m_downloadsInProgress = false;
-    bool m_inSeparateFolder;
     QSet<ConcertScraperInfo> m_infosToLoad;
     QString m_nfoContent;
-    bool m_syncNeeded;
     QVector<ScraperData> m_loadsLeft;
     QMutex m_loadMutex;
     QStringList m_extraFanartsToRemove;
-    bool m_hasExtraFanarts;
 
     QMap<ImageType, bool> m_hasImageChanged;
     QVector<QByteArray> m_extraFanartImagesToAdd;
     QVector<ImageType> m_imagesToRemove;
     QMap<ImageType, bool> m_hasImage;
+
+    bool m_hasExtraFanarts{false};
+    bool m_syncNeeded{false};
+    bool m_hasChanged{false};
+    bool m_downloadsInProgress{false};
+    bool m_inSeparateFolder{false};
 };

--- a/src/renamer/MovieRenamer.cpp
+++ b/src/renamer/MovieRenamer.cpp
@@ -201,14 +201,14 @@ MovieRenamer::RenameError MovieRenamer::renameMovie(Movie& movie)
                 return;
             }
 
-            QVector<DataFile> files = Settings::instance()->dataFiles(dataFileType);
-            if (files.isEmpty()) {
+            QVector<DataFile> dataFiles = Settings::instance()->dataFiles(dataFileType);
+            if (dataFiles.isEmpty()) {
                 return;
             }
 
             QString fileName = QFileInfo(filePath).fileName();
             QString newDataFileName =
-                files.first().saveFileName(newFileName, SeasonNumber::NoSeason, movie.files().count() > 1);
+                dataFiles.first().saveFileName(newFileName, SeasonNumber::NoSeason, movie.files().count() > 1);
             helper::sanitizeFileName(newDataFileName);
 
             if (newDataFileName == fileName) {

--- a/src/renamer/MovieRenamer.cpp
+++ b/src/renamer/MovieRenamer.cpp
@@ -59,7 +59,8 @@ MovieRenamer::RenameError MovieRenamer::renameMovie(Movie& movie)
             QString baseName = fi.completeBaseName();
             QDir currentDir = fi.dir();
             MovieRenamer::replace(newFileName, "title", movie.name());
-            MovieRenamer::replace(newFileName, "originalTitle", movie.originalName());
+            MovieRenamer::replace(
+                newFileName, "originalTitle", movie.originalName().isEmpty() ? movie.name() : movie.originalName());
             MovieRenamer::replace(newFileName, "sortTitle", movie.sortTitle());
             MovieRenamer::replace(newFileName, "director", movie.director());
             // TODO: Let the user decide whether only the first should be used or
@@ -254,7 +255,8 @@ MovieRenamer::RenameError MovieRenamer::renameMovie(Movie& movie)
     if (m_config.renameDirectories && movie.inSeparateFolder()) {
         Renamer::replace(newFolderName, "title", movie.name());
         Renamer::replace(newFolderName, "extension", extension);
-        Renamer::replace(newFolderName, "originalTitle", movie.originalName());
+        Renamer::replace(
+            newFolderName, "originalTitle", movie.originalName().isEmpty() ? movie.name() : movie.originalName());
         Renamer::replace(newFolderName, "sortTitle", movie.sortTitle());
         // TODO: Let the user decide whether only the first should be used or
         //       if a space should be the separator.
@@ -289,7 +291,8 @@ MovieRenamer::RenameError MovieRenamer::renameMovie(Movie& movie)
     else if (m_config.renameDirectories) {
         Renamer::replace(newFolderName, "title", movie.name());
         Renamer::replace(newFolderName, "extension", extension);
-        Renamer::replace(newFolderName, "originalTitle", movie.originalName());
+        Renamer::replace(
+            newFolderName, "originalTitle", movie.originalName().isEmpty() ? movie.name() : movie.originalName());
         Renamer::replace(newFolderName, "sortTitle", movie.sortTitle());
         // TODO: Let the user decide whether only the first should be used or
         //       if a space should be the separator.

--- a/src/renamer/RenamerDialog.cpp
+++ b/src/renamer/RenamerDialog.cpp
@@ -76,10 +76,44 @@ int RenamerDialog::exec()
     Settings::instance()->renamePatterns(m_renameType, fileName, fileNameMulti, directoryName, seasonName);
     Settings::instance()->renamings(m_renameType, renameFiles, renameFolders, useSeasonDirectories);
 
+    // Default texts for combo box.
+    QStringList fileNameDefaults;
+    QStringList fileNameMultiDefaults;
+    if (m_renameType == Renamer::RenameType::TvShows) {
+        fileNameDefaults = QStringList{//
+            "S<season>E<episode> - <title>.<extension>",
+            "Season <season> Episode <episode> - <title>.<extension>"};
+        fileNameMultiDefaults = QStringList{//
+            "S<season>E<episode> - <title>-part<partNo>.<extension>"};
+    } else {
+        fileNameDefaults = QStringList{//
+            "<title>.<extension>",
+            "<originalTitle>.<extension>"};
+        fileNameMultiDefaults = QStringList{//
+            "<title>-part<partNo>.<extension>",
+            "<originalTitle>-part<partNo>.<extension>"};
+    }
+    QStringList directoryNameDefaults{//
+        "<title> (<year>)",
+        "{movieset}<movieset> - {/movieset}<title> (<year>)",
+        "<originalTitle> (<year>)",
+        "<sortTitle>{imdbId} [<imdbId>]{/imdbId} (<year>)"};
+    QStringList seasonNameDefaults = QStringList{//
+        "Season <season>",
+        "Season <season> - <seasonName>"};
+
+    ui->fileNaming->setItems(fileNameDefaults);
     ui->fileNaming->setText(fileName);
+
+    ui->fileNamingMulti->setItems(fileNameMultiDefaults);
     ui->fileNamingMulti->setText(fileNameMulti);
+
+    ui->directoryNaming->setItems(directoryNameDefaults);
     ui->directoryNaming->setText(directoryName);
+
+    ui->seasonNaming->setItems(seasonNameDefaults);
     ui->seasonNaming->setText(seasonName);
+
     ui->chkFileNaming->setChecked(renameFiles);
     ui->chkDirectoryNaming->setChecked(renameFolders);
     ui->chkSeasonDirectories->setChecked(useSeasonDirectories);

--- a/src/renamer/RenamerDialog.ui
+++ b/src/renamer/RenamerDialog.ui
@@ -88,11 +88,26 @@
          </item>
          <item row="4" column="1">
           <widget class="PlaceholderLineEdit" name="directoryNaming">
-           <property name="inputMask">
-            <string notr="true"/>
-           </property>
-           <property name="text">
+           <property name="currentText">
             <string notr="true">&lt;title&gt; (&lt;year&gt;)</string>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>500</width>
+             <height>16777215</height>
+            </size>
            </property>
           </widget>
          </item>
@@ -118,11 +133,26 @@
          </item>
          <item row="2" column="1">
           <widget class="PlaceholderLineEdit" name="fileNamingMulti">
-           <property name="inputMask">
-            <string notr="true"/>
-           </property>
-           <property name="text">
+           <property name="currentText">
             <string notr="true">&lt;title&gt;-part&lt;partNo&gt;.&lt;extension&gt;</string>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>500</width>
+             <height>16777215</height>
+            </size>
            </property>
           </widget>
          </item>
@@ -135,11 +165,26 @@
          </item>
          <item row="1" column="1">
           <widget class="PlaceholderLineEdit" name="fileNaming">
-           <property name="inputMask">
-            <string notr="true"/>
-           </property>
-           <property name="text">
+           <property name="currentText">
             <string notr="true">&lt;title&gt;.&lt;extension&gt;</string>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>500</width>
+             <height>16777215</height>
+            </size>
            </property>
           </widget>
          </item>
@@ -159,8 +204,26 @@
          </item>
          <item row="6" column="1">
           <widget class="PlaceholderLineEdit" name="seasonNaming">
-           <property name="text">
+           <property name="currentText">
             <string>Season &lt;season&gt;</string>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>500</width>
+             <height>16777215</height>
+            </size>
            </property>
           </widget>
          </item>
@@ -323,7 +386,7 @@ p, li { white-space: pre-wrap; }
  <customwidgets>
   <customwidget>
    <class>PlaceholderLineEdit</class>
-   <extends>QLineEdit</extends>
+   <extends>QComboBox</extends>
    <header location="global">ui/small_widgets/PlaceholderLineEdit.h</header>
   </customwidget>
   <customwidget>

--- a/src/renamer/RenamerPlaceholders.ui
+++ b/src/renamer/RenamerPlaceholders.ui
@@ -252,7 +252,7 @@
             <property name="text">
              <string notr="true">&lt;seasonName&gt;</string>
             </property>
-            <property name="itemType" stdset="0">
+            <property name="itemTypes" stdset="0">
              <stringlist notr="true">
               <string>tvshow</string>
              </stringlist>

--- a/src/ui/settings/ConcertSettingsWidget.cpp
+++ b/src/ui/settings/ConcertSettingsWidget.cpp
@@ -55,7 +55,7 @@ void ConcertSettingsWidget::loadSettings()
 void ConcertSettingsWidget::saveSettings()
 {
     QVector<DataFile> dataFiles;
-    for (QLineEdit* lineEdit : findChildren<PlaceholderLineEdit*>()) {
+    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
         if (lineEdit->property("dataFileType").isNull()) {
             continue;
         }

--- a/src/ui/settings/ConcertSettingsWidget.ui
+++ b/src/ui/settings/ConcertSettingsWidget.ui
@@ -80,6 +80,18 @@
      </item>
      <item row="0" column="1">
       <widget class="PlaceholderLineEdit" name="concertNfo">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -90,6 +102,18 @@
      </item>
      <item row="1" column="1">
       <widget class="PlaceholderLineEdit" name="concertPoster">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -100,6 +124,18 @@
      </item>
      <item row="2" column="1">
       <widget class="PlaceholderLineEdit" name="concertBackdrop">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -110,6 +146,18 @@
      </item>
      <item row="3" column="1">
       <widget class="PlaceholderLineEdit" name="concertLogo">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -120,6 +168,18 @@
      </item>
      <item row="4" column="1">
       <widget class="PlaceholderLineEdit" name="concertClearArt">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -130,6 +190,18 @@
      </item>
      <item row="5" column="1">
       <widget class="PlaceholderLineEdit" name="concertDiscArt">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -145,7 +217,7 @@
  <customwidgets>
   <customwidget>
    <class>PlaceholderLineEdit</class>
-   <extends>QLineEdit</extends>
+   <extends>QComboBox</extends>
    <header location="global">ui/small_widgets/PlaceholderLineEdit.h</header>
   </customwidget>
  </customwidgets>

--- a/src/ui/settings/MovieSettingsWidget.ui
+++ b/src/ui/settings/MovieSettingsWidget.ui
@@ -80,6 +80,18 @@
      </item>
      <item row="0" column="1">
       <widget class="PlaceholderLineEdit" name="movieNfo">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -90,6 +102,18 @@
      </item>
      <item row="1" column="1">
       <widget class="PlaceholderLineEdit" name="moviePoster">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -100,6 +124,18 @@
      </item>
      <item row="2" column="1">
       <widget class="PlaceholderLineEdit" name="movieBackdrop">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -110,6 +146,18 @@
      </item>
      <item row="3" column="1">
       <widget class="PlaceholderLineEdit" name="movieLogo">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -120,6 +168,18 @@
      </item>
      <item row="4" column="1">
       <widget class="PlaceholderLineEdit" name="movieClearArt">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -130,6 +190,18 @@
      </item>
      <item row="5" column="1">
       <widget class="PlaceholderLineEdit" name="movieCdArt">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -154,6 +226,18 @@
      </item>
      <item row="6" column="1">
       <widget class="PlaceholderLineEdit" name="movieBanner">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -164,6 +248,18 @@
      </item>
      <item row="7" column="1">
       <widget class="PlaceholderLineEdit" name="movieThumb">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -212,16 +308,31 @@
      </item>
      <item row="3" column="1">
       <widget class="PlaceholderLineEdit" name="movieSetPosterFileName">
-       <property name="text">
+       <property name="currentText">
         <string notr="true">folder.jpg</string>
-       </property>
-       <property name="placeholderText">
-        <string>folder.jpg</string>
        </property>
        <property name="placeholders" stdset="0">
         <stringlist notr="true">
          <string>setName</string>
         </stringlist>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>400</width>
+         <height>16777215</height>
+        </size>
        </property>
       </widget>
      </item>
@@ -234,16 +345,31 @@
      </item>
      <item row="4" column="1">
       <widget class="PlaceholderLineEdit" name="movieSetFanartFileName">
-       <property name="text">
-        <string>fanart.jpg</string>
-       </property>
-       <property name="placeholderText">
+       <property name="currentText">
         <string>fanart.jpg</string>
        </property>
        <property name="placeholders" stdset="0">
         <stringlist notr="true">
          <string>setName</string>
         </stringlist>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>400</width>
+         <height>16777215</height>
+        </size>
        </property>
       </widget>
      </item>
@@ -289,7 +415,7 @@
  <customwidgets>
   <customwidget>
    <class>PlaceholderLineEdit</class>
-   <extends>QLineEdit</extends>
+   <extends>QComboBox</extends>
    <header location="global">ui/small_widgets/PlaceholderLineEdit.h</header>
   </customwidget>
  </customwidgets>

--- a/src/ui/settings/TvShowSettingsWidget.cpp
+++ b/src/ui/settings/TvShowSettingsWidget.cpp
@@ -52,7 +52,7 @@ void TvShowSettingsWidget::setSettings(Settings& settings)
 
 void TvShowSettingsWidget::loadSettings()
 {
-    for (auto* lineEdit : findChildren<QLineEdit*>()) {
+    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
         if (lineEdit->property("dataFileType").isNull()) {
             continue;
         }
@@ -69,7 +69,7 @@ void TvShowSettingsWidget::loadSettings()
 void TvShowSettingsWidget::saveSettings()
 {
     QVector<DataFile> dataFiles;
-    for (QLineEdit* lineEdit : findChildren<QLineEdit*>()) {
+    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
         if (lineEdit->property("dataFileType").isNull()) {
             continue;
         }

--- a/src/ui/settings/TvShowSettingsWidget.ui
+++ b/src/ui/settings/TvShowSettingsWidget.ui
@@ -122,6 +122,18 @@
      </item>
      <item row="0" column="1">
       <widget class="PlaceholderLineEdit" name="showNfo">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -132,6 +144,18 @@
      </item>
      <item row="1" column="1">
       <widget class="PlaceholderLineEdit" name="showEpisodeNfo">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -142,6 +166,18 @@
      </item>
      <item row="2" column="1">
       <widget class="PlaceholderLineEdit" name="showPoster">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -152,6 +188,18 @@
      </item>
      <item row="3" column="1">
       <widget class="PlaceholderLineEdit" name="showBackdrop">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -162,6 +210,18 @@
      </item>
      <item row="4" column="1">
       <widget class="PlaceholderLineEdit" name="showBanner">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -172,6 +232,18 @@
      </item>
      <item row="5" column="1">
       <widget class="PlaceholderLineEdit" name="showLogo">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -182,6 +254,18 @@
      </item>
      <item row="7" column="1">
       <widget class="PlaceholderLineEdit" name="showClearArt">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -192,6 +276,18 @@
      </item>
      <item row="8" column="1">
       <widget class="PlaceholderLineEdit" name="showCharacterArt">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -202,6 +298,18 @@
      </item>
      <item row="9" column="1">
       <widget class="PlaceholderLineEdit" name="showEpisodeThumbnail">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -212,6 +320,18 @@
      </item>
      <item row="10" column="1">
       <widget class="PlaceholderLineEdit" name="showSeasonPoster">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -222,6 +342,18 @@
      </item>
      <item row="11" column="1">
       <widget class="PlaceholderLineEdit" name="showSeasonBackdrop">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -232,6 +364,18 @@
      </item>
      <item row="12" column="1">
       <widget class="PlaceholderLineEdit" name="showSeasonBanner">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -256,6 +400,18 @@
      </item>
      <item row="6" column="1">
       <widget class="PlaceholderLineEdit" name="showThumb">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -266,6 +422,18 @@
      </item>
      <item row="13" column="1">
       <widget class="PlaceholderLineEdit" name="showSeasonThumb">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>400</width>
@@ -281,7 +449,7 @@
  <customwidgets>
   <customwidget>
    <class>PlaceholderLineEdit</class>
-   <extends>QLineEdit</extends>
+   <extends>QComboBox</extends>
    <header location="global">ui/small_widgets/PlaceholderLineEdit.h</header>
   </customwidget>
  </customwidgets>

--- a/src/ui/small_widgets/PlaceholderLineEdit.cpp
+++ b/src/ui/small_widgets/PlaceholderLineEdit.cpp
@@ -3,25 +3,34 @@
 #include "globals/Meta.h"
 
 #include <QContextMenuEvent>
+#include <QDebug>
+#include <QLineEdit>
 #include <QMenu>
 #include <QPainter>
 #include <QStyle>
 #include <QStyleOptionFrame>
 
+PlaceholderLineEdit::PlaceholderLineEdit(QWidget* parent) : QComboBox(parent)
+{
+    setEditable(true);
+}
+
 void PlaceholderLineEdit::contextMenuEvent(QContextMenuEvent* event)
 {
-    QMenu* menu = createStandardContextMenu();
+    QLineEdit* field = lineEdit();
+
+    QMenu* menu = field->createStandardContextMenu();
 
     if (!m_placeholders.isEmpty()) {
         menu->addSeparator();
         QMenu* placeholderMenu = menu->addMenu(tr("Insert placeholder"));
 
         for (const QString& placeholder : asConst(m_placeholders)) {
-            placeholderMenu->addAction(
-                addDelimiters(placeholder), this, [this, placeholder]() { insert(addDelimiters(placeholder)); });
+            placeholderMenu->addAction(addDelimiters(placeholder), this, [this, placeholder, field]() {
+                field->insert(addDelimiters(placeholder));
+            });
         }
     }
-
 
     menu->exec(event->globalPos());
     delete menu;
@@ -40,4 +49,26 @@ QStringList PlaceholderLineEdit::placeholders() const
 void PlaceholderLineEdit::setPlaceholders(const QStringList& placeholders)
 {
     m_placeholders = placeholders;
+}
+
+void PlaceholderLineEdit::setText(const QString& text)
+{
+    const int index = findText(text);
+    if (index > -1) {
+        setCurrentIndex(index);
+    } else {
+        addItem(text);
+        setCurrentIndex(count() - 1);
+    }
+}
+
+QString PlaceholderLineEdit::text() const
+{
+    return currentText();
+}
+
+void PlaceholderLineEdit::setItems(const QStringList& items)
+{
+    clear();
+    addItems(items);
 }

--- a/src/ui/small_widgets/PlaceholderLineEdit.h
+++ b/src/ui/small_widgets/PlaceholderLineEdit.h
@@ -1,23 +1,31 @@
 #pragma once
 
-#include <QLineEdit>
+#include <QComboBox>
 
-/// \brief Line edit with confort functions for custom placeholder strings.
+/// \brief Combobox with comfort functions for custom placeholder strings.
 /// \details This widget adds a custom QMenu to the standard context menu that
 ///          makes it easy to insert placeholders wrapped in "<" and ">".
 ///          Custom placeholders can be set through the property "placeholders".
-class PlaceholderLineEdit : public QLineEdit
+class PlaceholderLineEdit : public QComboBox
 {
     Q_OBJECT
 
     Q_PROPERTY(QStringList placeholders READ placeholders WRITE setPlaceholders)
 
 public:
-    using QLineEdit::QLineEdit;
+    PlaceholderLineEdit(QWidget* parent = nullptr);
     ~PlaceholderLineEdit() override = default;
 
     void setPlaceholders(const QStringList& placeholders);
     QStringList placeholders() const;
+
+    /// \brief Add the given text if not already present and set it as the current one.
+    void setText(const QString& text);
+    /// \brief Alias for \see currentText
+    QString text() const;
+
+    /// \brief Clears all current items and adds the given ones.
+    void setItems(const QStringList& items);
 
 protected:
     void contextMenuEvent(QContextMenuEvent* event) override;


### PR DESCRIPTION
This commit makes it possible to set default values for certain text
fields such as in the RenamerDialog.  This allows users to switch
back to defaults if they accidentally edited the box.

This is done for Renamer line edits.  Only few examples were edited by
default.

-------------

Fix  #657