### PR TITLE
feat(TvShow Search): Add preview of poster/overview to search dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
  - Dark Mode: MediaElch has gained an experimental dark mode for its _main window_ (#761).
    It can only be set through `advancedsettings.xml` and will be made into a proper
    settings option in future releases.
+ - The TV show search dialog has gained a preview
 
 ### Removed
 

--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -458,6 +458,7 @@ SOURCES += src/main.cpp \
     src/ui/tv_show/TvShowWidgetTvShow.cpp \
     src/ui/tv_show/TvTunesDialog.cpp \
     src/ui/UiUtils.cpp \
+    src/ui/tv_show/search_dialog/TvShowScrapePreview.cpp \
     src/utils/Containers.cpp \
     src/utils/Math.cpp \
     src/utils/Meta.cpp \
@@ -806,6 +807,7 @@ HEADERS  += Version.h \
     src/ui/tv_show/TvShowWidgetSeason.h \
     src/ui/tv_show/TvShowWidgetTvShow.h \
     src/ui/tv_show/TvTunesDialog.h \
+    src/ui/tv_show/search_dialog/TvShowScrapePreview.h \
     src/ui/UiUtils.h \
     src/utils/Containers.h \
     src/utils/Math.h \
@@ -890,6 +892,7 @@ FORMS += src/ui/concerts/ConcertFilesWidget.ui \
     src/ui/tv_show/TvShowWidgetEpisode.ui \
     src/ui/tv_show/TvShowWidgetSeason.ui \
     src/ui/tv_show/TvShowWidgetTvShow.ui \
+    src/ui/tv_show/search_dialog/TvShowScrapePreview.ui \
     src/ui/tv_show/TvTunesDialog.ui
 
 RESOURCES += \

--- a/src/ui/small_widgets/WebImageLabel.h
+++ b/src/ui/small_widgets/WebImageLabel.h
@@ -30,6 +30,7 @@ public:
     void showImageFrom(QUrl url);
     /// \brief Clears the image label (shows a placeholder) and aborts all downloads.
     void clearAndAbortDownload();
+
     /// \brief Start a loading icon (animated spinner).
     void startLoadingSpinner();
     /// \brief Show a placeholder image.

--- a/src/ui/tv_show/CMakeLists.txt
+++ b/src/ui/tv_show/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(
   TvShowWidgetSeason.cpp
   TvShowWidgetTvShow.cpp
   TvTunesDialog.cpp
+  search_dialog/TvShowScrapePreview.cpp
 )
 
 target_link_libraries(

--- a/src/ui/tv_show/TvShowSearch.cpp
+++ b/src/ui/tv_show/TvShowSearch.cpp
@@ -19,6 +19,7 @@ TvShowSearch::TvShowSearch(QWidget* parent) : QDialog(parent), ui(new Ui::TvShow
 #endif
 
     connect(ui->buttonClose, &QAbstractButton::clicked, this, &QDialog::reject);
+    connect(ui->buttonScrape, &QAbstractButton::clicked, this, &QDialog::accept);
     connect(ui->tvShowSearchWidget, &TvShowSearchWidget::sigResultClicked, this, &QDialog::accept);
 }
 

--- a/src/ui/tv_show/TvShowSearch.ui
+++ b/src/ui/tv_show/TvShowSearch.ui
@@ -52,6 +52,16 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QPushButton" name="buttonScrape">
+       <property name="text">
+        <string>Scrape</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>

--- a/src/ui/tv_show/TvShowSearchWidget.h
+++ b/src/ui/tv_show/TvShowSearchWidget.h
@@ -4,9 +4,9 @@
 #include "globals/Globals.h"
 #include "scrapers/ScraperInfos.h"
 #include "scrapers/ScraperInterface.h"
-#include "scrapers/ScraperResult.h"
 #include "scrapers/tv_show/TvScraper.h"
 
+#include <QPointer>
 #include <QTableWidgetItem>
 #include <QWidget>
 
@@ -46,14 +46,25 @@ private slots:
     void initializeAndStartSearch();
     /// \brief Starts the TV show search with the selected _initialized_ scraper.
     void startSearch();
+
+    /// \brief   Called when a scraper was initialized.
+    /// \details If a scraper needs initialization, we call initialize().
+    ///          This is the callback.
+    void onScraperInitialized(bool wasSuccessful, mediaelch::scraper::TvScraper* scraper);
+
     void onShowResults(mediaelch::scraper::ShowSearchJob* searchJob);
-    /// \brief Stores the clicked id and accepts the dialog.
+    /// \brief When the selected item changes, e.g. via click or keys.
+    /// \param item Item which was selected
+    void onResultChanged(QTableWidgetItem* current, QTableWidgetItem* previous);
+    /// \brief Stores the double-clicked id and accepts the dialog.
     /// \param item Item which was clicked
-    void onResultClicked(QTableWidgetItem* item);
+    void onResultDoubleClicked(QTableWidgetItem* item);
+
     void onShowInfoToggled();
     void onEpisodeInfoToggled();
     void onChkAllShowInfosToggled();
     void onChkAllEpisodeInfosToggled();
+
     void onUpdateTypeChanged(int index);
     void onSeasonOrderChanged(int index);
     void onScraperChanged(int index);
@@ -63,9 +74,11 @@ private:
     void setupSeasonOrderComboBox();
     void setupScraperDropdown();
     void setupLanguageDropdown();
+
     void showError(const QString& message);
     void showSuccess(const QString& message);
-    void clearResultTable();
+    void abortAndClearResults();
+    void abortCurrentJobs();
     void updateCheckBoxes();
 
 private:
@@ -79,5 +92,6 @@ private:
     TvShowUpdateType m_updateType = TvShowUpdateType::Show;
 
     mediaelch::scraper::TvScraper* m_currentScraper = nullptr;
+    QPointer<mediaelch::scraper::ShowSearchJob> m_currentSearchJob = nullptr;
     mediaelch::Locale m_currentLanguage = mediaelch::Locale::English;
 };

--- a/src/ui/tv_show/TvShowSearchWidget.ui
+++ b/src/ui/tv_show/TvShowSearchWidget.ui
@@ -6,23 +6,11 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>746</width>
-    <height>606</height>
+    <width>740</width>
+    <height>600</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
    <item>
     <layout class="QHBoxLayout" name="hLayoutSearchConfig">
      <item>
@@ -92,53 +80,93 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
      <item>
-      <widget class="QTableWidget" name="results">
-       <property name="editTriggers">
-        <set>QAbstractItemView::NoEditTriggers</set>
+      <widget class="QSplitter" name="splitter">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
        </property>
-       <property name="alternatingRowColors">
-        <bool>true</bool>
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
        </property>
-       <property name="selectionMode">
-        <enum>QAbstractItemView::SingleSelection</enum>
-       </property>
-       <property name="selectionBehavior">
-        <enum>QAbstractItemView::SelectRows</enum>
-       </property>
-       <property name="showGrid">
+       <property name="opaqueResize">
         <bool>false</bool>
        </property>
-       <attribute name="horizontalHeaderVisible">
+       <property name="childrenCollapsible">
         <bool>false</bool>
-       </attribute>
-       <attribute name="horizontalHeaderStretchLastSection">
-        <bool>true</bool>
-       </attribute>
-       <attribute name="verticalHeaderVisible">
-        <bool>false</bool>
-       </attribute>
-       <column>
-        <property name="text">
-         <string>Result</string>
+       </property>
+       <widget class="QTableWidget" name="results">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>1</verstretch>
+         </sizepolicy>
         </property>
-       </column>
+        <property name="editTriggers">
+         <set>QAbstractItemView::NoEditTriggers</set>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::SingleSelection</enum>
+        </property>
+        <property name="selectionBehavior">
+         <enum>QAbstractItemView::SelectRows</enum>
+        </property>
+        <property name="showGrid">
+         <bool>false</bool>
+        </property>
+        <attribute name="horizontalHeaderVisible">
+         <bool>false</bool>
+        </attribute>
+        <attribute name="horizontalHeaderStretchLastSection">
+         <bool>true</bool>
+        </attribute>
+        <attribute name="verticalHeaderVisible">
+         <bool>false</bool>
+        </attribute>
+        <column>
+         <property name="text">
+          <string>Result</string>
+         </property>
+        </column>
+       </widget>
+       <widget class="TvShowScrapePreview" name="tvShowPreview" native="true"/>
       </widget>
      </item>
      <item>
-      <layout class="QVBoxLayout" name="vLayout_Details">
+      <layout class="QVBoxLayout" name="vboxDetails">
        <item>
-        <widget class="QLabel" name="label_2">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Details to load</string>
-         </property>
+        <widget class="QComboBox" name="comboUpdate">
+         <item>
+          <property name="text">
+           <string>Update TV Show only</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Update TV Show and new Episodes</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Update TV Show and all Episodes</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Update new Episodes</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Update all episodes</string>
+          </property>
+         </item>
         </widget>
        </item>
        <item>
@@ -159,7 +187,19 @@
              <property name="flat">
               <bool>true</bool>
              </property>
-             <layout class="QVBoxLayout" name="verticalLayout_4">
+             <layout class="QVBoxLayout" name="vboxShowDetails">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
               <item>
                <layout class="QHBoxLayout" name="verticalLayout_41">
                 <item>
@@ -456,7 +496,19 @@
              <property name="flat">
               <bool>true</bool>
              </property>
-             <layout class="QVBoxLayout" name="verticalLayout_42">
+             <layout class="QVBoxLayout" name="vboxEpisodeDetails">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
               <item>
                <layout class="QHBoxLayout" name="verticalLayout_412">
                 <item>
@@ -666,35 +718,6 @@
          </widget>
         </widget>
        </item>
-       <item>
-        <widget class="QComboBox" name="comboUpdate">
-         <item>
-          <property name="text">
-           <string>Update TV Show only</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Update TV Show and new Episodes</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Update TV Show and all Episodes</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Update new Episodes</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Update all episodes</string>
-          </property>
-         </item>
-        </widget>
-       </item>
       </layout>
      </item>
     </layout>
@@ -703,9 +726,14 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>LanguageCombo</class>
+   <extends>QComboBox</extends>
+   <header>ui/small_widgets/LanguageCombo.h</header>
+  </customwidget>
+  <customwidget>
    <class>MyCheckBox</class>
    <extends>QCheckBox</extends>
-   <header location="global">ui/small_widgets/MyCheckBox.h</header>
+   <header>ui/small_widgets/MyCheckBox.h</header>
   </customwidget>
   <customwidget>
    <class>MyLineEdit</class>
@@ -713,9 +741,10 @@
    <header>ui/small_widgets/MyLineEdit.h</header>
   </customwidget>
   <customwidget>
-   <class>LanguageCombo</class>
-   <extends>QComboBox</extends>
-   <header location="global">ui/small_widgets/LanguageCombo.h</header>
+   <class>TvShowScrapePreview</class>
+   <extends>QWidget</extends>
+   <header>ui/tv_show/search_dialog/TvShowScrapePreview.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/ui/tv_show/TvShowWidgetTvShow.cpp
+++ b/src/ui/tv_show/TvShowWidgetTvShow.cpp
@@ -546,6 +546,7 @@ void TvShowWidgetTvShow::onLoadDone(TvShow* show, QMap<ImageType, QVector<Poster
     } else {
         qCDebug(generic) << "Show has changed";
     }
+
     int downloadsSize = 0;
     if (!show->posters().isEmpty() && show->infosToLoad().contains(ShowScraperInfo::Poster)) {
         emit sigSetActionSaveEnabled(false, MainWidgets::TvShows);

--- a/src/ui/tv_show/search_dialog/TvShowScrapePreview.cpp
+++ b/src/ui/tv_show/search_dialog/TvShowScrapePreview.cpp
@@ -1,0 +1,70 @@
+#include "ui/tv_show/search_dialog/TvShowScrapePreview.h"
+#include "ui_TvShowScrapePreview.h"
+
+#include "data/Poster.h"
+#include "data/tv_show/TvShow.h"
+#include "scrapers/tv_show/ShowScrapeJob.h"
+
+namespace {
+static const char* WAS_ABORTED = "WAS_ABORTED";
+}
+
+TvShowScrapePreview::TvShowScrapePreview(QWidget* parent) : QWidget{parent}, ui(new Ui::TvShowScrapePreview)
+{
+    ui->setupUi(this);
+}
+
+void TvShowScrapePreview::loadPreviewFor(mediaelch::scraper::TvScraper* scraper,
+    mediaelch::scraper::ShowIdentifier id,
+    mediaelch::Locale locale)
+{
+    using namespace mediaelch::scraper;
+
+    clearAndAbortPreview();
+
+    ui->poster->startLoadingSpinner(); // indicate that we're loading data
+
+    ShowScrapeJob::Config config;
+    config.identifier = std::move(id);
+    config.locale = std::move(locale);
+    config.details = {ShowScraperInfo::Title, ShowScraperInfo::Overview, ShowScraperInfo::Poster};
+
+    m_currentScrapeJob = scraper->loadShow(config);
+    connect(m_currentScrapeJob, &ShowScrapeJob::loadFinished, this, &TvShowScrapePreview::onScrapeJobFinished);
+    m_currentScrapeJob->start();
+}
+
+void TvShowScrapePreview::clearAndAbortPreview()
+{
+    ui->lblDescriptionContent->clear();
+    ui->poster->clearAndAbortDownload();
+
+    auto currentScrapeJob = m_currentScrapeJob;
+    m_currentScrapeJob = nullptr;
+    if (currentScrapeJob != nullptr && !currentScrapeJob->isFinished()) {
+        // kill() may return false and not kill the job.
+        // In that case, it will finish and call onScrapeJobFinished. To distinguish
+        // killed jobs from the current one, store a bool.
+        currentScrapeJob->setProperty(WAS_ABORTED, QVariant::fromValue(true));
+        currentScrapeJob->kill();
+    }
+}
+
+void TvShowScrapePreview::onScrapeJobFinished(mediaelch::scraper::ShowScrapeJob* scrapeJob)
+{
+    auto dls = makeDeleteLaterScope(scrapeJob);
+    if (scrapeJob->hasError() || scrapeJob->property(WAS_ABORTED).toBool()) {
+        return;
+    }
+
+    MediaElch_Expects(scrapeJob == m_currentScrapeJob);
+
+    ui->lblDescriptionContent->setPlainText(scrapeJob->tvShow().overview());
+    ui->poster->clearAndAbortDownload();
+
+    if (!scrapeJob->tvShow().posters().isEmpty()) {
+        const Poster poster = scrapeJob->tvShow().posters().first();
+        const QUrl url = !poster.thumbUrl.isEmpty() ? poster.thumbUrl : poster.originalUrl;
+        ui->poster->showImageFrom(url);
+    }
+}

--- a/src/ui/tv_show/search_dialog/TvShowScrapePreview.h
+++ b/src/ui/tv_show/search_dialog/TvShowScrapePreview.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "data/Locale.h"
+#include "scrapers/tv_show/ShowIdentifier.h"
+#include "scrapers/tv_show/TvScraper.h"
+
+#include <QPointer>
+#include <QWidget>
+
+
+namespace Ui {
+class TvShowScrapePreview;
+}
+
+class TvShowScrapePreview : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit TvShowScrapePreview(QWidget* parent = nullptr);
+
+    void loadPreviewFor(mediaelch::scraper::TvScraper* scraper,
+        mediaelch::scraper::ShowIdentifier id,
+        mediaelch::Locale locale);
+    void clearAndAbortPreview();
+
+signals:
+
+private slots:
+    void onScrapeJobFinished(mediaelch::scraper::ShowScrapeJob* scrapeJob);
+
+private:
+    void abortCurrentJobs();
+
+private:
+    Ui::TvShowScrapePreview* ui = nullptr;
+
+    QPointer<mediaelch::scraper::ShowScrapeJob> m_currentScrapeJob = nullptr;
+
+    QPixmap m_placeholderPoster;
+};

--- a/src/ui/tv_show/search_dialog/TvShowScrapePreview.ui
+++ b/src/ui/tv_show/search_dialog/TvShowScrapePreview.ui
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TvShowScrapePreview</class>
+ <widget class="QWidget" name="TvShowScrapePreview">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>420</width>
+    <height>200</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>160</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>300</height>
+   </size>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <layout class="QVBoxLayout" name="vboxPoster" stretch="0,1,0">
+     <item>
+      <widget class="QLabel" name="lblPreview">
+       <property name="text">
+        <string>&lt;b&gt;Preview&lt;/p&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="WebImageLabel" name="poster" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>120</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>180</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="spacerPoster">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="vboxOverview" stretch="0,1,0">
+     <item>
+      <widget class="QLabel" name="lblDescription">
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Description&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::RichText</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPlainTextEdit" name="lblDescriptionContent">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>100</height>
+        </size>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="spacerOverview">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>WebImageLabel</class>
+   <extends>QWidget</extends>
+   <header>ui/small_widgets/WebImageLabel.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This commit adds a preview widget to the TV show search widget.
This makes it easier to select the correct TV show, especially if
there are multiple results that are quite similar.

__Before__

![MediaElch_old](https://user-images.githubusercontent.com/1667306/209350221-77f44ed6-2ebd-4caf-97da-185bde897e87.png)


__After__:

<img width="1369" alt="MediaElch_new_preview" src="https://user-images.githubusercontent.com/1667306/209349719-be880e68-4c8d-401d-ad9c-cf95495648cb.png">
