### PR TITLE
[NetworkSettings/KodiSync] Allow disabling proxy for Kodi sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 
 ### Changes
 
- - *tbd*
+ - Network proxy is disabled (per default) for Kodi Synchronisation (#1430)  
+   This can be re-enabled in MediaElch's network settings. 
 
 ### Added
 

--- a/src/network/NetworkManager.cpp
+++ b/src/network/NetworkManager.cpp
@@ -2,6 +2,8 @@
 
 #include "network/NetworkReplyWatcher.h"
 
+#include <QNetworkProxy>
+
 namespace mediaelch {
 namespace network {
 
@@ -12,6 +14,11 @@ NetworkManager::NetworkManager(QObject* parent) : QObject(parent)
     connect(&m_qnam, &QNetworkAccessManager::authenticationRequired, this, &NetworkManager::authenticationRequired, Qt::UniqueConnection);
     connect(&m_qnam, &QNetworkAccessManager::finished,               this, &NetworkManager::finished,               Qt::UniqueConnection);
     // clang-format on
+}
+
+void NetworkManager::disableProxy()
+{
+    m_qnam.setProxy(QNetworkProxy::NoProxy);
 }
 
 QNetworkReply* NetworkManager::get(const QNetworkRequest& request)

--- a/src/network/NetworkManager.h
+++ b/src/network/NetworkManager.h
@@ -19,6 +19,8 @@ public:
     ~NetworkManager() override = default;
 
 public:
+    void disableProxy();
+
     QNetworkReply* get(const QNetworkRequest& request);
     QNetworkReply* getWithWatcher(const QNetworkRequest& request);
 

--- a/src/settings/NetworkSettings.cpp
+++ b/src/settings/NetworkSettings.cpp
@@ -8,6 +8,7 @@ void NetworkSettings::loadSettings()
 {
     // Proxy
     m_useProxy = m_settings->value("Proxy/Enable", false).toBool();
+    m_useProxyForKodi = m_settings->value("Proxy/UseForKodi", false).toBool();
     m_proxyType = m_settings->value("Proxy/Type", 0).toInt();
     m_proxyHost = m_settings->value("Proxy/Host").toString();
     m_proxyPort = static_cast<uint16_t>(m_settings->value("Proxy/Port", 0).toInt());
@@ -20,6 +21,7 @@ void NetworkSettings::saveSettings()
 {
     // Proxy
     m_settings->setValue("Proxy/Enable", m_useProxy);
+    m_settings->setValue("Proxy/UseForKodi", m_useProxyForKodi);
     m_settings->setValue("Proxy/Type", m_proxyType);
     m_settings->setValue("Proxy/Host", m_proxyHost);
     m_settings->setValue("Proxy/Port", m_proxyPort);
@@ -35,6 +37,11 @@ void NetworkSettings::saveSettings()
 bool NetworkSettings::useProxy() const
 {
     return m_useProxy;
+}
+
+bool NetworkSettings::useProxyForKodi() const
+{
+    return m_useProxyForKodi;
 }
 
 /**
@@ -89,6 +96,11 @@ QString NetworkSettings::proxyPassword() const
 void NetworkSettings::setUseProxy(bool use)
 {
     m_useProxy = use;
+}
+
+void NetworkSettings::setUseProxyForKodi(bool use)
+{
+    m_useProxyForKodi = use;
 }
 
 /**

--- a/src/settings/NetworkSettings.h
+++ b/src/settings/NetworkSettings.h
@@ -11,6 +11,7 @@ public:
     void setQSettings(QSettings* settings) { m_settings = settings; }
 
     bool useProxy() const;
+    bool useProxyForKodi() const;
     int proxyType() const;
     QString proxyHost() const;
     int proxyPort() const;
@@ -18,6 +19,7 @@ public:
     QString proxyPassword() const;
 
     void setUseProxy(bool use);
+    void setUseProxyForKodi(bool use);
     void setProxyType(int type);
     void setProxyHost(QString host);
     void setProxyPort(uint16_t port);
@@ -27,9 +29,10 @@ public:
 private:
     void setupProxy();
 
-    QSettings* m_settings = nullptr;
+    QSettings* m_settings{nullptr};
 
-    bool m_useProxy = false;
+    bool m_useProxy{false};
+    bool m_useProxyForKodi{false};
     int m_proxyType = 0;
     QString m_proxyHost;
     uint16_t m_proxyPort = 0;

--- a/src/tv_shows/TvShowEpisode.cpp
+++ b/src/tv_shows/TvShowEpisode.cpp
@@ -181,7 +181,8 @@ bool TvShowEpisode::saveData(MediaCenterInterface* mediaCenterInterface)
         }
     }
     bool saved = mediaCenterInterface->saveTvShowEpisode(this);
-    qCDebug(generic) << "[TvShowEpisode] Saving episode" << (saved ? "successful" : "not successful");
+    qCDebug(generic) << "[TvShowEpisode] Saving episode" << (saved ? "successful:" : "not successful:") << "Season"
+                     << m_season.toPaddedString() << "Episode" << m_episode.toPaddedString();
     if (!m_infoLoaded) {
         m_infoLoaded = saved;
     }

--- a/src/ui/main/MainWindow.cpp
+++ b/src/ui/main/MainWindow.cpp
@@ -103,7 +103,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
     m_supportDialog = new SupportDialog(this);
     m_settingsWindow = new SettingsWindow(this);
     m_fileScannerDialog = new FileScannerDialog(this);
-    m_xbmcSync = new KodiSync(Settings::instance()->kodiSettings(), this);
+    m_xbmcSync = new KodiSync(*Settings::instance(), this);
     m_renamer = new RenamerDialog(this);
     setupToolbar();
 

--- a/src/ui/media_centers/KodiSync.h
+++ b/src/ui/media_centers/KodiSync.h
@@ -2,7 +2,7 @@
 
 #include "movies/Movie.h"
 #include "network/NetworkManager.h"
-#include "settings/KodiSettings.h"
+#include "settings/Settings.h"
 
 #include <QAuthenticator>
 #include <QDialog>
@@ -21,7 +21,7 @@ class KodiSync : public QDialog
     Q_OBJECT
 
 public:
-    explicit KodiSync(KodiSettings& settings, QWidget* parent = nullptr);
+    explicit KodiSync(Settings& settings, QWidget* parent = nullptr);
     ~KodiSync() override;
     enum class Element
     {
@@ -72,7 +72,7 @@ private slots:
 
 private:
     Ui::KodiSync* ui;
-    KodiSettings& m_settings;
+    Settings& m_settings;
 
     mediaelch::network::NetworkManager m_network;
     QVector<Movie*> m_moviesToSync;

--- a/src/ui/settings/NetworkSettingsWidget.cpp
+++ b/src/ui/settings/NetworkSettingsWidget.cpp
@@ -26,6 +26,7 @@ void NetworkSettingsWidget::loadSettings()
 {
     const auto& netSettings = m_settings->networkSettings();
     ui->chkUseProxy->setChecked(netSettings.useProxy());
+    ui->chkUseProxyForKodi->setChecked(netSettings.useProxyForKodi());
     ui->proxyType->setCurrentIndex(netSettings.proxyType());
     ui->proxyHost->setText(netSettings.proxyHost());
     ui->proxyPort->setValue(netSettings.proxyPort());
@@ -37,6 +38,7 @@ void NetworkSettingsWidget::loadSettings()
 void NetworkSettingsWidget::saveSettings()
 {
     m_settings->networkSettings().setUseProxy(ui->chkUseProxy->isChecked());
+    m_settings->networkSettings().setUseProxyForKodi(ui->chkUseProxyForKodi->isChecked());
     m_settings->networkSettings().setProxyType(ui->proxyType->currentIndex());
     m_settings->networkSettings().setProxyHost(ui->proxyHost->text());
     // Explicitly check that we are in the allowed range of 2^16
@@ -49,7 +51,8 @@ void NetworkSettingsWidget::saveSettings()
 
 void NetworkSettingsWidget::onUseProxy()
 {
-    bool enabled = ui->chkUseProxy->isChecked();
+    const bool enabled = ui->chkUseProxy->isChecked();
+    ui->chkUseProxyForKodi->setEnabled(enabled);
     ui->proxyType->setEnabled(enabled);
     ui->proxyHost->setEnabled(enabled);
     ui->proxyPort->setEnabled(enabled);

--- a/src/ui/settings/NetworkSettingsWidget.ui
+++ b/src/ui/settings/NetworkSettingsWidget.ui
@@ -13,41 +13,41 @@
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
     <layout class="QFormLayout" name="formLayout_2">
-     <item row="3" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="lblHost">
        <property name="text">
         <string>Host</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="5" column="0">
       <widget class="QLabel" name="lblPort">
        <property name="text">
         <string>Port</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="lblUsername">
        <property name="text">
         <string>Username</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="0">
+     <item row="7" column="0">
       <widget class="QLabel" name="lblPassword">
        <property name="text">
         <string>Password</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="4" column="1">
       <widget class="QLineEdit" name="proxyHost"/>
      </item>
-     <item row="5" column="1">
+     <item row="6" column="1">
       <widget class="QLineEdit" name="proxyUsername"/>
      </item>
-     <item row="6" column="1">
+     <item row="7" column="1">
       <widget class="QLineEdit" name="proxyPassword">
        <property name="echoMode">
         <enum>QLineEdit::Password</enum>
@@ -71,14 +71,14 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="lblType">
        <property name="text">
         <string comment="Proxy Type">Type</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
       <widget class="QComboBox" name="proxyType">
        <item>
         <property name="text">
@@ -92,7 +92,7 @@
        </item>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="5" column="1">
       <widget class="QSpinBox" name="proxyPort">
        <property name="buttonSymbols">
         <enum>QAbstractSpinBox::NoButtons</enum>
@@ -102,12 +102,27 @@
        </property>
       </widget>
      </item>
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="chkUseProxyForKodi">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="lblUseProxyForKodi">
+       <property name="text">
+        <string>Use Proxy for Kodi</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>
  </widget>
  <tabstops>
   <tabstop>chkUseProxy</tabstop>
+  <tabstop>chkUseProxyForKodi</tabstop>
   <tabstop>proxyType</tabstop>
   <tabstop>proxyHost</tabstop>
   <tabstop>proxyPort</tabstop>


### PR DESCRIPTION
Default: Proxy disabled for Kodi, since it's most likely in the local
network.

------------

Fix  #1430