### PR TITLE
[TmdbApi] Use "aggregate_credits" call for shows, Prevent invalid actor profile URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
  - HotMovies: Search and scraping of ratings was fixed
  - Fixed crash if custom movie scraper was used with adult scrapers
  - Kodi NFO files will only contain `<uniqueid>` if there are valid ones
+ - TMDb TV now scrapes the full cast of a TV show instead of only the last season's (#1454)
 
 ### Changes
 

--- a/src/scrapers/tmdb/TmdbApi.cpp
+++ b/src/scrapers/tmdb/TmdbApi.cpp
@@ -180,7 +180,7 @@ QUrl TmdbApi::getShowUrl(const TmdbId& id, const Locale& locale, bool onlyBasicD
     QUrlQuery queries;
     if (!onlyBasicDetails) {
         // Instead of multiple HTTP requests, use just one for everything.
-        queries.addQueryItem("append_to_response", "content_ratings,keywords,external_ids,images,credits");
+        queries.addQueryItem("append_to_response", "content_ratings,keywords,external_ids,images,aggregate_credits");
     }
     return makeApiUrl(QStringLiteral("/tv/") + id.toString(), locale, queries);
 }

--- a/src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp
+++ b/src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp
@@ -190,7 +190,11 @@ void TmdbTvShowParser::parseInfos(const QJsonDocument& json, const Locale& local
             actor.name = actorObj["name"].toString();
             actor.role = roles.join(", ");
             actor.id = QString::number(actorObj["id"].toInt());
-            actor.thumb = m_api.makeImageUrl(actorObj["profile_path"].toString()).toString();
+
+            if (!actorObj["profile_path"].isNull()) {
+                actor.thumb = m_api.makeImageUrl(actorObj["profile_path"].toString()).toString();
+            }
+            
             m_show.addActor(actor);
         }
     }

--- a/src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp
+++ b/src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp
@@ -175,14 +175,20 @@ void TmdbTvShowParser::parseInfos(const QJsonDocument& json, const Locale& local
 
     // -------------------------------------
     {
-        const QJsonObject credits = data["credits"].toObject();
+        const QJsonObject credits = data["aggregate_credits"].toObject();
         QJsonArray cast = credits["cast"].toArray();
 
         for (QJsonValueRef val : cast) {
             QJsonObject actorObj = val.toObject();
+
+            QStringList roles;
+            for (QJsonValueRef role : actorObj["roles"].toArray()) {
+                roles.append(role.toObject()["character"].toString());
+            }
+
             Actor actor;
             actor.name = actorObj["name"].toString();
-            actor.role = actorObj["character"].toString();
+            actor.role = roles.join(", ");
             actor.id = QString::number(actorObj["id"].toInt());
             actor.thumb = m_api.makeImageUrl(actorObj["profile_path"].toString()).toString();
             m_show.addActor(actor);


### PR DESCRIPTION
Hello,

please excuse if this PR should have been a discussion issue first, I am hoping this way it is easiest to see what I am trying to achieve.

I noticed that an actor was missing from the metadata of a tv show scraped by MediaElch using Tmdb.
The show in this case was one of the main characters in Stargate SG1 (https://www.themoviedb.org/tv/4629-stargate-sg-1).
On the web "Richard Dean Anderson - Jack O'Neill" is listed first, but he was missing from the saved metadata.

An investigation showed that the "credits" API call defaults to the cast of the last season of a show. Some time later an "aggregate_credits" call has been added that returns the full cast more alike it is shown on the website.

I would like to switch to this call as to me it seems unexpected to be limited to the last season (which in this case omitted a main character of the overall show).
Apologies if this has been discussed before, I did not find mentions of these calls. What is your opinion on this change?

I also noticed that "profile_path" can be null (in both endpoints), in this case an incomplete/invalid thumb-URL would be saved.

Best regards,
Philipp