### PR TITLE
fix(ImageDialog): Clear pointer after call to deleteLater()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
  - Fixed crash if custom movie scraper was used with adult scrapers
  - Kodi NFO files will only contain `<uniqueid>` if there are valid ones
  - TMDb TV now scrapes the full cast of a TV show instead of only the last season's (#1454)
+ - A crash in the image dialog was fixed
 
 ### Changes
 

--- a/src/ui/image/ImageDialog.cpp
+++ b/src/ui/image/ImageDialog.cpp
@@ -326,10 +326,16 @@ void ImageDialog::startNextDownload()
 
 void ImageDialog::downloadFinished()
 {
+    if (m_currentDownloadReply == nullptr) {
+        // In case that the dialog was cancelled, the pointer resetted, and
+        // this signal handler is still reached.
+        return;
+    }
     if (m_currentDownloadReply->error() == QNetworkReply::OperationCanceledError) {
         // It is possible that m_elements has been cleared by aborting all downloads
         // via abort() or close().
         m_currentDownloadReply->deleteLater();
+        m_currentDownloadReply = nullptr;
         return;
     }
 
@@ -357,6 +363,7 @@ void ImageDialog::downloadFinished()
     }
 
     m_currentDownloadReply->deleteLater();
+    m_currentDownloadReply = nullptr;
     startNextDownload();
 }
 
@@ -500,6 +507,8 @@ void ImageDialog::cancelDownloads()
         m_currentDownloadReply->abort();
     }
 
+    m_currentDownloadIndex = 0;
+    m_currentDownloadReply = nullptr;
     m_elements.clear();
 }
 


### PR DESCRIPTION
This (hopefully) fixes a use after free bug, where `m_currentDownloadReply->abort()` was called after `m_currentDownloadReply` was deleted.  This went undetected, because `deleteLater()` does not clear the pointer (only if `QPointer<>` were to be used).

Maybe we should use QPointer here, but that's for another commit.


------------

For https://github.com/Komet/MediaElch/issues/1475