### PR TITLE
[Kodi XML] Only write unique id if there is one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
    - Fix rating scraping of TV episodes (#1441)
  - HotMovies: Search and scraping of ratings was fixed
  - Fixed crash if custom movie scraper was used with adult scrapers
+ - Kodi NFO files will only contain `<uniqueid>` if there are valid ones
 
 ### Changes
 

--- a/src/media_centers/kodi/ConcertXmlWriter.cpp
+++ b/src/media_centers/kodi/ConcertXmlWriter.cpp
@@ -34,7 +34,7 @@ QByteArray ConcertXmlWriterGeneric::getConcertXml(bool testMode)
     // v16 id
     xml.writeTextElement("id", m_concert.imdbId().toString());
     // unique id: IMDb and TMDb
-    {
+    if (m_concert.imdbId().isValid()) {
         xml.writeStartElement("uniqueid");
         xml.writeAttribute("type", "imdb");
         xml.writeAttribute("default", "true");

--- a/src/media_centers/kodi/EpisodeXmlWriter.cpp
+++ b/src/media_centers/kodi/EpisodeXmlWriter.cpp
@@ -48,8 +48,9 @@ void EpisodeXmlWriterGeneric::writeSingleEpisodeDetails(QXmlStreamWriter& xml, T
     xml.writeTextElement("showtitle", episode->showTitle());
 
     // unique id: IMDb and TMDb
-    // one uniqueid is required
-    {
+    // TODO: one uniqueid is required; we don't check that at the moment
+    // Empty default unique ID is not valid in Kodi.
+    if (episode->tvdbId().isValid()) {
         xml.writeStartElement("uniqueid");
         xml.writeAttribute("type", "tvdb");
         xml.writeAttribute("default", "true");

--- a/src/media_centers/kodi/MovieXmlWriter.cpp
+++ b/src/media_centers/kodi/MovieXmlWriter.cpp
@@ -78,7 +78,7 @@ QByteArray MovieXmlWriterGeneric::getMovieXml(bool testMode)
     // id
     xml.writeTextElement("id", m_movie.imdbId().toString());
     // unique id: IMDb and TMDb
-    {
+    if (m_movie.imdbId().isValid()) {
         xml.writeStartElement("uniqueid");
         xml.writeAttribute("default", "true");
         xml.writeAttribute("type", "imdb");


### PR DESCRIPTION
Kodi can't handle empty `uniqueid`s.