### PR TITLE
refactor: Move different file filters into FileFilter class

### DIFF
--- a/src/file_search/MusicFileSearcher.cpp
+++ b/src/file_search/MusicFileSearcher.cpp
@@ -17,9 +17,10 @@ MusicFileSearcher::MusicFileSearcher(QObject* parent) :
 
 void MusicFileSearcher::setMusicDirectories(QVector<mediaelch::MediaDirectory> directories)
 {
+    const auto& filter = Settings::instance()->advanced()->musicFilters();
     m_directories.clear();
     for (const mediaelch::MediaDirectory& dir : directories) {
-        if (Settings::instance()->advanced()->isFolderExcluded(dir.path.dirName())) {
+        if (filter.isFolderExcluded(dir.path.dirName())) {
             qCWarning(generic) << "[MusicFileSearcher] Music directory is excluded by advanced settings! "
                                   "Is this intended? Directory:"
                                << dir.path.path();
@@ -42,6 +43,8 @@ void MusicFileSearcher::reload(bool force)
 
     emit searchStarted(tr("Searching for Music..."));
     Manager::instance()->musicModel()->clear();
+
+    const auto& filter = Settings::instance()->advanced()->musicFilters();
 
     QVector<Artist*> artists;
     QVector<Artist*> artistsFromDb;
@@ -75,7 +78,7 @@ void MusicFileSearcher::reload(bool force)
 
                 it.next();
 
-                if (Settings::instance()->advanced()->isFolderExcluded(it.fileInfo().dir().dirName())) {
+                if (filter.isFolderExcluded(it.fileInfo().dir().dirName())) {
                     continue;
                 }
 
@@ -89,7 +92,7 @@ void MusicFileSearcher::reload(bool force)
                 while (itAlbums.hasNext()) {
                     itAlbums.next();
 
-                    if (Settings::instance()->advanced()->isFolderExcluded(itAlbums.fileInfo().dir().dirName())) {
+                    if (filter.isFolderExcluded(itAlbums.fileInfo().dir().dirName())) {
                         continue;
                     }
 

--- a/src/file_search/TvShowFileSearcher.cpp
+++ b/src/file_search/TvShowFileSearcher.cpp
@@ -21,9 +21,10 @@ TvShowFileSearcher::TvShowFileSearcher(QObject* parent) :
 
 void TvShowFileSearcher::setTvShowDirectories(QVector<mediaelch::MediaDirectory> directories)
 {
+    const auto& filter = Settings::instance()->advanced()->tvShowFilters();
     m_directories.clear();
     for (auto& dir : directories) {
-        if (Settings::instance()->advanced()->isFolderExcluded(dir.path.dirName())) {
+        if (filter.isFolderExcluded(dir.path.dirName())) {
             qCWarning(generic) << "[TvShowFileSearcher] TV show directory is excluded by advanced settings! "
                                   "Is this intended? Directory:"
                                << dir.path.path();
@@ -169,6 +170,7 @@ TvShowEpisode* TvShowFileSearcher::reloadEpisodeData(TvShowEpisode* episode)
  */
 void TvShowFileSearcher::getTvShows(const mediaelch::DirectoryPath& path, QMap<QString, QVector<QStringList>>& contents)
 {
+    const auto& filter = Settings::instance()->advanced()->tvShowFilters();
     QDir dir(path.toString());
     QStringList tvShows = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
     for (const QString& cDir : tvShows) {
@@ -176,7 +178,7 @@ void TvShowFileSearcher::getTvShows(const mediaelch::DirectoryPath& path, QMap<Q
             return;
         }
 
-        if (Settings::instance()->advanced()->isFolderExcluded(cDir)) {
+        if (filter.isFolderExcluded(cDir)) {
             continue;
         }
 
@@ -198,6 +200,7 @@ void TvShowFileSearcher::scanTvShowDir(const mediaelch::DirectoryPath& startPath
     QVector<QStringList>& contents)
 {
     emit currentDir(path.toString().mid(startPath.toString().length()));
+    const auto& filter = Settings::instance()->advanced()->tvShowFilters();
 
     QDir dir(path.toString());
     for (const QString& cDir : dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot)) {
@@ -205,7 +208,7 @@ void TvShowFileSearcher::scanTvShowDir(const mediaelch::DirectoryPath& startPath
             return;
         }
 
-        if (Settings::instance()->advanced()->isFolderExcluded(cDir)) {
+        if (filter.isFolderExcluded(cDir)) {
             continue;
         }
 
@@ -237,7 +240,7 @@ void TvShowFileSearcher::scanTvShowDir(const mediaelch::DirectoryPath& startPath
     QStringList files;
     QStringList entries = getFiles(path);
     for (const QString& file : entries) {
-        if (Settings::instance()->advanced()->isFileExcluded(file)) {
+        if (filter.isFileExcluded(file)) {
             continue;
         }
         // Skip Trailers and Sample files
@@ -286,7 +289,9 @@ void TvShowFileSearcher::scanTvShowDir(const mediaelch::DirectoryPath& startPath
 /// Get a list of files in a directory
 QStringList TvShowFileSearcher::getFiles(const mediaelch::DirectoryPath& path)
 {
-    return Settings::instance()->advanced()->tvShowFilters().files(QDir(path.toString()));
+    const auto& fileFilter = Settings::instance()->advanced()->tvShowFilters();
+    QDir dir(path.dir());
+    return dir.entryList(fileFilter.fileGlob, QDir::Files | QDir::System);
 }
 
 void TvShowFileSearcher::abort()

--- a/src/file_search/movie/MovieDirScan.cpp
+++ b/src/file_search/movie/MovieDirScan.cpp
@@ -1,6 +1,7 @@
 #include "MovieDirScan.h"
 
 #include "globals/Helper.h"
+#include "media/FileFilter.h"
 #include "settings/Settings.h"
 
 #include <QApplication>
@@ -14,6 +15,7 @@ void MovieDirScan::scanDir(QString startPath,
     bool separateFolders,
     bool firstScan)
 {
+    const auto& filter = Settings::instance()->advanced()->movieFilters();
     m_aborted = false;
 
     emit currentDir(path.mid(startPath.length()));
@@ -24,7 +26,7 @@ void MovieDirScan::scanDir(QString startPath,
             return;
         }
 
-        if (Settings::instance()->advanced()->isFolderExcluded(cDir)) {
+        if (filter.isFolderExcluded(cDir)) {
             continue;
         }
 
@@ -61,7 +63,7 @@ void MovieDirScan::scanDir(QString startPath,
             return;
         }
 
-        if (Settings::instance()->advanced()->isFileExcluded(file)) {
+        if (filter.isFileExcluded(file)) {
             continue;
         }
 
@@ -136,13 +138,12 @@ void MovieDirScan::abort()
 
 QStringList MovieDirScan::getFiles(QString path)
 {
-    const auto& filters = Settings::instance()->advanced()->movieFilters();
-    QStringList files;
-
-    for (const QString& file : filters.files(QDir(path))) {
+    QDir dir(path);
+    const auto& filter = Settings::instance()->advanced()->movieFilters();
+    QStringList files = dir.entryList(filter.fileGlob, QDir::Files | QDir::System);
+    for (const QString& file : files) {
         m_lastModifications.insert(
             QDir::toNativeSeparators(path + "/" + file), QFileInfo(path + QDir::separator() + file).lastModified());
-        files.append(file);
     }
     return files;
 }

--- a/src/file_search/movie/MovieDirectorySearcher.cpp
+++ b/src/file_search/movie/MovieDirectorySearcher.cpp
@@ -87,8 +87,8 @@ void MovieDiskLoader::doStart()
     qCInfo(c_movie) << "[Movie] Scanning directory:" << QDir::toNativeSeparators(m_dir.path.path());
 
     // No filter, no media files...
-    if (!m_filter.hasFilter()) {
-        qCCritical(c_movie) << "[Movie] Can't scan for movies because there is no movie file filter!";
+    if (!m_filter.hasValidFilters()) {
+        qCCritical(c_movie) << "[Movie] Can't scan for movies because there is no valid movie file filter!";
         if (!isAborted()) {
             emitFinished();
         }
@@ -133,7 +133,7 @@ bool MovieDiskLoader::doKill()
 void MovieDiskLoader::loadMovieContents()
 {
     QDirIterator it(m_dir.path.path(),
-        m_filter.filters(),
+        m_filter.fileGlob,
         QDir::NoDotAndDotDot | QDir::Dirs | QDir::Files,
         QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
 
@@ -152,14 +152,13 @@ void MovieDiskLoader::loadMovieContents()
         const bool isDir = it.fileInfo().isDir();
         bool isSpecialDir = false; // set to true for DVD or BluRay Structure
 
-        if (isFile && Settings::instance()->advanced()->isFileExcluded(fileName)) {
+        if (isFile && m_filter.isFileExcluded(fileName)) {
             continue;
         }
 
         // TODO: If there is a BluRay structure then the directory filter may not work
         // because BDMV's parent directory is not listed.
-        if ((isDir && Settings::instance()->advanced()->isFolderExcluded(fileName))
-            || Settings::instance()->advanced()->isFolderExcluded(dirName)) {
+        if ((isDir && m_filter.isFolderExcluded(fileName)) || m_filter.isFolderExcluded(dirName)) {
             continue;
         }
 

--- a/src/file_search/movie/MovieFileSearcher.cpp
+++ b/src/file_search/movie/MovieFileSearcher.cpp
@@ -25,10 +25,10 @@ MovieFileSearcher::MovieFileSearcher(QObject* parent) : QObject(parent), m_store
 void MovieFileSearcher::setMovieDirectories(const QVector<mediaelch::MediaDirectory>& directories)
 {
     abort(true);
-
+    const auto& filter = Settings::instance()->advanced()->movieFilters();
     m_directories.clear();
     for (const auto& dir : directories) {
-        if (Settings::instance()->advanced()->isFolderExcluded(dir.path.dirName())) {
+        if (filter.isFolderExcluded(dir.path.dirName())) {
             qCWarning(c_movie) << "[Movies] Movie directory is excluded by advanced settings:" << dir.path;
             continue;
         }

--- a/src/import/DownloadFileSearcher.cpp
+++ b/src/import/DownloadFileSearcher.cpp
@@ -107,9 +107,9 @@ bool DownloadFileSearcher::isPackage(const QFileInfo& file) const
 bool DownloadFileSearcher::isImportable(const QFileInfo& file) const
 {
     QStringList filters;
-    filters << Settings::instance()->advanced()->movieFilters().filters();
-    filters << Settings::instance()->advanced()->tvShowFilters().filters();
-    filters << Settings::instance()->advanced()->concertFilters().filters();
+    filters << Settings::instance()->advanced()->movieFilters().fileGlob;
+    filters << Settings::instance()->advanced()->tvShowFilters().fileGlob;
+    filters << Settings::instance()->advanced()->concertFilters().fileGlob;
     filters.removeDuplicates();
 
     for (const QString& filter : asConst(filters)) {
@@ -131,7 +131,7 @@ bool DownloadFileSearcher::isImportable(const QFileInfo& file) const
 
 bool DownloadFileSearcher::isSubtitle(const QFileInfo& file) const
 {
-    const QStringList filters = Settings::instance()->advanced()->subtitleFilters().filters();
+    const QStringList filters = Settings::instance()->advanced()->subtitleFilters().fileGlob;
     for (const QString& filter : filters) {
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
         QRegExp rx(filter);

--- a/src/media/FileFilter.cpp
+++ b/src/media/FileFilter.cpp
@@ -2,22 +2,25 @@
 
 namespace mediaelch {
 
-QStringList FileFilter::files(QDir directory) const
+bool FileFilter::isFileExcluded(const QString& filename) const
 {
-    if (m_filters.isEmpty() || !directory.exists()) {
-        return {};
+    for (const QRegularExpression& rx : fileExcludes) {
+        if (rx.isValid() && rx.match(filename).hasMatch()) {
+            return true;
+        }
     }
-    return directory.entryList(m_filters, QDir::Files | QDir::System);
+    return false;
 }
 
-bool FileFilter::hasFilter() const
+bool FileFilter::isFolderExcluded(const QString& folder) const
 {
-    return !m_filters.isEmpty();
+    for (const QRegularExpression& rx : folderExcludes) {
+        if (rx.isValid() && rx.match(folder).hasMatch()) {
+            return true;
+        }
+    }
+    return false;
 }
 
-QStringList FileFilter::filters() const
-{
-    return m_filters;
-}
 
 } // namespace mediaelch

--- a/src/media/FileFilter.h
+++ b/src/media/FileFilter.h
@@ -1,23 +1,30 @@
 #pragma once
 
-#include <QDir>
+#include <QRegularExpression>
 #include <QString>
 #include <QStringList>
+#include <QVector>
 
 namespace mediaelch {
 
+/// \brief Filter which files should be used and which ignored.
+/// \details Qt's QDir::entryList supports a positive filter list such as *.mp3, etc.
+///          This class does exactly that.  Filter what's allowed and what not.
 class FileFilter
 {
 public:
     FileFilter() = default;
-    explicit FileFilter(QStringList filters) : m_filters(std::move(filters)) {}
+    explicit FileFilter(QStringList filenameGlob) : fileGlob(std::move(filenameGlob)) {}
 
-    QStringList files(QDir directory) const;
-    bool hasFilter() const;
-    QStringList filters() const;
+    bool hasValidFilters() const { return !fileGlob.isEmpty(); }
 
-private:
-    QStringList m_filters;
+    bool isFileExcluded(const QString& filename) const;
+    bool isFolderExcluded(const QString& folder) const;
+
+public:
+    QStringList fileGlob = {{"*"}};
+    QVector<QRegularExpression> fileExcludes;
+    QVector<QRegularExpression> folderExcludes;
 };
 
 } // namespace mediaelch

--- a/src/renamer/ConcertRenamer.cpp
+++ b/src/renamer/ConcertRenamer.cpp
@@ -90,7 +90,7 @@ ConcertRenamer::RenameError ConcertRenamer::renameConcert(Concert& concert)
                 }
 
                 QStringList filters;
-                for (const QString& extra : m_extraFiles.filters()) {
+                for (const QString& extra : m_extraFiles.fileGlob) {
                     filters << baseName + extra;
                 }
                 for (const QString& subFileName : currentDir.entryList(filters, QDir::Files | QDir::NoDotAndDotDot)) {

--- a/src/renamer/EpisodeRenamer.cpp
+++ b/src/renamer/EpisodeRenamer.cpp
@@ -109,7 +109,7 @@ EpisodeRenamer::RenameError EpisodeRenamer::renameEpisode(TvShowEpisode& episode
                 }
 
                 QStringList filters;
-                for (const QString& extra : m_extraFiles.filters()) {
+                for (const QString& extra : m_extraFiles.fileGlob) {
                     filters << baseName + extra;
                 }
                 for (const QString& subFileName : currentDir.entryList(filters, QDir::Files | QDir::NoDotAndDotDot)) {

--- a/src/settings/AdvancedSettings.h
+++ b/src/settings/AdvancedSettings.h
@@ -1,74 +1,17 @@
 #pragma once
 
 #include "data/ThumbnailDimensions.h"
-#include "globals/Globals.h"
-#include "log/Log.h"
 #include "media/FileFilter.h"
 
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QHash>
+#include <QLocale>
 #include <QRegularExpression>
 #include <QString>
 #include <QStringList>
 #include <QVector>
-
-class FileSearchExclude
-{
-public:
-    static FileSearchExclude excludeFilePattern(QRegularExpression regex)
-    {
-        return FileSearchExclude(ExcludeType::File, regex);
-    }
-    static FileSearchExclude excludeFolderPattern(QRegularExpression regex)
-    {
-        return FileSearchExclude(ExcludeType::Folder, regex);
-    }
-
-    FileSearchExclude() = default; // required for QVector
-
-    bool matchFilename(QString filename) const
-    {
-        if (m_type == ExcludeType::File) {
-            return m_regex.isValid() && m_regex.match(filename).hasMatch();
-        }
-        return false;
-    }
-
-    bool matchFoldername(QString folder) const
-    {
-        if (m_type == ExcludeType::Folder) {
-            return m_regex.isValid() && m_regex.match(folder).hasMatch();
-        }
-        return false;
-    }
-
-    QString toString() const { return excludeTypeToString(m_type) + ": " + m_regex.pattern(); }
-
-private:
-    enum class ExcludeType
-    {
-        File,
-        Folder
-    };
-
-    QString excludeTypeToString(ExcludeType type) const
-    {
-        switch (type) {
-        case ExcludeType::File: return "file";
-        case ExcludeType::Folder: return "folder";
-        }
-        qCCritical(generic) << "[ExcludeType] Unhandled switch/case";
-        return "";
-    }
-
-    FileSearchExclude(ExcludeType type, QRegularExpression regex) : m_type{type}, m_regex{regex} {}
-
-private:
-    ExcludeType m_type = ExcludeType::File;
-    QRegularExpression m_regex;
-};
 
 class AdvancedSettings
 {
@@ -85,6 +28,7 @@ public:
     const mediaelch::FileFilter& movieFilters() const;
     const mediaelch::FileFilter& concertFilters() const;
     const mediaelch::FileFilter& tvShowFilters() const;
+    const mediaelch::FileFilter& musicFilters() const;
     const mediaelch::FileFilter& subtitleFilters() const;
 
     QHash<QString, QString> audioCodecMappings() const;
@@ -99,9 +43,6 @@ public:
     int bookletCut() const;
     bool writeThumbUrlsToNfo() const;
     mediaelch::ThumbnailDimensions episodeThumbnailDimensions() const;
-
-    bool isFileExcluded(QString file) const;
-    bool isFolderExcluded(QString dir) const;
 
     /// \brief Returns true if the user has provided a custom advancedsettings.xml
     ///        "false" if default values are used.
@@ -124,13 +65,15 @@ private:
     mediaelch::FileFilter m_concertFilters;
     mediaelch::FileFilter m_tvShowFilters;
     mediaelch::FileFilter m_subtitleFilters;
+    mediaelch::FileFilter m_musicFilters;
     QHash<QString, QString> m_audioCodecMappings;
     QHash<QString, QString> m_videoCodecMappings;
     QHash<QString, QString> m_certificationMappings;
     QHash<QString, QString> m_studioMappings;
     QHash<QString, QString> m_countryMappings;
     mediaelch::ThumbnailDimensions m_episodeThumbnailDimensions;
-    QVector<FileSearchExclude> m_excludePatterns;
+    QVector<QRegularExpression> m_fileExcludes;
+    QVector<QRegularExpression> m_folderExcludes;
     bool m_forceCache = false;
     bool m_portableMode = false;
     int m_bookletCut = 2;

--- a/src/settings/AdvancedSettingsXmlReader.cpp
+++ b/src/settings/AdvancedSettingsXmlReader.cpp
@@ -158,6 +158,20 @@ void AdvancedSettingsXmlReader::parseSettings(const QString& xmlSource)
             skipUnsupportedTag();
         }
     }
+
+    // Proper setup of file filters: m_fileExcludes / m_folderExcludes may be
+    // used generically, but in the end, we have different file filters.
+    m_settings.m_movieFilters.fileExcludes = m_settings.m_fileExcludes;
+    m_settings.m_concertFilters.fileExcludes = m_settings.m_fileExcludes;
+    m_settings.m_tvShowFilters.fileExcludes = m_settings.m_fileExcludes;
+    m_settings.m_musicFilters.fileExcludes = m_settings.m_fileExcludes;
+    m_settings.m_subtitleFilters.fileExcludes = m_settings.m_fileExcludes;
+
+    m_settings.m_movieFilters.folderExcludes = m_settings.m_folderExcludes;
+    m_settings.m_concertFilters.folderExcludes = m_settings.m_folderExcludes;
+    m_settings.m_tvShowFilters.folderExcludes = m_settings.m_folderExcludes;
+    m_settings.m_musicFilters.folderExcludes = m_settings.m_folderExcludes;
+    m_settings.m_subtitleFilters.folderExcludes = m_settings.m_folderExcludes;
 }
 
 void AdvancedSettingsXmlReader::loadLog()
@@ -255,6 +269,7 @@ void AdvancedSettingsXmlReader::loadExcludePatterns()
     while (m_xml.readNextStartElement()) {
         if (m_xml.name() == QLatin1String("pattern")) {
             QString applyTo = m_xml.attributes().value("applyTo").toString();
+            // TODO: Sanitize input string
             QRegularExpression pattern(m_xml.readElementText().trimmed());
             if (!pattern.isValid()) {
                 qCCritical(generic) << "[AdvancedSettings] Invalid regular expression! Message:"
@@ -265,9 +280,9 @@ void AdvancedSettingsXmlReader::loadExcludePatterns()
             pattern.optimize();
 
             if (applyTo == "filename") {
-                m_settings.m_excludePatterns << FileSearchExclude::excludeFilePattern(pattern);
+                m_settings.m_fileExcludes << pattern;
             } else if (applyTo == "folders") {
-                m_settings.m_excludePatterns << FileSearchExclude::excludeFolderPattern(pattern);
+                m_settings.m_folderExcludes << pattern;
             } else {
                 qCWarning(generic) << "[AdvancedSettings] Unknown value for 'applyTo' attribute of <pattern> element at"
                                    << currentLocation();


### PR DESCRIPTION
The FileFilter class was only used for filtering directories using QDir's filter functionality.  That's only used as a positive glob filter.  But we also have file name and directory name filters.  Those are now also part of it.  Furthermore, rename some methods to make it more clear what they are, e.g. "filter" is too generic.  Is it a positive or negative filter? What does it filter?