### PR TITLE
[KodiSync] Explicitly use default proxy if enabled in settings

### DIFF
--- a/src/network/NetworkManager.cpp
+++ b/src/network/NetworkManager.cpp
@@ -21,6 +21,11 @@ void NetworkManager::disableProxy()
     m_qnam.setProxy(QNetworkProxy::NoProxy);
 }
 
+void NetworkManager::enableDefaultProxy()
+{
+    m_qnam.setProxy(QNetworkProxy::DefaultProxy);
+}
+
 QNetworkReply* NetworkManager::get(const QNetworkRequest& request)
 {
     return m_qnam.get(request);

--- a/src/network/NetworkManager.h
+++ b/src/network/NetworkManager.h
@@ -19,7 +19,13 @@ public:
     ~NetworkManager() override = default;
 
 public:
+    /// \brief   Disables the network proxy when syncing with Kodi.
+    /// \details Useful if Kodi is in the local network but a proxy should be
+    ///          used for downloading artwork.
     void disableProxy();
+    /// \brief Enables the default proxy used by MediaElch, i.e. the proxy set
+    ///        in MediaElch's network settings.
+    void enableDefaultProxy();
 
     QNetworkReply* get(const QNetworkRequest& request);
     QNetworkReply* getWithWatcher(const QNetworkRequest& request);

--- a/src/ui/media_centers/KodiSync.cpp
+++ b/src/ui/media_centers/KodiSync.cpp
@@ -57,8 +57,10 @@ int KodiSync::exec()
     ui->progressBar->setVisible(false);
 
     if (!m_settings.networkSettings().useProxyForKodi()) {
-        qCDebug(generic) << "[KodiSync] Disbaled Proxy";
+        qCDebug(generic) << "[KodiSync] Disabled Proxy";
         m_network.disableProxy();
+    } else {
+        m_network.enableDefaultProxy();
     }
 
     return QDialog::exec();


### PR DESCRIPTION
If a proxy was disabled for syncing Kodi, and then enabled again,
subsequent kodi-sync steps still did not use the proxy.

-----------------

Fix #1446