### PR TITLE
fix(DownloadManager): Register meta types for `Movie`/etc for signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
  - IMDb: TV show runtimes are scraped correctly again.
  - UI: Incorrectly scaled tables on HighDPI display now work with Qt6.
  - Multi-Movie Scraper: If using TheMovieDb, scraping could get stuck and not continue (#1505)
+ - TV Show Scraper: The "Downloading images..." dialog was not removed when finished (#1507)
 
 ### Changes
 

--- a/src/utils/Meta.cpp
+++ b/src/utils/Meta.cpp
@@ -1,8 +1,12 @@
 #include "utils/Meta.h"
 
+#include "data/concert/Concert.h"
 #include "data/Image.h"
+#include "data/movie/Movie.h"
 #include "data/music/Album.h"
 #include "data/music/Artist.h"
+#include "data/tv_show/TvShow.h"
+#include "data/tv_show/TvShowEpisode.h"
 #include "model/ImageModel.h"
 #include "model/ImageProxyModel.h"
 #include "model/music/MusicModelItem.h"
@@ -17,4 +21,9 @@ void registerAllMetaTypes()
     qRegisterMetaType<Album*>("Album*");
     qRegisterMetaType<Artist*>("Artist*");
     qRegisterMetaType<MusicModelItem*>("MusicModelItem*");
+    // Required e.g. for DonloadManager
+    qRegisterMetaType<Movie*>("Movie*");
+    qRegisterMetaType<TvShow*>("TvShow*");
+    qRegisterMetaType<TvShowEpisode*>("TvShowEpisode*");
+    qRegisterMetaType<Concert*>("Concert*");
 }


### PR DESCRIPTION
Signals "allMovieDownloadsFinished", etc. are queued in some widgets. Because of that, the meta types "TvShow*", etc. need to be registered. That was not yet the case and the "Downloading Images..." dialog was never removed.

----


Fix  #1507