### PR TITLE
fix(TMDb search): Don't assume 1923 or other numbers are a TMDb ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
  - AllMusic: Fix loading of "born" and "died" (#1336)
  - TvTunes: Spaces around titles were not removed
  - Discogs: Albums are loaded properly again.
+ - TMDb TV show and movie search: If a TV show title looks like a TMDb id
+   (i.e. only numbers such as 1899 or 1923),
+   we assumed it indeed is an ID and not a search query (#1527).
 
 ### Changes
 
@@ -35,6 +38,9 @@
    instead of the actor's image, e.g. use "Homer Simpson" for "Dan Castellaneta".
  - For Kodi v19 and later, `<episodeguide>` will use the new format, see
    [Kodi Forum](https://forum.kodi.tv/showthread.php?tid=370489)
+ - If the query in the TV show or movie search dialog has the format `tmdb12345`,
+   we search by TMDb ID `12345`.  Previously, this worked for search query
+   `12345` as well, but that clashed with TV shows and movies such as `1923`.
 
 ### Added
 

--- a/src/data/TmdbId.cpp
+++ b/src/data/TmdbId.cpp
@@ -36,14 +36,25 @@ QString TmdbId::withPrefix() const
 
 bool TmdbId::isValid() const
 {
-    QRegularExpression rx("^\\d+$");
+    static QRegularExpression rx("^\\d+$");
     return rx.match(m_tmdbId).hasMatch();
 }
 
-bool TmdbId::isValidFormat(const QString& tmdbId)
+bool TmdbId::isValidPrefixedFormat(const QString& tmdbId)
 {
-    QRegularExpression rx("^\\d+$");
-    return rx.match(tmdbId).hasMatch();
+    static QRegularExpression rx("^tmdb\\d+$");
+    QRegularExpressionMatch match = rx.match(tmdbId);
+    // id is greater 0
+    return match.hasMatch() && tmdbId != "id0";
+}
+
+QString TmdbId::removePrefix(const QString& tmdbId)
+{
+    if (!tmdbId.startsWith("tmdb")) {
+        return "";
+    }
+    // Remove "tmdb"
+    return tmdbId.mid(4);
 }
 
 std::ostream& operator<<(std::ostream& os, const TmdbId& id)

--- a/src/data/TmdbId.h
+++ b/src/data/TmdbId.h
@@ -17,7 +17,10 @@ public:
     QString toString() const;
     QString withPrefix() const;
     bool isValid() const;
-    static bool isValidFormat(const QString& tmdbId);
+    /// \brief Returns true if the given id has the common TheTvDb ID format.
+    /// \details A TheTvDb ID is valid if it starts with "id".
+    static bool isValidPrefixedFormat(const QString& tmdbId);
+    static QString removePrefix(const QString& tmdbId);
 
     static const TmdbId NoId;
 

--- a/src/data/TvDbId.cpp
+++ b/src/data/TvDbId.cpp
@@ -53,10 +53,10 @@ bool TvDbId::isValid() const
 
 bool TvDbId::isValidPrefixedFormat(const QString& tvdbId)
 {
-    QRegularExpression rx("^id\\d+$");
+    static QRegularExpression rx("^id\\d+$");
     QRegularExpressionMatch match = rx.match(tvdbId);
     // id is greater 0
-    return match.hasMatch() && match.captured(0) != "id0";
+    return match.hasMatch() && tvdbId != "id0";
 }
 
 std::ostream& operator<<(std::ostream& os, const TvDbId& id)

--- a/src/scrapers/concert/ConcertSearchJob.cpp
+++ b/src/scrapers/concert/ConcertSearchJob.cpp
@@ -9,9 +9,9 @@ namespace scraper {
 QPair<QString, QString> ConcertSearchJob::extractTitleAndYear(const QString& query)
 {
     QVector<QRegularExpression> yearRegEx;
-    yearRegEx << QRegularExpression(R"(^(.*) \((\d{4})\)$)") //
-              << QRegularExpression(R"(^(.*) (\d{4})$)")     //
-              << QRegularExpression(R"(^(.*) - (\d{4})$)");
+    yearRegEx << QRegularExpression(R"(^(.+) \((\d{4})\)$)") //
+              << QRegularExpression(R"(^(.+) (\d{4})$)")     //
+              << QRegularExpression(R"(^(.+) - (\d{4})$)");
 
     for (auto& rxYear : yearRegEx) {
         // minimal matching

--- a/src/scrapers/movie/MovieSearchJob.cpp
+++ b/src/scrapers/movie/MovieSearchJob.cpp
@@ -9,9 +9,9 @@ namespace scraper {
 QPair<QString, QString> MovieSearchJob::extractTitleAndYear(const QString& query)
 {
     QVector<QRegularExpression> yearRegEx;
-    yearRegEx << QRegularExpression(R"(^(.*) \((\d{4})\)$)") //
-              << QRegularExpression(R"(^(.*) (\d{4})$)")     //
-              << QRegularExpression(R"(^(.*) - (\d{4})$)");
+    yearRegEx << QRegularExpression(R"(^(.+) \((\d{4})\)$)") //
+              << QRegularExpression(R"(^(.+) (\d{4})$)")     //
+              << QRegularExpression(R"(^(.+) - (\d{4})$)");
 
     for (auto& rxYear : yearRegEx) {
         // minimal matching

--- a/src/scrapers/tmdb/TmdbApi.cpp
+++ b/src/scrapers/tmdb/TmdbApi.cpp
@@ -157,8 +157,8 @@ QUrl TmdbApi::getShowSearchUrl(const QString& searchStr, const Locale& locale, b
     QUrlQuery queries;
     // Special handling of certain ID types. TheMovieDb supports other IDs and not only
     // their TMDb IDs.
-    if (TmdbId::isValidFormat(searchStr)) {
-        return makeApiUrl(QStringLiteral("/tv/") + searchStr, locale, queries);
+    if (TmdbId::isValidPrefixedFormat(searchStr)) {
+        return makeApiUrl(QStringLiteral("/tv/") + TmdbId::removePrefix(searchStr), locale, queries);
     }
     if (ImdbId::isValidFormat(searchStr)) {
         queries.addQueryItem("external_source", "imdb_id");
@@ -215,8 +215,8 @@ QUrl TmdbApi::getMovieSearchUrl(const QString& searchStr,
     QUrlQuery queries;
     // Special handling of certain ID types. TheMovieDb supports other IDs and not only
     // their TMDb IDs.
-    if (TmdbId::isValidFormat(searchStr)) {
-        return makeApiUrl(QStringLiteral("/movie/") + searchStr, locale, queries);
+    if (TmdbId::isValidPrefixedFormat(searchStr)) {
+        return makeApiUrl(QStringLiteral("/movie/") + TmdbId::removePrefix(searchStr), locale, queries);
     }
     if (ImdbId::isValidFormat(searchStr)) {
         queries.addQueryItem("external_source", "imdb_id");

--- a/src/scrapers/tv_show/ShowSearchJob.cpp
+++ b/src/scrapers/tv_show/ShowSearchJob.cpp
@@ -9,9 +9,9 @@ namespace scraper {
 QPair<QString, QString> ShowSearchJob::extractTitleAndYear(const QString& query)
 {
     QVector<QRegularExpression> yearRegEx;
-    yearRegEx << QRegularExpression(R"(^(.*) \((\d{4})\)$)") //
-              << QRegularExpression(R"(^(.*) (\d{4})$)")     //
-              << QRegularExpression(R"(^(.*) - (\d{4})$)");
+    yearRegEx << QRegularExpression(R"(^(.+) \((\d{4})\)$)") //
+              << QRegularExpression(R"(^(.+) (\d{4})$)")     //
+              << QRegularExpression(R"(^(.+) - (\d{4})$)");
 
     for (auto& rxYear : yearRegEx) {
         QRegularExpressionMatch match = rxYear.match(query);


### PR DESCRIPTION
If a TV show title looked like a TMDb id (i.e. only numbers such as 1899 or 1923), we assumed it indeed was an ID and not a search query.

--------------

Fix #1527