### PR TITLE
fix(UI): Explicitly set default font size to what it already is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
  - macOS: CMD+R now correctly triggers a reload.
  - IMDb: TV show runtimes are scraped correctly again.
+ - UI: Incorrectly scaled tables on HighDPI display now work with Qt6.
 
 ### Changes
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,6 +138,10 @@ int main(int argc, char* argv[])
     initLogFile();
     loadStylesheet(app, Settings::instance()->advanced()->customStylesheet());
 
+    // Set the current font again. Workaround for #1502.
+    QFont font = app.font();
+    app.setFont(font);
+
     MainWindow window;
     window.show();
     int ret = QApplication::exec();

--- a/src/ui/UiUtils.cpp
+++ b/src/ui/UiUtils.cpp
@@ -173,7 +173,7 @@ void applyStyle(QWidget* widget, bool removeFocus, bool /*isTable*/)
 #ifdef Q_OS_MAC
         font.setPointSize(13);
 #else
-        font.setPixelSize(12);
+        font.setPointSize(12);
 #endif
         font.setWeight(QFont::DemiBold);
         tabWidget->setFont(font);

--- a/src/ui/main/MyIconFont.cpp
+++ b/src/ui/main/MyIconFont.cpp
@@ -510,6 +510,6 @@ void MyIconFont::give(const QString& name, MyIconFontIconPainter* painter)
 QFont MyIconFont::font(int size)
 {
     QFont font(fontName_);
-    font.setPixelSize(size);
+    font.setPointSize(size);
     return font;
 }

--- a/src/ui/small_widgets/Badge.cpp
+++ b/src/ui/small_widgets/Badge.cpp
@@ -35,7 +35,7 @@ void Badge::paintEvent(QPaintEvent* event)
 
         p.setPen(QColor(255, 255, 255));
         QFont font;
-        font.setPixelSize(8);
+        font.setPointSize(8);
         p.setFont(font);
         p.drawText(width() - 12, 0, 12, height() - 1, Qt::AlignVCenter, "x");
         p.restore();


### PR DESCRIPTION
By settings the font size explicitly to what it already is, we get rid
of Windows scaling issues on HighDPI screens with scaling > 100%.

Fixes #1502 