### PR TITLE
fix(FileLoader): Fix use-after-free in `onDirectoryLoaded(MovieLoader*)`

### DIFF
--- a/src/file_search/movie/MovieDirectorySearcher.cpp
+++ b/src/file_search/movie/MovieDirectorySearcher.cpp
@@ -458,7 +458,7 @@ QThread* createAutoDeleteThreadWithMovieLoader(MovieLoader* worker, QObject* thr
 
     // Startup & delete setup
     QObject::connect(thread, &QThread::started, worker, &MovieLoader::start);
-    QObject::connect(worker, &MovieLoader::finished, thread, &QThread::quit);
+    QObject::connect(worker, &MovieLoader::destroyed, thread, &QThread::quit);
     QObject::connect(thread, &QThread::finished, thread, &QThread::deleteLater);
     return thread;
 }


### PR DESCRIPTION
A recently regularly reported bug was that the "loading files" dialog did not disappear and movies were not loaded.  Few even reported crashes.  I was not able to reproduce this issue for a long time, so didn't get to debug it.

The reason the dialog was stuck was that the `MovieLoader*` object was destroyed in its thread before it was used in the main thread. That happened for two reasons: `MovieLoader::finished` was connected to `QThread::quit` which in turn deleted the thread.  Deleting the thread also deleted the `MovieLoader` object.
Secondly, calling `job->deleteLater()` from the main thread enqueues the object for deletion in the worker thread.  Using `job` after that was never safe.

The coding got that way because calling `deleteLater()` early is a pattern I use: The object gets deleted only after the function has run, because normally we only return to the event queue after the function was executed.  But that isn't the case for multi-threading.

We fix this by (1) calling `deleteLater()` after the job was used and (2) only quit the thread after the object was destroyed.

From the Qt documentation on `QObject::deleteLater()`:

> Since Qt 4.8, if deleteLater() is called on an object that lives in a
> thread with no running event loop, the object will be destroyed when
> the thread finishes.

------

Fix #1489