### PR TITLE
feat(UI theme): Add UI theme settings to global settings dialog

### DIFF
--- a/.ci/macOS/build_macOS_release_Qt6.sh
+++ b/.ci/macOS/build_macOS_release_Qt6.sh
@@ -35,7 +35,7 @@ and builds a release binary of MediaElch for macOS for Qt6.
 Uses hard-coded paths of the current maintainer.
 
 You may need to adapt your \$PATH or macdeployqt may not be found.
-  export PATH="\$HOME/Qt/6.4.1/macos/bin/:\$PATH"
+  export PATH="\$HOME/Qt/6.4.2/macos/bin/:\$PATH"
 
 Options
   --no-confirm   Build MediaElch without confirm dialog.
@@ -81,8 +81,8 @@ parse_params "$@"
 export CXX=clang++
 export CC=clang
 
-print_important "Using Qt6 from \$HOME/Qt/6.4.1"
-export PATH="$HOME/Qt/6.4.1/macos/bin/:$OLD_PATH"
+print_important "Using Qt6 from \$HOME/Qt/6.4.2"
+export PATH="$HOME/Qt/6.4.2/macos/bin/:$OLD_PATH"
 
 # Check for macOS build and packaging dependencies
 ./.ci/macOS/check_macOS_dependencies.sh

--- a/.ci/macOS/package_macOS_Qt6.sh
+++ b/.ci/macOS/package_macOS_Qt6.sh
@@ -36,7 +36,7 @@ for our nightly builds.
 Use .ci/macOS/build_macOS_release_Qt6.sh if you want to build MediaElch.
 
 You may need to adapt your \$PATH or macdeployqt may not be found.
-  export PATH="\$HOME/Qt/6.4.1/macos/bin/:\$PATH"
+  export PATH="\$HOME/Qt/6.4.2/macos/bin/:\$PATH"
 
 Options
   --no-confirm   Package MediaElch without confirm dialog.
@@ -85,8 +85,8 @@ parse_params "$@"
 #######################################################
 # Getting Details
 
-print_important "Using Qt6 from \$HOME/Qt/6.4.1"
-export PATH="$HOME/Qt/6.4.1/macos/bin/:$OLD_PATH"
+print_important "Using Qt6 from \$HOME/Qt/6.4.2"
+export PATH="$HOME/Qt/6.4.2/macos/bin/:$OLD_PATH"
 
 # Check for macOS build and packaging dependencies
 ./.ci/macOS/check_macOS_dependencies.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,8 @@
 ### Added
 
  - Dark Mode: MediaElch has gained an experimental dark mode for its _main window_ (#761).
-   It can only be set through `advancedsettings.xml` and will be made into a proper
-   settings option in future releases.
+   It can only be set through MediaElch's settings.  On macOS, the theme is automatically
+   detected if set to "auto".
  - The TV show search dialog has gained a preview
 
 ### Removed

--- a/MediaElch.plist
+++ b/MediaElch.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.kvibes.MediaElch</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>2021 Daniel Kabel</string>
+	<string>2023 Daniel Kabel</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.13.0</string>
 	<key>LSApplicationCategoryType</key>
@@ -30,8 +30,6 @@
 	<string>yes</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>NSRequiresAquaSystemAppearance</key>
-	<string>True</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
     <key>NSHighResolutionCapable</key>

--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -467,7 +467,10 @@ SOURCES += src/main.cpp \
     src/workers/Job.cpp
 
 macx {
-    OBJECTIVE_SOURCES += src/ui/notifications/MacNotificationHandler.mm
+    HEADERS += src/ui/notifications/MacNotificationHandler.h \
+        src/ui/MacUiUtilities.h
+    OBJECTIVE_SOURCES += src/ui/notifications/MacNotificationHandler.mm \
+        src/ui/MacUiUtilities.mm
 }
 
 HEADERS  += Version.h \
@@ -742,7 +745,6 @@ HEADERS  += Version.h \
     src/ui/music/MusicWidget.h \
     src/ui/music/MusicWidgetAlbum.h \
     src/ui/music/MusicWidgetArtist.h \
-    src/ui/notifications/MacNotificationHandler.h \
     src/ui/notifications/NotificationBox.h \
     src/ui/notifications/Notificator.h \
     src/ui/renamer/RenamerDialog.h \

--- a/docs/contributing/guides/build-qt6-with-tsan.md
+++ b/docs/contributing/guides/build-qt6-with-tsan.md
@@ -73,7 +73,7 @@ cd "${PROJECT_DIR:?}"
 git clone git://code.qt.io/qt/qt5.git qt6
 cd qt6
 perl init-repository
-git checkout v6.4.1
+git checkout v6.4.2
 cd ..
 ```
 

--- a/src/settings/AdvancedSettings.cpp
+++ b/src/settings/AdvancedSettings.cpp
@@ -164,11 +164,6 @@ QString AdvancedSettings::customStylesheet() const
     return m_customStylesheet;
 }
 
-QString AdvancedSettings::mainWindowTheme() const
-{
-    return m_mainWindowTheme;
-}
-
 QHash<QString, QString> AdvancedSettings::genreMappings() const
 {
     return m_genreMappings;

--- a/src/settings/AdvancedSettings.h
+++ b/src/settings/AdvancedSettings.h
@@ -22,7 +22,6 @@ public:
     QString logFile() const;
     QLocale locale() const;
     QStringList sortTokens() const;
-    QString mainWindowTheme() const;
     QString customStylesheet() const;
     QHash<QString, QString> genreMappings() const;
 
@@ -60,7 +59,6 @@ private:
     QString m_logFile;
     QLocale m_locale;
     QStringList m_sortTokens;
-    QString m_mainWindowTheme;
     QString m_customStylesheet;
     QHash<QString, QString> m_genreMappings;
     mediaelch::FileFilter m_movieFilters;

--- a/src/settings/AdvancedSettingsXmlReader.cpp
+++ b/src/settings/AdvancedSettingsXmlReader.cpp
@@ -192,13 +192,6 @@ void AdvancedSettingsXmlReader::loadGui()
     while (m_xml.readNextStartElement()) {
         if (m_xml.name() == QLatin1String("forceCache")) {
             expectBool(m_settings.m_forceCache);
-        } else if (m_xml.name() == QLatin1String("theme")) {
-            QString theme = m_xml.readElementText().trimmed();
-            if (theme != "light" && theme != "dark") {
-                invalidValue();
-            } else {
-                m_settings.m_mainWindowTheme = theme;
-            }
         } else if (m_xml.name() == QLatin1String("stylesheet")) {
             m_settings.m_customStylesheet = m_xml.readElementText().trimmed();
         } else {

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -24,6 +24,7 @@ static constexpr char KEY_CUSTOM_TV_SCRAPER_SHOW[] = "CustomTvScraperShow";
 static constexpr char KEY_CUSTOM_TV_SCRAPER_EPISODE[] = "CustomTvScraperEpisode";
 static constexpr char KEY_DEBUG_MODE_ACTIVATED[] = "DebugModeActivated";
 static constexpr char KEY_DONATED[] = "Donated";
+static constexpr char KEY_THEME[] = "Theme";
 
 static constexpr char KEY_CSV_EXPORT_SEPARATOR[] = "CsvExport/Separator";
 static constexpr char KEY_CSV_EXPORT_REPLACEMENT[] = "CsvExport/Replacement";
@@ -162,9 +163,6 @@ ScraperSettings* Settings::scraperSettings(const QString& id)
     return m_scraperSettings[idStd].get();
 }
 
-/**
- * \brief Loads all settings
- */
 void Settings::loadSettings()
 {
     // Globals
@@ -183,6 +181,13 @@ void Settings::loadSettings()
     m_showAdultScrapers = settings()->value(KEY_SCRAPERS_SHOW_ADULT, false).toBool();
     m_startupSection = settings()->value(KEY_STARTUP_SECTION, "movies").toString();
     m_donated = settings()->value(KEY_DONATED, false).toBool();
+
+    m_theme = settings()->value(KEY_THEME, "auto").toString();
+    if (m_theme != "auto" && m_theme != "dark" && m_theme != "light") {
+        qCWarning(generic) << "[Settings] Unknown theme value:" << m_theme << "(available: light, dark)";
+        m_theme = "auto";
+    }
+
     m_lastImagePath = mediaelch::DirectoryPath(settings()->value(KEY_LAST_IMAGE_PATH, QDir::homePath()).toString());
 
     // Window positions
@@ -397,6 +402,7 @@ void Settings::saveSettings()
     settings()->setValue(KEY_SCRAPERS_SHOW_ADULT, m_showAdultScrapers);
     settings()->setValue(KEY_STARTUP_SECTION, m_startupSection);
     settings()->setValue(KEY_DONATED, m_donated);
+    settings()->setValue(KEY_THEME, m_theme);
     settings()->setValue(KEY_LAST_IMAGE_PATH, m_lastImagePath.toString());
 
 
@@ -1383,9 +1389,21 @@ bool Settings::donated() const
     return m_donated;
 }
 
+void Settings::setTheme(QString theme)
+{
+    m_theme = theme;
+}
+
+QString Settings::theme()
+{
+    return m_theme;
+}
+
 void Settings::setLastImagePath(mediaelch::DirectoryPath path)
 {
+    // Also save in this setter, because this method is called in ImageDialog as well.
     m_lastImagePath = path;
+    settings()->setValue(KEY_LAST_IMAGE_PATH, m_lastImagePath.toString());
     settings()->sync();
 }
 

--- a/src/settings/Settings.h
+++ b/src/settings/Settings.h
@@ -105,6 +105,7 @@ public:
     bool showAdultScrapers() const;
     QString startupSection();
     bool donated() const;
+    QString theme();
     mediaelch::DirectoryPath lastImagePath();
 
     template<typename T>
@@ -180,6 +181,7 @@ public:
     void setShowAdultScrapers(bool show);
     void setStartupSection(QString startupSection);
     void setDonated(bool donated);
+    void setTheme(QString theme);
     void setLastImagePath(mediaelch::DirectoryPath path);
 
     static QString applicationDir();
@@ -255,6 +257,7 @@ private:
     bool m_multiScrapeSaveEach = false;
     bool m_showAdultScrapers = false;
     QString m_startupSection;
+    QString m_theme;
     bool m_donated = false;
     mediaelch::DirectoryPath m_lastImagePath;
     int m_extraFanartsMusicArtists = 0;

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -18,6 +18,10 @@ add_library(
   UiUtils.cpp
 )
 
+if(APPLE)
+  target_sources(mediaelch_ui PRIVATE MacUiUtilities.mm)
+endif()
+
 target_link_libraries(
   mediaelch_ui
   PRIVATE

--- a/src/ui/MacUiUtilities.h
+++ b/src/ui/MacUiUtilities.h
@@ -1,0 +1,8 @@
+
+namespace mediaelch {
+namespace ui {
+
+bool macIsInDarkTheme();
+
+}
+} // namespace mediaelch

--- a/src/ui/MacUiUtilities.mm
+++ b/src/ui/MacUiUtilities.mm
@@ -1,0 +1,20 @@
+#include "ui/MacUiUtilities.h"
+
+#import <Cocoa/Cocoa.h>
+
+namespace mediaelch {
+namespace ui {
+
+bool macIsInDarkTheme()
+{
+    // See tutorial at <https://successfulsoftware.net/2021/03/31/how-to-add-a-dark-theme-to-your-qt-application/>
+    if (__builtin_available(macOS 10.14, *)) {
+        auto appearance = [NSApp.effectiveAppearance
+            bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
+        return [appearance isEqualToString:NSAppearanceNameDarkAqua];
+    }
+    return false;
+}
+
+} // namespace ui
+} // namespace mediaelch

--- a/src/ui/light.css
+++ b/src/ui/light.css
@@ -19,7 +19,7 @@
 }
 
 #centralWidget QLabel {
-    color: #2a2a2b;
+    color: #27272f;
 }
 #centralWidget QLabel[isHeader] {
     color: #1b69a5;
@@ -89,7 +89,7 @@
 
 #centralWidget QTabBar::tab {
     padding: 8px;
-    color: #2a2a2b;
+    color: #27272f;
     border: 0;
 }
 
@@ -117,12 +117,12 @@
     background-color: #ffffff;
     selection-color: #ffffff;
     /* This color is used by TvShowTreeView for font-writing */
-    color: #2a2a2b;
+    color: #27272f;
 }
 #centralWidget QTableWidget::item,
 #centralWidget QTableView::item,
 #centralWidget QTreeView::item {
-    color: #2a2a2b;
+    color: #27272f;
 }
 #centralWidget QTableWidget::item:selected,
 #centralWidget QTableView::item:selected,
@@ -311,7 +311,7 @@ Navbar QToolButton {
 Navbar QToolButton::menu-indicator {
     subcontrol-origin: padding;
     subcontrol-position: bottom right;
-    color: #2a2a2b;
+    color: #27272f;
     image: url(':/img/ui_select_light.svg');
     width: 16px;
     height: 16px;
@@ -563,7 +563,7 @@ TvShowWidgetEpisode #missingLabel {
     border-bottom-left-radius: 20px;
     padding-top: 5px;
     padding-bottom: 5px;
-    color: #2a2a2b;
+    color: #27272f;
     font-size: 14px;
     padding-left: 20px;
     padding-right: 20px;
@@ -586,7 +586,7 @@ TvShowWidgetSeason #missingLabel {
     border-bottom-left-radius: 20px;
     padding-top: 5px;
     padding-bottom: 5px;
-    color: #2a2a2b;
+    color: #27272f;
     font-size: 14px;
     padding-left: 20px;
     padding-right: 20px;

--- a/src/ui/palette_light.json
+++ b/src/ui/palette_light.json
@@ -20,7 +20,7 @@
   "radio_button_background_color": "#595959",
   "radio_button_background_checked_color": "#428BCA",
 
-  "font_primary_color": "#2a2a2b",
+  "font_primary_color": "#27272f",
   "font_secondary_color": "#33333",
   "font_disabled_color": "#787878",
   "font_accent_color": "#1b69a5"

--- a/src/ui/settings/GlobalSettingsWidget.cpp
+++ b/src/ui/settings/GlobalSettingsWidget.cpp
@@ -44,6 +44,10 @@ GlobalSettingsWidget::GlobalSettingsWidget(QWidget* parent) : QWidget(parent), u
     ui->comboStartupSection->addItem(tr("Concerts"), "concerts");
     ui->comboStartupSection->addItem(tr("Music"), "music");
     ui->comboStartupSection->addItem(tr("Import"), "import");
+
+    ui->comboTheme->addItem(tr("Auto"), "auto");
+    ui->comboTheme->addItem(tr("Light"), "light");
+    ui->comboTheme->addItem(tr("Dark"), "dark");
 }
 
 GlobalSettingsWidget::~GlobalSettingsWidget()
@@ -91,6 +95,13 @@ void GlobalSettingsWidget::loadSettings()
         }
     }
 
+    for (int i = 0, n = ui->comboTheme->count(); i < n; ++i) {
+        if (ui->comboTheme->itemData(i, Qt::UserRole) == m_settings->theme()) {
+            ui->comboTheme->setCurrentIndex(i);
+            break;
+        }
+    }
+
     // Directories
     ui->dirs->setRowCount(0);
     ui->dirs->clearContents();
@@ -132,7 +143,8 @@ void GlobalSettingsWidget::saveSettings()
     m_settings->setIgnoreArticlesWhenSorting(ui->chkIgnoreArticlesWhenSorting->isChecked());
     m_settings->setCheckForUpdates(ui->chkCheckForUpdates->isChecked());
     m_settings->setStartupSection(
-        ui->comboStartupSection->itemData(ui->comboStartupSection->currentIndex()).toString());
+        ui->comboStartupSection->itemData(ui->comboStartupSection->currentIndex(), Qt::UserRole).toString());
+    m_settings->setTheme(ui->comboTheme->itemData(ui->comboTheme->currentIndex(), Qt::UserRole).toString());
 
     // save directories
     QVector<mediaelch::MediaDirectory> movieDirectories;

--- a/src/ui/settings/GlobalSettingsWidget.ui
+++ b/src/ui/settings/GlobalSettingsWidget.ui
@@ -10,7 +10,7 @@
     <height>625</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QHBoxLayout" name="horizontalLayout_2">
    <item>
     <widget class="QTabWidget" name="globalSettingsTab">
      <property name="currentIndex">
@@ -34,7 +34,7 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>900</width>
+            <width>885</width>
             <height>610</height>
            </rect>
           </property>
@@ -292,6 +292,30 @@ The directories containing your music must contain subdirectories for each artis
           </layout>
          </widget>
         </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="globalSettingsAppearanceTab">
+      <attribute name="title">
+       <string>Appearance</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <layout class="QFormLayout" name="formLayout">
+         <property name="fieldGrowthPolicy">
+          <enum>QFormLayout::ExpandingFieldsGrow</enum>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="lblTheme">
+           <property name="text">
+            <string>Main Window Theme (changing it requires restart of MediaElch)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="comboTheme"/>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>

--- a/test/scrapers/tmdbtv/testTmdbTvShowSearch.cpp
+++ b/test/scrapers/tmdbtv/testTmdbTvShowSearch.cpp
@@ -42,4 +42,16 @@ TEST_CASE("TmdbTv returns valid search results", "[tv][TmdbTv][search]")
         CHECK(p.first.length() == 0);
         CHECK(p.second.error == ScraperError::Type::NoError);
     }
+
+    SECTION("Search by TV show name returns correct results for number-only title")
+    {
+        ShowSearchJob::Config config{"1899", Locale::English};
+        auto* searchJob = new TmdbTvShowSearchJob(getTmdbApi(), config);
+        const auto scraperResults = searchTvScraperSync(searchJob).first;
+
+        REQUIRE(scraperResults.length() >= 1);
+        CHECK(scraperResults[0].title == "1899");
+        CHECK(scraperResults[0].identifier.str() == "90669");
+        CHECK(scraperResults[0].released == QDate(2022, 11, 17));
+    }
 }


### PR DESCRIPTION
This commit adds a combobox to MediaElch's global settings.  The new
"theme" setting is used to determine MediaElch's main window theme.

On macOS, "auto" can be used to determine the theme automatically.
On other systems, we (currently) default to "light".

This commit also reverts https://github.com/Komet/MediaElch/commit/e5d2a63bdf8f900a301a5a31ff969ec007689470
which disabled dark mode for MediaElch.

-------------

For #761