### PR TITLE
[NetworkManager] Explicitly use applicationProxy() in enabledefaultProxy()

### DIFF
--- a/src/network/NetworkManager.cpp
+++ b/src/network/NetworkManager.cpp
@@ -23,7 +23,7 @@ void NetworkManager::disableProxy()
 
 void NetworkManager::enableDefaultProxy()
 {
-    m_qnam.setProxy(QNetworkProxy::DefaultProxy);
+    m_qnam.setProxy(QNetworkProxy::applicationProxy());
 }
 
 QNetworkReply* NetworkManager::get(const QNetworkRequest& request)

--- a/src/ui/media_centers/KodiSync.cpp
+++ b/src/ui/media_centers/KodiSync.cpp
@@ -713,25 +713,25 @@ QStringList KodiSync::splitFile(const QString& file)
 
 void KodiSync::onRadioContents()
 {
-    ui->labelContents->setVisible(true);
-    ui->labelWatched->setVisible(false);
-    ui->labelClean->setVisible(false);
+    ui->lblContents->setVisible(true);
+    ui->lblWatched->setVisible(false);
+    ui->lblClean->setVisible(false);
     m_syncType = SyncType::Contents;
 }
 
 void KodiSync::onRadioClean()
 {
-    ui->labelContents->setVisible(false);
-    ui->labelWatched->setVisible(false);
-    ui->labelClean->setVisible(true);
+    ui->lblContents->setVisible(false);
+    ui->lblWatched->setVisible(false);
+    ui->lblClean->setVisible(true);
     m_syncType = SyncType::Clean;
 }
 
 void KodiSync::onRadioWatched()
 {
-    ui->labelContents->setVisible(false);
-    ui->labelWatched->setVisible(true);
-    ui->labelClean->setVisible(false);
+    ui->lblContents->setVisible(false);
+    ui->lblWatched->setVisible(true);
+    ui->lblClean->setVisible(false);
     m_syncType = SyncType::Watched;
 }
 

--- a/src/ui/media_centers/KodiSync.ui
+++ b/src/ui/media_centers/KodiSync.ui
@@ -10,8 +10,14 @@
     <x>0</x>
     <y>0</y>
     <width>680</width>
-    <height>400</height>
+    <height>420</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Kodi Synchronization</string>
@@ -21,7 +27,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="label_5">
+    <widget class="QLabel" name="lblIntro">
      <property name="text">
       <string>Please make sure you have setup your sources in Kodi and that the webserver is enabled (Kodi -&gt; Settings -&gt; Services -&gt; Webserver).</string>
      </property>
@@ -41,7 +47,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="labelContents">
+    <widget class="QLabel" name="lblContents">
      <property name="text">
       <string>This will tell Kodi to remove the changed movies, concerts or shows. Afterwards a Kodi library update is triggered and the removed items will be picked up again.</string>
      </property>
@@ -58,7 +64,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="labelClean">
+    <widget class="QLabel" name="lblClean">
      <property name="text">
       <string>Kodi will remove not longer existing items from your database.</string>
      </property>
@@ -72,7 +78,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="labelWatched">
+    <widget class="QLabel" name="lblWatched">
      <property name="text">
       <string>The fields last played and playcount will be retrieved from Kodi.</string>
      </property>
@@ -88,16 +94,16 @@
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>20</width>
-       <height>40</height>
+       <width>0</width>
+       <height>0</height>
       </size>
      </property>
     </spacer>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
+    <layout class="QHBoxLayout" name="laytouStatus" stretch="0,1">
      <item>
-      <widget class="QLabel" name="label_4">
+      <widget class="QLabel" name="lblStatus">
        <property name="font">
         <font>
          <bold>true</bold>
@@ -125,7 +131,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="layoutButtons">
      <item>
       <widget class="QPushButton" name="buttonClose">
        <property name="text">

--- a/src/ui/media_centers/KodiSync.ui
+++ b/src/ui/media_centers/KodiSync.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>667</width>
-    <height>361</height>
+    <width>680</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -100,7 +100,6 @@
       <widget class="QLabel" name="label_4">
        <property name="font">
         <font>
-         <weight>75</weight>
          <bold>true</bold>
         </font>
        </property>


### PR DESCRIPTION
For #1446

-----

The documentation of Qt is clear.  I thought that `DefaultProxy` uses,
well, the default proxy, i.e. applicationProxy().  That seems not to be
the case.