### PR TITLE
fix(UI): TV show file tree: Use stylesheet's selection background

### DIFF
--- a/scripts/create_themes_from_palettes.py
+++ b/scripts/create_themes_from_palettes.py
@@ -23,7 +23,7 @@ class Palette:
 
 palettes = [
     Palette('../src/ui/palette_light.json', None, '../src/ui/light.css'),
-    # Palette('../src/ui/palette_dark.json', None, '../src/ui/dark.css'),
+    Palette('../src/ui/palette_dark.json', None, '../src/ui/dark.css'),
 ]
 
 for palette in palettes:

--- a/src/model/TvShowModel.cpp
+++ b/src/model/TvShowModel.cpp
@@ -106,22 +106,6 @@ QVariant TvShowModel::data(const QModelIndex& index, int role) const
     if (role == Qt::DisplayRole) {
         return helper::appendArticle(item.data(0).toString());
     }
-    if (role == Qt::FontRole) {
-        QFont font;
-        if (item.data(2).toBool()) {
-            font.setItalic(true);
-        }
-        if (item.type() == TvShowType::TvShow || item.type() == TvShowType::Season) {
-            font.setBold(true);
-        }
-
-        if (item.type() == TvShowType::Season || item.type() == TvShowType::Episode) {
-#ifdef Q_OS_MAC
-            font.setPointSize(font.pointSize() - 2);
-#endif
-        }
-        return font;
-    }
     if (role == Qt::SizeHintRole) {
         return QSize(0, (item.type() == TvShowType::TvShow) ? 44 : (item.type() == TvShowType::Season) ? 26 : 22);
     }
@@ -130,25 +114,6 @@ QVariant TvShowModel::data(const QModelIndex& index, int role) const
     }
     if (role == TvShowRoles::EpisodeCount && item.type() == TvShowType::TvShow) {
         return item.data(1);
-    }
-    if (role == Qt::ForegroundRole) {
-        // hasChanged()
-        if (item.data(2).toBool()) {
-            return QColor(255, 0, 0);
-        }
-        if (item.type() == TvShowType::Episode) {
-            auto* showEpisode = dynamic_cast<const EpisodeModelItem*>(&item);
-            if (showEpisode != nullptr && showEpisode->tvShowEpisode()->isDummy()) {
-                return QColor(150, 150, 150);
-            }
-        }
-        if (item.type() == TvShowType::Season) {
-            auto* seasonModel = dynamic_cast<const SeasonModelItem*>(&item);
-            if (seasonModel != nullptr && item.tvShow()->isDummySeason(seasonModel->seasonNumber())) {
-                return QColor(150, 150, 150);
-            }
-        }
-        return QColor(17, 51, 80);
     }
 
     switch (role) {
@@ -166,7 +131,6 @@ QVariant TvShowModel::data(const QModelIndex& index, int role) const
     case TvShowRoles::HasCharacterArt: return item.data(108);
     case TvShowRoles::MissingEpisodes: return item.data(109);
     case TvShowRoles::LogoPath: return item.data(110);
-    case TvShowRoles::SelectionForeground: return QColor(255, 255, 255);
     case TvShowRoles::FilePath:
         if (item.type() == TvShowType::Episode) {
             auto* episode = dynamic_cast<const EpisodeModelItem*>(&item);

--- a/src/model/TvShowModel.h
+++ b/src/model/TvShowModel.h
@@ -31,7 +31,6 @@ const int HasCharacterArt = Qt::UserRole + 15;
 const int MissingEpisodes = Qt::UserRole + 16;
 const int LogoPath = Qt::UserRole + 17;
 const int FilePath = Qt::UserRole + 18;
-const int SelectionForeground = Qt::UserRole + 19;
 const int HasDummyEpisodes = Qt::UserRole + 20;
 } // namespace TvShowRoles
 

--- a/src/ui/base.css
+++ b/src/ui/base.css
@@ -116,7 +116,8 @@
     alternate-background-color: $background_secondary_color;
     background-color: $background_primary_color;
     selection-color: $table_selection_font_color;
-    color: $font_accent_color;
+    /* This color is used by TvShowTreeView for font-writing */
+    color: $font_primary_color;
 }
 #centralWidget QTableWidget::item,
 #centralWidget QTableView::item,

--- a/src/ui/dark.css
+++ b/src/ui/dark.css
@@ -116,7 +116,8 @@
     alternate-background-color: #272c2f;
     background-color: #2c3135;
     selection-color: #EBEBEB;
-    color: #2487e3;
+    /* This color is used by TvShowTreeView for font-writing */
+    color: #EBEBEB;
 }
 #centralWidget QTableWidget::item,
 #centralWidget QTableView::item,
@@ -152,7 +153,7 @@
 
 #centralWidget QPushButton {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #428BCA, stop:1 #3071A9);
-    color: #EBEBEB;
+    color: #595959;
     border: 1px solid #2D6CA2;
     border-radius: 4px;
     padding: 4px;
@@ -324,7 +325,7 @@ Navbar #widget {
 }
 Navbar #btnDonate {
     border-radius: 4px;
-    color: #EBEBEB;
+    color: #595959;
     font-family: Helvetica Neue;
     padding: 2px;
     padding-left: 4px;
@@ -369,7 +370,7 @@ CertificationWidget #infoGroupBox {
  *********************************************************/
 MakeMkvDialog #btnImportTracks,
 MakeMkvDialog #btnImportComplete {
-    color: #EBEBEB;
+    color: #ffffff;
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #428bca, stop:1 #3071a9);
     border: 1px solid #2D6CA2;
     border-radius: 4px;
@@ -458,7 +459,7 @@ ConcertWidget #buttonRevert {
  * UnpackButtons
  *********************************************************/
 UnpackButtons #progressBar {
-    color: #EBEBEB;
+    color: #ffffff;
     font-size: 10px;
 }
 UnpackButtons #progressBar:horizontal {
@@ -637,7 +638,7 @@ TvShowWidgetTvShow #tvShowGroupBox {
 
 QPushButton[buttonstyle],
 #centralWidget QPushButton[buttonstyle] {
-    color: #EBEBEB;
+    color: #595959;
     padding: 4px;
     margin: 4px;
     border-radius: 4px;

--- a/src/ui/light.css
+++ b/src/ui/light.css
@@ -116,7 +116,8 @@
     alternate-background-color: #f9f9f9;
     background-color: #ffffff;
     selection-color: #ffffff;
-    color: #1b69a5;
+    /* This color is used by TvShowTreeView for font-writing */
+    color: #2a2a2b;
 }
 #centralWidget QTableWidget::item,
 #centralWidget QTableView::item,

--- a/src/ui/palette_dark.json
+++ b/src/ui/palette_dark.json
@@ -16,7 +16,7 @@
   "accent_color": "#f89b35",
   "accent_secondary_color": "#2093FE",
   "stroke_color": "#1E1E1E",
-  "button_color": "#595959",
+  "button_font_color": "#595959",
   "radio_button_background_color": "#595959",
   "radio_button_background_checked_color": "#2093FE",
 

--- a/src/ui/small_widgets/TvShowTreeView.h
+++ b/src/ui/small_widgets/TvShowTreeView.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "globals/Globals.h"
-
 #include <QPainter>
 #include <QPixmap>
 #include <QTreeView>
@@ -19,12 +17,15 @@ protected:
     void drawRow(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
 
 private:
+    void drawBranches(QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QRect& rect,
+        const QModelIndex& index) const;
+
     void drawTvShowRow(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const;
     void drawTvShowIcons(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const;
     void drawEpisodeRow(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const;
-    void drawRowBackground(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const;
-
-    void setAlternateRowColors(QStyleOptionViewItem& option, const QModelIndex& index) const;
+    void drawRowBackground(QPainter* painter, QStyleOptionViewItem opt, const QModelIndex& index) const;
 
     bool isShowRow(const QModelIndex& index) const;
     bool isSeasonRow(const QModelIndex& index) const;


### PR DESCRIPTION
Instead of hard-coding the background color, use the stylesheet's background definition.  We had a workaround for Windows, which seems not to be needed anymore.  Still needs to be tested on Windows.

__Light__

<table><tr><th>Before<th><th>After<th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/1667306/210070612-0ba09c2c-a897-4427-bbc8-6137d0e726eb.png"/><td><td><img src="https://user-images.githubusercontent.com/1667306/210070617-25e3f6d3-8c13-4b3d-8542-7a22180095ad.png"/><td>
</tr></table>

__Dark__

<table><tr><th>Before<th><th>After<th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/1667306/210070615-5936922e-91fd-471a-9b96-545c6fbae6c1.png"/><td>
<td><img src="https://user-images.githubusercontent.com/1667306/210070618-40f373ef-e6dd-4714-b403-ed1dc2643c91.png"/><td>
</tr></table>