### PR TITLE
fix(TV show): Adapt `<episodeguide>` to Kodi v20 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 
  - TvMaze: For a TV show's cast, if there are character images, use those
    instead of the actor's image, e.g. use "Homer Simpson" for "Dan Castellaneta".
+ - For Kodi v19 and later, `<episodeguide>` will use the new format, see
+   [Kodi Forum](https://forum.kodi.tv/showthread.php?tid=370489)
 
 ### Added
 

--- a/src/media_center/kodi/TvShowXmlReader.cpp
+++ b/src/media_center/kodi/TvShowXmlReader.cpp
@@ -169,6 +169,8 @@ void TvShowXmlReader::parseNfoDom(QDomDocument domDoc)
     }
     if (!domDoc.elementsByTagName("episodeguide").isEmpty()
         && !domDoc.elementsByTagName("episodeguide").at(0).toElement().elementsByTagName("url").isEmpty()) {
+        // TODO: Only kept for backwards compatibility to Kodi < v19.  Later versions use uniqueids
+        //       again in <episodeguide>, which is of no use for us.
         m_show.setEpisodeGuideUrl(domDoc.elementsByTagName("episodeguide")
                                       .at(0)
                                       .toElement()

--- a/test/resources/show/kodi_v20_show_Game_of_Thrones.nfo
+++ b/test/resources/show/kodi_v20_show_Game_of_Thrones.nfo
@@ -21,13 +21,12 @@
     <plot>Seven noble families fight for control of the mythical land of Westeros. Friction between the houses leads to full-scale war. All while a very ancient evil awakens in the farthest north. Amidst the war, a neglected military order of misfits, the Night's Watch, is all that stands between the realms of men and the icy horrors beyond.</plot>
     <mpaa>TV-MA</mpaa>
     <premiered>2011-04-17</premiered>
-    <year>2011</year>
     <dateadded>2019-07-05 17:35:08</dateadded>
     <status></status>
     <studio>HBO</studio>
     <runtime>55</runtime>
     <trailer></trailer>
-    <episodeguide>1399</episodeguide>
+    <episodeguide>{&quot;imdb&quot;:&quot;tt0944947&quot;,&quot;tmdb&quot;:&quot;1399&quot;,&quot;tvdb&quot;:&quot;121361&quot;,&quot;tvmaze&quot;:&quot;82&quot;}</episodeguide>
     <genre>Adventure</genre>
     <genre>Drama</genre>
     <genre>Fantasy</genre>

--- a/test/resources/show/kodi_v20_show_Game_of_Thrones_TvDb_episode_guide.nfo
+++ b/test/resources/show/kodi_v20_show_Game_of_Thrones_TvDb_episode_guide.nfo
@@ -20,15 +20,12 @@
     <plot>Seven noble families fight for control of the mythical land of Westeros. Friction between the houses leads to full-scale war. All while a very ancient evil awakens in the farthest north. Amidst the war, a neglected military order of misfits, the Night's Watch, is all that stands between the realms of men and the icy horrors beyond.</plot>
     <mpaa>TV-MA</mpaa>
     <premiered>2011-04-17</premiered>
-    <year>2011</year>
     <dateadded>2019-07-05 17:35:08</dateadded>
     <status></status>
     <studio>HBO</studio>
     <runtime>55</runtime>
     <trailer></trailer>
-    <episodeguide>
-        <url post="yes" cache="auth.json">https://api.thetvdb.com/login?{&quot;apikey&quot;:&quot;439DFEBA9D3059C6&quot;,&quot;id&quot;:121361}|Content-Type=application/json</url>
-    </episodeguide>
+    <episodeguide>{&quot;imdb&quot;:&quot;tt0944947&quot;,&quot;tvdb&quot;:&quot;121361&quot;,&quot;tvmaze&quot;:&quot;82&quot;}</episodeguide>
     <genre>Adventure</genre>
     <genre>Drama</genre>
     <genre>Fantasy</genre>

--- a/test/resources/show/kodi_v20_show_Torchwood.nfo
+++ b/test/resources/show/kodi_v20_show_Torchwood.nfo
@@ -21,7 +21,6 @@
     <plot>Captain Jack Harkness is a man from the 51st century trapped in the past who leads the last remnants of the Torchwood Institute, a top secret British agency outside the government whose job it is to investigate alien goings on in the world, act in mankind's best interest, and, if needed, be the Earth's last line of defense.</plot>
     <mpaa>TV-MA</mpaa>
     <premiered>2006-10-22</premiered>
-    <year>2006</year>
     <dateadded>2019-07-07 11:03:47</dateadded>
     <status></status>
     <studio>BBC Three</studio>
@@ -29,7 +28,7 @@
     <trailer></trailer>
     <namedseason number="3">Children of Earth</namedseason>
     <namedseason number="4">Miracle Day</namedseason>
-    <episodeguide>424</episodeguide>
+    <episodeguide>{&quot;imdb&quot;:&quot;tt0485301&quot;,&quot;tmdb&quot;:&quot;424&quot;,&quot;tvdb&quot;:&quot;79511&quot;,&quot;tvmaze&quot;:&quot;659&quot;}</episodeguide>
     <genre>Adventure</genre>
     <genre>Crime</genre>
     <genre>Drama</genre>

--- a/test/resources/show/kodi_v20_show_all.nfo
+++ b/test/resources/show/kodi_v20_show_all.nfo
@@ -22,13 +22,12 @@
     <plot>Angel is an American television series, a spin-off from the television series Buffy the Vampire Slayer. Angel (David Boreanaz), a 240-year old vampire cursed with a conscience, haunts the dark streets of Los Angeles alone</plot>
     <mpaa>TV-PG</mpaa>
     <premiered>1999-10-05</premiered>
-    <year>1999</year>
     <dateadded></dateadded>
     <status>Ended</status>
     <studio>The WB</studio>
     <runtime>45</runtime>
     <trailer></trailer>
-    <episodeguide>2426</episodeguide>
+    <episodeguide>{&quot;imdb&quot;:&quot;tt0162065&quot;,&quot;tmdb&quot;:&quot;2426&quot;,&quot;tvdb&quot;:&quot;71035&quot;,&quot;tvmaze&quot;:&quot;428&quot;}</episodeguide>
     <genre>Action</genre>
     <genre>Comedy</genre>
     <genre>Drama</genre>

--- a/test/resources/show/kodi_v20_show_empty.nfo
+++ b/test/resources/show/kodi_v20_show_empty.nfo
@@ -11,9 +11,9 @@
     <plot></plot>
     <mpaa></mpaa>
     <premiered></premiered>
-    <year></year>
     <dateadded></dateadded>
     <status></status>
     <studio></studio>
     <trailer></trailer>
+    <episodeguide>{}</episodeguide>
 </tvshow>


### PR DESCRIPTION
Kodi v19.5 and later use a different episodeguide format.  Use that as well.  Since we don't need to read the episodeguide (since we already have all unique IDs), we can simply write what we already know: A map of IDs in JSON format.

Furthermore, remove `year` for Kodi v19 and later, because in v20, only `premiered` must be used.

Fixes #1519