### PR TITLE
[Settings] Fix storing values from QComboBox

### DIFF
--- a/src/ui/settings/ConcertSettingsWidget.cpp
+++ b/src/ui/settings/ConcertSettingsWidget.cpp
@@ -3,6 +3,8 @@
 
 #include "settings/Settings.h"
 
+#include <QLineEdit>
+
 ConcertSettingsWidget::ConcertSettingsWidget(QWidget* parent) : QWidget(parent), ui(new Ui::ConcertSettingsWidget)
 {
     ui->setupUi(this);
@@ -38,9 +40,9 @@ void ConcertSettingsWidget::setSettings(Settings& settings)
 
 void ConcertSettingsWidget::loadSettings()
 {
-    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
+    const auto loadLineEdit = [this](auto* lineEdit) {
         if (lineEdit->property("dataFileType").isNull()) {
-            continue;
+            return;
         }
         DataFileType dataFileType = DataFileType(lineEdit->property("dataFileType").toInt());
         QVector<DataFile> dataFiles = m_settings->dataFiles(dataFileType);
@@ -49,15 +51,21 @@ void ConcertSettingsWidget::loadSettings()
             filenames << dataFile.fileName();
         }
         lineEdit->setText(filenames.join(","));
+    };
+    for (auto* lineEdit : findChildren<QLineEdit*>()) {
+        loadLineEdit(lineEdit);
+    }
+    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
+        loadLineEdit(lineEdit);
     }
 }
 
 void ConcertSettingsWidget::saveSettings()
 {
     QVector<DataFile> dataFiles;
-    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
+    const auto storeLineEdit = [&dataFiles](auto* lineEdit) {
         if (lineEdit->property("dataFileType").isNull()) {
-            continue;
+            return;
         }
         int pos = 0;
         DataFileType dataFileType = DataFileType(lineEdit->property("dataFileType").toInt());
@@ -66,5 +74,11 @@ void ConcertSettingsWidget::saveSettings()
             DataFile df(dataFileType, filename.trimmed(), pos++);
             dataFiles << df;
         }
+    };
+    for (auto* lineEdit : findChildren<QLineEdit*>()) {
+        storeLineEdit(lineEdit);
+    }
+    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
+        storeLineEdit(lineEdit);
     }
 }

--- a/src/ui/settings/MovieSettingsWidget.cpp
+++ b/src/ui/settings/MovieSettingsWidget.cpp
@@ -81,14 +81,14 @@ void MovieSettingsWidget::loadSettings()
     ui->movieSetArtworkDir->setText(m_settings->movieSetArtworkDirectory().toNativePathString());
     onComboMovieSetArtworkChanged(ui->comboMovieSetArtwork->currentIndex());
 
-    for (auto* lineEdit : findChildren<QLineEdit*>()) {
+    const auto loadLineEdit = [this](auto* lineEdit) {
         if (lineEdit->property("dataFileType").isNull()) {
-            continue;
+            return;
         }
         bool ok = false;
         DataFileType dataFileType = DataFileType(lineEdit->property("dataFileType").toInt(&ok));
         if (!ok) {
-            continue;
+            return;
         }
         const QVector<DataFile> dataFiles = m_settings->dataFiles(dataFileType);
         QStringList filenames;
@@ -96,15 +96,21 @@ void MovieSettingsWidget::loadSettings()
             filenames << dataFile.fileName();
         }
         lineEdit->setText(filenames.join(","));
+    };
+    for (auto* lineEdit : findChildren<QLineEdit*>()) {
+        loadLineEdit(lineEdit);
+    }
+    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
+        loadLineEdit(lineEdit);
     }
 }
 
 void MovieSettingsWidget::saveSettings()
 {
     QVector<DataFile> dataFiles;
-    for (QLineEdit* lineEdit : findChildren<QLineEdit*>()) {
+    const auto storeLineEdit = [&dataFiles](auto* lineEdit) {
         if (lineEdit->property("dataFileType").isNull()) {
-            continue;
+            return;
         }
         int pos = 0;
         DataFileType dataFileType = DataFileType(lineEdit->property("dataFileType").toInt());
@@ -113,6 +119,13 @@ void MovieSettingsWidget::saveSettings()
             DataFile df(dataFileType, filename.trimmed(), pos++);
             dataFiles << df;
         }
+    };
+
+    for (auto* lineEdit : findChildren<QLineEdit*>()) {
+        storeLineEdit(lineEdit);
+    }
+    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
+        storeLineEdit(lineEdit);
     }
 
     m_settings->setUsePlotForOutline(ui->usePlotForOutline->isChecked());

--- a/src/ui/settings/MusicSettingsWidget.cpp
+++ b/src/ui/settings/MusicSettingsWidget.cpp
@@ -3,6 +3,7 @@
 
 #include "settings/DataFile.h"
 #include "settings/Settings.h"
+#include "ui/small_widgets/PlaceholderLineEdit.h"
 
 MusicSettingsWidget::MusicSettingsWidget(QWidget* parent) : QWidget(parent), ui(new Ui::MusicSettingsWidget)
 {
@@ -27,9 +28,9 @@ void MusicSettingsWidget::setSettings(Settings& settings)
 
 void MusicSettingsWidget::loadSettings()
 {
-    for (auto* lineEdit : findChildren<QLineEdit*>()) {
+    const auto loadLineEdit = [this](auto* lineEdit) {
         if (lineEdit->property("dataFileType").isNull()) {
-            continue;
+            return;
         }
         DataFileType dataFileType = DataFileType(lineEdit->property("dataFileType").toInt());
         QVector<DataFile> dataFiles = m_settings->dataFiles(dataFileType);
@@ -38,6 +39,12 @@ void MusicSettingsWidget::loadSettings()
             filenames << dataFile.fileName();
         }
         lineEdit->setText(filenames.join(","));
+    };
+    for (auto* lineEdit : findChildren<QLineEdit*>()) {
+        loadLineEdit(lineEdit);
+    }
+    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
+        loadLineEdit(lineEdit);
     }
 
     ui->artistExtraFanarts->setValue(m_settings->extraFanartsMusicArtists());
@@ -46,9 +53,9 @@ void MusicSettingsWidget::loadSettings()
 void MusicSettingsWidget::saveSettings()
 {
     QVector<DataFile> dataFiles;
-    for (QLineEdit* lineEdit : findChildren<QLineEdit*>()) {
+    const auto storeLineEdit = [&dataFiles](auto* lineEdit) {
         if (lineEdit->property("dataFileType").isNull()) {
-            continue;
+            return;
         }
         int pos = 0;
         DataFileType dataFileType = DataFileType(lineEdit->property("dataFileType").toInt());
@@ -57,6 +64,12 @@ void MusicSettingsWidget::saveSettings()
             DataFile df(dataFileType, filename.trimmed(), pos++);
             dataFiles << df;
         }
+    };
+    for (auto* lineEdit : findChildren<QLineEdit*>()) {
+        storeLineEdit(lineEdit);
+    }
+    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
+        storeLineEdit(lineEdit);
     }
 
     m_settings->setExtraFanartsMusicArtists(ui->artistExtraFanarts->value());

--- a/src/ui/settings/SettingsWindow.cpp
+++ b/src/ui/settings/SettingsWindow.cpp
@@ -8,6 +8,7 @@
 #include "settings/DataFile.h"
 #include "settings/Settings.h"
 #include "ui/notifications/NotificationBox.h"
+#include "ui/small_widgets/PlaceholderLineEdit.h"
 
 #include <QAction>
 
@@ -127,9 +128,9 @@ void SettingsWindow::loadSettings()
     ui->concertSettings->loadSettings();
     ui->networkSettings->loadSettings();
 
-    for (auto* lineEdit : findChildren<QLineEdit*>()) {
+    const auto work = [this](auto* lineEdit) {
         if (lineEdit->property("dataFileType").isNull()) {
-            continue;
+            return;
         }
         DataFileType dataFileType = DataFileType(lineEdit->property("dataFileType").toInt());
         QVector<DataFile> dataFiles = m_settings->dataFiles(dataFileType);
@@ -138,15 +139,21 @@ void SettingsWindow::loadSettings()
             filenames << dataFile.fileName();
         }
         lineEdit->setText(filenames.join(","));
+    };
+    for (auto* lineEdit : findChildren<QLineEdit*>()) {
+        work(lineEdit);
+    }
+    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
+        work(lineEdit);
     }
 }
 
 void SettingsWindow::saveSettings()
 {
     QVector<DataFile> dataFiles;
-    for (QLineEdit* lineEdit : findChildren<QLineEdit*>()) {
+    const auto work = [&dataFiles](auto* lineEdit) {
         if (lineEdit->property("dataFileType").isNull()) {
-            continue;
+            return;
         }
         int pos = 0;
         DataFileType dataFileType = DataFileType(lineEdit->property("dataFileType").toInt());
@@ -155,6 +162,12 @@ void SettingsWindow::saveSettings()
             DataFile df(dataFileType, filename.trimmed(), pos++);
             dataFiles << df;
         }
+    };
+    for (auto* lineEdit : findChildren<QLineEdit*>()) {
+        work(lineEdit);
+    }
+    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
+        work(lineEdit);
     }
     m_settings->setDataFiles(dataFiles);
 

--- a/src/ui/settings/TvShowSettingsWidget.cpp
+++ b/src/ui/settings/TvShowSettingsWidget.cpp
@@ -4,6 +4,8 @@
 #include "settings/DataFile.h"
 #include "settings/Settings.h"
 
+#include <QLineEdit>
+
 TvShowSettingsWidget::TvShowSettingsWidget(QWidget* parent) : QWidget(parent), ui(new Ui::TvShowSettingsWidget)
 {
     ui->setupUi(this);
@@ -52,9 +54,9 @@ void TvShowSettingsWidget::setSettings(Settings& settings)
 
 void TvShowSettingsWidget::loadSettings()
 {
-    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
+    const auto loadLineEdit = [this](auto* lineEdit) {
         if (lineEdit->property("dataFileType").isNull()) {
-            continue;
+            return;
         }
         DataFileType dataFileType = DataFileType(lineEdit->property("dataFileType").toInt());
         QVector<DataFile> dataFiles = m_settings->dataFiles(dataFileType);
@@ -63,15 +65,21 @@ void TvShowSettingsWidget::loadSettings()
             filenames << dataFile.fileName();
         }
         lineEdit->setText(filenames.join(","));
+    };
+    for (auto* lineEdit : findChildren<QLineEdit*>()) {
+        loadLineEdit(lineEdit);
+    }
+    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
+        loadLineEdit(lineEdit);
     }
 }
 
 void TvShowSettingsWidget::saveSettings()
 {
     QVector<DataFile> dataFiles;
-    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
+    const auto storeLineEdit = [&dataFiles](auto* lineEdit) {
         if (lineEdit->property("dataFileType").isNull()) {
-            continue;
+            return;
         }
         int pos = 0;
         DataFileType dataFileType = DataFileType(lineEdit->property("dataFileType").toInt());
@@ -80,5 +88,11 @@ void TvShowSettingsWidget::saveSettings()
             DataFile df(dataFileType, filename.trimmed(), pos++);
             dataFiles << df;
         }
+    };
+    for (auto* lineEdit : findChildren<QLineEdit*>()) {
+        storeLineEdit(lineEdit);
+    }
+    for (auto* lineEdit : findChildren<PlaceholderLineEdit*>()) {
+        storeLineEdit(lineEdit);
     }
 }

--- a/src/ui/small_widgets/PlaceholderLineEdit.cpp
+++ b/src/ui/small_widgets/PlaceholderLineEdit.cpp
@@ -53,13 +53,7 @@ void PlaceholderLineEdit::setPlaceholders(const QStringList& placeholders)
 
 void PlaceholderLineEdit::setText(const QString& text)
 {
-    const int index = findText(text);
-    if (index > -1) {
-        setCurrentIndex(index);
-    } else {
-        addItem(text);
-        setCurrentIndex(count() - 1);
-    }
+    setCurrentText(text);
 }
 
 QString PlaceholderLineEdit::text() const


### PR DESCRIPTION
This is a follow up to commit https://github.com/bugwelle/MediaElch/commit/b15d5d2752745ce60f36c3fd87b4b00503f3b6b0.

Because the underlying type changed from QLineEdit to QComboBox,
`findChildren<QLineEdit*>()` failed.  That was an oversight back then.

This effects all settings of MediaElch and is a major bug!
Fix #1448

