### PR TITLE
feat(Renamer): Add TMDb ID as a placeholder for movies to the renamer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Added
 
- - …
+ - Movie renamer: It is now possible to use a movie's TMDb ID as placeholder (#1542)
 
 ### Removed
 

--- a/scripts/library/movies_en.txt
+++ b/scripts/library/movies_en.txt
@@ -14,6 +14,11 @@ Modern Times - 1936
 It Happened One Night - 1934
 Singin' in the Rain - 1952
 
+Harry Potter and the Deathly Hallows - Part 1 (2010)
+Harry Potter and the Deathly Hallows - Part 2 (2011)
+The Hunger Games - Mockingjay - Part 1 (2014)
+The Hunger Games - Mockingjay - Part 2 (2015)
+
 The Godfather (1972)
 Spotlight (2015)
 Psycho (1960)

--- a/src/renamer/MovieRenamer.cpp
+++ b/src/renamer/MovieRenamer.cpp
@@ -84,6 +84,7 @@ MovieRenamer::RenameError MovieRenamer::renameMovie(Movie& movie)
                     videoDetails.value(StreamDetails::VideoDetails::Height).toInt(),
                     videoDetails.value(StreamDetails::VideoDetails::ScanType)));
             MovieRenamer::replaceCondition(newFileName, "imdbId", movie.imdbId().toString());
+            MovieRenamer::replaceCondition(newFileName, "tmdbId", movie.tmdbId().toString());
             MovieRenamer::replaceCondition(newFileName, "movieset", movie.set().name);
             MovieRenamer::replaceCondition(
                 newFileName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
@@ -106,7 +107,7 @@ MovieRenamer::RenameError MovieRenamer::renameMovie(Movie& movie)
                 }
 
                 for (const QString& trailerFile : currentDir.entryList(
-                         QStringList() << fi.completeBaseName() + "-trailer.*", QDir::Files | QDir::NoDotAndDotDot)) {
+                         QStringList() << baseName + "-trailer.*", QDir::Files | QDir::NoDotAndDotDot)) {
                     QFileInfo trailer(fi.canonicalPath() + "/" + trailerFile);
                     QString newTrailerFileName = newFileName;
                     newTrailerFileName =
@@ -281,6 +282,7 @@ MovieRenamer::RenameError MovieRenamer::renameMovie(Movie& movie)
             newFolderName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
         Renamer::replaceCondition(newFolderName, "movieset", movie.set().name);
         Renamer::replaceCondition(newFolderName, "imdbId", movie.imdbId().toString());
+        Renamer::replaceCondition(newFolderName, "tmdbId", movie.tmdbId().toString());
         helper::sanitizeFolderName(newFolderName);
         if (dir.dirName() != newFolderName) {
             renameRow = m_dialog->addResultToTable(dir.dirName(), newFolderName, RenameOperation::Rename);
@@ -317,6 +319,7 @@ MovieRenamer::RenameError MovieRenamer::renameMovie(Movie& movie)
             newFolderName, "3D", videoDetails.value(StreamDetails::VideoDetails::StereoMode) != "");
         Renamer::replaceCondition(newFolderName, "movieset", movie.set().name);
         Renamer::replaceCondition(newFolderName, "imdbId", movie.imdbId().toString());
+        Renamer::replaceCondition(newFolderName, "tmdbId", movie.tmdbId().toString());
         helper::sanitizeFolderName(newFolderName);
 
         if (dir.dirName() != newFolderName) { // check if movie is not already on good folder

--- a/src/ui/renamer/RenamerDialog.cpp
+++ b/src/ui/renamer/RenamerDialog.cpp
@@ -94,11 +94,22 @@ int RenamerDialog::exec()
             "<title>-part<partNo>.<extension>",
             "<originalTitle>-part<partNo>.<extension>"};
     }
+
+    if (m_renameType == Renamer::RenameType::Movies) {
+        fileNameDefaults
+            << "<title>{tmdbId} tmdbId-<tmdbId>{/tmdbId}{imdbId} imdbId-<imdbId>{/imdbId} (<year>).<extension>";
+    }
+
     QStringList directoryNameDefaults{//
         "<title> (<year>)",
         "{movieset}<movieset> - {/movieset}<title> (<year>)",
         "<originalTitle> (<year>)",
         "<sortTitle>{imdbId} [<imdbId>]{/imdbId} (<year>)"};
+
+    if (m_renameType == Renamer::RenameType::Movies) {
+        directoryNameDefaults << "<sortTitle>{tmdbId} tmdbId-<tmdbId>{/tmdbId} (<year>)";
+    }
+
     QStringList seasonNameDefaults = QStringList{//
         "Season <season>",
         "Season <season> - <seasonName>"};

--- a/src/ui/renamer/RenamerPlaceholders.ui
+++ b/src/ui/renamer/RenamerPlaceholders.ui
@@ -53,21 +53,15 @@
          <bool>true</bool>
         </property>
         <widget class="QWidget" name="placeholderItems">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>-530</y>
+           <width>524</width>
+           <height>688</height>
+          </rect>
+         </property>
          <layout class="QGridLayout" name="placeholderLayout" columnstretch="0,1">
-          <item row="26" column="1">
-           <widget class="QLabel" name="desc3d">
-            <property name="text">
-             <string>File is 3D</string>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-              <string>tvshow</string>
-              <string>concert</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
           <item row="24" column="1">
            <widget class="QLabel" name="descDvd">
             <property name="text">
@@ -81,10 +75,10 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="1">
-           <widget class="QLabel" name="descEpisode">
+          <item row="12" column="1">
+           <widget class="QLabel" name="descShowTitle">
             <property name="text">
-             <string>Episode Number</string>
+             <string>Title of the show</string>
             </property>
             <property name="itemTypes" stdset="0">
              <stringlist notr="true">
@@ -93,10 +87,10 @@
             </property>
            </widget>
           </item>
-          <item row="19" column="1">
-           <widget class="QLabel" name="descAudioCodec">
+          <item row="2" column="1">
+           <widget class="QLabel" name="descExtension">
             <property name="text">
-             <string>Audio Codec</string>
+             <string>File extension</string>
             </property>
             <property name="itemTypes" stdset="0">
              <stringlist notr="true">
@@ -121,21 +115,6 @@
             </property>
            </widget>
           </item>
-          <item row="27" column="0">
-           <widget class="QLabel" name="labelMovieSet">
-            <property name="text">
-             <string notr="true">{movieset}...&lt;movieset&gt;...{/movieset}</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::PlainText</enum>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
           <item row="27" column="1">
            <widget class="QLabel" name="descMovieSet">
             <property name="text">
@@ -148,13 +127,81 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="labelEpisode">
+          <item row="0" column="1">
+           <widget class="QLabel" name="lblDescription">
+            <property name="font">
+             <font>
+              <bold>true</bold>
+             </font>
+            </property>
             <property name="text">
-             <string notr="true">&lt;episode&gt;</string>
+             <string>Description</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="0">
+           <widget class="QLabel" name="labelSeason">
+            <property name="text">
+             <string notr="true">&lt;season&gt;</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>tvshow</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="17" column="1">
+           <widget class="QLabel" name="descResolution">
+            <property name="text">
+             <string>Resolution (1080p, 720p, ...)</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="16" column="0">
+           <widget class="QLabel" name="labelAlbum">
+            <property name="text">
+             <string notr="true">&lt;album&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="16" column="1">
+           <widget class="QLabel" name="descAlbum">
+            <property name="text">
+             <string>Album</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="25" column="1">
+           <widget class="QLabel" name="descCondSeasonName">
+            <property name="text">
+             <string>Episode has a season name</string>
             </property>
             <property name="itemTypes" stdset="0">
              <stringlist notr="true">
@@ -191,10 +238,10 @@
             </property>
            </widget>
           </item>
-          <item row="13" column="0">
-           <widget class="QLabel" name="labelDirector">
+          <item row="28" column="0">
+           <widget class="QLabel" name="labelImdbId">
             <property name="text">
-             <string notr="true">&lt;director&gt;</string>
+             <string notr="true">{imdbId}...&lt;imdbId&gt;...{/imdbId}</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -202,83 +249,6 @@
             <property name="itemTypes" stdset="0">
              <stringlist notr="true">
               <string>movie</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="15" column="0">
-           <widget class="QLabel" name="labelArtist">
-            <property name="text">
-             <string notr="true">&lt;artist&gt;</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::PlainText</enum>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>concert</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QLabel" name="descOriginalTitle">
-            <property name="text">
-             <string>Original Title</string>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="13" column="1">
-           <widget class="QLabel" name="descDirector">
-            <property name="text">
-             <string>Director(s)</string>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="11" column="0">
-           <widget class="QLabel" name="labelSeasonName">
-            <property name="text">
-             <string notr="true">&lt;seasonName&gt;</string>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>tvshow</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="28" column="1">
-           <widget class="QLabel" name="descImdbId">
-            <property name="text">
-             <string>IMDb ID</string>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="22" column="0">
-           <widget class="QLabel" name="labelChannels">
-            <property name="text">
-             <string notr="true">&lt;channels&gt;</string>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-              <string>tvshow</string>
-              <string>concert</string>
              </stringlist>
             </property>
            </widget>
@@ -290,20 +260,6 @@
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-              <string>tvshow</string>
-              <string>concert</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="20" column="0">
-           <widget class="QLabel" name="labelAudioLanguage">
-            <property name="text">
-             <string notr="true">&lt;audioLanguage&gt;</string>
             </property>
             <property name="itemTypes" stdset="0">
              <stringlist notr="true">
@@ -329,53 +285,13 @@
             </property>
            </widget>
           </item>
-          <item row="28" column="0">
-           <widget class="QLabel" name="labelImdbId">
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelExtension">
             <property name="text">
-             <string notr="true">{imdbId}...&lt;imdbId&gt;...{/imdbId}</string>
+             <string notr="true">&lt;extension&gt;</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="1">
-           <widget class="QLabel" name="descSortTitle">
-            <property name="text">
-             <string>Sort Title</string>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="23" column="0">
-           <widget class="QLabel" name="labelBluray">
-            <property name="text">
-             <string notr="true">{bluray}...{/bluray}</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::PlainText</enum>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-              <string>concert</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="21" column="0">
-           <widget class="QLabel" name="labelSubtitleLanguage">
-            <property name="text">
-             <string notr="true">&lt;subtitleLanguage&gt;</string>
             </property>
             <property name="itemTypes" stdset="0">
              <stringlist notr="true">
@@ -386,10 +302,87 @@
             </property>
            </widget>
           </item>
-          <item row="22" column="1">
-           <widget class="QLabel" name="descAudioChannels">
+          <item row="7" column="0">
+           <widget class="QLabel" name="labelYear">
             <property name="text">
-             <string>Number of audio channels</string>
+             <string notr="true">&lt;year&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="26" column="0">
+           <widget class="QLabel" name="label3d">
+            <property name="text">
+             <string notr="true">{3D}...{/3D}</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="19" column="1">
+           <widget class="QLabel" name="descAudioCodec">
+            <property name="text">
+             <string>Audio Codec</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="19" column="0">
+           <widget class="QLabel" name="labelAudioCodec">
+            <property name="text">
+             <string notr="true">&lt;audioCodec&gt;</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="13" column="0">
+           <widget class="QLabel" name="labelDirector">
+            <property name="text">
+             <string notr="true">&lt;director&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="18" column="1">
+           <widget class="QLabel" name="descVideoCodec">
+            <property name="text">
+             <string>Video Codec</string>
             </property>
             <property name="itemTypes" stdset="0">
              <stringlist notr="true">
@@ -415,57 +408,36 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="1">
-           <widget class="QLabel" name="descYear">
+          <item row="28" column="1">
+           <widget class="QLabel" name="descImdbId">
             <property name="text">
-             <string>Year</string>
+             <string>IMDb ID</string>
             </property>
             <property name="itemTypes" stdset="0">
              <stringlist notr="true">
               <string>movie</string>
-              <string>tvshow</string>
-              <string>concert</string>
              </stringlist>
             </property>
            </widget>
           </item>
-          <item row="16" column="1">
-           <widget class="QLabel" name="descAlbum">
+          <item row="21" column="1">
+           <widget class="QLabel" name="descSubtitleLanguage">
             <property name="text">
-             <string>Album</string>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>concert</string>
-             </stringlist>
+             <string>Subtitle Language(s) (separated by a minus)</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="labelExtension">
+          <item row="15" column="0">
+           <widget class="QLabel" name="labelArtist">
             <property name="text">
-             <string notr="true">&lt;extension&gt;</string>
+             <string notr="true">&lt;artist&gt;</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
             </property>
             <property name="itemTypes" stdset="0">
              <stringlist notr="true">
-              <string>movie</string>
-              <string>tvshow</string>
               <string>concert</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="12" column="1">
-           <widget class="QLabel" name="descShowTitle">
-            <property name="text">
-             <string>Title of the show</string>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>tvshow</string>
              </stringlist>
             </property>
            </widget>
@@ -485,10 +457,22 @@
             </property>
            </widget>
           </item>
-          <item row="17" column="1">
-           <widget class="QLabel" name="descResolution">
+          <item row="5" column="1">
+           <widget class="QLabel" name="descOriginalTitle">
             <property name="text">
-             <string>Resolution (1080p, 720p, ...)</string>
+             <string>Original Title</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="26" column="1">
+           <widget class="QLabel" name="desc3d">
+            <property name="text">
+             <string>File is 3D</string>
             </property>
             <property name="itemTypes" stdset="0">
              <stringlist notr="true">
@@ -499,90 +483,10 @@
             </property>
            </widget>
           </item>
-          <item row="24" column="0">
-           <widget class="QLabel" name="labelDvd">
+          <item row="11" column="1">
+           <widget class="QLabel" name="descSeasonName">
             <property name="text">
-             <string notr="true">{dvd}...{/dvd}</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::PlainText</enum>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-              <string>concert</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="18" column="1">
-           <widget class="QLabel" name="descVideoCodec">
-            <property name="text">
-             <string>Video Codec</string>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-              <string>tvshow</string>
-              <string>concert</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="20" column="1">
-           <widget class="QLabel" name="descAudioLanguage">
-            <property name="text">
-             <string>Audio Language(s) (separated by a minus)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLabel" name="descExtension">
-            <property name="text">
-             <string>File extension</string>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-              <string>tvshow</string>
-              <string>concert</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="14" column="1">
-           <widget class="QLabel" name="descStudio">
-            <property name="text">
-             <string>Studio(s) (separated by a comma)</string>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="labelYear">
-            <property name="text">
-             <string notr="true">&lt;year&gt;</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::PlainText</enum>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-              <string>tvshow</string>
-              <string>concert</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="10" column="1">
-           <widget class="QLabel" name="descSeason">
-            <property name="text">
-             <string>Season Number</string>
+             <string>Season Name</string>
             </property>
             <property name="itemTypes" stdset="0">
              <stringlist notr="true">
@@ -591,80 +495,10 @@
             </property>
            </widget>
           </item>
-          <item row="21" column="1">
-           <widget class="QLabel" name="descSubtitleLanguage">
+          <item row="13" column="1">
+           <widget class="QLabel" name="descDirector">
             <property name="text">
-             <string>Subtitle Language(s) (separated by a minus)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLabel" name="lblDescription">
-            <property name="font">
-             <font>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Description</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-            </property>
-           </widget>
-          </item>
-          <item row="26" column="0">
-           <widget class="QLabel" name="label3d">
-            <property name="text">
-             <string notr="true">{3D}...{/3D}</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::PlainText</enum>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-              <string>tvshow</string>
-              <string>concert</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="labelTitle">
-            <property name="text">
-             <string notr="true">&lt;title&gt;</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::PlainText</enum>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-              <string>tvshow</string>
-              <string>concert</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="19" column="0">
-           <widget class="QLabel" name="labelAudioCodec">
-            <property name="text">
-             <string notr="true">&lt;audioCodec&gt;</string>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>movie</string>
-              <string>tvshow</string>
-              <string>concert</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="14" column="0">
-           <widget class="QLabel" name="labelStudio">
-            <property name="text">
-             <string notr="true">&lt;studio&gt;</string>
+             <string>Director(s)</string>
             </property>
             <property name="itemTypes" stdset="0">
              <stringlist notr="true">
@@ -690,6 +524,120 @@
             </property>
            </widget>
           </item>
+          <item row="8" column="1">
+           <widget class="QLabel" name="descEpisode">
+            <property name="text">
+             <string>Episode Number</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>tvshow</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="25" column="0">
+           <widget class="QLabel" name="labelCondSeasonName">
+            <property name="text">
+             <string notr="true">{seasonName}...{/seasonName}</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>tvshow</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="0">
+           <widget class="QLabel" name="labelSeasonName">
+            <property name="text">
+             <string notr="true">&lt;seasonName&gt;</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>tvshow</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="22" column="1">
+           <widget class="QLabel" name="descAudioChannels">
+            <property name="text">
+             <string>Number of audio channels</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="27" column="0">
+           <widget class="QLabel" name="labelMovieSet">
+            <property name="text">
+             <string notr="true">{movieset}...&lt;movieset&gt;...{/movieset}</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QLabel" name="descSortTitle">
+            <property name="text">
+             <string>Sort Title</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="24" column="0">
+           <widget class="QLabel" name="labelDvd">
+            <property name="text">
+             <string notr="true">{dvd}...{/dvd}</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="22" column="0">
+           <widget class="QLabel" name="labelChannels">
+            <property name="text">
+             <string notr="true">&lt;channels&gt;</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="20" column="1">
+           <widget class="QLabel" name="descAudioLanguage">
+            <property name="text">
+             <string>Audio Language(s) (separated by a minus)</string>
+            </property>
+           </widget>
+          </item>
           <item row="15" column="1">
            <widget class="QLabel" name="descArtist">
             <property name="text">
@@ -702,40 +650,13 @@
             </property>
            </widget>
           </item>
-          <item row="10" column="0">
-           <widget class="QLabel" name="labelSeason">
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelTitle">
             <property name="text">
-             <string notr="true">&lt;season&gt;</string>
+             <string notr="true">&lt;title&gt;</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>tvshow</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="16" column="0">
-           <widget class="QLabel" name="labelAlbum">
-            <property name="text">
-             <string notr="true">&lt;album&gt;</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::PlainText</enum>
-            </property>
-            <property name="itemTypes" stdset="0">
-             <stringlist notr="true">
-              <string>concert</string>
-             </stringlist>
-            </property>
-           </widget>
-          </item>
-          <item row="18" column="0">
-           <widget class="QLabel" name="labelVideoCodec">
-            <property name="text">
-             <string notr="true">&lt;videoCodec&gt;</string>
             </property>
             <property name="itemTypes" stdset="0">
              <stringlist notr="true">
@@ -746,14 +667,26 @@
             </property>
            </widget>
           </item>
-          <item row="11" column="1">
-           <widget class="QLabel" name="descSeasonName">
+          <item row="14" column="1">
+           <widget class="QLabel" name="descStudio">
             <property name="text">
-             <string>Season Name</string>
+             <string>Studio(s) (separated by a comma)</string>
             </property>
             <property name="itemTypes" stdset="0">
              <stringlist notr="true">
-              <string>tvshow</string>
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="14" column="0">
+           <widget class="QLabel" name="labelStudio">
+            <property name="text">
+             <string notr="true">&lt;studio&gt;</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
              </stringlist>
             </property>
            </widget>
@@ -775,10 +708,27 @@
             </property>
            </widget>
           </item>
-          <item row="25" column="0">
-           <widget class="QLabel" name="labelCondSeasonName">
+          <item row="21" column="0">
+           <widget class="QLabel" name="labelSubtitleLanguage">
             <property name="text">
-             <string notr="true">{seasonName}...{/seasonName}</string>
+             <string notr="true">&lt;subtitleLanguage&gt;</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="labelEpisode">
+            <property name="text">
+             <string notr="true">&lt;episode&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
             </property>
             <property name="itemTypes" stdset="0">
              <stringlist notr="true">
@@ -787,14 +737,99 @@
             </property>
            </widget>
           </item>
-          <item row="25" column="1">
-           <widget class="QLabel" name="descCondSeasonName">
+          <item row="18" column="0">
+           <widget class="QLabel" name="labelVideoCodec">
             <property name="text">
-             <string>Episode has a season name</string>
+             <string notr="true">&lt;videoCodec&gt;</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="23" column="0">
+           <widget class="QLabel" name="labelBluray">
+            <property name="text">
+             <string notr="true">{bluray}...{/bluray}</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="1">
+           <widget class="QLabel" name="descSeason">
+            <property name="text">
+             <string>Season Number</string>
             </property>
             <property name="itemTypes" stdset="0">
              <stringlist notr="true">
               <string>tvshow</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="20" column="0">
+           <widget class="QLabel" name="labelAudioLanguage">
+            <property name="text">
+             <string notr="true">&lt;audioLanguage&gt;</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QLabel" name="descYear">
+            <property name="text">
+             <string>Year</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+              <string>tvshow</string>
+              <string>concert</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="29" column="0">
+           <widget class="QLabel" name="labelTmdbId">
+            <property name="text">
+             <string notr="true">{tmdbId}...&lt;tmdbId&gt;...{/tmdbId}</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="29" column="1">
+           <widget class="QLabel" name="descTmdbId">
+            <property name="text">
+             <string>TMDb ID</string>
+            </property>
+            <property name="itemTypes" stdset="0">
+             <stringlist notr="true">
+              <string>movie</string>
              </stringlist>
             </property>
            </widget>


### PR DESCRIPTION
It is now possible to add TMDb ID as a placeholder for movie files and directories.

Fix #1542