### PR TITLE
fix(movie search): Delete old database entries if autoReload is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 ### Bugfixes
 
  - macOS: CMD+R now correctly triggers a reload.
+ - If a movie directory had "auto-reload" enabled, each start of MediaElch added
+   entries to our cache database without remove old entries.  The database
+   size grew fast.  Clicking "reload" is a workaround (#1487)
  - IMDb:
    - Movie search did not return any results.
    - TV show search did not return any results.

--- a/src/file_search/TvShowFileSearcher.cpp
+++ b/src/file_search/TvShowFileSearcher.cpp
@@ -457,12 +457,13 @@ void TvShowFileSearcher::clearOldTvShows(bool forceClear)
     if (forceClear) {
         // Simply delete all shows
         database().clearAllTvShows();
-        return;
-    }
 
-    for (const mediaelch::MediaDirectory& dir : asConst(m_directories)) {
-        if (dir.autoReload || dir.disabled) {
-            database().clearTvShowsInDirectory(mediaelch::DirectoryPath(dir.path));
+    } else {
+        // Otherwise, only clear disabled directories and those with autoReload.
+        for (const mediaelch::MediaDirectory& dir : asConst(m_directories)) {
+            if (dir.autoReload || dir.disabled) {
+                database().clearTvShowsInDirectory(mediaelch::DirectoryPath(dir.path));
+            }
         }
     }
 }

--- a/src/file_search/movie/MovieFileSearcher.cpp
+++ b/src/file_search/movie/MovieFileSearcher.cpp
@@ -76,6 +76,13 @@ void MovieFileSearcher::reload(bool reloadFromDisk)
     }
 
     for (mediaelch::MediaDirectory movieDir : asConst(m_directories)) {
+        // If we auto-reload directories, but didn't force to load _all_ movies, then we need
+        // to clear all movies of that directory.  If reloadFromDisk is set, then the database
+        // was cleared above.  If the directory is disabled, we also clear the cache if
+        // autoReload is on.
+        if (movieDir.autoReload && !reloadFromDisk) {
+            Manager::instance()->database()->clearMoviesInDirectory(DirectoryPath(movieDir.path));
+        }
         if (!movieDir.disabled) {
             movieDir.autoReload = movieDir.autoReload || reloadFromDisk;
             m_directoryQueue.enqueue(std::move(movieDir));


### PR DESCRIPTION
The movie file searcher did not clear old entries of our cache database if "autoReload" was enabled for a directory.  The database was only cleared if the "reload" button is clicked explicitly.

This bug only affected movies.  The behavior was correct for TV shows, etc.

Note that the SQLite3 database size likely won't shrink, unless `VACUUM;` was run, see <https://sqlite.org/lang_vacuum.html>

Fix https://github.com/Komet/MediaElch/issues/1487