### PR TITLE
fix(UI): Adapt color labels for dark theme

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[mediaelch.main]
-file_filter = data/i18n/MediaElch_<lang>.ts
-minimum_perc = 20
-source_file = data/i18n/MediaElch_en.ts
-source_lang = en
-type = QT
+[o:komet:p:mediaelch:r:main]
+file_filter   = data/i18n/MediaElch_<lang>.ts
+source_file   = data/i18n/MediaElch_en.ts
+source_lang   = en
+type          = QT
+minimum_perc  = 0
+resource_name = Main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
- - …
+ - UI: Color labels have better color for the dark theme (#1545)
 
 ### Changed
 

--- a/data/i18n/MediaElch_ar.ts
+++ b/data/i18n/MediaElch_ar.ts
@@ -1,112 +1,110 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="pt_PT">
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ar">
 <context>
     <name>AboutDialog</name>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="23"/>
         <source>About MediaElch</source>
-        <translation>Sobre o MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="44"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="112"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="155"/>
         <source>Icon Sets: Retina by &quot;The Working Group&quot; and &quot;Capital Suite&quot; by &quot;capital18 (Jugal Paryani)&quot;</source>
-        <translation>Conjuntos de ícones: Retina de &quot;The Working Group&quot; e &quot;Capital Suite&quot;, de &quot;capital18 (Jugal Paryani)&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="178"/>
         <source>MediaElch Icon by Kathrin Luckner</source>
-        <translation>Ícone do MediaElch por Kathrin Luckner</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="120"/>
         <source>MediaElch was built with &lt;a href=&quot;https://www.qt.io/&quot;&gt;Qt&lt;/a&gt;</source>
-        <translation>O MediaElch foi feito com o &lt;a href=&quot;https://www.qt.io/&quot;&gt;Qt&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="146"/>
         <source>About Qt</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="165"/>
         <source>&lt;a href=&quot;https://develop.kde.org/frameworks/breeze-icons/&quot; title=&quot;KDE Breeze Website&quot;&gt;Breeze icons&lt;/a&gt; copyright KDE and licenced under the GNU LGPL version 3 or later</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="188"/>
         <source>Stream Details detection with &lt;a href=&quot;https://www.mediaarea.net&quot;&gt;Media Info&lt;/a&gt;</source>
-        <translation>Deteção de detalhes da transmissão com &lt;a href=&quot;https://www.mediaarea.net&quot;&gt;Media Info&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="201"/>
         <source>&lt;a href=&quot;https://www.mediaelch.de/mediaelch/&quot;&gt;http://www.mediaelch.de&lt;/a&gt; powered by &lt;a href=&quot;https://www.kvibes.de&quot;&gt;k.vibes&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="211"/>
         <source>Bugs and wishes can be reported on &lt;a href=&quot;https://github.com/Komet/MediaElch/issues&quot;&gt;GitHub&lt;/a&gt; .</source>
-        <translation>Os erros e desejos podem ser reportados no &lt;a href=&quot;https://github.com/Komet/MediaElch/issues&quot;&gt;GitHub&lt;/a&gt; .</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="238"/>
         <source>Developer</source>
-        <translation>Programador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="244"/>
         <source>The information below is important for developers. Please provide if you need help.</source>
-        <translation>Os dados abaixo são importantes para os programadores. Por favor, inclua no seu pedido de ajuda.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="272"/>
         <source>Copy to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="295"/>
         <source>Your Collection</source>
-        <translation>A sua coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="304"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="337"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="370"/>
         <source>Episodes</source>
-        <translation>Episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="403"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="436"/>
         <source>Artists</source>
-        <translation>Artistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="466"/>
         <source>Albums</source>
-        <translation>Álbuns</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -114,12 +112,12 @@
     <message>
         <location filename="../../src/model/ActorModel.cpp" line="83"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/ActorModel.cpp" line="84"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -127,47 +125,47 @@
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="14"/>
         <source>Form</source>
-        <translation>Formulário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="46"/>
         <source>Remove Actor</source>
-        <translation>Remover ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="73"/>
         <source>Add Actor</source>
-        <translation>Adicionar ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="107"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="123"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="66"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="67"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="159"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="161"/>
         <source>Images (*.jpg *.jpeg *.png)</source>
-        <translation>Imagens (*.jpg *.jpeg *.png)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -175,63 +173,63 @@
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="52"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="79"/>
         <source>TextLabel</source>
-        <translation>EtiquetaTexto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="116"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="139"/>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="142"/>
         <source>Add Movie</source>
-        <translation>Adicionar Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="149"/>
         <source>Remove Current Movie</source>
-        <translation>Remover filme atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="152"/>
         <source>Remove Movie</source>
-        <translation>Remover Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="165"/>
         <source>Double click a certification to rename it, right click to delete. If you want to merge two certifications just give them the same name.</source>
-        <translation>Clique duas vezes numa certificação para lhe alterar o nome, clique com o botão direito para eliminá-la. Se quiser fundir duas classificações, basta colocar-lhes o mesmo nome.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="175"/>
         <source>Please keep in mind that the changes you make here (renaming or deleting certifications) will be made for every movie.</source>
-        <translation>Por favor, lembre-se que todas as alterações feitas aqui (alterar o nome ou eliminar certificações) serão feitas para todos os filmes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="28"/>
         <source>Add Certification</source>
-        <translation>Adicionar certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="29"/>
         <source>Delete Certification</source>
-        <translation>Eliminar certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="175"/>
         <source>New Certification</source>
-        <translation>Nova certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="286"/>
         <source>All Movies Saved</source>
-        <translation>Foram guardados todos os filmes</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -239,37 +237,37 @@
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="112"/>
         <source>Delete Image</source>
-        <translation>Eliminar imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="119"/>
         <source>Zoom Image</source>
-        <translation>Ampliar imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="125"/>
         <source>Capture random screenshot</source>
-        <translation>Capturar ecrã aleatório</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="131"/>
         <source>Select another image</source>
-        <translation>Selecionar outra imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="420"/>
         <source>Really delete image?</source>
-        <translation>Quer eliminar a imagem?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="421"/>
         <source>Are you sure you want to delete this image?</source>
-        <translation>Tem a certeza que quer eliminar esta imagem?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="423"/>
         <source>Do not ask again</source>
-        <translation>Não perguntar de novo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -277,12 +275,12 @@
     <message>
         <location filename="../../src/file_search/ConcertFileSearcher.cpp" line="53"/>
         <source>Searching for Concerts...</source>
-        <translation>A procurar concertos...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/ConcertFileSearcher.cpp" line="59"/>
         <source>Loading Concerts...</source>
-        <translation>A carregar concertos...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -291,58 +289,52 @@
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="22"/>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="363"/>
         <source>%n concerts</source>
-        <translation>
-            <numerusform>%n concerto</numerusform>
-            <numerusform>%n concertos</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="42"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="43"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="44"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="45"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="46"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="47"/>
         <source>Open Concert Folder</source>
-        <translation>Abrir pasta do concerto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="48"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="49"/>
         <source>Play concert</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="365"/>
         <source>%1 of %n concerts</source>
-        <translation>
-            <numerusform>%1 de %n concerto</numerusform>
-            <numerusform>%1 de %n concertos</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -350,108 +342,108 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="38"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="105"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="119"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="129"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="139"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="149"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="159"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="170"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="210"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="227"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="237"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="247"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="264"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="274"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="309"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="339"/>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="342"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="345"/>
         <source>Not watched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="354"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="52"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="63"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="94"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -459,12 +451,12 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -472,115 +464,112 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="31"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="41"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="110"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="132"/>
         <source>Infos to load</source>
-        <translation>Informações a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="155"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="162"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="169"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="176"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="183"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="190"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="197"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="204"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="211"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="218"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="225"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="232"/>
         <source>Logo, Clear Art, CD Art</source>
-        <translation>Logótipo, Clear Art, CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="235"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="249"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="106"/>
         <source>The %1 scraper could not be initialized!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="119"/>
         <source>Please insert a search string!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="141"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="226"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -588,42 +577,42 @@
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your concerts. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Em baixo, pode ver os nomes de ficheiros usados para carregar e guardar os seus concertos. Pode editá-los à sua vontade, se quiser usar vários ficheiros separe-os com uma vírgula.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o de nome de ficheiro sem extensão.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="42"/>
         <source>Nfo</source>
-        <translation>Nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="71"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="100"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="129"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="158"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="187"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -633,63 +622,63 @@
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="132"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="135"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="54"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="76"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="91"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="101"/>
         <source>Scantype</source>
-        <translation>Varrimento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="111"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="165"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="185"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="195"/>
         <source>Stereo Mode</source>
-        <translation>Modo de estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="212"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="71"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="125"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="159"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="131"/>
@@ -697,18 +686,18 @@
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="163"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="164"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="133"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="136"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="151"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -716,47 +705,47 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="50"/>
         <source>Concert has changed. Click to revert changes.</source>
-        <translation>O concerto foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="76"/>
         <source>Concert Name</source>
-        <translation>Nome do concerto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="127"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="153"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="175"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="198"/>
         <source>Add Images</source>
-        <translation>Adicionar Imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="208"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="354"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="376"/>
@@ -765,62 +754,62 @@
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="537"/>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="581"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="398"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="471"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="515"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="559"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="79"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="80"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="84"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="85"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="447"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="458"/>
         <source>Concerts Saved</source>
-        <translation>Concertos guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="485"/>
         <source>All Concerts Saved</source>
-        <translation>Todos os concertos guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -828,185 +817,185 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="14"/>
         <source>CSV Export</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="22"/>
         <source>CSV Columns</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="35"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="242"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="40"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="252"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="45"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="262"/>
         <source>TV Episodes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="50"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="272"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="55"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="282"/>
         <source>Music Artists</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="60"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="292"/>
         <source>Music Albums</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="225"/>
         <source>Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="233"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="304"/>
         <source>Separator</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="321"/>
         <source>Replacement</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="340"/>
         <source>Linebreaks will be replaced by &lt;code&gt;\n&lt;/code&gt;. </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="350"/>
         <source>If any text contains the separator, it will be replaced by the replacement set above.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="373"/>
         <source>&lt;b&gt;Tip:&lt;/b&gt; You can sort the items by Drag &amp;amp; Drop.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="390"/>
         <source>Export as CSV</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="29"/>
         <source>Tab</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="30"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="35"/>
         <source>Semicolon (;)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="31"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="36"/>
         <source>Comma (,)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="34"/>
         <source>Space</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="37"/>
         <source>Minus (-)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="52"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="112"/>
         <source>Export directory</source>
-        <translation>Exportar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="114"/>
         <source>Export aborted. No directory was selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="130"/>
         <source>Export movies...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="147"/>
         <source>Export TV shows...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="161"/>
         <source>Export TV episodes...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="179"/>
         <source>Export concerts...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="197"/>
         <source>Export artists...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="212"/>
         <source>Export albums...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="227"/>
         <source>Export completed in %1 seconds.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="319"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="399"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="444"/>
         <source>Streamdetails - Duration (in seconds)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="400"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="445"/>
         <source>Streamdetails - Video Aspect</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="321"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="401"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="446"/>
         <source>Streamdetails - Video Width</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="290"/>
@@ -1016,162 +1005,162 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="467"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="495"/>
         <source>Type</source>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="320"/>
         <source>Streamdetails - Video Aspect Ratio</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="322"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="402"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="447"/>
         <source>Streamdetails - Video Height</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="323"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="403"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="448"/>
         <source>Streamdetails - Video Codec</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="324"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="404"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="449"/>
         <source>Streamdetails - Audio Language(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="325"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="405"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="450"/>
         <source>Streamdetails - Audio Codec(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="326"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="406"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="451"/>
         <source>Streamdetails - Audio Channel(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="327"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="407"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="452"/>
         <source>Streamdetails - Subtitle Language(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="380"/>
         <source>TV Show - TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="379"/>
         <source>TV Show - IMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="291"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="345"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="425"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="292"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="344"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="424"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="293"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="348"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="423"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="294"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="350"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="426"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="295"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="349"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="296"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="361"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="429"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="297"/>
         <source>Outline</source>
-        <translation>Resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="298"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="299"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="359"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="431"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="300"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="358"/>
         <source>IMDb Top 250</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="301"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="432"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="302"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="433"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="303"/>
         <source>Runtime in minutes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="304"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="353"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="435"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="305"/>
         <source>Writers</source>
-        <translation>Argumentistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="306"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="307"/>
@@ -1179,51 +1168,51 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="436"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="469"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="308"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="309"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="310"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="355"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="437"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="311"/>
         <source>Trailers</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="312"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="360"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="313"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Playcount</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="314"/>
         <source>Last played</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="315"/>
         <source>Movie Set</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="316"/>
@@ -1231,301 +1220,301 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="442"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="480"/>
         <source>Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="443"/>
         <source>Filename(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="318"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="441"/>
         <source>Last Modified Date</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="346"/>
         <source>TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="347"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="351"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="352"/>
         <source>network</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="356"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="434"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="357"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="430"/>
         <source>Ratings</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="381"/>
         <source>TV Show - TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="382"/>
         <source>TV Show - TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="383"/>
         <source>TV Show - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="427"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="428"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Trailer URL</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="440"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="468"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="470"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="471"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="472"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="473"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="474"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="475"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="476"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="477"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="478"/>
         <source>MusicBrainz ID</source>
-        <translation>Identificador MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="479"/>
         <source>AllMusic ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="384"/>
         <source>Episode - Season</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="385"/>
         <source>Episode - Number</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="386"/>
         <source>Episode - IMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="387"/>
         <source>Episode - TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="388"/>
         <source>Episode - TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="389"/>
         <source>Episode - TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="390"/>
         <source>Episode - First Aired</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="391"/>
         <source>Episode - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="392"/>
         <source>Episode - Overview</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="393"/>
         <source>Episode - User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="394"/>
         <source>Episode - Directors</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <source>Episode - Writers</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <source>Episode - Actors</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="397"/>
         <source>Episode - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="398"/>
         <source>Episode - Filename(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="496"/>
         <source>Artist - Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="497"/>
         <source>Album - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="498"/>
         <source>Album - Artist Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="499"/>
         <source>Album - Genres</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="500"/>
         <source>Album - Styles</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="501"/>
         <source>Album - Moods</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="502"/>
         <source>Album - Review</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="503"/>
         <source>Album - Release Date</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="504"/>
         <source>Album - Label</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="505"/>
         <source>Album - Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="506"/>
         <source>Album - Year</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="507"/>
         <source>Album - MusicBrainz ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="508"/>
         <source>Album - MusicBrainz ReleaseGroup ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="509"/>
         <source>Album - AllMusic ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="510"/>
         <source>Album - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="550"/>
         <source>Export failed. Could not write to CSV file.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="540"/>
         <source>Export failed. File could not be opened for writing.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1533,35 +1522,35 @@
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="29"/>
         <source>Select which site you prefer for each element of a TV show and episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="43"/>
         <source>TV show details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="65"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="101"/>
         <source>Item</source>
-        <translation>Item</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="70"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="106"/>
         <source>Site</source>
-        <translation>Site</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="79"/>
         <source>Episode details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.cpp" line="149"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.cpp" line="183"/>
         <source>No Scraper Available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1569,65 +1558,62 @@
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="50"/>
         <source>Archives</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="94"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="215"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="99"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="220"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="104"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="225"/>
         <source>Size</source>
-        <translation>Tamanho</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="146"/>
         <source>Importable items</source>
-        <translation>Itens importáveis</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="172"/>
         <source>Import movie with MakeMKV</source>
-        <translation>Importar filme com o MakeMKV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="230"/>
         <source>Import Type</source>
         <extracomment>(e.g. movie, TV show, concert)</extracomment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="233"/>
         <source>Type of this file.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="238"/>
         <source>Import Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="241"/>
         <source>Where to store the file when importing it.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="126"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="268"/>
         <source>%n files</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="202"/>
@@ -1635,50 +1621,50 @@
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="209"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="221"/>
         <source>Extraction failed</source>
-        <translation>A extração falhou</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="203"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="206"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="209"/>
         <source>Extraction of %1 has failed: %2</source>
-        <translation>A extração de %1 falhou: %2</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="219"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="233"/>
         <source>Extraction finished</source>
-        <translation>A extração terminou</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="233"/>
         <source>Extraction of %1 finished</source>
-        <translation>A extração de %1 foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="281"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="282"/>
         <source>TV Show</source>
-        <translation>Série TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="283"/>
         <source>Concert</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="464"/>
         <source>makemkvcon missing</source>
-        <translation>makemkvcon não foi encontrado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="465"/>
         <source>Please set the correct path to makemkvcon in MediaElch&apos;s settings.</source>
-        <translation>Por favor defina o caminho para o makemkvcon.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1687,87 +1673,87 @@
         <location filename="../../src/ui/export/ExportDialog.ui" line="23"/>
         <location filename="../../src/ui/export/ExportDialog.ui" line="132"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="32"/>
         <source>Export your complete collection.</source>
-        <translation>Exportar a sua coleção completa.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="39"/>
         <source>Message</source>
-        <translation>Mensagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="51"/>
         <source>Theme</source>
-        <translation>Tema</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="61"/>
         <source>Items to export</source>
-        <translation>Itens para exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="68"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="78"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="88"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="109"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="36"/>
         <source>You need to install at least one theme.</source>
-        <translation>Tem de instalar pelo menos um tema.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="58"/>
         <source>You need to select at least one media type to export.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="68"/>
         <source>Export directory</source>
-        <translation>Exportar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="70"/>
         <source>Export aborted. No directory was selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="78"/>
         <source>Could not create export directory.</source>
-        <translation>Não foi possível criar a pasta para exportação.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="95"/>
         <source>Export canceled.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="98"/>
         <source>Export completed.</source>
-        <translation>Exportação concluída.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="145"/>
         <source>Selected theme not found! Try to restart MediaElch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1775,28 +1761,28 @@
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.ui" line="17"/>
         <source>Message</source>
-        <translation>Mensagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.ui" line="43"/>
         <source>Theme</source>
-        <translation>Tema</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="67"/>
         <source>Theme &quot;%1&quot; was successfully installed</source>
-        <translation>O tema &quot;%1&quot; foi instalado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="70"/>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="81"/>
         <source>There was an error while processing the theme &quot;%1&quot;</source>
-        <translation>Ocorreu um erro ao processar o tema &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="78"/>
         <source>Theme &quot;%1&quot; was successfully uninstalled</source>
-        <translation>O tema &quot;%1&quot; foi desinstalado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1805,47 +1791,47 @@
         <location filename="../../src/ui/settings/ExportTemplateWidget.ui" line="102"/>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="42"/>
         <source>Install</source>
-        <translation>Instalar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="25"/>
         <source>by %1</source>
-        <translation>de %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="30"/>
         <source>No website available.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="33"/>
         <source>Version %1</source>
-        <translation>Versão %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="36"/>
         <source>Update</source>
-        <translation>Atualizar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="39"/>
         <source>Uninstall</source>
-        <translation>Desinstalar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="52"/>
         <source>Updating...</source>
-        <translation>A atualizar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="56"/>
         <source>Installing...</source>
-        <translation>A instalar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="60"/>
         <source>Uninstalling...</source>
-        <translation>A desinstalar...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1853,12 +1839,12 @@
     <message>
         <location filename="../../src/import/Extractor.cpp" line="30"/>
         <source>No files to extract</source>
-        <translation>Não há ficheiros para extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/import/Extractor.cpp" line="40"/>
         <source>Unrar not found</source>
-        <translation>Unrar não foi encontrado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1866,7 +1852,7 @@
     <message>
         <location filename="../../src/ui/main/FileScannerDialog.ui" line="17"/>
         <source>File Scanner</source>
-        <translation>Analisador de ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1874,94 +1860,94 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.ui" line="17"/>
         <source>Filter</source>
-        <translation>Filtro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="117"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="214"/>
         <source>Title contains &quot;%1&quot;</source>
-        <translation>O título contém &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="127"/>
         <source>Filename contains &quot;%1&quot;</source>
-        <translation>O ficheiro contém &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="393"/>
         <source>Label &quot;%1&quot;</source>
-        <translation>Etiqueta &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="395"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="371"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="372"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="373"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>Country</source>
-        <translation>País</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="384"/>
         <source>Released %1</source>
-        <translation>Lançamento %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="384"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="378"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="122"/>
         <source>Original Title contains &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="137"/>
         <source>TMDb ID &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="374"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="375"/>
         <source>Tag</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="376"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="377"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>Video codec</source>
-        <translation>Codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="437"/>
@@ -1969,226 +1955,226 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="516"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="517"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="438"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="439"/>
         <source>Filename</source>
-        <translation>Nome do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>IMDb</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="442"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>Movie has no TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>No TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>TMDb</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="469"/>
         <source>Movie has Poster</source>
-        <translation>O filme tem cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="469"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>Movie has no Poster</source>
-        <translation>O filme não tem cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>No Poster</source>
-        <translation>Nenhum cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="471"/>
         <source>Movie has Extra Fanarts</source>
-        <translation>O filme tem fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="471"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>Movie has no Extra Fanarts</source>
-        <translation>O filme não tem fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>No Extra Fanarts</source>
-        <translation>Nenhuma fanart extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <source>Movie has Backdrop</source>
-        <translation>O filme tem fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Movie has no Backdrop</source>
-        <translation>O filme não tem fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>No Backdrop</source>
-        <translation>Nenhum fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>No Fanart</source>
-        <translation>Sem fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="475"/>
         <source>Movie has Logo</source>
-        <translation>O filme tem logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="475"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>Movie has no Logo</source>
-        <translation>O filme não tem logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>No Logo</source>
-        <translation>Nenhum logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="477"/>
         <source>Movie has Clear Art</source>
-        <translation>O filme tem Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="477"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>Movie has no Clear Art</source>
-        <translation>O filme não tem Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>No Clear Art</source>
-        <translation>Nenhuma Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="479"/>
         <source>Movie has Banner</source>
-        <translation>O filme tem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="479"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>Movie has no Banner</source>
-        <translation>O filme não tem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>No Banner</source>
-        <translation>Sem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="481"/>
         <source>Movie has Thumb</source>
-        <translation>O filme tem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="481"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>Movie has no Thumb</source>
-        <translation>O filme não tem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>No Thumb</source>
-        <translation>Sem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="483"/>
         <source>Movie has CD Art</source>
-        <translation>O filme tem CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="483"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>Movie has no CD Art</source>
-        <translation>O filme não tem CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>No CD Art</source>
-        <translation>Nenhuma CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="487"/>
         <source>Movie has Trailer</source>
-        <translation>O filme tem trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="487"/>
@@ -2196,239 +2182,239 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="488"/>
         <source>Movie has no Trailer</source>
-        <translation>O filme não tem trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="488"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>No Trailer</source>
-        <translation>Nenhum trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <source>Movie has local Trailer</source>
-        <translation>O filme tem um trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Movie has no local Trailer</source>
-        <translation>O filme não tem trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>No local Trailer</source>
-        <translation>Nenhum trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <source>Movie is Watched</source>
-        <translation>O filme foi visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Seen</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Movie is Unwatched</source>
-        <translation>O filme está por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Unwatched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Unseen</source>
-        <translation>Não visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>Movie has no Certification</source>
-        <translation>O filme não tem certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>No Certification</source>
-        <translation>Nenhuma certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>Movie has no Genre</source>
-        <translation>O filme não tem género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="132"/>
         <source>IMDb ID &quot;%1&quot;</source>
-        <translation>Identificador do IMDB &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="440"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>No Genre</source>
-        <translation>Nenhum género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="456"/>
         <source>Movie has Rating</source>
-        <translation>O filme tem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="456"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>Movie has no Rating</source>
-        <translation>O filme não tem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>No Rating</source>
-        <translation>Sem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="464"/>
         <source>Stream Details loaded</source>
-        <translation>Os detalhes da pista foram carregados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="464"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>Stream Details</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>Stream Details not loaded</source>
-        <translation>Os detalhes da pista não foram carregados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>No Stream Details</source>
-        <translation>Nenhuns detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="460"/>
         <source>Movie has Actors</source>
-        <translation>O filme tem atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="460"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>Movie has no Actors</source>
-        <translation>O filme não tem atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>No Actors</source>
-        <translation>Nenhuns atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>Movie has no Studio</source>
-        <translation>O filme não tem estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>No Studio</source>
-        <translation>Nenhum estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>Movie has no Country</source>
-        <translation>O filme não tem país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>No Country</source>
-        <translation>Nenhum país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>Movie has no Director</source>
-        <translation>O filme não tem realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>No Director</source>
-        <translation>Nenhum realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>No information about video codec</source>
-        <translation>Nenhuma informação sobre o codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>No video codec</source>
-        <translation>Sem codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>Movie has no Tags</source>
-        <translation>O filme não tem etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>No Tags</source>
-        <translation>Nenhumas etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>Movie has no IMDb ID</source>
-        <translation>Filme sem identificador IMDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>No IMDb ID</source>
-        <translation>Sem identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
         <source>Resolution 720p</source>
-        <translation>Resolução 720p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
         <source>720p</source>
-        <translation>720p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
@@ -2436,68 +2422,68 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="494"/>
         <source>Resolution 1080p</source>
-        <translation>Resolução 1080p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="494"/>
         <source>1080p</source>
-        <translation>1080p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <source>Resolution 2160p</source>
-        <translation>Resolução 2160p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <source>2160p</source>
-        <translation>2160p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>Resolution SD</source>
-        <translation>Resolução SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>SD</source>
-        <translation>SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <source>Format DVD</source>
-        <translation>Formato DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <source>DVD</source>
-        <translation>DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>Format</source>
-        <translation>Formato</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>BluRay Format</source>
-        <translation>Formato BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>BluRay</source>
-        <translation>BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
         <source>Channels 2.0</source>
-        <translation>Canais 2.0</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
@@ -2507,59 +2493,59 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="502"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="503"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="502"/>
         <source>Channels 5.1</source>
-        <translation>Canais 5.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="503"/>
         <source>Channels 7.1</source>
-        <translation>Canais 7.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="504"/>
         <source>Audio Quality HD</source>
-        <translation>Qualidade de áudio HD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="504"/>
         <source>HD Audio</source>
-        <translation>Áudio HD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <source>Audio Quality Normal</source>
-        <translation>Qualidade de áudio normal</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <source>Normal Audio</source>
-        <translation>Áudio normal</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>Audio Quality SD</source>
-        <translation>Qualidade de áudio SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>SD Audio</source>
-        <translation>Áudio SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="509"/>
         <source>Movie has Subtitle</source>
-        <translation>Filme com legenda</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="509"/>
@@ -2567,39 +2553,39 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>Subtitle</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="510"/>
         <source>Movie has no Subtitle</source>
-        <translation>O filme não tem legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="510"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>No Subtitle</source>
-        <translation>Sem legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <source>Movie has external Subtitle</source>
-        <translation>O filme tem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>External Subtitle</source>
-        <translation>Legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>Movie has no external Subtitle</source>
-        <translation>O filme não tem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>No External Subtitle</source>
-        <translation>Sem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2607,63 +2593,63 @@
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="52"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="79"/>
         <source>TextLabel</source>
-        <translation>EtiquetaTexto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="116"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="139"/>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="142"/>
         <source>Add Movie</source>
-        <translation>Adicionar filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="149"/>
         <source>Remove Current Movie</source>
-        <translation>Remover filme atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="152"/>
         <source>Remove Movie</source>
-        <translation>Remover filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="165"/>
         <source>Double click a genre to rename it, right click to delete. If you want to merge two genres just give them the same name.</source>
-        <translation>Clique duas vezes num género para lhe alterar o nome, clique com o botão direito para eliminá-lo. Se quiser fundir dois géneros, basta colocar-lhes o mesmo nome.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="175"/>
         <source>Please keep in mind that the changes you make here (renaming or deleting genres) will be made for every movie.</source>
-        <translation>Por favor, lembre-se que todas as alterações feitas aqui (alterar o nome ou eliminar géneros) serão feitas para todos os filmes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="28"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="29"/>
         <source>Delete Genre</source>
-        <translation>Eliminar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="172"/>
         <source>New Genre</source>
-        <translation>Novo género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="287"/>
         <source>All Movies Saved</source>
-        <translation>Todos os filmes foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2671,189 +2657,189 @@
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="21"/>
         <source>Directories</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="57"/>
         <source>Add one or more directories containing your movies, TV Shows, concerts, music or files to import.
 TV Show Episodes have to be in subfolders with the name of the show.
 The directories containing your music must contain subdirectories for each artist which contain directories of albums.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="91"/>
         <source>Type</source>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="96"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="101"/>
         <source>Sep. folders</source>
-        <translation>Pastas separadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="104"/>
         <source>Items are in separate folders</source>
-        <translation>Os itens estão em pastas separadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="109"/>
         <source>Reload On Start</source>
-        <translation>Recarregar ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="112"/>
         <source>Automatically reload contents on start</source>
-        <translation>Recarrega automaticamente os conteúdos ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="117"/>
         <source>Disabled</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="120"/>
         <source>Ignore this folder.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="130"/>
         <source>Add</source>
-        <translation>Adicionar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="137"/>
         <source>Remove</source>
-        <translation>Remover</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="144"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sort movies into separate directories&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ordenar filmes em pastas separadas&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="147"/>
         <source>Organize</source>
-        <translation>Organizar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="174"/>
         <source>Store trailer URLs in YouTube Plugin format</source>
-        <translation>Guardar endereços de trailers no formato YouTube Plugin</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="188"/>
         <source>Automatically load and save stream details from files</source>
-        <translation>Carregar e guardar automaticamente detalhes das pistas dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="202"/>
         <source>Ignore articles when sorting (&quot;The&quot;)</source>
-        <translation>Ignorar artigos iniciais ao ordenar (&quot;The&quot;)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="216"/>
         <source>Download actor images</source>
-        <translation>Descarregar imagens de atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="230"/>
         <source>Check for Updates on start</source>
-        <translation>Verificar se existem atualizações ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="244"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="263"/>
         <source>Words to exclude from media names (seperated by commas and non case-sensitive)</source>
-        <translation>Palavras a excluir dos nomes de média (separar com vírgulas e sem sensibilidade a maiúsculas)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="270"/>
         <source>Startup section</source>
-        <translation>Secção inicial</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="300"/>
         <source>Appearance</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="311"/>
         <source>Main Window Theme (changing it requires restart of MediaElch)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="42"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="43"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="44"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="45"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="46"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="48"/>
         <source>Auto</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="49"/>
         <source>Light</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="50"/>
         <source>Dark</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="66"/>
         <source>Choose a directory containing your movies, TV show or concerts</source>
-        <translation>Escolher uma pasta que contém os seus filmes, séries TV ou concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Downloads</source>
-        <translation>Descarregamentos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="265"/>
         <source>Organizing movies does only work on movies, not already sorted to separate folders.</source>
-        <translation>Organizar filmes funciona apenas em filmes, sem estarem já organizados em pastas separadas.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="273"/>
         <source>Are you sure?</source>
-        <translation>Tem a certeza?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="275"/>
         <source>This operation sorts all movies in this directory to separate sub-directories based on the file name. Click &quot;Ok&quot;, if that&apos;s, what you want to do. </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2861,22 +2847,22 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="17"/>
         <source>Choose an Image</source>
-        <translation>Escolher uma imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="31"/>
         <source>Enter a search term or URL</source>
-        <translation>Introduza um termo de busca ou um endereço</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="44"/>
         <source>Language to use when searching for a TV show by title.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="124"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="176"/>
@@ -2885,96 +2871,93 @@ The directories containing your music must contain subdirectories for each artis
         <location filename="../../src/ui/image/ImageDialog.ui" line="191"/>
         <location filename="../../src/ui/image/ImageDialog.ui" line="196"/>
         <source>Neue Spalte</source>
-        <translation>Nova coluna</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="703"/>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="711"/>
         <source>No images found</source>
-        <translation>Nenhumas imagens encontradas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="249"/>
         <source>Zoom out</source>
-        <translation>Diminuir ampliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="275"/>
         <source>Preview size</source>
-        <translation>Tamanho de pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="303"/>
         <source>Zoom in</source>
-        <translation>Aumentar ampliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="324"/>
         <source>Loading...</source>
-        <translation>A carregar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="347"/>
         <source>Choose Local Image</source>
-        <translation>Escolher imagem local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="360"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="367"/>
         <source>Accept Images</source>
-        <translation>Aceitar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="251"/>
         <source>Default</source>
-        <translation>Padrão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="158"/>
         <source>Neither an image provider nor previously scraped image URLs are available for the requested image type.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="360"/>
         <source>Error while downloading one or more images: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="523"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="523"/>
         <source>Images (*.jpg *.jpeg *.png)</source>
-        <translation>Imagens (*.jpg *.jpeg *.png)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="708"/>
         <source>Images provided by &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
-        <translation>Imagens fornecidas por  &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="712"/>
         <source>Contribute by uploading images to &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
-        <translation>Contribua enviando novas imagens para &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/image/ImageDialog.cpp" line="812"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="941"/>
         <source>Error while querying image provider: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2982,7 +2965,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/small_widgets/ImageLabel.ui" line="42"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2990,12 +2973,12 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/image/ImagePreviewDialog.ui" line="17"/>
         <source>Preview</source>
-        <translation>Pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImagePreviewDialog.ui" line="82"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3003,22 +2986,22 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/import/ImportActions.ui" line="23"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.ui" line="30"/>
         <source>Delete</source>
-        <translation>Eliminar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.cpp" line="128"/>
         <source>Delete file?</source>
-        <translation>Eliminar o ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.cpp" line="129"/>
         <source>Do you really want to delete this file?</source>
-        <translation>Quer mesmo eliminar este ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3026,144 +3009,141 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="17"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="40"/>
         <source>Loading</source>
-        <translation>A carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="47"/>
         <source>Success</source>
-        <translation>Sucesso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="54"/>
         <source>Loading movie...</source>
-        <translation>A carregar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="81"/>
         <source>Directory Naming</source>
-        <translation>Nomes das pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="91"/>
         <source>File Naming</source>
-        <translation>Nomes dos Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="108"/>
         <source>Use Season Directories</source>
-        <translation>Usar pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="115"/>
         <source>Season Directory Naming</source>
-        <translation>Nomes das pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="132"/>
         <source>Keep source files after import</source>
-        <translation>Manter ficheiros originais após importação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="175"/>
         <location filename="../../src/ui/import/ImportDialog.ui" line="185"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="205"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="274"/>
         <source>Loading movie information...</source>
-        <translation>A carregar a informação do filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="296"/>
         <source>Loading concert information...</source>
-        <translation>A carregar a informação do concerto...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="320"/>
         <source>Loading episode information...</source>
-        <translation>A carregar a informação do episódio...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="390"/>
         <source>Movie information was loaded</source>
-        <translation>A informação do filme foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="404"/>
         <source>Concert information was loaded</source>
-        <translation>A informação do concerto foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="423"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="442"/>
         <source>Episode information was loaded</source>
-        <translation>A informação do episódio foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="454"/>
         <source>Renaming not possible</source>
-        <translation>Não é possível alterar o nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="454"/>
         <source>Please enter all naming patterns</source>
-        <translation>Por favor, introduza todos os padrões de nomenclatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="484"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="577"/>
         <source>Creating destination directory failed</source>
-        <translation>Não foi possível criar a pasta de destino</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="485"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="578"/>
         <source>The destination directory %1 could not be created</source>
-        <translation>Não foi possível criar a pasta de destino %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="514"/>
         <source>Importing movie...</source>
-        <translation>A importar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="553"/>
         <source>Importing episode...</source>
-        <translation>A importar o episódio...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="605"/>
         <source>Importing concert...</source>
-        <translation>A importar o concerto...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="708"/>
         <source>Import finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/import/ImportDialog.cpp" line="709"/>
         <source>Import of %n files has finished</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="712"/>
         <source>Import has finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3171,33 +3151,33 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="19"/>
         <source>Automatically delete archives after extraction</source>
-        <translation>Eliminar ficheiros automaticamente após extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="33"/>
         <source>Path to unrar</source>
-        <translation>Localização do Unrar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="45"/>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="66"/>
         <source>Choose</source>
-        <translation>Escolher</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="54"/>
         <source>Path to makemkvcon</source>
-        <translation>Localização de makemkvcon</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.cpp" line="46"/>
         <source>Choose unrar</source>
-        <translation>Escolher Unrar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.cpp" line="54"/>
         <source>Choose makemkvcon</source>
-        <translation>Escolher makemkvco</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3205,49 +3185,47 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="17"/>
         <source>General Kodi Settings. MediaElch uses the Kodi version below for writing NFO files.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="29"/>
         <source>Kodi Version</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="48"/>
         <source>If you want to use the synchronization feature you need to enable the webserver within Kodi (Settings -&gt; Services -&gt; Webserver). Enter the port of the webserver here (usually 80 or 8080).</source>
-        <translation>Se quer usar o recurso de sincronização, deve antes ativar o servidor web dentro do Kodi.
-Veja em Kodi -&gt; Definições -&gt; Serviços -&gt; Servidor web. Anote os números de host (IP) e da porta.
-Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="63"/>
         <source>Host</source>
-        <translation>Anfitrião</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="70"/>
         <source>127.0.0.1</source>
-        <translation>127.0.0.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="77"/>
         <source>Port</source>
-        <translation>Porta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="84"/>
         <source>8080</source>
-        <translation>8080</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="91"/>
         <source>User</source>
-        <translation>Utilizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="98"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3255,68 +3233,68 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="23"/>
         <source>Kodi Synchronization</source>
-        <translation>Sincronização com Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="32"/>
         <source>Please make sure you have setup your sources in Kodi and that the webserver is enabled (Kodi -&gt; Settings -&gt; Services -&gt; Webserver).</source>
-        <translation>Por favor, certifique-se que configurou as suas fontes no Kodi e que o seu servidor web está ativado (Kodi -&gt; Definições -&gt; Serviços -&gt; Servidor web).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="42"/>
         <source>Update contents</source>
-        <translation>Atualizar conteúdos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="52"/>
         <source>This will tell Kodi to remove the changed movies, concerts or shows. Afterwards a Kodi library update is triggered and the removed items will be picked up again.</source>
-        <translation>Isto irá dizer ao Kodi para remover os filmes, concertos e séries com alterações. Após isso, o Kodi irá fazer uma atualização e os itens removidos serão novamente recolhidos e reinseridos.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="62"/>
         <source>Remove non-existent items from Kodis database (Clean library)</source>
-        <translation>Remover itens não existentes da base de dados do Kodi (limpar coleção).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="69"/>
         <source>Kodi will remove not longer existing items from your database.</source>
-        <translation>O Kodi irá remover os itens não localizados da sua base de dados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="76"/>
         <source>Retrieve watched status</source>
-        <translation>Obter estado de &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="83"/>
         <source>The fields last played and playcount will be retrieved from Kodi.</source>
-        <translation>Os campos Última Reprodução e Contador de Sessões virão do Kodi.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="113"/>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="120"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="138"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="161"/>
         <source>Start</source>
-        <translation>Iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="165"/>
         <source>Please fill in your Kodi host and port.</source>
-        <translation>Por favor introduza os dados de Host e Porta no menu Definições -&gt; Kodi.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="238"/>
         <source>Getting contents from Kodi</source>
-        <translation>A obter conteúdos do Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="254"/>
@@ -3324,52 +3302,52 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="318"/>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="350"/>
         <source>Network error</source>
-        <translation>Erro de rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="448"/>
         <source>Removing movies from database</source>
-        <translation>A remover filmes da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="463"/>
         <source>Removing concerts from database</source>
-        <translation>A remover concertos da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="478"/>
         <source>Removing TV shows from database</source>
-        <translation>A remover séries de TV da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="493"/>
         <source>Removing episodes from database</source>
-        <translation>A remover episódios da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="533"/>
         <source>Trigger scan for new items</source>
-        <translation>Requisitar busca de novos itens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="555"/>
         <source>Error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="560"/>
         <source>Finished. Kodi is now loading your updated items.</source>
-        <translation>Terminado. O Kodi está agora a carregar os seus itens atualizados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="582"/>
         <source>Finished. Kodi is now cleaning your database.</source>
-        <translation>Terminado. O Kodi está agora a limpar a sua base de dados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="627"/>
         <source>Finished. Your items play count and last played date have been updated.</source>
-        <translation>Concluído. O &quot;Nº de reproduções&quot; e a &quot;última reprodução&quot; dos seus itens foram atualizadas.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3377,7 +3355,7 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/small_widgets/LanguageCombo.cpp" line="37"/>
         <source>No language available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3385,17 +3363,17 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="23"/>
         <source>Loading Stream Details</source>
-        <translation>A carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="32"/>
         <source>Loading Stream Details...</source>
-        <translation>A carregar detalhes da pista...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="46"/>
         <source>File</source>
-        <translation>Ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3403,414 +3381,414 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/data/Locale.cpp" line="28"/>
         <source>Arabic</source>
-        <translation>Árabe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="29"/>
         <source>Arabic (U.A.E.)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="30"/>
         <source>Arabic (Saudi Arabia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="31"/>
         <source>Belarusian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="32"/>
         <location filename="../../src/data/Locale.cpp" line="33"/>
         <source>Bulgarian</source>
-        <translation>Búlgaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="34"/>
         <source>Bengali</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="35"/>
         <source>Catalan (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="36"/>
         <source>Chamorro (Guam)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="37"/>
         <source>Cantonese</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="38"/>
         <location filename="../../src/data/Locale.cpp" line="39"/>
         <source>Czech</source>
-        <translation>Checo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="40"/>
         <location filename="../../src/data/Locale.cpp" line="41"/>
         <source>Danish</source>
-        <translation>Dinamarquês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="42"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="43"/>
         <source>German (AT)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="44"/>
         <source>German (CH)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="45"/>
         <source>German (DE)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="46"/>
         <location filename="../../src/data/Locale.cpp" line="47"/>
         <source>Greek</source>
-        <translation>Grego</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="48"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="49"/>
         <source>English (Australia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="50"/>
         <source>English (Canada)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="51"/>
         <source>English (GB)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="52"/>
         <source>English (NZ)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="53"/>
         <source>English (US)</source>
-        <translation>Inglês (US)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="54"/>
         <source>Esperanto</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="55"/>
         <location filename="../../src/data/Locale.cpp" line="56"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="57"/>
         <source>Spanish (Mexico)</source>
-        <translation>Castelhano (México)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="58"/>
         <source>Estonian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="59"/>
         <source>Basque (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="60"/>
         <source>Persian (Iran)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="61"/>
         <location filename="../../src/data/Locale.cpp" line="62"/>
         <source>Finnish</source>
-        <translation>Finlandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="63"/>
         <location filename="../../src/data/Locale.cpp" line="65"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="64"/>
         <source>French (Canada)</source>
-        <translation>Francês (Canadá)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="66"/>
         <source>Galician (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="67"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="68"/>
         <source>Hebrew (Israel)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="69"/>
         <source>Hindi (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="70"/>
         <source>Croatian</source>
-        <translation>Croata</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="71"/>
         <source>Croatian (Croatia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="72"/>
         <location filename="../../src/data/Locale.cpp" line="73"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="74"/>
         <source>Indonesian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="75"/>
         <location filename="../../src/data/Locale.cpp" line="76"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="77"/>
         <location filename="../../src/data/Locale.cpp" line="78"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="79"/>
         <source>Georgian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="80"/>
         <source>Kazakh</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="81"/>
         <source>Kannada</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="82"/>
         <location filename="../../src/data/Locale.cpp" line="83"/>
         <source>Korean</source>
-        <translation>Coreano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="84"/>
         <source>Lithuanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="85"/>
         <source>Latvian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="86"/>
         <source>Malayalam</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="87"/>
         <source>Malay (Malaysia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="88"/>
         <source>Malay (Singapore)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="89"/>
         <source>Norwegian Bokmål</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="90"/>
         <location filename="../../src/data/Locale.cpp" line="91"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="92"/>
         <location filename="../../src/data/Locale.cpp" line="93"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="94"/>
         <location filename="../../src/data/Locale.cpp" line="95"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="96"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="97"/>
         <source>Portuguese (Brazil)</source>
-        <translation>Português (Brasil)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="98"/>
         <source>Portuguese (Portugal)</source>
-        <translation>Português (Portugal)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="99"/>
         <source>Romanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="100"/>
         <location filename="../../src/data/Locale.cpp" line="101"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="102"/>
         <source>Sinhalese (Sri Lanka)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="103"/>
         <source>Slovak</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="104"/>
         <source>Slovene</source>
-        <translation>Eslovaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="105"/>
         <source>Slovenian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="106"/>
         <source>Albanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="107"/>
         <source>Serbian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="108"/>
         <location filename="../../src/data/Locale.cpp" line="109"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="110"/>
         <source>Tamil (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="111"/>
         <source>Telugu (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="112"/>
         <source>Thai</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="113"/>
         <source>Tagalog (Philippines)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="114"/>
         <location filename="../../src/data/Locale.cpp" line="115"/>
         <source>Turkish</source>
-        <translation>Turco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="116"/>
         <source>Ukrainian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="117"/>
         <source>Vietnamese</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="118"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="119"/>
         <source>Chinese (PRC)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="120"/>
         <source>Chinese (Hong Kong)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="121"/>
         <source>Chinese (Taiwan)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="122"/>
         <source>Zulu</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="124"/>
         <source>No language available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3818,55 +3796,55 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="14"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="75"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="94"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="125"/>
         <source>Movie Sets</source>
-        <translation>Coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="156"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="187"/>
         <source>Certifications</source>
-        <translation>Certificações</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="218"/>
         <source>Duplicates</source>
-        <translation>Duplicados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="248"/>
         <source>Shows</source>
-        <translation>Séries</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="267"/>
         <source>TV Shows</source>
-        <translation>Séries TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="297"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="316"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="346"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="365"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="395"/>
@@ -3875,92 +3853,92 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
         <extracomment>Main menu entry
 ----------
 Main menu entry (tooltip)</extracomment>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="883"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="888"/>
         <source>Quit</source>
-        <translation>Sair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="893"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="52"/>
         <source>FAQ</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="53"/>
         <source>Troubleshooting</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="54"/>
         <source>Report Issue</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="56"/>
         <source>Release Notes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="57"/>
         <source>Documentation</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="58"/>
         <source>Blog</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="59"/>
         <source>Official Kodi Forum</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="61"/>
         <source>View License</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="340"/>
         <source>&amp;Quick Open</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="807"/>
         <source>Reload all Movies (%1)</source>
-        <translation>Recarregar todos os filmes (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="813"/>
         <source>Reload all TV Shows (%1)</source>
-        <translation>Recarregar todas as séries de TV (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="824"/>
         <source>Reload all Concerts (%1)</source>
-        <translation>Recarregar todos os Concertos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="840"/>
         <source>Reload all Downloads (%1)</source>
-        <translation>Recarregar todos os descarregamentos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="846"/>
         <source>Reload Music (%1)</source>
-        <translation>Recarregar música (%1)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3968,147 +3946,147 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="50"/>
         <source>Scan</source>
-        <translation>Análise</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="92"/>
         <source>Import Tracks</source>
-        <translation>Importar faixas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="118"/>
         <source>Backup Disc</source>
-        <translation>Disco de cópia de segurança</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="163"/>
         <source>Loading</source>
-        <translation>A carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="170"/>
         <source>Success</source>
-        <translation>Sucesso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="177"/>
         <source>Loading movie...</source>
-        <translation>A carregar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="199"/>
         <source>Placeholders</source>
-        <translation>Marcadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="207"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="236"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="259"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="282"/>
         <source>File extension</source>
-        <translation>Extensão de ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="298"/>
         <source>Placeholder</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="321"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="338"/>
         <source>Part number of the current file</source>
-        <translation>Número da parte do ficheiro atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="355"/>
         <source>Directory Naming</source>
-        <translation>Nomes das pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="365"/>
         <source>File Naming</source>
-        <translation>Nomes dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="375"/>
         <source>Multi-File Naming</source>
-        <translation>Renomear múltiplos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="385"/>
         <source>Import directory</source>
-        <translation>Pasta de importação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="429"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="452"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="207"/>
         <source>No tracks selected</source>
-        <translation>Não foram selecionadas faixas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="208"/>
         <source>Please select at least one track you want to import.</source>
-        <translation>Por favor, selecione pelo menos uma faixa para importar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="246"/>
         <source>Loading movie information...</source>
-        <translation>A carregar a informação do filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="274"/>
         <source>Movie information was loaded</source>
-        <translation>A informação de filme foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="297"/>
         <source>Creating destination directory failed</source>
-        <translation>Não foi possível criar a pasta de destino</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="298"/>
         <source>The destination directory %1 could not be created</source>
-        <translation>Não foi possível criar a pasta de destino %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="386"/>
         <source>MakeMKV import finished</source>
-        <translation>Importação MakeMKV foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="386"/>
         <source>Import with MakeMKV has finished</source>
-        <translation>A importação com o MakeMKV foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="389"/>
         <source>Import has finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4116,17 +4094,17 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="116"/>
         <source>Movie title</source>
-        <translation>Título do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="145"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="152"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4134,27 +4112,27 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.ui" line="67"/>
         <source>Detect duplicate movies</source>
-        <translation>Detetar filmes duplicados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="75"/>
         <source>Detecting duplicate movies...</source>
-        <translation>A detetar filmes duplicados...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="129"/>
         <source>Open Detail Page</source>
-        <translation>Abrir página de detalhes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="130"/>
         <source>Open Movie Folder</source>
-        <translation>Abrir pasta do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="131"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4162,19 +4140,18 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="25"/>
         <source>Source %1 is no directory</source>
-        <translation>A fonte %1 não é uma pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="83"/>
         <source>Operation not possible.</source>
-        <translation>Não foi possível efetuar a operação.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="84"/>
         <source>%1
  Operation Canceled.</source>
-        <translation>%1
- Operação Cancelada.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4182,99 +4159,93 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="144"/>
         <source>New</source>
-        <translation>Novo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="160"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="176"/>
         <source>Date Added</source>
-        <translation>Data de adição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="192"/>
         <source>Seen</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="208"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="30"/>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="562"/>
         <source>%n movies</source>
-        <translation>
-            <numerusform>%n filme</numerusform>
-            <numerusform>%n filmes</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="58"/>
         <source>Media Status Columns</source>
-        <translation>Colunas de estado do média</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="69"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="80"/>
         <source>Load Information</source>
-        <translation>Carregar informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="81"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="82"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="83"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="84"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="85"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="86"/>
         <source>Open Movie Folder</source>
-        <translation>Abrir pasta do Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="87"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="88"/>
         <source>Play movie</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="564"/>
         <source>%1 of %n movies</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -4282,85 +4253,85 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="17"/>
         <source>Choose a movie</source>
-        <translation>Escolher o filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="26"/>
         <source>Filter</source>
-        <translation>Filtro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="58"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="68"/>
         <source>Add selected movies</source>
-        <translation>Adicionar filmes selecionados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="88"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="326"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <source>Extra Arts</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <source>Extra Fanarts</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="329"/>
-        <source>Extra Arts</source>
-        <translation>Arts extras</translation>
+        <source>Fanart</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="330"/>
-        <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <source>Poster</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="331"/>
-        <source>Fanart</source>
-        <translation>Fanart</translation>
+        <source>Stream Details</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="332"/>
-        <source>Poster</source>
-        <translation>Cartaz</translation>
+        <source>Trailer</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="333"/>
-        <source>Stream Details</source>
-        <translation>Detalhes da pista</translation>
+        <source>Local Trailer</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="334"/>
-        <source>Trailer</source>
-        <translation>Trailer</translation>
+        <source>Subtitles</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="335"/>
-        <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <source>Tags</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="336"/>
-        <source>Subtitles</source>
-        <translation>Legendas</translation>
-    </message>
-    <message>
-        <location filename="../../src/model/MovieModel.cpp" line="337"/>
-        <source>Tags</source>
-        <translation>Etiquetas</translation>
-    </message>
-    <message>
-        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4368,185 +4339,182 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="23"/>
         <source>Movie Multi Scrape</source>
-        <translation>Extração múltipla de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="36"/>
         <source>Please select the scraper and the infos you want to be loaded. MediaElch will use the best result for each movie you selected.</source>
-        <translation>Por favor, escolha o extrator e as informações que pretende carregar. O MediaElch usará o melhor resultado para cada filme que selecionou.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="48"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="84"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="143"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="233"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="163"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="303"/>
         <source>Logo</source>
-        <translation>Logotipos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="223"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="133"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="113"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="93"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="103"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="173"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="213"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="203"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="153"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="123"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="183"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="243"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="253"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="193"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="293"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="283"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="273"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="263"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="313"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="332"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="358"/>
         <source>Automatically save each movie after scraping</source>
-        <translation>Guardar automaticamente cada filme após a extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="365"/>
         <source>Update only movies with IMDb ID/TMDb Id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="380"/>
         <source>1/20</source>
-        <translation>1/20</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="387"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="412"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="435"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="448"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.cpp" line="201"/>
         <source>Scraping of %n movies has finished.</source>
-        <translation>
-            <numerusform>A extração de %n filmes terminou.</numerusform>
-            <numerusform>A extração de %n filmes terminou.</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -4554,12 +4522,12 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4567,166 +4535,163 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="31"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="41"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="70"/>
         <source>When using IMDb you can also use the IMDb id as search query.
 If you want to search by an TMDb id please prefix it with &quot;id&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="128"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="163"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="170"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="177"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="184"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="191"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="198"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="205"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="212"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="219"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="226"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="233"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="240"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="264"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="271"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="278"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="285"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="292"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="299"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="306"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="313"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="320"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="327"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="334"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="365"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="77"/>
         <source>Cannot scrape a movie without an active scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="153"/>
         <source>Internal inconsistency: Cannot set language dropdown in movie search widget!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="175"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="314"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4734,112 +4699,112 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your movies. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Em baixo, pode ver os nomes de ficheiros usados para carregar e guardar os seus filmes. Pode editá-los à sua vontade, se quiser usar vários ficheiros separe-os com uma vírgula.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o de nome de ficheiro sem extensão.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="42"/>
         <source>Nfo</source>
-        <translation>Nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="49"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="56"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="63"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="70"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="77"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="216"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="223"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="281"/>
         <source>Movie outline</source>
-        <translation>Resumo do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="288"/>
         <source>Use plot when outline is not available</source>
-        <translation>Usar enredo quando não existir resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="295"/>
         <source>Movie Set Artwork</source>
-        <translation>Artwork de coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="21"/>
         <source>Artwork next to movies</source>
-        <translation>Artwork próxima dos filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="23"/>
         <source>Separate artwork directory</source>
-        <translation>Pasta separada de artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="305"/>
         <source>Movie Set Poster Filename</source>
-        <translation>Nome do ficheiro do cartaz da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="342"/>
         <source>Movie Set Fanart Filname</source>
-        <translation>Nome de ficheiro da fanart da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="379"/>
         <source>Artwork directory</source>
-        <translation>Pasta de artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="391"/>
         <source>Choose directory</source>
-        <translation>Escolher pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="400"/>
         <source>Movie Original Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="407"/>
         <source>Don&apos;t store the original title if it is the same as the normal title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="163"/>
         <source>Choose a directory where your movie set artwork is stored</source>
-        <translation>Escolher uma pasta onde a artwork da coleção de filmes está guardada</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4847,283 +4812,283 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="50"/>
         <source>Movie has changed. Click to revert changes.</source>
-        <translation>O filme foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="75"/>
         <source>Movie Name</source>
-        <translation>Nome do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="121"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="141"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1050"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="155"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="165"/>
         <source>Original Name</source>
-        <translation>Nome original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="175"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="185"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="211"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="228"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="235"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="245"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="255"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="275"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="282"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="317"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="347"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="350"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="353"/>
         <source>Not watched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="362"/>
         <source>Plot</source>
-        <translation>Enredo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="386"/>
         <source>Insert YouTube Dummy Link</source>
-        <translation>Inserir link falso do YouTube</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="405"/>
         <source>Download Trailer</source>
-        <translation>Descarregar trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="421"/>
         <source>Play local trailer</source>
-        <translation>Reproduzir trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="431"/>
         <source>Local trailer is available</source>
-        <translation>Está disponível um trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="434"/>
         <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="447"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="480"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="548"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="558"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="570"/>
         <source>Outline</source>
-        <translation>Resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="592"/>
         <source>Open movie on IMDb.com</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="595"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="631"/>
         <source>Go</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="618"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="628"/>
         <source>Open movie on TheMovieDB.org</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="663"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="695"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="786"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="705"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="717"/>
         <source>Support for extra fanarts is only available when your movies are stored in separate folders. Check the settings if you&apos;ve stored your movies in separate folders already.</source>
-        <translation>O recurso a fanarts extra só está disponível quando os seus filmes estão guardados em pastas separadas. Verifique as definições, caso já tenha guardado os seus filmes em pastas separadas.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="735"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="758"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="768"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="806"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="796"/>
         <source>Scantype</source>
-        <translation>Varrimento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="942"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="788"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="791"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="847"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="862"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="888"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="881"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="221"/>
         <source>Ratings</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="653"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="952"/>
         <source>Stereo Mode</source>
-        <translation>Modo de Estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="973"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1030"/>
         <source>External Subtitles</source>
-        <translation>Legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1060"/>
         <source>Forced</source>
-        <translation>Forçadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1216"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1256"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1238"/>
@@ -5134,103 +5099,103 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1502"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1549"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1263"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1303"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1310"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1350"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1386"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1426"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1433"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1473"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1480"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1520"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1527"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1567"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="88"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="89"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="93"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="94"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="98"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="99"/>
         <source>Add Country</source>
-        <translation>Adicionar país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="103"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="104"/>
         <source>Add Studio</source>
-        <translation>Adicionar estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="485"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="492"/>
         <source>Scraping...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="780"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="816"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1055"/>
@@ -5239,49 +5204,49 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="821"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="822"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="789"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="792"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="807"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="850"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="921"/>
         <source>Saving movie...</source>
-        <translation>A guardar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="926"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="902"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="950"/>
         <source>Saving movies...</source>
-        <translation>A guardar os filmes...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="919"/>
         <source>Movies Saved</source>
-        <translation>Filmes guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="971"/>
         <source>All Movies Saved</source>
-        <translation>Todos os filmes foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5289,12 +5254,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/file_search/MusicFileSearcher.cpp" line="44"/>
         <source>Searching for Music...</source>
-        <translation>A procurar por músia...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MusicFileSearcher.cpp" line="129"/>
         <source>Loading Music...</source>
-        <translation>A carregar a música...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5302,38 +5267,29 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="31"/>
         <source>Open Folder</source>
-        <translation>Abrir pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="32"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="25"/>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="155"/>
         <source>%n artists</source>
-        <translation>
-            <numerusform>%n artista</numerusform>
-            <numerusform>%n artistas</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="25"/>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="155"/>
         <source>%n albums</source>
-        <translation>
-            <numerusform>%n álbum</numerusform>
-            <numerusform>%n álbuns</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="158"/>
         <source>%1 of %n artists</source>
-        <translation>
-            <numerusform>%1 de %n artista</numerusform>
-            <numerusform>%1 de %n artistas</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5341,170 +5297,167 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="17"/>
         <source>Music Multi Scrape</source>
-        <translation>Extração múltipla de músicas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="39"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="48"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="61"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="74"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="87"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="100"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="113"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="126"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="139"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="152"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="165"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="178"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="191"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="204"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="217"/>
         <source>Moods</source>
-        <translation>Disposição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="230"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="243"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="256"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="269"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="282"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="295"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="308"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="321"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="334"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="347"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="369"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="395"/>
         <source>Scrape all albums of selected artists (and not only selected albums)</source>
-        <translation>Extrair todos os álbuns de artistas selecionados (e não apenas dos álbuns selecionados)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="402"/>
         <source>Automatically save each artist and album after scraping</source>
-        <translation>Guardar automaticamente cada artista e álbum após a extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="449"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="472"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="485"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.cpp" line="205"/>
         <source>Scraping of %n items has finished.</source>
-        <translation>
-            <numerusform>Terminou a extração de %n itens.</numerusform>
-            <numerusform>Terminou a extração de %n itens.</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5512,12 +5465,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5525,142 +5478,142 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="34"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="89"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="117"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="140"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="150"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="160"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="170"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="180"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="190"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="200"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="210"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="220"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="230"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="240"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="250"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="260"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="270"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="280"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="290"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="300"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="310"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="320"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="330"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="340"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="350"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="360"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="370"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="387"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5668,39 +5621,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your artists and albums. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Abaixo pode ver os nomes de ficheiros que são usados ​​para carregar e guardar os Artistas e Álbuns. Pode editá-los como quiser.
-Se quiser guardar o mesmo ficheiro com vários nomes, deve separar os nomes com uma vírgula.
-Por exemplo:  folder.jpg,cover.jpg</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="32"/>
         <source>Artist Thumbnail</source>
-        <translation>Miniatura de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="49"/>
         <source>Artist Fanart</source>
-        <translation>Fanart de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="66"/>
         <source>Artist Logo</source>
-        <translation>Logótipo de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="83"/>
         <source>Album Thumbnail</source>
-        <translation>Miniatura de álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="100"/>
         <source>Album Disc Art</source>
-        <translation>Capa do álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="117"/>
         <source>Download Extra Fanarts for Artists</source>
-        <translation>Descarregar Fanarts extras para artistas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5708,10 +5659,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message numerus="yes">
         <location filename="../../src/ui/small_widgets/MusicTreeView.cpp" line="105"/>
         <source>%n albums</source>
-        <translation>
-            <numerusform>%n album</numerusform>
-            <numerusform>%n álbuns</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5720,13 +5668,13 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="122"/>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="162"/>
         <source>Saving changed Artists and Albums</source>
-        <translation>A guardar alterações em artistas e álbuns</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="140"/>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="187"/>
         <source>All Artists and Albums Saved</source>
-        <translation>Todos os artistas e álbuns foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5734,150 +5682,150 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="53"/>
         <source>Album has changed. Click to revert changes.</source>
-        <translation>O álbum foi alterando. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="79"/>
         <source>Album Name</source>
-        <translation>Nome do álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="137"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="158"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="179"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="186"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="193"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="200"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="207"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="214"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="254"/>
         <source>MusicBrainz Album ID</source>
-        <translation>Identificador do álbum MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="268"/>
         <source>MusicBrainz Release Group ID</source>
-        <translation>Identificador do grupo de lançamento MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="285"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="326"/>
         <source>Booklet</source>
-        <translation>Brochura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="345"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="368"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="420"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="460"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="442"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="505"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="483"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="523"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="41"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="42"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="46"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="47"/>
         <source>Add Mood</source>
-        <translation>Adicionar estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="51"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="52"/>
         <source>Add Style</source>
-        <translation>Adicionar estilo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="186"/>
         <source>Saving Album...</source>
-        <translation>A guardar o álbum...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="192"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="524"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5885,182 +5833,182 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="53"/>
         <source>Artist has changed. Click to revert changes.</source>
-        <translation>O artista foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="79"/>
         <source>Artist Name</source>
-        <translation>Nome do artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="137"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="158"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="186"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="193"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="200"/>
         <source>Years active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="207"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="214"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="235"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="245"/>
         <source>MusicBrainz ID</source>
-        <translation>Identificador MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="262"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="303"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="325"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="330"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="340"/>
         <source>Add Album</source>
-        <translation>Adicionar álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="347"/>
         <source>Remove Album</source>
-        <translation>Remover álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="370"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="392"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="415"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="467"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="507"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="633"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="489"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="552"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="615"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="530"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="570"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="593"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="49"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="50"/>
         <source>Add Genre</source>
-        <translation>Adicionar Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="54"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="55"/>
         <source>Add Mood</source>
-        <translation>Adicionar estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="59"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="60"/>
         <source>Add Style</source>
-        <translation>Adicionar estilo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="196"/>
         <source>Saving Artist...</source>
-        <translation>A guardar o artista...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="202"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="501"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="586"/>
         <source>Unknown Album</source>
-        <translation>Álbum Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6068,87 +6016,87 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="38"/>
         <source>Scrape</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="58"/>
         <source>Save</source>
-        <translation>Guardar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="78"/>
         <source>Save All</source>
-        <translation>Guardar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="98"/>
         <source>Rename selected files</source>
-        <translation>Renomear ficheiros selecionados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="118"/>
         <source>Synchronize to Kodi</source>
-        <translation>Sincronizar com o Kodl</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="138"/>
         <source>Export Database</source>
-        <translation>Exportar base de Dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="161"/>
         <source>Reload</source>
-        <translation>Recarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="181"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="201"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="247"/>
         <source>Donate</source>
-        <translation>Fazer um donativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="17"/>
         <source>Scrape (%1)</source>
-        <translation>Extrair (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="20"/>
         <source>Save (%1)</source>
-        <translation>Guardar (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="24"/>
         <source>Save All (%1)</source>
-        <translation>Guardar todos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="28"/>
         <source>Reload all files (%1)</source>
-        <translation>Recarregar todos os ficheiros (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="32"/>
         <source>Export HTML</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="36"/>
         <source>Export CSV</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="43"/>
         <source>Export Database (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6156,7 +6104,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/scrapers/ScraperInterface.cpp" line="17"/>
         <source>Network Error</source>
-        <translation>Erro na rede</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6164,43 +6112,43 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="71"/>
         <source>Host</source>
-        <translation>Anfitrião</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="78"/>
         <source>Port</source>
-        <translation>Porta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="98"/>
         <source>Username</source>
-        <translation>Nome de utilizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="108"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="19"/>
         <source>Enable Proxy</source>
-        <translation>Ativar proxy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="64"/>
         <source>Type</source>
         <comment>Proxy Type</comment>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="51"/>
         <source>HTTP</source>
-        <translation>HTTP</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="36"/>
         <source>Use Proxy for Kodi</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6208,7 +6156,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/PlaceholderLineEdit.cpp" line="26"/>
         <source>Insert placeholder</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6216,183 +6164,183 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/main.cpp" line="36"/>
         <source>Logfile could not be openened</source>
-        <translation>Não foi possível abrir o ficheiro de registo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="37"/>
         <source>The logfile %1 could not be openend for writing.</source>
-        <translation>Não foi possível modificar o ficheiro de registo %1.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="76"/>
         <source>Stylesheet could not be opened!</source>
-        <translation>Não foi possível abrir a folha de estilo.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="78"/>
         <source>The default stylesheet could not be openend for reading.</source>
-        <translation>Não foi possível abrir a folha de estilos padrão para leitura.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="79"/>
         <source>The custom stylesheet could not be openend for reading. Using: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <source>No Label</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <source>Red</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <source>Orange</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <source>Yellow</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="392"/>
-        <source>No Label</source>
-        <translation>Sem etiqueta</translation>
+        <source>Green</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="393"/>
-        <source>Red</source>
-        <translation>Vermelho</translation>
+        <source>Blue</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="394"/>
-        <source>Orange</source>
-        <translation>Laranja</translation>
+        <source>Purple</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="395"/>
-        <source>Yellow</source>
-        <translation>Amarelo</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="396"/>
-        <source>Green</source>
-        <translation>Verde</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="397"/>
-        <source>Blue</source>
-        <translation>Azul</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="398"/>
-        <source>Purple</source>
-        <translation>Roxo</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
-        <translation>Cinzento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="12"/>
         <source>File not found:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="13"/>
         <source>Cannot open advancedsettings.xml in read-only mode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="14"/>
         <source>Couldn&apos;t find an &lt;advancedsettings&gt; tag!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="15"/>
         <source>Found unsupported xml tag:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="16"/>
         <source>Invalid value for xml tag:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
-        <translation>&lt;b&gt;Mover Ficheiro&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowCommonWidgets.cpp" line="59"/>
         <source>Aired order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowCommonWidgets.cpp" line="62"/>
         <source>DVD order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="8"/>
         <source>Timeout by MediaElch</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="9"/>
         <source>Content not found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="10"/>
         <source>Remote connection timed out</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="11"/>
         <source>SSL handshake failed</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="12"/>
         <source>Too many redirects</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="13"/>
         <source>Connection refused by host</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="14"/>
         <source>Host not found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="15"/>
         <source>Unknown network error</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="16"/>
         <source>Could not load the requested resource</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="18"/>
         <location filename="../../src/scrapers/ScraperError.cpp" line="25"/>
         <source>Network Error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="32"/>
         <source>The scraper&apos;s rate limit reached. Please wait ~10 seconds and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="37"/>
         <source>An unknown network error occurred. Are you connected to the internet?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="51"/>
         <source>The scraper did not respond with any data.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="55"/>
         <source>The scraper response could not be parsed.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media_center/kodi/ConcertXmlReader.cpp" line="29"/>
         <source>No valid musicvideo root entry found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6400,22 +6348,22 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="60"/>
         <source>QIODevice::Append is not supported for GZIP</source>
-        <translation>QIODevice::Append não é suportado pelo GZIP</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="66"/>
         <source>Opening gzip for both reading and writing is not supported</source>
-        <translation>A abertura do gzip para leitura e escrita não é suportada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="74"/>
         <source>You can open a gzip either for reading or for writing. Which is it?</source>
-        <translation>Pode abrir um gzip para ler ou gravar. Qual deles?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="80"/>
         <source>Could not gzopen() file</source>
-        <translation>Não foi possível abrir o ficheiro gzopen()</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6423,12 +6371,12 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quaziodevice.cpp" line="188"/>
         <source>QIODevice::Append is not supported for QuaZIODevice</source>
-        <translation>QIODevice::Append não é suportado pelo QuaZIODevice</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quaziodevice.cpp" line="193"/>
         <source>QIODevice::ReadWrite is not supported for QuaZIODevice</source>
-        <translation>QIODevice::ReadWrite não é suportado pelo QuaZIODevice</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6436,7 +6384,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quazipfile.cpp" line="251"/>
         <source>ZIP/UNZIP API error %1</source>
-        <translation>Erro da API ZIP/UNZIP %1</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6444,27 +6392,27 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="100"/>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="101"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="102"/>
         <source>Vote Count</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="103"/>
         <source>Min. Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="104"/>
         <source>Max. Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6472,17 +6420,17 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="14"/>
         <source>Form</source>
-        <translation>Formulário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="80"/>
         <source>Add rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="94"/>
         <source>Remove selected rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6490,145 +6438,133 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="17"/>
         <source>Renamer</source>
-        <translation>Alteração de nomes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="34"/>
         <source>Pattern</source>
-        <translation>Padrão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="75"/>
         <source>Use Season Directories</source>
-        <translation>Usar pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="85"/>
         <source>Multi-File Naming</source>
-        <translation>Alterar nome de vários ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="117"/>
         <source>Rename Directories</source>
-        <translation>Alterar nome de pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="127"/>
         <source>Rename Files</source>
-        <translation>Alterar nome de ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="162"/>
         <source>Directory Naming</source>
-        <translation>Alterar nome de pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="194"/>
         <source>File Naming</source>
-        <translation>Nomes dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="201"/>
         <source>Season Directory Naming</source>
-        <translation>Nomes das pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="208"/>
         <source>Season &lt;season&gt;</source>
-        <translation>Temporada &lt;season&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="249"/>
         <source>Results</source>
-        <translation>Resultados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="342"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="365"/>
         <source>Dry Run</source>
-        <translation>Operação &quot;a seco&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
         <source>Rename</source>
-        <translation>Alterar nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="38"/>
         <source>Please see %1 for help and examples on how to use the renamer.</source>
-        <translation>Veja a ajuda em %1. Temos exemplos de como usar o alterador de nomes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="58"/>
         <source>%n concerts will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="60"/>
         <source>%n movies will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="62"/>
         <source>%n TV shows and %1</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="63"/>
         <source>%n episodes will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
         <source>Finished</source>
-        <translation>Concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
         <source>Create dir</source>
-        <translation>Criar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
         <source>Move</source>
-        <translation>Mover</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6636,152 +6572,147 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="35"/>
         <source>Placeholders</source>
-        <translation>Marcadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
         <source>Placeholder</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
         <source>File extension</source>
-        <translation>Extensão de ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
         <source>Season Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
         <source>Part number of the current file</source>
-        <translation>Número da parte do ficheiro atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
-        <source>TMDb ID</source>
-        <translation type="unfinished">Identificador do TMDb</translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
         <source>Season Number</source>
-        <translation>Número da temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
         <source>Title of the show</source>
-        <translation>Título da série</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
         <source>Studio(s) (separated by a comma)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
         <source>Director(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
         <source>Audio Language(s) (separated by a minus)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
         <source>Episode Number</source>
-        <translation>Número do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
         <source>Resolution (1080p, 720p, ...)</source>
-        <translation>Resolução (1080p, 720p...)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
         <source>File/directory is BluRay</source>
-        <translation>Ficheiro ou pasta é BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
         <source>File/directory is DVD</source>
-        <translation>Ficheiro ou pasta é DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
         <source>File is 3D</source>
-        <translation>Ficheiro é 3D</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
         <source>Movie set name</source>
-        <translation>Nome da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
         <source>Video Codec</source>
-        <translation>Codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
         <source>Episode has a season name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
         <source>Audio Codec</source>
-        <translation>Codec de áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
         <source>Number of audio channels</source>
-        <translation>Número de canais de áudio</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6790,141 +6721,141 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="121"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="151"/>
         <source>Invalid</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="122"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="152"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="123"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="124"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="153"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="125"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="126"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="155"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="127"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="128"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="156"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="129"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="157"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="130"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="131"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="158"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="132"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="133"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="161"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="134"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="159"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="135"/>
         <source>Extra Art</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="136"/>
         <source>Season Backdrop</source>
-        <translation>Fundo de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="137"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="138"/>
         <source>Extra Fanart</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="139"/>
         <source>Show Thumbnail</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="140"/>
         <source>Season Thumbnail</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="141"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="142"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="145"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="165"/>
         <source>Unknown</source>
-        <translation>Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="160"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="154"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="162"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6933,162 +6864,162 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="21"/>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="138"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="57"/>
         <source>Enable adult movie scrapers</source>
-        <translation>Ativar extratores de filmes para adultos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="95"/>
         <source>Custom Movie Scraper</source>
-        <translation>Extrator de filmes personalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="101"/>
         <source>Combine multiple scrapers to your custom scraper. If you select other scrapers than IMDB, The Movie DB and Fanart.tv multiple searches may be necessary as only these three share an id.</source>
-        <translation>Combine vários extratores num único extrator personalizado. Se selecionar outros extratores além do IMDB, The Movie DB e Fanart.tv, poderão ser necessárias várias procuras, já que apenas estes três usam identificadores comuns.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="133"/>
         <source>Item</source>
-        <translation>Item</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="147"/>
         <source>TV Scraper</source>
-        <translation>Extrator de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="157"/>
         <source>Custom TV Scraper</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="172"/>
         <source>Don&apos;t use</source>
-        <translation>Não usar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="218"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="219"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="220"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="221"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="222"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="223"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="224"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="225"/>
         <source>Plot</source>
-        <translation>Enredo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="226"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="227"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="228"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="229"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="230"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="231"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="232"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="233"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="234"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="235"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="236"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="237"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="238"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="239"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="240"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="241"/>
         <source>Unsupported</source>
-        <translation>Incompatível</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7096,12 +7027,12 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/model/tv_show/SeasonModelItem.cpp" line="135"/>
         <source>Season %1 - %2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/tv_show/SeasonModelItem.cpp" line="137"/>
         <source>Season %1</source>
-        <translation>Temporada %1</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7109,59 +7040,59 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="61"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="88"/>
         <source>Set Name</source>
-        <translation>Nome da coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="122"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="127"/>
         <source>Sorttitle</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="150"/>
         <source>Add movie to set</source>
-        <translation>Adicionar filme à coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="153"/>
         <source>Add Movie</source>
-        <translation>Adicionar filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="160"/>
         <source>Remove selected movie from set</source>
-        <translation>Remover filme selecionado da coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="163"/>
         <source>Remove Movie</source>
-        <translation>Remover Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="182"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="204"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="276"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="225"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="300"/>
         <source>Full preview</source>
-        <translation>Pré-visualização inteira</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="239"/>
@@ -7169,32 +7100,32 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="314"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="317"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="254"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="56"/>
         <source>Add Movie Set</source>
-        <translation>Adicionar coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="57"/>
         <source>Delete Movie Set</source>
-        <translation>Eliminar coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="459"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="491"/>
         <source>New Movie Set</source>
-        <translation>Nova coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7202,79 +7133,79 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="20"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="184"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="162"/>
         <source>Kodi</source>
-        <translation>Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="206"/>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="209"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="220"/>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="223"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="62"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="69"/>
         <source>Save Settings</source>
-        <translation>Guardar definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="79"/>
         <source>toolBar</source>
-        <translation>barraFerramentas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="118"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="129"/>
         <source>TV Shows</source>
-        <translation>Séries TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="140"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="151"/>
         <source>Global</source>
-        <translation>Global</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="173"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="195"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.cpp" line="192"/>
         <source>Settings saved</source>
-        <translation>As definições foram guardadas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7282,32 +7213,32 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="17"/>
         <source>Support MediaElch</source>
-        <translation>Doações para o MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="30"/>
         <source>If you like MediaElch and wish to support it you have the chance to do so! You can donate as much as you like via PayPal.</source>
-        <translation>Se gosta do MediaElch e gostaria de apoiá-lo, tem a oportunidade de o fazer! Pode fazer uma doação da quantia que quiser através do PayPal.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="74"/>
         <source>MediaElch makes use of various movie and TV show databases. These databases also need your help to keep their services up and running for free. If you don&apos;t want to donate you can also contribute information and missing artwork if possible.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="127"/>
         <source>Thanks for your help and support!</source>
-        <translation>Obrigado pela sua ajuda e apoio!</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="149"/>
         <source>Hide donate button</source>
-        <translation>Ocultar botão para donativos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="172"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7315,7 +7246,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/TagCloud.ui" line="31"/>
         <source>Tag</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7323,115 +7254,115 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="17"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="47"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="87"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="110"/>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="206"/>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="369"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="166"/>
         <source>Preview</source>
-        <translation>Pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="171"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="176"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="186"/>
         <source>Back to Search Results</source>
-        <translation>Regressar aos resultados da busca</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="277"/>
         <source>URL</source>
-        <translation>Endereço</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="308"/>
         <source>Progress</source>
-        <translation>Progresso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="331"/>
         <source>Download</source>
-        <translation>Descarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="338"/>
         <source>Cancel Download</source>
-        <translation>Cancelar descarregamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="349"/>
         <source>Back to Trailers</source>
-        <translation>Regressar aos trailers</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="345"/>
         <source>Download Finished</source>
-        <translation>Descarregamento concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="356"/>
         <source>The file %1 already exists.</source>
-        <translation>O ficheiro %1 já existe.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="358"/>
         <source>Do you want to overwrite it?</source>
         <extracomment>&quot;it&quot; refers to the file</extracomment>
-        <translation>Quer substituí-lo?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="371"/>
         <source>Download Canceled</source>
-        <translation>Descarregamento cancelado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="375"/>
         <source>Download Not Found (404)</source>
-        <translation>Descarregamento não encontrado (404)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="379"/>
         <source>Download Error (%1)</source>
-        <translation>Erro no descarregamento (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="433"/>
         <source>Network Error</source>
-        <translation>Erro na rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="434"/>
         <source>Resource could not be played</source>
-        <translation>Não foi possível reproduzir o ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="435"/>
         <source>Video format error</source>
-        <translation>Erro de formato de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7439,92 +7370,92 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="36"/>
         <source>TV Scraper</source>
-        <translation>Extrator de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="88"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="107"/>
         <source>ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="114"/>
         <source>Internal TV scraper ID. Used as key in MediaElch&apos;s settings.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="124"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="169"/>
         <source>Website</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="179"/>
         <source>The scraper&apos;s main website.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="192"/>
         <source>Terms of Service</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="199"/>
         <source>Terms of service of the TV scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="212"/>
         <source>Privacy Policy</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="219"/>
         <source>Privacy Policy of the scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="232"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="239"/>
         <source>Where to get help for the TV scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="252"/>
         <source>Is the scraper initialized?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="255"/>
         <source>Is initialized?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="262"/>
         <source>Default Language</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.cpp" line="112"/>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.cpp" line="112"/>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7532,22 +7463,22 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="52"/>
         <source>Searching for TV Shows...</source>
-        <translation>A procurar séries de TV...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="58"/>
         <source>Loading TV Shows...</source>
-        <translation>A carregar séries de TV...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="87"/>
         <source>Searching for Episodes...</source>
-        <translation>A procurar episódios...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="126"/>
         <source>Loading Episodes...</source>
-        <translation>A carregar episódios...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7556,103 +7487,94 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="27"/>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="670"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="27"/>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="670"/>
         <source>%n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="466"/>
-        <source>You need to update the show once and load the show&apos;s TMDb ID to list missing episodes.
+        <source>You need to update the show once and load the show's TMDb ID to list missing episodes.
 Afterwards MediaElch will check automatically for new episodes on startup.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="470"/>
         <source>Don&apos;t show this hint again</source>
-        <translation>Não voltar a mostrar esta dica</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="674"/>
         <source>%1 of %n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="758"/>
         <source>Load Information</source>
-        <translation>Carregar informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="759"/>
         <source>Search for new episodes</source>
-        <translation>A procurar por novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="760"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="761"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="762"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="763"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="764"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="765"/>
         <source>Open TV Show Folder</source>
-        <translation>Abrir pasta da série de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="766"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="767"/>
         <source>Play episode</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="784"/>
         <source>Show missing episodes</source>
-        <translation>Mostrar episódios que faltam</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="787"/>
         <source>Hide specials in missing episodes</source>
-        <translation>Ocultar episódios especiais ao listar episódios em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="465"/>
         <source>Show update needed</source>
-        <translation>É necessário atualizar a série</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7660,42 +7582,42 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="91"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="92"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="93"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="94"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="95"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="96"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="97"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="98"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7703,303 +7625,297 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="20"/>
         <source>TV Show Multi Scrape</source>
-        <translation>Extrator múltiplo de episódios de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="30"/>
         <source>Please select the infos you want to be loaded. MediaElch will use the best result for each TV show and episode you selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="61"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="365"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="70"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="400"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="83"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="278"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="304"/>
         <source>Season Fanart</source>
-        <translation>Fanart de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="96"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="265"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="226"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="109"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="252"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="213"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="501"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="122"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="374"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="239"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="291"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="475"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="200"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="449"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="135"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="387"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="436"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="426"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="46"/>
         <source>Show Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="148"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="161"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="413"/>
         <source>First aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="174"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="488"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="187"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="317"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="339"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="526"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="350"/>
         <source>Episode Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="462"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="559"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="569"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="579"/>
         <source>Order for seasons</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="607"/>
         <source>Update only TV shows/episodes
 which have an ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="621"/>
         <source>Automatically save each TV show/
 episode after scraping</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="660"/>
         <source>1/20</source>
-        <translation>1/20</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="706"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="729"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="742"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="306"/>
         <source>Start scraping using &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="352"/>
         <source>Skipping show &quot;%1&quot; because it does not have a valid ID.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="371"/>
         <source>Search for TV show &quot;%1&quot; because no valid ID was found.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="378"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="475"/>
         <source>Scraping next TV show with ID &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="408"/>
         <source>Search for TV show &quot;%1&quot; because no valid show ID was found for the episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="417"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="493"/>
         <source>S%1E%2: Scraping next episode with show ID &quot;%3&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="463"/>
         <source>Error while searching for TV show: &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="468"/>
         <source>Did not find any results for search term &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="511"/>
         <source>Done.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="531"/>
         <source>%n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="532"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="534"/>
         <source>Scraping of %1 and %2 has finished.</source>
-        <translation>Terminou a extração de %1 e %2.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="536"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="538"/>
         <source>Scraping of %1 has finished.</source>
-        <translation>A extração de  %1 terminou.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="561"/>
         <source>Finished scraping details of TV show &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="570"/>
         <source>Start loading extra fanart from TheTvDb for TV show with ID &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="753"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="832"/>
         <source>Internal inconsistency: Cannot set language dropdown in TV show search widget!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="848"/>
         <source>S%2E%3: Finished scraping episode details. Title is: &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8007,12 +7923,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/search_dialog/TvShowScrapePreview.ui" line="43"/>
         <source>&lt;b&gt;Preview&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/search_dialog/TvShowScrapePreview.ui" line="83"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Description&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8020,17 +7936,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="58"/>
         <source>Scrape</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8038,219 +7954,216 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="19"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="29"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="134"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="179"/>
         <source>Show Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="210"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="519"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="220"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="230"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="539"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="240"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="549"/>
         <source>First aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="250"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="260"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="559"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="270"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="529"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="280"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="290"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="626"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="300"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="606"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="327"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="616"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="337"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="347"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="357"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="367"/>
         <source>Season Fanart</source>
-        <translation>Fanart de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="377"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="387"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="397"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="407"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="417"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="451"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="670"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="464"/>
         <source>No show details will be loaded because only episodes were selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="488"/>
         <source>Episode Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="586"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="596"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="636"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="682"/>
         <source>Season order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="697"/>
         <source>No episodes will be loaded. If you want to load episodes, change the update mode below.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="147"/>
         <source>Update TV Show only</source>
-        <translation>Atualizar apenas Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="152"/>
         <source>Update TV Show and new Episodes</source>
-        <translation>Atualizar séries de TV e novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="157"/>
         <source>Update TV Show and all Episodes</source>
-        <translation>Atualizar séries de TV e todos os episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="162"/>
         <source>Update new Episodes</source>
-        <translation>Atualizar novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="167"/>
         <source>Update all episodes</source>
-        <translation>Atualizar todos os episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="170"/>
         <source>The %1 scraper could not be initialized!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="148"/>
         <source>Please insert a search string!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="188"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="364"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8258,82 +8171,82 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your TV shows. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension and for season posters &lt;seasonNumber&gt; which is the season number.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o nome do ficheiro, sem extensão, e para cartazes de temporada &lt;seasonNumber&gt;, que é o número da temporada.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="42"/>
         <source>Show nfo</source>
-        <translation>Mostrar nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="49"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="56"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="63"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="70"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="77"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="84"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="91"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="98"/>
         <source>Season Backdrop</source>
-        <translation>Fundo de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="105"/>
         <source>Episode nfo</source>
-        <translation>Nfo do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="112"/>
         <source>Episode thumbnail</source>
-        <translation>Miniatura de episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="119"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="390"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="397"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8341,10 +8254,7 @@ episode after scraping</source>
     <message numerus="yes">
         <location filename="../../src/ui/small_widgets/TvShowTreeView.cpp" line="146"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -8352,7 +8262,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/TvShowUpdater.cpp" line="42"/>
         <source>Updating TV Shows</source>
-        <translation>A atualizar séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8361,22 +8271,22 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="161"/>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="218"/>
         <source>Saving changed TV Shows and Episodes</source>
-        <translation>A guardar alterações em séries de TV e episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="180"/>
         <source>Could not save episode S%1E%2 of show &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="193"/>
         <source>TV Shows and Episodes Saved</source>
-        <translation>Séries de TV e episódios guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="239"/>
         <source>All TV Shows and Episodes Saved</source>
-        <translation>Todas as séries TV e episódios foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8384,292 +8294,292 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="63"/>
         <source>Episode has changed. Click to revert changes.</source>
-        <translation>O episódio foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="82"/>
         <source>Episode Title</source>
-        <translation>Título do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="137"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="154"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="460"/>
         <source>TheTVDB ID</source>
-        <translation>Identificador TheTVDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="514"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="168"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="178"/>
         <source>Show Title</source>
-        <translation>Mostrar título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="188"/>
         <source>Season</source>
-        <translation>Temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="223"/>
         <source>Episode</source>
-        <translation>Episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="242"/>
         <source>Display Season</source>
-        <translation>Mostrar temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="302"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="350"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="367"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="377"/>
         <source>dd.MM.yyyy</source>
-        <translation>dd.MM.yyyy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="384"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="400"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="410"/>
         <source>dd.MM.yyyy HH:mm</source>
-        <translation>dd.MM.yyyy HH:mm</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="436"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="446"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="280"/>
         <source>Display Episode</source>
-        <translation>Mostrar episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="419"/>
         <source>Bookmark</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="313"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="477"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="548"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="558"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="595"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="663"/>
         <source>Directors</source>
-        <translation>Realizadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="691"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="701"/>
         <source>Add Director</source>
-        <translation>Adicionar Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="715"/>
         <source>Remove Director</source>
-        <translation>Remover Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="567"/>
         <source>Writers</source>
-        <translation>Argumentistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="605"/>
         <source>Add Writer</source>
-        <translation>Adicionar argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="619"/>
         <source>Remove Writer</source>
-        <translation>Remover Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="759"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="784"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="789"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="831"/>
         <source>Add Actor</source>
-        <translation>Adicionar Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="804"/>
         <source>Remove Actor</source>
-        <translation>Remover Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="878"/>
         <source>Click to change</source>
-        <translation>Clique para Alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="932"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="991"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="940"/>
         <source>Scantype</source>
-        <translation>TipoAnálise</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="894"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1081"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1106"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="525"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="528"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="981"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1096"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1045"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="429"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="959"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="924"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1116"/>
         <source>Stereo Mode</source>
-        <translation>Modo de Estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1137"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1211"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1233"/>
         <source>Click to Change</source>
-        <translation>Clique para Alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="115"/>
         <source>Episode missing</source>
-        <translation>Episódio em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="92"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="518"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="552"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="524"/>
@@ -8677,68 +8587,68 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="556"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="557"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="526"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="529"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="544"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="585"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="618"/>
         <source>Episode Saved</source>
-        <translation>O episódio foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="620"/>
         <source>Could not save episode S%1E%2 of show &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="666"/>
         <source>Scraping episode...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="800"/>
         <source>Unknown Director</source>
-        <translation>Realizador Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="850"/>
         <source>Unknown Writer</source>
-        <translation>Argumentista desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1107"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1108"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1171"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1171"/>
         <source>Images (*.jpg *.jpeg)</source>
-        <translation>Imagens (*.jpg *.jpeg)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8746,69 +8656,69 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="63"/>
         <source>Episode has changed. Click to revert changes.</source>
-        <translation>O episódio foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="83"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="138"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="149"/>
         <source>Season Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="171"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="232"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="193"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="254"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="298"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="276"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="320"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="342"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="119"/>
         <source>Season missing</source>
-        <translation>Temporada em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.cpp" line="111"/>
         <source>Season %1</source>
-        <translation>Temporada %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.cpp" line="188"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8816,208 +8726,208 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="50"/>
         <source>TV Show has changed. Click to revert changes.</source>
-        <translation>A série de TV foi alterada. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="70"/>
         <source>Show Title</source>
-        <translation>Mostrar título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="98"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="112"/>
         <source>Dir</source>
-        <translation>Dir</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="126"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="208"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="242"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="252"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="315"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="352"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="369"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="379"/>
         <source>dd.MM.yyyy</source>
-        <translation>dd.MM.yyyy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="406"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="460"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="416"/>
         <source>TV Tune</source>
-        <translation>Tema musical</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="425"/>
         <source>Existing</source>
-        <translation>Presente</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="432"/>
         <source>Missing</source>
-        <translation>Em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="448"/>
         <source>Download Theme</source>
-        <translation>Descarregar tema musical</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="386"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="396"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="505"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="201"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="522"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="533"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="558"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="563"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="605"/>
         <source>Add Actor</source>
-        <translation>Adicionar ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="578"/>
         <source>Remove Actor</source>
-        <translation>Remover ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="263"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="137"/>
         <source>TheTVDB ID</source>
-        <translation>Identificador TheTVDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="482"/>
         <source>Continuing</source>
-        <translation>Continuando</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="487"/>
         <source>Ended</source>
-        <translation>Finalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="495"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="154"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="512"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="652"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1221"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="668"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="717"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="739"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="762"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="906"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="928"/>
@@ -9027,92 +8937,92 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1133"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1177"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="950"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="994"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1199"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1067"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1111"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1155"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="78"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="79"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="83"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="84"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="456"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="497"/>
         <source>Please wait while your TV show is scraped</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="724"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="878"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="879"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="960"/>
         <source>Choose Image</source>
-        <translation>Escolher Imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="960"/>
         <source>Images (*.jpg *.jpeg)</source>
-        <translation>Imagens (*.jpg *.jpeg)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9120,53 +9030,53 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="17"/>
         <source>TV Tunes</source>
-        <translation>Temas musicais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="54"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="118"/>
         <source>Progress</source>
-        <translation>Progresso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="141"/>
         <source>Download</source>
-        <translation>Descarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="148"/>
         <source>Cancel Download</source>
-        <translation>Cancelar descarregamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="172"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="251"/>
         <source>Download Finished</source>
-        <translation>Descarregamento concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="256"/>
         <source>The file %1 already exists.</source>
-        <translation>O ficheiro %1 já existe.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="258"/>
         <source>Do you want to overwrite it?</source>
         <extracomment>&quot;it&quot; refers to the file</extracomment>
-        <translation>Quer substituí-lo?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="272"/>
         <source>Download Canceled</source>
-        <translation>Descarregamento cancelado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9174,47 +9084,47 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="45"/>
         <source>Cancel extraction</source>
-        <translation>Cancelar extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="65"/>
         <source>Extract without password</source>
-        <translation>Extrair sem palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="68"/>
         <source>Extract</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="75"/>
         <source>Extract with password</source>
-        <translation>Extrair com palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="95"/>
         <source>Delete this archive</source>
-        <translation>Eliminar este ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="50"/>
         <source>Extraction password</source>
-        <translation>Palavra-passe para extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="50"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="65"/>
         <source>Delete archive?</source>
-        <translation>Eliminar ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="66"/>
         <source>Do you really want to delete this archive?</source>
-        <translation>Quer mesmo eliminar este ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9222,17 +9132,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="63"/>
         <source>Updates available</source>
-        <translation>Atualizações disponíveis</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="64"/>
         <source>%1 is now available.&lt;br&gt;Get it now on %2</source>
-        <translation>%1 já está disponível.&lt;br&gt;Obtenha-o agora em %2</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="68"/>
         <source>Don&apos;t check for updates</source>
-        <translation>Não verificar atualizações</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9240,7 +9150,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/small_widgets/WebImageLabel.ui" line="47"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9248,33 +9158,33 @@ episode after scraping</source>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="28"/>
         <source>Could not get duration of file</source>
-        <translation>Não foi possível obter a duração do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="47"/>
         <source>Could not detect runtime of file</source>
-        <translation>Não foi possível detetar o tempo de reprodução do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="56"/>
         <location filename="../../src/media/ImageCapture.cpp" line="84"/>
         <source>Temporary output file could not be opened</source>
-        <translation>Não foi possível abrir o ficheiro de saída temporário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="71"/>
         <source>Could not start ffmpeg</source>
-        <translation>Não foi possível iniciar o ffmpeg</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="74"/>
         <source>Could not start ffmpeg. Please install it and make it available in your $PATH</source>
-        <translation>Não foi possível iniciar o ffmpeg. Por favor instale-o e torne-o disponível no seu $PATH</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="80"/>
         <source>ffmpeg did not finish</source>
-        <translation>ffmpeg não finalizou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9282,7 +9192,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/file_search/movie/MovieDirectorySearcher.cpp" line="391"/>
         <source>Storing movies in database...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9290,35 +9200,35 @@ episode after scraping</source>
     <message>
         <location filename="../../src/file_search/movie/MovieFileSearcher.cpp" line="58"/>
         <source>Searching for Movies...</source>
-        <translation>A procurar por filmes...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/movie/MovieFileSearcher.cpp" line="148"/>
         <source>Searching for movies...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
         <source>Straight</source>
-        <translation>Heterossexual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Gay</source>
-        <translation>Homossexual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9326,12 +9236,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/custom/CustomMovieScraper.cpp" line="20"/>
         <source>Custom Movie Scraper</source>
-        <translation>Extrator de filmes personalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/custom/CustomMovieScraper.cpp" line="178"/>
         <source>TMDb ID is invalid. Cannot scrape movie.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9339,12 +9249,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/custom/CustomTvScraper.cpp" line="28"/>
         <source>Custom TV scraper</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/custom/CustomTvScraper.cpp" line="33"/>
         <source>The custom TV scraper combines multiple scrapers so that details can be loaded from different sites in one step. It depends on TMDb for loading other scraper IDs.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9352,162 +9262,162 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="26"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="84"/>
         <source>Bulgarian</source>
-        <translation>Búlgaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="85"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="86"/>
         <source>Croatian</source>
-        <translation>Croata</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="87"/>
         <source>Czech</source>
-        <translation>Checo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="88"/>
         <source>Danish</source>
-        <translation>Dinamarquês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="89"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="90"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="91"/>
         <source>Finnish</source>
-        <translation>Finlandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="92"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="93"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="94"/>
         <source>Greek</source>
-        <translation>Grego</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="95"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="96"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="97"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="98"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="99"/>
         <source>Korean</source>
-        <translation>Coreano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="100"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="101"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="102"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="103"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="104"/>
         <source>Slovene</source>
-        <translation>Eslovaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="105"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="106"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="107"/>
         <source>Turkish</source>
-        <translation>Turco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="111"/>
         <source>Blu-ray</source>
-        <translation>BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="112"/>
         <source>DVD</source>
-        <translation>DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="115"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="117"/>
         <source>Preferred Disc Type</source>
-        <translation>Tipo de disco preferido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="119"/>
         <source>Personal API key</source>
-        <translation>Chave pessoal da API</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="356"/>
         <source>Movie not found on Fanart.tv</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="568"/>
         <source>TV show not found on Fanart.tv</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9515,7 +9425,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTvMusic.cpp" line="25"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9523,7 +9433,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTvMusicArtists.cpp" line="22"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9531,12 +9441,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/imdb/ImdbMovie.cpp" line="20"/>
         <source>IMDb is the world&apos;s most popular and authoritative source for movie, TV and celebrity content, designed to help fans explore the world of movies and shows and decide what to watch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/imdb/ImdbMovie.cpp" line="47"/>
         <source>Load all tags</source>
-        <translation>Carregar todas as etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9544,7 +9454,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTv.cpp" line="20"/>
         <source>IMDb is the world&apos;s most popular and authoritative source for movie, TV and celebrity content, designed to help fans explore the world of movies and shows and decide what to watch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9552,22 +9462,22 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="37"/>
         <source>Neither IMDb show ID nor episode ID are valid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="61"/>
         <source>IMDb ID could not be loaded from season page! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="76"/>
         <source>IMDb ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="90"/>
         <source>Loaded IMDb content is empty. Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9575,7 +9485,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing an IMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9583,17 +9493,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="92"/>
         <source>Could not extract JSON details from IMDb page!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="102"/>
         <source>Could not parse JSON from IMDb page!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="108"/>
         <source>Expected parsed IMDb JSON to be an object!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9601,7 +9511,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowScrapeJob.cpp" line="34"/>
         <source>Show is missing an IMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9609,12 +9519,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowSearchJob.cpp" line="20"/>
         <source>Loaded IMDb web page content is empty. Cannot scrape requested TV show.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowSearchJob.cpp" line="24"/>
         <source>Could not find result table in the scraped HTML. Please contact MediaElch&apos;s developers.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9622,7 +9532,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/TMDbImages.cpp" line="15"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9630,7 +9540,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDb.cpp" line="19"/>
         <source>TheTvDb is one of the most accurate sources for TV and film. Their information comes from fans like you, so create a free account on their website and help your favorite shows and movies. Everything added is shared not only with MediaElch but many other sites, mobile apps, and devices as well.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9638,7 +9548,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbEpisodeScrapeJob.cpp" line="65"/>
         <source>TheTvDb ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9646,7 +9556,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/TheTvDbImages.cpp" line="19"/>
         <source>TheTvDb is one of the most accurate sources for TV and film. Their information comes from fans like you, so create a free account on their website and help your favorite shows and movies. Everything added is shared not only with MediaElch but many other sites, mobile apps, and devices as well.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9654,7 +9564,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbSeasonScrapeJob.cpp" line="26"/>
         <source>Show is missing a TheTvDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9662,7 +9572,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbShowScrapeJob.cpp" line="46"/>
         <source>Show is missing a TheTvDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9670,12 +9580,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/concert/tmdb/TmdbConcert.cpp" line="28"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/concert/tmdb/TmdbConcert.cpp" line="132"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9683,12 +9593,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/tmdb/TmdbMovie.cpp" line="45"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/tmdb/TmdbMovie.cpp" line="158"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9696,7 +9606,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTv.cpp" line="20"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9704,7 +9614,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvEpisodeScrapeJob.cpp" line="26"/>
         <source>TMDb show ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9712,7 +9622,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9720,12 +9630,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp" line="41"/>
         <source>Continuing</source>
-        <translation>Continuando</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp" line="41"/>
         <source>Ended</source>
-        <translation>Finalizado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9733,7 +9643,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowScrapeJob.cpp" line="23"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9741,7 +9651,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMaze.cpp" line="19"/>
         <source>TVmaze is a collaborative site, which can be edited by any registered user. Find episode information for any show on any device. anytime, anywhere!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9749,12 +9659,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.cpp" line="39"/>
         <source>TVmaze show ID are valid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.cpp" line="66"/>
         <source>TVmaze ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9762,7 +9672,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9770,7 +9680,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeShowScrapeJob.cpp" line="29"/>
         <source>TV show is missing a TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9778,107 +9688,107 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="31"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="32"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="33"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="34"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="35"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="36"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="37"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="38"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="39"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="40"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="41"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="42"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="43"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="44"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="45"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="47"/>
         <source>The Audio DB</source>
-        <translation>The Audio DB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="48"/>
         <source>MusicBrainz</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="49"/>
         <source>AllMusic</source>
-        <translation>AllMusic</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="50"/>
         <source>Discogs</source>
-        <translation>Discogs</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="52"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="54"/>
         <source>Prefer</source>
-        <translation>Preferir</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9886,7 +9796,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/videobuster/VideoBuster.cpp" line="18"/>
         <source>VideoBuster is a German movie database.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/data/i18n/MediaElch_bg.ts
+++ b/data/i18n/MediaElch_bg.ts
@@ -4307,57 +4307,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation>Актьори</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation>Допълнителни изображения</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation>Допълнителни фанарти</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation>Фанарт</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation>Постер</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation>Стрийм детайли</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation>Трейлър</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation type="unfinished">Локален трейлър</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation>Субтитри</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation>Ключови думи</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6236,42 +6236,42 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
         <source>No Label</source>
         <translation>Няма етикет</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
         <source>Red</source>
         <translation>Червено</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
         <source>Orange</source>
         <translation>Оранжево</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
         <source>Yellow</source>
         <translation>Жълто</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
         <source>Green</source>
         <translation>Зелено</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
         <source>Blue</source>
         <translation>Синьо</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
         <source>Purple</source>
         <translation>Лилаво</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
         <translation>Сиво</translation>
     </message>
@@ -6301,7 +6301,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6551,7 +6551,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation>Преименувай</translation>
     </message>
@@ -6593,37 +6593,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation>Приключено</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6636,142 +6636,147 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation>Пълнители</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation>Пълнител</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
         <source>Artist</source>
         <translation>Артист</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
         <source>File extension</source>
         <translation>Файлово разширение</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
         <source>Original Title</source>
         <translation>Оригинално заглавие</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
         <source>Season Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
         <source>Part number of the current file</source>
         <translation>Номер на часта за текущия файл</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
         <source>Album</source>
         <translation>Албум</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
         <source>Title</source>
         <translation>Заглавие</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
         <source>Season Number</source>
         <translation>Номер на сезона</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
         <source>Title of the show</source>
         <translation>Заглавие на шоуто</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
         <source>Year</source>
         <translation>Година</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
         <source>Description</source>
         <translation>Описание</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
         <source>Studio(s) (separated by a comma)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
         <source>Sort Title</source>
         <translation>Кратко заглавие</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
         <source>Director(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
         <source>Audio Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
         <source>Episode Number</source>
         <translation>Номер на епизода</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
         <source>Episode has a season name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9293,22 +9298,22 @@ episode after scraping</source>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation>Език</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation>Жанр</translation>
     </message>

--- a/data/i18n/MediaElch_cs_CZ.ts
+++ b/data/i18n/MediaElch_cs_CZ.ts
@@ -4314,57 +4314,57 @@ operace zrušena.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation>Herci</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation>Extra arty</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation>Extra fanarty</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation>Plakát</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation>Podrobnosti streamu</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation>Upoutávka</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation>Titulky</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation>Tagy</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
@@ -6250,42 +6250,42 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
         <source>No Label</source>
         <translation>Žádný štítek</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
         <source>Red</source>
         <translation>Červený</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
         <source>Orange</source>
         <translation>Oranžový</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
         <source>Yellow</source>
         <translation>Žlutý</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
         <source>Green</source>
         <translation>Zelený</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
         <source>Blue</source>
         <translation>Modrý</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
         <source>Purple</source>
         <translation>Fialový</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
         <translation>Šedý</translation>
     </message>
@@ -6315,7 +6315,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6565,7 +6565,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation>Přejmenovat</translation>
     </message>
@@ -6611,37 +6611,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation>Dokončeno</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6654,142 +6654,147 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation>Zástupné tagy</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation>Zástupce</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
         <source>Artist</source>
         <translation>Umělec</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
         <source>File extension</source>
         <translation>Přípona souboru</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
         <source>Original Title</source>
         <translation>Originální název</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
         <source>Season Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
         <source>Part number of the current file</source>
         <translation>Číslo části vybraného souboru</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
         <source>Title</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
         <source>Season Number</source>
         <translation>Číslo řady</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
         <source>Title of the show</source>
         <translation>Název seriálu</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
         <source>Year</source>
         <translation>Rok</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
         <source>Description</source>
         <translation>Popis</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
         <source>Studio(s) (separated by a comma)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
         <source>Sort Title</source>
         <translation>Třídící název</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
         <source>Director(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
         <source>Audio Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
         <source>Episode Number</source>
         <translation>Číslo epizody</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
         <source>Episode has a season name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9318,22 +9323,22 @@ episode after scraping</source>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation>Hetero</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation>Jazyk</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation>Žánr</translation>
     </message>

--- a/data/i18n/MediaElch_da.ts
+++ b/data/i18n/MediaElch_da.ts
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="da_DK">
+<TS version="2.1" language="da">
 <context>
     <name>AboutDialog</name>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="23"/>
         <source>About MediaElch</source>
-        <translation type="unfinished"></translation>
+        <translation>Om MediaElch</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="44"/>
         <source>MediaElch</source>
-        <translation type="unfinished"></translation>
+        <translation>MediaElch</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="112"/>
@@ -21,12 +21,12 @@
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="155"/>
         <source>Icon Sets: Retina by &quot;The Working Group&quot; and &quot;Capital Suite&quot; by &quot;capital18 (Jugal Paryani)&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Ikoner: Retina af &quot;The Working Group&quot; og &quot;Capital Suite&quot; af &quot;capital18 (Jugal Paryani)&quot;</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="178"/>
         <source>MediaElch Icon by Kathrin Luckner</source>
-        <translation type="unfinished"></translation>
+        <translation>MediaElch ikon af Kathrin Luckner</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="120"/>
@@ -81,22 +81,22 @@
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="304"/>
         <source>Movies</source>
-        <translation type="unfinished"></translation>
+        <translation>Film</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="337"/>
         <source>TV Shows</source>
-        <translation type="unfinished"></translation>
+        <translation>TV Serier</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="370"/>
         <source>Episodes</source>
-        <translation type="unfinished"></translation>
+        <translation>Episoder</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="403"/>
         <source>Concerts</source>
-        <translation type="unfinished"></translation>
+        <translation>Koncerter</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="436"/>
@@ -185,18 +185,18 @@
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="116"/>
         <source>Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>Film</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="139"/>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="142"/>
         <source>Add Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>Tilføj film</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="149"/>
         <source>Remove Current Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>Fjern nuværende film</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="152"/>
@@ -231,7 +231,7 @@
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="286"/>
         <source>All Movies Saved</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle film gemt</translation>
     </message>
 </context>
 <context>
@@ -839,13 +839,13 @@
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="35"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="242"/>
         <source>Movies</source>
-        <translation type="unfinished"></translation>
+        <translation>Film</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="40"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="252"/>
         <source>TV Shows</source>
-        <translation type="unfinished"></translation>
+        <translation>TV Serier</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="45"/>
@@ -857,7 +857,7 @@
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="50"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="272"/>
         <source>Concerts</source>
-        <translation type="unfinished"></translation>
+        <translation>Koncerter</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="55"/>
@@ -1658,7 +1658,7 @@
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="281"/>
         <source>Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>Film</translation>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="282"/>
@@ -1668,7 +1668,7 @@
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="283"/>
         <source>Concert</source>
-        <translation type="unfinished"></translation>
+        <translation>Koncerter</translation>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="464"/>
@@ -1712,17 +1712,17 @@
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="68"/>
         <source>Movies</source>
-        <translation type="unfinished"></translation>
+        <translation>Film</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="78"/>
         <source>TV Shows</source>
-        <translation type="unfinished"></translation>
+        <translation>TV Serier</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="88"/>
         <source>Concerts</source>
-        <translation type="unfinished"></translation>
+        <translation>Koncerter</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="109"/>
@@ -2427,15 +2427,15 @@
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
-        <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="494"/>
-        <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
-        <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
-        <source>Resolution</source>
+        <source>720p</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
-        <source>720p</source>
+        <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="494"/>
+        <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
+        <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
+        <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2475,13 +2475,13 @@
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
-        <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
-        <source>Format</source>
+        <source>DVD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
-        <source>DVD</source>
+        <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
+        <source>Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2617,18 +2617,18 @@
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="116"/>
         <source>Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>Film</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="139"/>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="142"/>
         <source>Add Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>Tilføj film</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="149"/>
         <source>Remove Current Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>Fjern nuværende film</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="152"/>
@@ -2663,7 +2663,7 @@
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="287"/>
         <source>All Movies Saved</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle film gemt</translation>
     </message>
 </context>
 <context>
@@ -2790,19 +2790,19 @@ The directories containing your music must contain subdirectories for each artis
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="42"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Movies</source>
-        <translation type="unfinished"></translation>
+        <translation>Film</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="43"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>TV Shows</source>
-        <translation type="unfinished"></translation>
+        <translation>TV Serier</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="44"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Concerts</source>
-        <translation type="unfinished"></translation>
+        <translation>Koncerter</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="45"/>
@@ -2876,7 +2876,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="124"/>
         <source>Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>Film</translation>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="176"/>
@@ -2885,6 +2885,12 @@ The directories containing your music must contain subdirectories for each artis
         <location filename="../../src/ui/image/ImageDialog.ui" line="191"/>
         <location filename="../../src/ui/image/ImageDialog.ui" line="196"/>
         <source>Neue Spalte</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/image/ImageDialog.cpp" line="703"/>
+        <location filename="../../src/ui/image/ImageDialog.cpp" line="711"/>
+        <source>No images found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2945,12 +2951,6 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="523"/>
         <source>Images (*.jpg *.jpeg *.png)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/image/ImageDialog.cpp" line="703"/>
-        <location filename="../../src/ui/image/ImageDialog.cpp" line="711"/>
-        <source>No images found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3026,7 +3026,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="17"/>
         <source>MediaElch</source>
-        <translation type="unfinished"></translation>
+        <translation>MediaElch</translation>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="40"/>
@@ -3816,13 +3816,13 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="14"/>
         <source>MediaElch</source>
-        <translation type="unfinished"></translation>
+        <translation>MediaElch</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="75"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="94"/>
         <source>Movies</source>
-        <translation type="unfinished"></translation>
+        <translation>Film</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="125"/>
@@ -3852,13 +3852,13 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="267"/>
         <source>TV Shows</source>
-        <translation type="unfinished"></translation>
+        <translation>TV Serier</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="297"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="316"/>
         <source>Concerts</source>
-        <translation type="unfinished"></translation>
+        <translation>Koncerter</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="346"/>
@@ -4305,57 +4305,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4383,6 +4383,41 @@ Main menu entry (tooltip)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="143"/>
+        <source>Countries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="233"/>
+        <source>Studios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="163"/>
+        <source>Actors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="303"/>
+        <source>Logo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="223"/>
+        <source>Director</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="133"/>
+        <source>Poster</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="113"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="93"/>
         <source>Set</source>
         <translation type="unfinished"></translation>
@@ -4393,53 +4428,8 @@ Main menu entry (tooltip)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="113"/>
-        <source>Rating</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="123"/>
-        <source>Overview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="133"/>
-        <source>Poster</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="143"/>
-        <source>Countries</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="153"/>
-        <source>Runtime</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="163"/>
-        <source>Actors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="173"/>
         <source>Certification</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="183"/>
-        <source>Trailer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="193"/>
-        <source>Tagline</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="203"/>
-        <source>Released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4448,13 +4438,23 @@ Main menu entry (tooltip)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="223"/>
-        <source>Director</source>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="203"/>
+        <source>Released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="233"/>
-        <source>Studios</source>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="153"/>
+        <source>Runtime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="123"/>
+        <source>Overview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="183"/>
+        <source>Trailer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4468,18 +4468,8 @@ Main menu entry (tooltip)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="263"/>
-        <source>Thumb</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="273"/>
-        <source>Banner</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="283"/>
-        <source>CD Art</source>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="193"/>
+        <source>Tagline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4488,8 +4478,18 @@ Main menu entry (tooltip)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="303"/>
-        <source>Logo</source>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="283"/>
+        <source>CD Art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="273"/>
+        <source>Banner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="263"/>
+        <source>Thumb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4520,7 +4520,7 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="387"/>
         <source>Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>Film</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="412"/>
@@ -4969,18 +4969,13 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieWidget.ui" line="653"/>
-        <source>IMDb ID</source>
+        <location filename="../../src/ui/movies/MovieWidget.ui" line="480"/>
+        <source>User Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="548"/>
         <source>Runtime</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieWidget.ui" line="480"/>
-        <source>User Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5035,11 +5030,6 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieWidget.ui" line="221"/>
-        <source>Ratings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="717"/>
         <source>Support for extra fanarts is only available when your movies are stored in separate folders. Check the settings if you&apos;ve stored your movies in separate folders already.</source>
         <translation type="unfinished"></translation>
@@ -5060,13 +5050,20 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/movies/MovieWidget.ui" line="806"/>
+        <source>Aspect Ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="796"/>
         <source>Scantype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieWidget.ui" line="806"/>
-        <source>Aspect Ratio</source>
+        <location filename="../../src/ui/movies/MovieWidget.ui" line="942"/>
+        <location filename="../../src/ui/movies/MovieWidget.cpp" line="788"/>
+        <location filename="../../src/ui/movies/MovieWidget.cpp" line="791"/>
+        <source>Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5080,20 +5077,23 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieWidget.ui" line="881"/>
-        <source>HH:mm:ss</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="888"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieWidget.ui" line="942"/>
-        <location filename="../../src/ui/movies/MovieWidget.cpp" line="788"/>
-        <location filename="../../src/ui/movies/MovieWidget.cpp" line="791"/>
-        <source>Codec</source>
+        <location filename="../../src/ui/movies/MovieWidget.ui" line="881"/>
+        <source>HH:mm:ss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieWidget.ui" line="221"/>
+        <source>Ratings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieWidget.ui" line="653"/>
+        <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5109,15 +5109,6 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1030"/>
         <source>External Subtitles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieWidget.ui" line="1055"/>
-        <location filename="../../src/ui/movies/MovieWidget.cpp" line="787"/>
-        <location filename="../../src/ui/movies/MovieWidget.cpp" line="790"/>
-        <location filename="../../src/ui/movies/MovieWidget.cpp" line="821"/>
-        <location filename="../../src/ui/movies/MovieWidget.cpp" line="822"/>
-        <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5239,6 +5230,15 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/movies/MovieWidget.ui" line="1055"/>
+        <location filename="../../src/ui/movies/MovieWidget.cpp" line="787"/>
+        <location filename="../../src/ui/movies/MovieWidget.cpp" line="790"/>
+        <location filename="../../src/ui/movies/MovieWidget.cpp" line="821"/>
+        <location filename="../../src/ui/movies/MovieWidget.cpp" line="822"/>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="789"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="792"/>
         <source>Channels</source>
@@ -5255,6 +5255,16 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/movies/MovieWidget.cpp" line="921"/>
+        <source>Saving movie...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieWidget.cpp" line="926"/>
+        <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="902"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="950"/>
         <source>Saving movies...</source>
@@ -5266,19 +5276,9 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieWidget.cpp" line="921"/>
-        <source>Saving movie...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieWidget.cpp" line="926"/>
-        <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="971"/>
         <source>All Movies Saved</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle film gemt</translation>
     </message>
 </context>
 <context>
@@ -6209,46 +6209,6 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
-        <source>No Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
-        <source>Red</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
-        <source>Orange</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
-        <source>Yellow</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
-        <source>Green</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
-        <source>Blue</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
-        <source>Purple</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
-        <source>Grey</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/main.cpp" line="36"/>
         <source>Logfile could not be openened</source>
         <translation type="unfinished"></translation>
@@ -6271,6 +6231,46 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/main.cpp" line="79"/>
         <source>The custom stylesheet could not be openend for reading. Using: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <source>No Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <source>Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <source>Orange</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <source>Yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
+        <source>Green</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
+        <source>Purple</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
+        <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6299,7 +6299,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6549,7 +6549,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6591,37 +6591,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6634,142 +6634,147 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
-        <source>Album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
-        <source>Season Number</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
-        <source>Director(s)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
-        <source>Title</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
-        <source>Season Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
-        <source>Part number of the current file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
-        <source>Episode has a season name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
-        <source>Original Title</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
-        <source>File extension</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
-        <source>Studio(s) (separated by a comma)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
-        <source>Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
-        <source>Year</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
-        <source>Title of the show</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
-        <source>Sort Title</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
-        <source>Audio Language(s) (separated by a minus)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
-        <source>Episode Number</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
-        <source>Artist</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
-        <source>Subtitle Language(s) (separated by a minus)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
+        <source>Artist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
+        <source>File extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
+        <source>Original Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
+        <source>Season Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
+        <source>Part number of the current file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
+        <source>Season Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
+        <source>Title of the show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
+        <source>Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
+        <source>Studio(s) (separated by a comma)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
+        <source>Sort Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
+        <source>Director(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
+        <source>Audio Language(s) (separated by a minus)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
+        <source>Episode Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
+        <source>Subtitle Language(s) (separated by a minus)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
+        <source>Episode has a season name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7109,7 +7114,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="122"/>
         <source>Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>Film</translation>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="127"/>
@@ -7124,7 +7129,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="153"/>
         <source>Add Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>Tilføj film</translation>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="160"/>
@@ -7200,6 +7205,23 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/settings/SettingsWindow.ui" line="162"/>
+        <source>Kodi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/settings/SettingsWindow.ui" line="206"/>
+        <location filename="../../src/ui/settings/SettingsWindow.ui" line="209"/>
+        <source>Import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/settings/SettingsWindow.ui" line="220"/>
+        <location filename="../../src/ui/settings/SettingsWindow.ui" line="223"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="62"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
@@ -7217,26 +7239,21 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="118"/>
         <source>Movies</source>
-        <translation type="unfinished"></translation>
+        <translation>Film</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="129"/>
         <source>TV Shows</source>
-        <translation type="unfinished"></translation>
+        <translation>TV Serier</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="140"/>
         <source>Concerts</source>
-        <translation type="unfinished"></translation>
+        <translation>Koncerter</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="151"/>
         <source>Global</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/settings/SettingsWindow.ui" line="162"/>
-        <source>Kodi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7247,18 +7264,6 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="195"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/settings/SettingsWindow.ui" line="206"/>
-        <location filename="../../src/ui/settings/SettingsWindow.ui" line="209"/>
-        <source>Import</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/settings/SettingsWindow.ui" line="220"/>
-        <location filename="../../src/ui/settings/SettingsWindow.ui" line="223"/>
-        <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8382,11 +8387,6 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="115"/>
-        <source>Episode missing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="137"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
@@ -8394,6 +8394,16 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="154"/>
         <source>Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="460"/>
+        <source>TheTVDB ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="514"/>
+        <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8447,6 +8457,16 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="400"/>
+        <source>Last Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="410"/>
+        <source>dd.MM.yyyy HH:mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="436"/>
         <source>Studio</source>
         <translation type="unfinished"></translation>
@@ -8462,34 +8482,8 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="400"/>
-        <source>Last Played</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="410"/>
-        <source>dd.MM.yyyy HH:mm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="419"/>
         <source>Bookmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="429"/>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="959"/>
-        <source>HH:mm:ss</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="460"/>
-        <source>TheTVDB ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="514"/>
-        <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8513,23 +8507,8 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="567"/>
-        <source>Writers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="595"/>
         <source>Writer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="605"/>
-        <source>Add Writer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="619"/>
-        <source>Remove Writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8553,6 +8532,21 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="567"/>
+        <source>Writers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="605"/>
+        <source>Add Writer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="619"/>
+        <source>Remove Writer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="759"/>
         <source>Actors</source>
         <translation type="unfinished"></translation>
@@ -8568,18 +8562,33 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="804"/>
-        <source>Remove Actor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="831"/>
         <source>Add Actor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="804"/>
+        <source>Remove Actor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="878"/>
         <source>Click to change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="932"/>
+        <source>Streamdetails</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="991"/>
+        <source>Aspect Ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="940"/>
+        <source>Scantype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8589,18 +8598,10 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="924"/>
-        <source>Tags</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="932"/>
-        <source>Streamdetails</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="940"/>
-        <source>Scantype</source>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1106"/>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="525"/>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="528"/>
+        <source>Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8609,8 +8610,8 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="991"/>
-        <source>Aspect Ratio</source>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1096"/>
+        <source>Video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8619,15 +8620,14 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1096"/>
-        <source>Video</source>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="429"/>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="959"/>
+        <source>HH:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1106"/>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="525"/>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="528"/>
-        <source>Codec</source>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="924"/>
+        <source>Tags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8648,6 +8648,11 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1233"/>
         <source>Click to Change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="115"/>
+        <source>Episode missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8744,11 +8749,6 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="119"/>
-        <source>Season missing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="138"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
@@ -8764,15 +8764,15 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="232"/>
+        <source>Poster</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="193"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="254"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="298"/>
         <source>Click to Change</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="232"/>
-        <source>Poster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8788,6 +8788,11 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="342"/>
         <source>Click to change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="119"/>
+        <source>Season missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8824,13 +8829,18 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="242"/>
-        <source>Name</source>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="126"/>
+        <source>IDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="505"/>
-        <source>Sort Title</source>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="208"/>
+        <source>TVmaze ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="242"/>
+        <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8841,11 +8851,6 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="315"/>
         <source>Top 250</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="263"/>
-        <source>User Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8864,18 +8869,13 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="386"/>
-        <source>Runtime</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="396"/>
-        <source> Minutes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="406"/>
         <source>Studio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="460"/>
+        <source>Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8899,53 +8899,23 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="460"/>
-        <source>Overview</source>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="386"/>
+        <source>Runtime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="137"/>
-        <source>TheTVDB ID</source>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="396"/>
+        <source> Minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="482"/>
-        <source>Continuing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="487"/>
-        <source>Ended</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="495"/>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="126"/>
-        <source>IDs</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="154"/>
-        <source>TMDb ID</source>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="505"/>
+        <source>Sort Title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="201"/>
         <source>IMDb ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="208"/>
-        <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="512"/>
-        <source>Original Title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8969,13 +8939,48 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="605"/>
+        <source>Add Actor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="578"/>
         <source>Remove Actor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="605"/>
-        <source>Add Actor</source>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="263"/>
+        <source>User Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="137"/>
+        <source>TheTVDB ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="482"/>
+        <source>Continuing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="487"/>
+        <source>Ended</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="495"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="154"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="512"/>
+        <source>Original Title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9030,6 +9035,11 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1199"/>
+        <source>Banner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1067"/>
         <source>Logo</source>
         <translation type="unfinished"></translation>
@@ -9042,11 +9052,6 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1155"/>
         <source>Character Art</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1199"/>
-        <source>Banner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9291,22 +9296,22 @@ episode after scraping</source>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/i18n/MediaElch_de.ts
+++ b/data/i18n/MediaElch_de.ts
@@ -4307,57 +4307,57 @@ Operation abgebrochen.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation>Schauspieler</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation>Extra Arts</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation>Extra Fanarts</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation>Streamdetails</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation>Lokaler Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation>Untertitel</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation>Tags</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
@@ -6237,42 +6237,42 @@ Wenn du bei TMDb nach einer ID suchen möchtest, stelle bitte &quot;id&quot; vor
         <translation>Das Standard Stylesheet konnte nicht zum Lesen geöffnet werden. Verwendet wird: %1</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
         <source>No Label</source>
         <translation>Kein Label</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
         <source>Red</source>
         <translation>Rot</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
         <source>Orange</source>
         <translation>Orange</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
         <source>Yellow</source>
         <translation>Gelb</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
         <source>Green</source>
         <translation>Grün</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
         <source>Blue</source>
         <translation>Blau</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
         <source>Purple</source>
         <translation>Lila</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
         <translation>Grau</translation>
     </message>
@@ -6302,7 +6302,7 @@ Wenn du bei TMDb nach einer ID suchen möchtest, stelle bitte &quot;id&quot; vor
         <translation>Invalider Wert für das XML-Tag:</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Verschiebe Datei&lt;/b&gt; &quot;%1&quot; nach &quot;%2&quot;
 </translation>
@@ -6553,7 +6553,7 @@ Wenn du bei TMDb nach einer ID suchen möchtest, stelle bitte &quot;id&quot; vor
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation>Umbenennen</translation>
     </message>
@@ -6595,37 +6595,37 @@ Wenn du bei TMDb nach einer ID suchen möchtest, stelle bitte &quot;id&quot; vor
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation>Fertig</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;Film&lt;/b&gt; &quot;%1&quot; nicht umbenannt: Film wurde bearbeitet aber noch nicht gespeichert</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; nicht umbenannt: Episode wurde bearbeitet aber noch nicht gespeichert</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;Serie&lt;/b&gt; &quot;%1&quot; nicht umbenannt: Serie wurde bearbeitet aber noch nicht gespeichert</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;Konzert&lt;/b&gt; &quot;%1&quot; nicht umbenannt: Konzert wurde bearbeitet aber noch nicht gespeichert</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation>Verzeichnis erstellen</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation>Verschieben</translation>
     </message>
@@ -6638,142 +6638,147 @@ Wenn du bei TMDb nach einer ID suchen möchtest, stelle bitte &quot;id&quot; vor
         <translation>Platzhalter</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation>Platzhalter</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
         <source>Artist</source>
         <translation>Interpret</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
         <source>File extension</source>
         <translation>Dateiendung</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
         <source>Original Title</source>
         <translation>Original Titel</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
         <source>Season Name</source>
         <translation>Staffelname</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
         <source>Part number of the current file</source>
         <translation>Teilnummer der aktuellen Datei</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished">TMDb ID</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
         <source>Title</source>
         <translation>Titel</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
         <source>Season Number</source>
         <translation>Staffel</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
         <source>Title of the show</source>
         <translation>Titel der Serie</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
         <source>Year</source>
         <translation>Jahr</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
         <source>Description</source>
         <translation>Beschreibung</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
         <source>Studio(s) (separated by a comma)</source>
         <translation>Studio(s) (durch ein Komma getrennt)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
         <source>Sort Title</source>
         <translation>Titel für Sortierung</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
         <source>Director(s)</source>
         <translation>Regisseur(e)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
         <source>Audio Language(s) (separated by a minus)</source>
         <translation>Audio Sprache(n) (durch ein Komma getrennt)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
         <source>Episode Number</source>
         <translation>Episode</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation>Auflösung (1080p, 720p, ...)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation>Datei/Verzeichnis ist BluRay</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
         <translation>Untertitel Sprache(n) (durch ein Komma getrennt)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation>Datei/Verzeichnis ist DVD</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation>Datei ist 3D</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation>Name der Zusammenstellung</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation>Video Codec</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
         <source>Episode has a season name</source>
         <translation>Episode hat einen Staffelnamen</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation>Audio Codec</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation>Anzahl der Audiokanäle</translation>
     </message>
@@ -9298,22 +9303,22 @@ automatisch nach dem Laden</translation>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation>Hetero</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation>Schwul</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation>Genre</translation>
     </message>

--- a/data/i18n/MediaElch_en.ts
+++ b/data/i18n/MediaElch_en.ts
@@ -4305,57 +4305,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6234,42 +6234,42 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
         <source>No Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6299,7 +6299,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6549,7 +6549,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6591,37 +6591,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6634,142 +6634,147 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
         <source>Artist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
         <source>File extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
         <source>Original Title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
         <source>Season Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
         <source>Part number of the current file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
         <source>Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
         <source>Season Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
         <source>Title of the show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
         <source>Studio(s) (separated by a comma)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
         <source>Sort Title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
         <source>Director(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
         <source>Audio Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
         <source>Episode Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
         <source>Episode has a season name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9291,22 +9296,22 @@ episode after scraping</source>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/i18n/MediaElch_es_ES.ts
+++ b/data/i18n/MediaElch_es_ES.ts
@@ -4306,57 +4306,57 @@ Operación cancelada.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation>Actores</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation>Artes extras</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation>Fanart extras</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation>Detalles del stream</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation>Trailer local</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation>Subtítulos</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation>Etiquetas</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6236,42 +6236,42 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
         <source>No Label</source>
         <translation>No hay etiqueta</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
         <source>Red</source>
         <translation>Red</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
         <source>Orange</source>
         <translation>Naranja</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
         <source>Yellow</source>
         <translation>Amarillo</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
         <source>Green</source>
         <translation>Verde</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
         <source>Blue</source>
         <translation>Azul</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
         <source>Purple</source>
         <translation>Morado</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
         <translation>Gris</translation>
     </message>
@@ -6301,7 +6301,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Archivo movido&lt;/b&gt; &quot;%1&quot; a &quot;%2&quot;
 </translation>
@@ -6552,7 +6552,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation>Renombrar</translation>
     </message>
@@ -6594,37 +6594,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation>Completado</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation>Crear directorio</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
@@ -6637,142 +6637,147 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation>Marcador</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation>Marcador</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
         <source>Artist</source>
         <translation>Artista</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
         <source>File extension</source>
         <translation>Extensión de archivo</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
         <source>Original Title</source>
         <translation>Título original</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
         <source>Season Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
         <source>Part number of the current file</source>
         <translation>Número de parte del archivo actual</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
         <source>Album</source>
         <translation>Álbum</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
         <source>Title</source>
         <translation>Título</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
         <source>Season Number</source>
         <translation>Número de temporada</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
         <source>Title of the show</source>
         <translation>Título de la serie</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
         <source>Year</source>
         <translation>Año</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
         <source>Description</source>
         <translation>Descripción</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
         <source>Studio(s) (separated by a comma)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
         <source>Sort Title</source>
         <translation>Título corto</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
         <source>Director(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
         <source>Audio Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
         <source>Episode Number</source>
         <translation>Número de episodio</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation>Resolución (1080p, 720p, ...)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation>Archivo/directorio es BluRay</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation>Archivo/directorio es DVD</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation>Archivo es 3D</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation>Nombre conjunto de la película</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation>Codec de video</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
         <source>Episode has a season name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation>Codec de audio</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation>Número de canales de audio</translation>
     </message>
@@ -9297,22 +9302,22 @@ No se pudo detectar el tiempo de ejecución del archivo</translation>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation>Géreno</translation>
     </message>

--- a/data/i18n/MediaElch_fi.ts
+++ b/data/i18n/MediaElch_fi.ts
@@ -4306,57 +4306,57 @@ Toiminto peruutettu.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation>Näyttelijät</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation>Lisätaiteet</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation>Lisäfanitaide</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation>Fanitaide</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation>Juliste</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation>Mediatiedot</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation>Traileri</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation>Paikallinen traileri</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation>Tekstitys</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation>Tunnisteet</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
@@ -6235,42 +6235,42 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
         <source>No Label</source>
         <translation>Ei merkintää</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
         <source>Red</source>
         <translation>Punainen</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
         <source>Orange</source>
         <translation>Oranssi</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
         <source>Yellow</source>
         <translation>Keltainen</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
         <source>Green</source>
         <translation>Vihreä</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
         <source>Blue</source>
         <translation>Sininen</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
         <source>Purple</source>
         <translation>Violetti</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
         <translation>Harmaa</translation>
     </message>
@@ -6300,7 +6300,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Siirrä tiedosto&lt;/b&gt; &quot;%1&quot; -&gt; &quot;%2&quot;</translation>
     </message>
@@ -6550,7 +6550,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation>Nimeä uudelleen</translation>
     </message>
@@ -6592,37 +6592,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation>Valmis</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation>Luo hakemisto</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation>Siirrä</translation>
     </message>
@@ -6635,142 +6635,147 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation>Paikkamerkit</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation>Paikkamerkki</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
         <source>Artist</source>
         <translation>Artisti</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
         <source>File extension</source>
         <translation>Tiedostopääte</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
         <source>Original Title</source>
         <translation>Alkuperäinen nimi</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
         <source>Season Name</source>
         <translation>Tuotantokauden nimi</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
         <source>Part number of the current file</source>
         <translation>Tämän tiedoston osanumero</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished">TMDb ID</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
         <source>Album</source>
         <translation>Albumi</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
         <source>Title</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
         <source>Season Number</source>
         <translation>Kauden numero</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
         <source>Title of the show</source>
         <translation>Sarjan nimi</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
         <source>Year</source>
         <translation>Vuosi</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
         <source>Description</source>
         <translation>Kuvaus</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
         <source>Studio(s) (separated by a comma)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
         <source>Sort Title</source>
         <translation>Lajittelunimi</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
         <source>Director(s)</source>
         <translation>Ohjaaja(t)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
         <source>Audio Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
         <source>Episode Number</source>
         <translation>Jakson numero</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation>Resoluutio (1080p, 720p, ...)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation>Tiedosto/hakemisto on BluRay</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation>Tiedosto/hakemisto on DVD</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation>Tiedosto on 3D</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation>Elokuvasetin nimi</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation>Videokoodekki</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
         <source>Episode has a season name</source>
         <translation>Jaksolla on tuotantokauden nimi</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation>Äänikoodekki</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation>Äänikanavien määrä</translation>
     </message>
@@ -9292,22 +9297,22 @@ episode after scraping</source>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation>Heteroseksuaali</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation>Homoseksuaali</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation>Kieli</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation>Tyylilaji</translation>
     </message>

--- a/data/i18n/MediaElch_fr.ts
+++ b/data/i18n/MediaElch_fr.ts
@@ -4308,57 +4308,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation>Acteurs</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation>Extra Arts</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation>Extra Fanarts</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation>Affiche</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation>Détails de flux</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation>Bande-annonce</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation>Bande-annonce locale</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation>Sous-titres</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation>Mots-clés</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation>ID IMDb</translation>
     </message>
@@ -6240,42 +6240,42 @@ Vérifiez les paramètres si vous avez déjà stocké vos films dans des dossier
         <translation>La feuille de style personnalisée n&apos;a pas pu être ouverte. Utilisation: %1</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
         <source>No Label</source>
         <translation>Pas d&apos;étiquette</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
         <source>Red</source>
         <translation>Rouge</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
         <source>Orange</source>
         <translation>Orange</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
         <source>Yellow</source>
         <translation>Jaune</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
         <source>Green</source>
         <translation>Vert</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
         <source>Blue</source>
         <translation>Bleu</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
         <source>Purple</source>
         <translation>Violet</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
         <translation>Gris</translation>
     </message>
@@ -6305,7 +6305,7 @@ Vérifiez les paramètres si vous avez déjà stocké vos films dans des dossier
         <translation>Valeur non valide pour la balise xml:</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Déplacer le fichier&lt;/b&gt; &quot;%1&quot; vers &quot;%2&quot;</translation>
     </message>
@@ -6555,7 +6555,7 @@ Vérifiez les paramètres si vous avez déjà stocké vos films dans des dossier
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation>Renommer</translation>
     </message>
@@ -6597,37 +6597,37 @@ Vérifiez les paramètres si vous avez déjà stocké vos films dans des dossier
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation>Terminer</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation>Créer le répertoire</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation>Déplacer</translation>
     </message>
@@ -6640,142 +6640,147 @@ Vérifiez les paramètres si vous avez déjà stocké vos films dans des dossier
         <translation>Espaces réservés</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation>Espaces réservés</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
         <source>Artist</source>
         <translation>Artiste</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
         <source>File extension</source>
         <translation>extension de fichier</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
         <source>Original Title</source>
         <translation>Titre Original</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
         <source>Season Name</source>
         <translation>Titre de la Saison</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
         <source>Part number of the current file</source>
         <translation>Numéro de pièce du fichier actuel</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished">ID TMDb</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
         <source>Title</source>
         <translation>Titre</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
         <source>Season Number</source>
         <translation>Numéro de la saison</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
         <source>Title of the show</source>
         <translation>Titre de la série</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
         <source>Year</source>
         <translation>Année</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
         <source>Description</source>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
         <source>Studio(s) (separated by a comma)</source>
         <translation>Studio(s) (séparés par une virgule)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
         <source>Sort Title</source>
         <translation>Trier par Titre</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
         <source>Director(s)</source>
         <translation>Réalisateur(s)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
         <source>Audio Language(s) (separated by a minus)</source>
         <translation>Langue(s) Audio (séparés par une virgule)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
         <source>Episode Number</source>
         <translation>Numéro de l&apos;épisode</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation>Résolution (1080p, 720p, ...)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation>Fichier/répertoire est un BluRay</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
         <translation>Sous-titre(s) (séparés par une virgule)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation>Fichier/répertoire est un DVD ?</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation>Fichier 3D ?</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation>Nom de la saga</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation>ID IMDb</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation>Codec vidéo</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
         <source>Episode has a season name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation>Codec audio</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation>Nombre de canaux audio</translation>
     </message>
@@ -9297,22 +9302,22 @@ episode after scraping</source>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation>Hétérosexuel</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation>Homosexuel</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation>Langue</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation>Genre</translation>
     </message>

--- a/data/i18n/MediaElch_he_IL.ts
+++ b/data/i18n/MediaElch_he_IL.ts
@@ -1,112 +1,110 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="pt_PT">
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="he_IL">
 <context>
     <name>AboutDialog</name>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="23"/>
         <source>About MediaElch</source>
-        <translation>Sobre o MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="44"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="112"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="155"/>
         <source>Icon Sets: Retina by &quot;The Working Group&quot; and &quot;Capital Suite&quot; by &quot;capital18 (Jugal Paryani)&quot;</source>
-        <translation>Conjuntos de ícones: Retina de &quot;The Working Group&quot; e &quot;Capital Suite&quot;, de &quot;capital18 (Jugal Paryani)&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="178"/>
         <source>MediaElch Icon by Kathrin Luckner</source>
-        <translation>Ícone do MediaElch por Kathrin Luckner</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="120"/>
         <source>MediaElch was built with &lt;a href=&quot;https://www.qt.io/&quot;&gt;Qt&lt;/a&gt;</source>
-        <translation>O MediaElch foi feito com o &lt;a href=&quot;https://www.qt.io/&quot;&gt;Qt&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="146"/>
         <source>About Qt</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="165"/>
         <source>&lt;a href=&quot;https://develop.kde.org/frameworks/breeze-icons/&quot; title=&quot;KDE Breeze Website&quot;&gt;Breeze icons&lt;/a&gt; copyright KDE and licenced under the GNU LGPL version 3 or later</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="188"/>
         <source>Stream Details detection with &lt;a href=&quot;https://www.mediaarea.net&quot;&gt;Media Info&lt;/a&gt;</source>
-        <translation>Deteção de detalhes da transmissão com &lt;a href=&quot;https://www.mediaarea.net&quot;&gt;Media Info&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="201"/>
         <source>&lt;a href=&quot;https://www.mediaelch.de/mediaelch/&quot;&gt;http://www.mediaelch.de&lt;/a&gt; powered by &lt;a href=&quot;https://www.kvibes.de&quot;&gt;k.vibes&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="211"/>
         <source>Bugs and wishes can be reported on &lt;a href=&quot;https://github.com/Komet/MediaElch/issues&quot;&gt;GitHub&lt;/a&gt; .</source>
-        <translation>Os erros e desejos podem ser reportados no &lt;a href=&quot;https://github.com/Komet/MediaElch/issues&quot;&gt;GitHub&lt;/a&gt; .</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="238"/>
         <source>Developer</source>
-        <translation>Programador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="244"/>
         <source>The information below is important for developers. Please provide if you need help.</source>
-        <translation>Os dados abaixo são importantes para os programadores. Por favor, inclua no seu pedido de ajuda.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="272"/>
         <source>Copy to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="295"/>
         <source>Your Collection</source>
-        <translation>A sua coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="304"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="337"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="370"/>
         <source>Episodes</source>
-        <translation>Episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="403"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="436"/>
         <source>Artists</source>
-        <translation>Artistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="466"/>
         <source>Albums</source>
-        <translation>Álbuns</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -114,12 +112,12 @@
     <message>
         <location filename="../../src/model/ActorModel.cpp" line="83"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/ActorModel.cpp" line="84"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -127,47 +125,47 @@
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="14"/>
         <source>Form</source>
-        <translation>Formulário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="46"/>
         <source>Remove Actor</source>
-        <translation>Remover ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="73"/>
         <source>Add Actor</source>
-        <translation>Adicionar ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="107"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="123"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="66"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="67"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="159"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="161"/>
         <source>Images (*.jpg *.jpeg *.png)</source>
-        <translation>Imagens (*.jpg *.jpeg *.png)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -175,63 +173,63 @@
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="52"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="79"/>
         <source>TextLabel</source>
-        <translation>EtiquetaTexto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="116"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="139"/>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="142"/>
         <source>Add Movie</source>
-        <translation>Adicionar Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="149"/>
         <source>Remove Current Movie</source>
-        <translation>Remover filme atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="152"/>
         <source>Remove Movie</source>
-        <translation>Remover Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="165"/>
         <source>Double click a certification to rename it, right click to delete. If you want to merge two certifications just give them the same name.</source>
-        <translation>Clique duas vezes numa certificação para lhe alterar o nome, clique com o botão direito para eliminá-la. Se quiser fundir duas classificações, basta colocar-lhes o mesmo nome.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="175"/>
         <source>Please keep in mind that the changes you make here (renaming or deleting certifications) will be made for every movie.</source>
-        <translation>Por favor, lembre-se que todas as alterações feitas aqui (alterar o nome ou eliminar certificações) serão feitas para todos os filmes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="28"/>
         <source>Add Certification</source>
-        <translation>Adicionar certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="29"/>
         <source>Delete Certification</source>
-        <translation>Eliminar certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="175"/>
         <source>New Certification</source>
-        <translation>Nova certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="286"/>
         <source>All Movies Saved</source>
-        <translation>Foram guardados todos os filmes</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -239,37 +237,37 @@
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="112"/>
         <source>Delete Image</source>
-        <translation>Eliminar imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="119"/>
         <source>Zoom Image</source>
-        <translation>Ampliar imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="125"/>
         <source>Capture random screenshot</source>
-        <translation>Capturar ecrã aleatório</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="131"/>
         <source>Select another image</source>
-        <translation>Selecionar outra imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="420"/>
         <source>Really delete image?</source>
-        <translation>Quer eliminar a imagem?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="421"/>
         <source>Are you sure you want to delete this image?</source>
-        <translation>Tem a certeza que quer eliminar esta imagem?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="423"/>
         <source>Do not ask again</source>
-        <translation>Não perguntar de novo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -277,12 +275,12 @@
     <message>
         <location filename="../../src/file_search/ConcertFileSearcher.cpp" line="53"/>
         <source>Searching for Concerts...</source>
-        <translation>A procurar concertos...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/ConcertFileSearcher.cpp" line="59"/>
         <source>Loading Concerts...</source>
-        <translation>A carregar concertos...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -291,58 +289,52 @@
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="22"/>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="363"/>
         <source>%n concerts</source>
-        <translation>
-            <numerusform>%n concerto</numerusform>
-            <numerusform>%n concertos</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="42"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="43"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="44"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="45"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="46"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="47"/>
         <source>Open Concert Folder</source>
-        <translation>Abrir pasta do concerto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="48"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="49"/>
         <source>Play concert</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="365"/>
         <source>%1 of %n concerts</source>
-        <translation>
-            <numerusform>%1 de %n concerto</numerusform>
-            <numerusform>%1 de %n concertos</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -350,108 +342,108 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="38"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="105"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="119"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="129"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="139"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="149"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="159"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="170"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="210"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="227"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="237"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="247"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="264"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="274"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="309"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="339"/>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="342"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="345"/>
         <source>Not watched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="354"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="52"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="63"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="94"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -459,12 +451,12 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -472,115 +464,112 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="31"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="41"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="110"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="132"/>
         <source>Infos to load</source>
-        <translation>Informações a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="155"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="162"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="169"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="176"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="183"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="190"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="197"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="204"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="211"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="218"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="225"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="232"/>
         <source>Logo, Clear Art, CD Art</source>
-        <translation>Logótipo, Clear Art, CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="235"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="249"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="106"/>
         <source>The %1 scraper could not be initialized!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="119"/>
         <source>Please insert a search string!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="141"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="226"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -588,42 +577,42 @@
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your concerts. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Em baixo, pode ver os nomes de ficheiros usados para carregar e guardar os seus concertos. Pode editá-los à sua vontade, se quiser usar vários ficheiros separe-os com uma vírgula.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o de nome de ficheiro sem extensão.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="42"/>
         <source>Nfo</source>
-        <translation>Nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="71"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="100"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="129"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="158"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="187"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -633,63 +622,63 @@
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="132"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="135"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="54"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="76"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="91"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="101"/>
         <source>Scantype</source>
-        <translation>Varrimento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="111"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="165"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="185"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="195"/>
         <source>Stereo Mode</source>
-        <translation>Modo de estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="212"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="71"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="125"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="159"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="131"/>
@@ -697,18 +686,18 @@
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="163"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="164"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="133"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="136"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="151"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -716,47 +705,47 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="50"/>
         <source>Concert has changed. Click to revert changes.</source>
-        <translation>O concerto foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="76"/>
         <source>Concert Name</source>
-        <translation>Nome do concerto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="127"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="153"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="175"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="198"/>
         <source>Add Images</source>
-        <translation>Adicionar Imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="208"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="354"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="376"/>
@@ -765,62 +754,62 @@
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="537"/>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="581"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="398"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="471"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="515"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="559"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="79"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="80"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="84"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="85"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="447"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="458"/>
         <source>Concerts Saved</source>
-        <translation>Concertos guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="485"/>
         <source>All Concerts Saved</source>
-        <translation>Todos os concertos guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -828,185 +817,185 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="14"/>
         <source>CSV Export</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="22"/>
         <source>CSV Columns</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="35"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="242"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="40"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="252"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="45"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="262"/>
         <source>TV Episodes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="50"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="272"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="55"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="282"/>
         <source>Music Artists</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="60"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="292"/>
         <source>Music Albums</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="225"/>
         <source>Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="233"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="304"/>
         <source>Separator</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="321"/>
         <source>Replacement</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="340"/>
         <source>Linebreaks will be replaced by &lt;code&gt;\n&lt;/code&gt;. </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="350"/>
         <source>If any text contains the separator, it will be replaced by the replacement set above.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="373"/>
         <source>&lt;b&gt;Tip:&lt;/b&gt; You can sort the items by Drag &amp;amp; Drop.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="390"/>
         <source>Export as CSV</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="29"/>
         <source>Tab</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="30"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="35"/>
         <source>Semicolon (;)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="31"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="36"/>
         <source>Comma (,)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="34"/>
         <source>Space</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="37"/>
         <source>Minus (-)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="52"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="112"/>
         <source>Export directory</source>
-        <translation>Exportar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="114"/>
         <source>Export aborted. No directory was selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="130"/>
         <source>Export movies...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="147"/>
         <source>Export TV shows...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="161"/>
         <source>Export TV episodes...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="179"/>
         <source>Export concerts...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="197"/>
         <source>Export artists...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="212"/>
         <source>Export albums...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="227"/>
         <source>Export completed in %1 seconds.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="319"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="399"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="444"/>
         <source>Streamdetails - Duration (in seconds)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="400"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="445"/>
         <source>Streamdetails - Video Aspect</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="321"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="401"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="446"/>
         <source>Streamdetails - Video Width</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="290"/>
@@ -1016,162 +1005,162 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="467"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="495"/>
         <source>Type</source>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="320"/>
         <source>Streamdetails - Video Aspect Ratio</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="322"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="402"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="447"/>
         <source>Streamdetails - Video Height</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="323"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="403"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="448"/>
         <source>Streamdetails - Video Codec</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="324"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="404"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="449"/>
         <source>Streamdetails - Audio Language(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="325"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="405"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="450"/>
         <source>Streamdetails - Audio Codec(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="326"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="406"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="451"/>
         <source>Streamdetails - Audio Channel(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="327"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="407"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="452"/>
         <source>Streamdetails - Subtitle Language(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="380"/>
         <source>TV Show - TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="379"/>
         <source>TV Show - IMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="291"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="345"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="425"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="292"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="344"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="424"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="293"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="348"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="423"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="294"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="350"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="426"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="295"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="349"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="296"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="361"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="429"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="297"/>
         <source>Outline</source>
-        <translation>Resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="298"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="299"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="359"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="431"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="300"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="358"/>
         <source>IMDb Top 250</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="301"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="432"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="302"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="433"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="303"/>
         <source>Runtime in minutes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="304"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="353"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="435"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="305"/>
         <source>Writers</source>
-        <translation>Argumentistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="306"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="307"/>
@@ -1179,51 +1168,51 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="436"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="469"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="308"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="309"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="310"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="355"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="437"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="311"/>
         <source>Trailers</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="312"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="360"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="313"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Playcount</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="314"/>
         <source>Last played</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="315"/>
         <source>Movie Set</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="316"/>
@@ -1231,301 +1220,301 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="442"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="480"/>
         <source>Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="443"/>
         <source>Filename(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="318"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="441"/>
         <source>Last Modified Date</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="346"/>
         <source>TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="347"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="351"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="352"/>
         <source>network</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="356"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="434"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="357"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="430"/>
         <source>Ratings</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="381"/>
         <source>TV Show - TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="382"/>
         <source>TV Show - TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="383"/>
         <source>TV Show - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="427"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="428"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Trailer URL</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="440"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="468"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="470"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="471"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="472"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="473"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="474"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="475"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="476"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="477"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="478"/>
         <source>MusicBrainz ID</source>
-        <translation>Identificador MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="479"/>
         <source>AllMusic ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="384"/>
         <source>Episode - Season</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="385"/>
         <source>Episode - Number</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="386"/>
         <source>Episode - IMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="387"/>
         <source>Episode - TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="388"/>
         <source>Episode - TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="389"/>
         <source>Episode - TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="390"/>
         <source>Episode - First Aired</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="391"/>
         <source>Episode - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="392"/>
         <source>Episode - Overview</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="393"/>
         <source>Episode - User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="394"/>
         <source>Episode - Directors</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <source>Episode - Writers</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <source>Episode - Actors</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="397"/>
         <source>Episode - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="398"/>
         <source>Episode - Filename(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="496"/>
         <source>Artist - Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="497"/>
         <source>Album - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="498"/>
         <source>Album - Artist Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="499"/>
         <source>Album - Genres</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="500"/>
         <source>Album - Styles</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="501"/>
         <source>Album - Moods</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="502"/>
         <source>Album - Review</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="503"/>
         <source>Album - Release Date</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="504"/>
         <source>Album - Label</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="505"/>
         <source>Album - Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="506"/>
         <source>Album - Year</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="507"/>
         <source>Album - MusicBrainz ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="508"/>
         <source>Album - MusicBrainz ReleaseGroup ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="509"/>
         <source>Album - AllMusic ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="510"/>
         <source>Album - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="550"/>
         <source>Export failed. Could not write to CSV file.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="540"/>
         <source>Export failed. File could not be opened for writing.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1533,35 +1522,35 @@
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="29"/>
         <source>Select which site you prefer for each element of a TV show and episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="43"/>
         <source>TV show details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="65"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="101"/>
         <source>Item</source>
-        <translation>Item</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="70"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="106"/>
         <source>Site</source>
-        <translation>Site</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="79"/>
         <source>Episode details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.cpp" line="149"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.cpp" line="183"/>
         <source>No Scraper Available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1569,65 +1558,62 @@
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="50"/>
         <source>Archives</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="94"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="215"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="99"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="220"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="104"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="225"/>
         <source>Size</source>
-        <translation>Tamanho</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="146"/>
         <source>Importable items</source>
-        <translation>Itens importáveis</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="172"/>
         <source>Import movie with MakeMKV</source>
-        <translation>Importar filme com o MakeMKV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="230"/>
         <source>Import Type</source>
         <extracomment>(e.g. movie, TV show, concert)</extracomment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="233"/>
         <source>Type of this file.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="238"/>
         <source>Import Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="241"/>
         <source>Where to store the file when importing it.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="126"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="268"/>
         <source>%n files</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="202"/>
@@ -1635,50 +1621,50 @@
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="209"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="221"/>
         <source>Extraction failed</source>
-        <translation>A extração falhou</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="203"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="206"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="209"/>
         <source>Extraction of %1 has failed: %2</source>
-        <translation>A extração de %1 falhou: %2</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="219"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="233"/>
         <source>Extraction finished</source>
-        <translation>A extração terminou</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="233"/>
         <source>Extraction of %1 finished</source>
-        <translation>A extração de %1 foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="281"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="282"/>
         <source>TV Show</source>
-        <translation>Série TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="283"/>
         <source>Concert</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="464"/>
         <source>makemkvcon missing</source>
-        <translation>makemkvcon não foi encontrado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="465"/>
         <source>Please set the correct path to makemkvcon in MediaElch&apos;s settings.</source>
-        <translation>Por favor defina o caminho para o makemkvcon.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1687,87 +1673,87 @@
         <location filename="../../src/ui/export/ExportDialog.ui" line="23"/>
         <location filename="../../src/ui/export/ExportDialog.ui" line="132"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="32"/>
         <source>Export your complete collection.</source>
-        <translation>Exportar a sua coleção completa.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="39"/>
         <source>Message</source>
-        <translation>Mensagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="51"/>
         <source>Theme</source>
-        <translation>Tema</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="61"/>
         <source>Items to export</source>
-        <translation>Itens para exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="68"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="78"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="88"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="109"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="36"/>
         <source>You need to install at least one theme.</source>
-        <translation>Tem de instalar pelo menos um tema.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="58"/>
         <source>You need to select at least one media type to export.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="68"/>
         <source>Export directory</source>
-        <translation>Exportar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="70"/>
         <source>Export aborted. No directory was selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="78"/>
         <source>Could not create export directory.</source>
-        <translation>Não foi possível criar a pasta para exportação.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="95"/>
         <source>Export canceled.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="98"/>
         <source>Export completed.</source>
-        <translation>Exportação concluída.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="145"/>
         <source>Selected theme not found! Try to restart MediaElch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1775,28 +1761,28 @@
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.ui" line="17"/>
         <source>Message</source>
-        <translation>Mensagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.ui" line="43"/>
         <source>Theme</source>
-        <translation>Tema</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="67"/>
         <source>Theme &quot;%1&quot; was successfully installed</source>
-        <translation>O tema &quot;%1&quot; foi instalado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="70"/>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="81"/>
         <source>There was an error while processing the theme &quot;%1&quot;</source>
-        <translation>Ocorreu um erro ao processar o tema &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="78"/>
         <source>Theme &quot;%1&quot; was successfully uninstalled</source>
-        <translation>O tema &quot;%1&quot; foi desinstalado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1805,47 +1791,47 @@
         <location filename="../../src/ui/settings/ExportTemplateWidget.ui" line="102"/>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="42"/>
         <source>Install</source>
-        <translation>Instalar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="25"/>
         <source>by %1</source>
-        <translation>de %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="30"/>
         <source>No website available.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="33"/>
         <source>Version %1</source>
-        <translation>Versão %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="36"/>
         <source>Update</source>
-        <translation>Atualizar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="39"/>
         <source>Uninstall</source>
-        <translation>Desinstalar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="52"/>
         <source>Updating...</source>
-        <translation>A atualizar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="56"/>
         <source>Installing...</source>
-        <translation>A instalar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="60"/>
         <source>Uninstalling...</source>
-        <translation>A desinstalar...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1853,12 +1839,12 @@
     <message>
         <location filename="../../src/import/Extractor.cpp" line="30"/>
         <source>No files to extract</source>
-        <translation>Não há ficheiros para extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/import/Extractor.cpp" line="40"/>
         <source>Unrar not found</source>
-        <translation>Unrar não foi encontrado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1866,7 +1852,7 @@
     <message>
         <location filename="../../src/ui/main/FileScannerDialog.ui" line="17"/>
         <source>File Scanner</source>
-        <translation>Analisador de ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1874,94 +1860,94 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.ui" line="17"/>
         <source>Filter</source>
-        <translation>Filtro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="117"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="214"/>
         <source>Title contains &quot;%1&quot;</source>
-        <translation>O título contém &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="127"/>
         <source>Filename contains &quot;%1&quot;</source>
-        <translation>O ficheiro contém &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="393"/>
         <source>Label &quot;%1&quot;</source>
-        <translation>Etiqueta &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="395"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="371"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="372"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="373"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>Country</source>
-        <translation>País</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="384"/>
         <source>Released %1</source>
-        <translation>Lançamento %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="384"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="378"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="122"/>
         <source>Original Title contains &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="137"/>
         <source>TMDb ID &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="374"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="375"/>
         <source>Tag</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="376"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="377"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>Video codec</source>
-        <translation>Codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="437"/>
@@ -1969,226 +1955,226 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="516"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="517"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="438"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="439"/>
         <source>Filename</source>
-        <translation>Nome do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>IMDb</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="442"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>Movie has no TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>No TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>TMDb</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="469"/>
         <source>Movie has Poster</source>
-        <translation>O filme tem cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="469"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>Movie has no Poster</source>
-        <translation>O filme não tem cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>No Poster</source>
-        <translation>Nenhum cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="471"/>
         <source>Movie has Extra Fanarts</source>
-        <translation>O filme tem fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="471"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>Movie has no Extra Fanarts</source>
-        <translation>O filme não tem fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>No Extra Fanarts</source>
-        <translation>Nenhuma fanart extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <source>Movie has Backdrop</source>
-        <translation>O filme tem fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Movie has no Backdrop</source>
-        <translation>O filme não tem fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>No Backdrop</source>
-        <translation>Nenhum fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>No Fanart</source>
-        <translation>Sem fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="475"/>
         <source>Movie has Logo</source>
-        <translation>O filme tem logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="475"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>Movie has no Logo</source>
-        <translation>O filme não tem logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>No Logo</source>
-        <translation>Nenhum logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="477"/>
         <source>Movie has Clear Art</source>
-        <translation>O filme tem Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="477"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>Movie has no Clear Art</source>
-        <translation>O filme não tem Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>No Clear Art</source>
-        <translation>Nenhuma Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="479"/>
         <source>Movie has Banner</source>
-        <translation>O filme tem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="479"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>Movie has no Banner</source>
-        <translation>O filme não tem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>No Banner</source>
-        <translation>Sem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="481"/>
         <source>Movie has Thumb</source>
-        <translation>O filme tem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="481"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>Movie has no Thumb</source>
-        <translation>O filme não tem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>No Thumb</source>
-        <translation>Sem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="483"/>
         <source>Movie has CD Art</source>
-        <translation>O filme tem CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="483"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>Movie has no CD Art</source>
-        <translation>O filme não tem CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>No CD Art</source>
-        <translation>Nenhuma CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="487"/>
         <source>Movie has Trailer</source>
-        <translation>O filme tem trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="487"/>
@@ -2196,239 +2182,239 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="488"/>
         <source>Movie has no Trailer</source>
-        <translation>O filme não tem trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="488"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>No Trailer</source>
-        <translation>Nenhum trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <source>Movie has local Trailer</source>
-        <translation>O filme tem um trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Movie has no local Trailer</source>
-        <translation>O filme não tem trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>No local Trailer</source>
-        <translation>Nenhum trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <source>Movie is Watched</source>
-        <translation>O filme foi visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Seen</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Movie is Unwatched</source>
-        <translation>O filme está por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Unwatched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Unseen</source>
-        <translation>Não visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>Movie has no Certification</source>
-        <translation>O filme não tem certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>No Certification</source>
-        <translation>Nenhuma certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>Movie has no Genre</source>
-        <translation>O filme não tem género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="132"/>
         <source>IMDb ID &quot;%1&quot;</source>
-        <translation>Identificador do IMDB &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="440"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>No Genre</source>
-        <translation>Nenhum género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="456"/>
         <source>Movie has Rating</source>
-        <translation>O filme tem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="456"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>Movie has no Rating</source>
-        <translation>O filme não tem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>No Rating</source>
-        <translation>Sem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="464"/>
         <source>Stream Details loaded</source>
-        <translation>Os detalhes da pista foram carregados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="464"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>Stream Details</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>Stream Details not loaded</source>
-        <translation>Os detalhes da pista não foram carregados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>No Stream Details</source>
-        <translation>Nenhuns detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="460"/>
         <source>Movie has Actors</source>
-        <translation>O filme tem atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="460"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>Movie has no Actors</source>
-        <translation>O filme não tem atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>No Actors</source>
-        <translation>Nenhuns atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>Movie has no Studio</source>
-        <translation>O filme não tem estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>No Studio</source>
-        <translation>Nenhum estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>Movie has no Country</source>
-        <translation>O filme não tem país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>No Country</source>
-        <translation>Nenhum país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>Movie has no Director</source>
-        <translation>O filme não tem realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>No Director</source>
-        <translation>Nenhum realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>No information about video codec</source>
-        <translation>Nenhuma informação sobre o codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>No video codec</source>
-        <translation>Sem codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>Movie has no Tags</source>
-        <translation>O filme não tem etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>No Tags</source>
-        <translation>Nenhumas etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>Movie has no IMDb ID</source>
-        <translation>Filme sem identificador IMDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>No IMDb ID</source>
-        <translation>Sem identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
         <source>Resolution 720p</source>
-        <translation>Resolução 720p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
         <source>720p</source>
-        <translation>720p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
@@ -2436,68 +2422,68 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="494"/>
         <source>Resolution 1080p</source>
-        <translation>Resolução 1080p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="494"/>
         <source>1080p</source>
-        <translation>1080p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <source>Resolution 2160p</source>
-        <translation>Resolução 2160p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <source>2160p</source>
-        <translation>2160p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>Resolution SD</source>
-        <translation>Resolução SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>SD</source>
-        <translation>SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <source>Format DVD</source>
-        <translation>Formato DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <source>DVD</source>
-        <translation>DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>Format</source>
-        <translation>Formato</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>BluRay Format</source>
-        <translation>Formato BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>BluRay</source>
-        <translation>BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
         <source>Channels 2.0</source>
-        <translation>Canais 2.0</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
@@ -2507,59 +2493,59 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="502"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="503"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="502"/>
         <source>Channels 5.1</source>
-        <translation>Canais 5.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="503"/>
         <source>Channels 7.1</source>
-        <translation>Canais 7.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="504"/>
         <source>Audio Quality HD</source>
-        <translation>Qualidade de áudio HD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="504"/>
         <source>HD Audio</source>
-        <translation>Áudio HD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <source>Audio Quality Normal</source>
-        <translation>Qualidade de áudio normal</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <source>Normal Audio</source>
-        <translation>Áudio normal</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>Audio Quality SD</source>
-        <translation>Qualidade de áudio SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>SD Audio</source>
-        <translation>Áudio SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="509"/>
         <source>Movie has Subtitle</source>
-        <translation>Filme com legenda</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="509"/>
@@ -2567,39 +2553,39 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>Subtitle</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="510"/>
         <source>Movie has no Subtitle</source>
-        <translation>O filme não tem legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="510"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>No Subtitle</source>
-        <translation>Sem legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <source>Movie has external Subtitle</source>
-        <translation>O filme tem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>External Subtitle</source>
-        <translation>Legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>Movie has no external Subtitle</source>
-        <translation>O filme não tem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>No External Subtitle</source>
-        <translation>Sem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2607,63 +2593,63 @@
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="52"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="79"/>
         <source>TextLabel</source>
-        <translation>EtiquetaTexto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="116"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="139"/>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="142"/>
         <source>Add Movie</source>
-        <translation>Adicionar filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="149"/>
         <source>Remove Current Movie</source>
-        <translation>Remover filme atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="152"/>
         <source>Remove Movie</source>
-        <translation>Remover filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="165"/>
         <source>Double click a genre to rename it, right click to delete. If you want to merge two genres just give them the same name.</source>
-        <translation>Clique duas vezes num género para lhe alterar o nome, clique com o botão direito para eliminá-lo. Se quiser fundir dois géneros, basta colocar-lhes o mesmo nome.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="175"/>
         <source>Please keep in mind that the changes you make here (renaming or deleting genres) will be made for every movie.</source>
-        <translation>Por favor, lembre-se que todas as alterações feitas aqui (alterar o nome ou eliminar géneros) serão feitas para todos os filmes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="28"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="29"/>
         <source>Delete Genre</source>
-        <translation>Eliminar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="172"/>
         <source>New Genre</source>
-        <translation>Novo género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="287"/>
         <source>All Movies Saved</source>
-        <translation>Todos os filmes foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2671,189 +2657,189 @@
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="21"/>
         <source>Directories</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="57"/>
         <source>Add one or more directories containing your movies, TV Shows, concerts, music or files to import.
 TV Show Episodes have to be in subfolders with the name of the show.
 The directories containing your music must contain subdirectories for each artist which contain directories of albums.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="91"/>
         <source>Type</source>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="96"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="101"/>
         <source>Sep. folders</source>
-        <translation>Pastas separadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="104"/>
         <source>Items are in separate folders</source>
-        <translation>Os itens estão em pastas separadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="109"/>
         <source>Reload On Start</source>
-        <translation>Recarregar ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="112"/>
         <source>Automatically reload contents on start</source>
-        <translation>Recarrega automaticamente os conteúdos ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="117"/>
         <source>Disabled</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="120"/>
         <source>Ignore this folder.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="130"/>
         <source>Add</source>
-        <translation>Adicionar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="137"/>
         <source>Remove</source>
-        <translation>Remover</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="144"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sort movies into separate directories&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ordenar filmes em pastas separadas&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="147"/>
         <source>Organize</source>
-        <translation>Organizar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="174"/>
         <source>Store trailer URLs in YouTube Plugin format</source>
-        <translation>Guardar endereços de trailers no formato YouTube Plugin</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="188"/>
         <source>Automatically load and save stream details from files</source>
-        <translation>Carregar e guardar automaticamente detalhes das pistas dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="202"/>
         <source>Ignore articles when sorting (&quot;The&quot;)</source>
-        <translation>Ignorar artigos iniciais ao ordenar (&quot;The&quot;)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="216"/>
         <source>Download actor images</source>
-        <translation>Descarregar imagens de atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="230"/>
         <source>Check for Updates on start</source>
-        <translation>Verificar se existem atualizações ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="244"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="263"/>
         <source>Words to exclude from media names (seperated by commas and non case-sensitive)</source>
-        <translation>Palavras a excluir dos nomes de média (separar com vírgulas e sem sensibilidade a maiúsculas)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="270"/>
         <source>Startup section</source>
-        <translation>Secção inicial</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="300"/>
         <source>Appearance</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="311"/>
         <source>Main Window Theme (changing it requires restart of MediaElch)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="42"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="43"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="44"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="45"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="46"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="48"/>
         <source>Auto</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="49"/>
         <source>Light</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="50"/>
         <source>Dark</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="66"/>
         <source>Choose a directory containing your movies, TV show or concerts</source>
-        <translation>Escolher uma pasta que contém os seus filmes, séries TV ou concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Downloads</source>
-        <translation>Descarregamentos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="265"/>
         <source>Organizing movies does only work on movies, not already sorted to separate folders.</source>
-        <translation>Organizar filmes funciona apenas em filmes, sem estarem já organizados em pastas separadas.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="273"/>
         <source>Are you sure?</source>
-        <translation>Tem a certeza?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="275"/>
         <source>This operation sorts all movies in this directory to separate sub-directories based on the file name. Click &quot;Ok&quot;, if that&apos;s, what you want to do. </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2861,22 +2847,22 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="17"/>
         <source>Choose an Image</source>
-        <translation>Escolher uma imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="31"/>
         <source>Enter a search term or URL</source>
-        <translation>Introduza um termo de busca ou um endereço</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="44"/>
         <source>Language to use when searching for a TV show by title.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="124"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="176"/>
@@ -2885,96 +2871,93 @@ The directories containing your music must contain subdirectories for each artis
         <location filename="../../src/ui/image/ImageDialog.ui" line="191"/>
         <location filename="../../src/ui/image/ImageDialog.ui" line="196"/>
         <source>Neue Spalte</source>
-        <translation>Nova coluna</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="703"/>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="711"/>
         <source>No images found</source>
-        <translation>Nenhumas imagens encontradas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="249"/>
         <source>Zoom out</source>
-        <translation>Diminuir ampliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="275"/>
         <source>Preview size</source>
-        <translation>Tamanho de pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="303"/>
         <source>Zoom in</source>
-        <translation>Aumentar ampliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="324"/>
         <source>Loading...</source>
-        <translation>A carregar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="347"/>
         <source>Choose Local Image</source>
-        <translation>Escolher imagem local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="360"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="367"/>
         <source>Accept Images</source>
-        <translation>Aceitar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="251"/>
         <source>Default</source>
-        <translation>Padrão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="158"/>
         <source>Neither an image provider nor previously scraped image URLs are available for the requested image type.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="360"/>
         <source>Error while downloading one or more images: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="523"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="523"/>
         <source>Images (*.jpg *.jpeg *.png)</source>
-        <translation>Imagens (*.jpg *.jpeg *.png)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="708"/>
         <source>Images provided by &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
-        <translation>Imagens fornecidas por  &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="712"/>
         <source>Contribute by uploading images to &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
-        <translation>Contribua enviando novas imagens para &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/image/ImageDialog.cpp" line="812"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="941"/>
         <source>Error while querying image provider: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2982,7 +2965,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/small_widgets/ImageLabel.ui" line="42"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2990,12 +2973,12 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/image/ImagePreviewDialog.ui" line="17"/>
         <source>Preview</source>
-        <translation>Pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImagePreviewDialog.ui" line="82"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3003,22 +2986,22 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/import/ImportActions.ui" line="23"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.ui" line="30"/>
         <source>Delete</source>
-        <translation>Eliminar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.cpp" line="128"/>
         <source>Delete file?</source>
-        <translation>Eliminar o ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.cpp" line="129"/>
         <source>Do you really want to delete this file?</source>
-        <translation>Quer mesmo eliminar este ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3026,144 +3009,141 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="17"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="40"/>
         <source>Loading</source>
-        <translation>A carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="47"/>
         <source>Success</source>
-        <translation>Sucesso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="54"/>
         <source>Loading movie...</source>
-        <translation>A carregar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="81"/>
         <source>Directory Naming</source>
-        <translation>Nomes das pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="91"/>
         <source>File Naming</source>
-        <translation>Nomes dos Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="108"/>
         <source>Use Season Directories</source>
-        <translation>Usar pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="115"/>
         <source>Season Directory Naming</source>
-        <translation>Nomes das pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="132"/>
         <source>Keep source files after import</source>
-        <translation>Manter ficheiros originais após importação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="175"/>
         <location filename="../../src/ui/import/ImportDialog.ui" line="185"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="205"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="274"/>
         <source>Loading movie information...</source>
-        <translation>A carregar a informação do filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="296"/>
         <source>Loading concert information...</source>
-        <translation>A carregar a informação do concerto...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="320"/>
         <source>Loading episode information...</source>
-        <translation>A carregar a informação do episódio...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="390"/>
         <source>Movie information was loaded</source>
-        <translation>A informação do filme foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="404"/>
         <source>Concert information was loaded</source>
-        <translation>A informação do concerto foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="423"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="442"/>
         <source>Episode information was loaded</source>
-        <translation>A informação do episódio foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="454"/>
         <source>Renaming not possible</source>
-        <translation>Não é possível alterar o nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="454"/>
         <source>Please enter all naming patterns</source>
-        <translation>Por favor, introduza todos os padrões de nomenclatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="484"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="577"/>
         <source>Creating destination directory failed</source>
-        <translation>Não foi possível criar a pasta de destino</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="485"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="578"/>
         <source>The destination directory %1 could not be created</source>
-        <translation>Não foi possível criar a pasta de destino %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="514"/>
         <source>Importing movie...</source>
-        <translation>A importar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="553"/>
         <source>Importing episode...</source>
-        <translation>A importar o episódio...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="605"/>
         <source>Importing concert...</source>
-        <translation>A importar o concerto...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="708"/>
         <source>Import finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/import/ImportDialog.cpp" line="709"/>
         <source>Import of %n files has finished</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="712"/>
         <source>Import has finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3171,33 +3151,33 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="19"/>
         <source>Automatically delete archives after extraction</source>
-        <translation>Eliminar ficheiros automaticamente após extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="33"/>
         <source>Path to unrar</source>
-        <translation>Localização do Unrar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="45"/>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="66"/>
         <source>Choose</source>
-        <translation>Escolher</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="54"/>
         <source>Path to makemkvcon</source>
-        <translation>Localização de makemkvcon</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.cpp" line="46"/>
         <source>Choose unrar</source>
-        <translation>Escolher Unrar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.cpp" line="54"/>
         <source>Choose makemkvcon</source>
-        <translation>Escolher makemkvco</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3205,49 +3185,47 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="17"/>
         <source>General Kodi Settings. MediaElch uses the Kodi version below for writing NFO files.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="29"/>
         <source>Kodi Version</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="48"/>
         <source>If you want to use the synchronization feature you need to enable the webserver within Kodi (Settings -&gt; Services -&gt; Webserver). Enter the port of the webserver here (usually 80 or 8080).</source>
-        <translation>Se quer usar o recurso de sincronização, deve antes ativar o servidor web dentro do Kodi.
-Veja em Kodi -&gt; Definições -&gt; Serviços -&gt; Servidor web. Anote os números de host (IP) e da porta.
-Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="63"/>
         <source>Host</source>
-        <translation>Anfitrião</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="70"/>
         <source>127.0.0.1</source>
-        <translation>127.0.0.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="77"/>
         <source>Port</source>
-        <translation>Porta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="84"/>
         <source>8080</source>
-        <translation>8080</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="91"/>
         <source>User</source>
-        <translation>Utilizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="98"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3255,68 +3233,68 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="23"/>
         <source>Kodi Synchronization</source>
-        <translation>Sincronização com Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="32"/>
         <source>Please make sure you have setup your sources in Kodi and that the webserver is enabled (Kodi -&gt; Settings -&gt; Services -&gt; Webserver).</source>
-        <translation>Por favor, certifique-se que configurou as suas fontes no Kodi e que o seu servidor web está ativado (Kodi -&gt; Definições -&gt; Serviços -&gt; Servidor web).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="42"/>
         <source>Update contents</source>
-        <translation>Atualizar conteúdos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="52"/>
         <source>This will tell Kodi to remove the changed movies, concerts or shows. Afterwards a Kodi library update is triggered and the removed items will be picked up again.</source>
-        <translation>Isto irá dizer ao Kodi para remover os filmes, concertos e séries com alterações. Após isso, o Kodi irá fazer uma atualização e os itens removidos serão novamente recolhidos e reinseridos.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="62"/>
         <source>Remove non-existent items from Kodis database (Clean library)</source>
-        <translation>Remover itens não existentes da base de dados do Kodi (limpar coleção).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="69"/>
         <source>Kodi will remove not longer existing items from your database.</source>
-        <translation>O Kodi irá remover os itens não localizados da sua base de dados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="76"/>
         <source>Retrieve watched status</source>
-        <translation>Obter estado de &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="83"/>
         <source>The fields last played and playcount will be retrieved from Kodi.</source>
-        <translation>Os campos Última Reprodução e Contador de Sessões virão do Kodi.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="113"/>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="120"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="138"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="161"/>
         <source>Start</source>
-        <translation>Iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="165"/>
         <source>Please fill in your Kodi host and port.</source>
-        <translation>Por favor introduza os dados de Host e Porta no menu Definições -&gt; Kodi.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="238"/>
         <source>Getting contents from Kodi</source>
-        <translation>A obter conteúdos do Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="254"/>
@@ -3324,52 +3302,52 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="318"/>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="350"/>
         <source>Network error</source>
-        <translation>Erro de rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="448"/>
         <source>Removing movies from database</source>
-        <translation>A remover filmes da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="463"/>
         <source>Removing concerts from database</source>
-        <translation>A remover concertos da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="478"/>
         <source>Removing TV shows from database</source>
-        <translation>A remover séries de TV da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="493"/>
         <source>Removing episodes from database</source>
-        <translation>A remover episódios da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="533"/>
         <source>Trigger scan for new items</source>
-        <translation>Requisitar busca de novos itens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="555"/>
         <source>Error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="560"/>
         <source>Finished. Kodi is now loading your updated items.</source>
-        <translation>Terminado. O Kodi está agora a carregar os seus itens atualizados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="582"/>
         <source>Finished. Kodi is now cleaning your database.</source>
-        <translation>Terminado. O Kodi está agora a limpar a sua base de dados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="627"/>
         <source>Finished. Your items play count and last played date have been updated.</source>
-        <translation>Concluído. O &quot;Nº de reproduções&quot; e a &quot;última reprodução&quot; dos seus itens foram atualizadas.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3377,7 +3355,7 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/small_widgets/LanguageCombo.cpp" line="37"/>
         <source>No language available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3385,17 +3363,17 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="23"/>
         <source>Loading Stream Details</source>
-        <translation>A carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="32"/>
         <source>Loading Stream Details...</source>
-        <translation>A carregar detalhes da pista...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="46"/>
         <source>File</source>
-        <translation>Ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3403,414 +3381,414 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/data/Locale.cpp" line="28"/>
         <source>Arabic</source>
-        <translation>Árabe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="29"/>
         <source>Arabic (U.A.E.)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="30"/>
         <source>Arabic (Saudi Arabia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="31"/>
         <source>Belarusian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="32"/>
         <location filename="../../src/data/Locale.cpp" line="33"/>
         <source>Bulgarian</source>
-        <translation>Búlgaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="34"/>
         <source>Bengali</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="35"/>
         <source>Catalan (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="36"/>
         <source>Chamorro (Guam)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="37"/>
         <source>Cantonese</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="38"/>
         <location filename="../../src/data/Locale.cpp" line="39"/>
         <source>Czech</source>
-        <translation>Checo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="40"/>
         <location filename="../../src/data/Locale.cpp" line="41"/>
         <source>Danish</source>
-        <translation>Dinamarquês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="42"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="43"/>
         <source>German (AT)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="44"/>
         <source>German (CH)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="45"/>
         <source>German (DE)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="46"/>
         <location filename="../../src/data/Locale.cpp" line="47"/>
         <source>Greek</source>
-        <translation>Grego</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="48"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="49"/>
         <source>English (Australia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="50"/>
         <source>English (Canada)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="51"/>
         <source>English (GB)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="52"/>
         <source>English (NZ)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="53"/>
         <source>English (US)</source>
-        <translation>Inglês (US)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="54"/>
         <source>Esperanto</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="55"/>
         <location filename="../../src/data/Locale.cpp" line="56"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="57"/>
         <source>Spanish (Mexico)</source>
-        <translation>Castelhano (México)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="58"/>
         <source>Estonian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="59"/>
         <source>Basque (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="60"/>
         <source>Persian (Iran)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="61"/>
         <location filename="../../src/data/Locale.cpp" line="62"/>
         <source>Finnish</source>
-        <translation>Finlandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="63"/>
         <location filename="../../src/data/Locale.cpp" line="65"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="64"/>
         <source>French (Canada)</source>
-        <translation>Francês (Canadá)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="66"/>
         <source>Galician (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="67"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="68"/>
         <source>Hebrew (Israel)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="69"/>
         <source>Hindi (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="70"/>
         <source>Croatian</source>
-        <translation>Croata</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="71"/>
         <source>Croatian (Croatia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="72"/>
         <location filename="../../src/data/Locale.cpp" line="73"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="74"/>
         <source>Indonesian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="75"/>
         <location filename="../../src/data/Locale.cpp" line="76"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="77"/>
         <location filename="../../src/data/Locale.cpp" line="78"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="79"/>
         <source>Georgian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="80"/>
         <source>Kazakh</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="81"/>
         <source>Kannada</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="82"/>
         <location filename="../../src/data/Locale.cpp" line="83"/>
         <source>Korean</source>
-        <translation>Coreano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="84"/>
         <source>Lithuanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="85"/>
         <source>Latvian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="86"/>
         <source>Malayalam</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="87"/>
         <source>Malay (Malaysia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="88"/>
         <source>Malay (Singapore)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="89"/>
         <source>Norwegian Bokmål</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="90"/>
         <location filename="../../src/data/Locale.cpp" line="91"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="92"/>
         <location filename="../../src/data/Locale.cpp" line="93"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="94"/>
         <location filename="../../src/data/Locale.cpp" line="95"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="96"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="97"/>
         <source>Portuguese (Brazil)</source>
-        <translation>Português (Brasil)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="98"/>
         <source>Portuguese (Portugal)</source>
-        <translation>Português (Portugal)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="99"/>
         <source>Romanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="100"/>
         <location filename="../../src/data/Locale.cpp" line="101"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="102"/>
         <source>Sinhalese (Sri Lanka)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="103"/>
         <source>Slovak</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="104"/>
         <source>Slovene</source>
-        <translation>Eslovaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="105"/>
         <source>Slovenian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="106"/>
         <source>Albanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="107"/>
         <source>Serbian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="108"/>
         <location filename="../../src/data/Locale.cpp" line="109"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="110"/>
         <source>Tamil (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="111"/>
         <source>Telugu (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="112"/>
         <source>Thai</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="113"/>
         <source>Tagalog (Philippines)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="114"/>
         <location filename="../../src/data/Locale.cpp" line="115"/>
         <source>Turkish</source>
-        <translation>Turco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="116"/>
         <source>Ukrainian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="117"/>
         <source>Vietnamese</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="118"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="119"/>
         <source>Chinese (PRC)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="120"/>
         <source>Chinese (Hong Kong)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="121"/>
         <source>Chinese (Taiwan)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="122"/>
         <source>Zulu</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="124"/>
         <source>No language available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3818,55 +3796,55 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="14"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="75"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="94"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="125"/>
         <source>Movie Sets</source>
-        <translation>Coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="156"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="187"/>
         <source>Certifications</source>
-        <translation>Certificações</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="218"/>
         <source>Duplicates</source>
-        <translation>Duplicados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="248"/>
         <source>Shows</source>
-        <translation>Séries</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="267"/>
         <source>TV Shows</source>
-        <translation>Séries TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="297"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="316"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="346"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="365"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="395"/>
@@ -3875,92 +3853,92 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
         <extracomment>Main menu entry
 ----------
 Main menu entry (tooltip)</extracomment>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="883"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="888"/>
         <source>Quit</source>
-        <translation>Sair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="893"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="52"/>
         <source>FAQ</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="53"/>
         <source>Troubleshooting</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="54"/>
         <source>Report Issue</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="56"/>
         <source>Release Notes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="57"/>
         <source>Documentation</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="58"/>
         <source>Blog</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="59"/>
         <source>Official Kodi Forum</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="61"/>
         <source>View License</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="340"/>
         <source>&amp;Quick Open</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="807"/>
         <source>Reload all Movies (%1)</source>
-        <translation>Recarregar todos os filmes (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="813"/>
         <source>Reload all TV Shows (%1)</source>
-        <translation>Recarregar todas as séries de TV (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="824"/>
         <source>Reload all Concerts (%1)</source>
-        <translation>Recarregar todos os Concertos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="840"/>
         <source>Reload all Downloads (%1)</source>
-        <translation>Recarregar todos os descarregamentos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="846"/>
         <source>Reload Music (%1)</source>
-        <translation>Recarregar música (%1)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3968,147 +3946,147 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="50"/>
         <source>Scan</source>
-        <translation>Análise</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="92"/>
         <source>Import Tracks</source>
-        <translation>Importar faixas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="118"/>
         <source>Backup Disc</source>
-        <translation>Disco de cópia de segurança</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="163"/>
         <source>Loading</source>
-        <translation>A carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="170"/>
         <source>Success</source>
-        <translation>Sucesso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="177"/>
         <source>Loading movie...</source>
-        <translation>A carregar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="199"/>
         <source>Placeholders</source>
-        <translation>Marcadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="207"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="236"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="259"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="282"/>
         <source>File extension</source>
-        <translation>Extensão de ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="298"/>
         <source>Placeholder</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="321"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="338"/>
         <source>Part number of the current file</source>
-        <translation>Número da parte do ficheiro atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="355"/>
         <source>Directory Naming</source>
-        <translation>Nomes das pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="365"/>
         <source>File Naming</source>
-        <translation>Nomes dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="375"/>
         <source>Multi-File Naming</source>
-        <translation>Renomear múltiplos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="385"/>
         <source>Import directory</source>
-        <translation>Pasta de importação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="429"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="452"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="207"/>
         <source>No tracks selected</source>
-        <translation>Não foram selecionadas faixas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="208"/>
         <source>Please select at least one track you want to import.</source>
-        <translation>Por favor, selecione pelo menos uma faixa para importar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="246"/>
         <source>Loading movie information...</source>
-        <translation>A carregar a informação do filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="274"/>
         <source>Movie information was loaded</source>
-        <translation>A informação de filme foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="297"/>
         <source>Creating destination directory failed</source>
-        <translation>Não foi possível criar a pasta de destino</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="298"/>
         <source>The destination directory %1 could not be created</source>
-        <translation>Não foi possível criar a pasta de destino %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="386"/>
         <source>MakeMKV import finished</source>
-        <translation>Importação MakeMKV foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="386"/>
         <source>Import with MakeMKV has finished</source>
-        <translation>A importação com o MakeMKV foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="389"/>
         <source>Import has finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4116,17 +4094,17 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="116"/>
         <source>Movie title</source>
-        <translation>Título do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="145"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="152"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4134,27 +4112,27 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.ui" line="67"/>
         <source>Detect duplicate movies</source>
-        <translation>Detetar filmes duplicados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="75"/>
         <source>Detecting duplicate movies...</source>
-        <translation>A detetar filmes duplicados...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="129"/>
         <source>Open Detail Page</source>
-        <translation>Abrir página de detalhes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="130"/>
         <source>Open Movie Folder</source>
-        <translation>Abrir pasta do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="131"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4162,19 +4140,18 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="25"/>
         <source>Source %1 is no directory</source>
-        <translation>A fonte %1 não é uma pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="83"/>
         <source>Operation not possible.</source>
-        <translation>Não foi possível efetuar a operação.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="84"/>
         <source>%1
  Operation Canceled.</source>
-        <translation>%1
- Operação Cancelada.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4182,99 +4159,93 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="144"/>
         <source>New</source>
-        <translation>Novo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="160"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="176"/>
         <source>Date Added</source>
-        <translation>Data de adição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="192"/>
         <source>Seen</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="208"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="30"/>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="562"/>
         <source>%n movies</source>
-        <translation>
-            <numerusform>%n filme</numerusform>
-            <numerusform>%n filmes</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="58"/>
         <source>Media Status Columns</source>
-        <translation>Colunas de estado do média</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="69"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="80"/>
         <source>Load Information</source>
-        <translation>Carregar informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="81"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="82"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="83"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="84"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="85"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="86"/>
         <source>Open Movie Folder</source>
-        <translation>Abrir pasta do Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="87"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="88"/>
         <source>Play movie</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="564"/>
         <source>%1 of %n movies</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -4282,85 +4253,85 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="17"/>
         <source>Choose a movie</source>
-        <translation>Escolher o filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="26"/>
         <source>Filter</source>
-        <translation>Filtro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="58"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="68"/>
         <source>Add selected movies</source>
-        <translation>Adicionar filmes selecionados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="88"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="326"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <source>Extra Arts</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <source>Extra Fanarts</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="329"/>
-        <source>Extra Arts</source>
-        <translation>Arts extras</translation>
+        <source>Fanart</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="330"/>
-        <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <source>Poster</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="331"/>
-        <source>Fanart</source>
-        <translation>Fanart</translation>
+        <source>Stream Details</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="332"/>
-        <source>Poster</source>
-        <translation>Cartaz</translation>
+        <source>Trailer</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="333"/>
-        <source>Stream Details</source>
-        <translation>Detalhes da pista</translation>
+        <source>Local Trailer</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="334"/>
-        <source>Trailer</source>
-        <translation>Trailer</translation>
+        <source>Subtitles</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="335"/>
-        <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <source>Tags</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="336"/>
-        <source>Subtitles</source>
-        <translation>Legendas</translation>
-    </message>
-    <message>
-        <location filename="../../src/model/MovieModel.cpp" line="337"/>
-        <source>Tags</source>
-        <translation>Etiquetas</translation>
-    </message>
-    <message>
-        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4368,185 +4339,182 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="23"/>
         <source>Movie Multi Scrape</source>
-        <translation>Extração múltipla de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="36"/>
         <source>Please select the scraper and the infos you want to be loaded. MediaElch will use the best result for each movie you selected.</source>
-        <translation>Por favor, escolha o extrator e as informações que pretende carregar. O MediaElch usará o melhor resultado para cada filme que selecionou.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="48"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="84"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="143"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="233"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="163"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="303"/>
         <source>Logo</source>
-        <translation>Logotipos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="223"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="133"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="113"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="93"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="103"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="173"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="213"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="203"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="153"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="123"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="183"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="243"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="253"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="193"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="293"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="283"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="273"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="263"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="313"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="332"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="358"/>
         <source>Automatically save each movie after scraping</source>
-        <translation>Guardar automaticamente cada filme após a extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="365"/>
         <source>Update only movies with IMDb ID/TMDb Id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="380"/>
         <source>1/20</source>
-        <translation>1/20</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="387"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="412"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="435"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="448"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.cpp" line="201"/>
         <source>Scraping of %n movies has finished.</source>
-        <translation>
-            <numerusform>A extração de %n filmes terminou.</numerusform>
-            <numerusform>A extração de %n filmes terminou.</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -4554,12 +4522,12 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4567,166 +4535,163 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="31"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="41"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="70"/>
         <source>When using IMDb you can also use the IMDb id as search query.
 If you want to search by an TMDb id please prefix it with &quot;id&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="128"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="163"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="170"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="177"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="184"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="191"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="198"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="205"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="212"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="219"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="226"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="233"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="240"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="264"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="271"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="278"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="285"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="292"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="299"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="306"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="313"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="320"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="327"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="334"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="365"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="77"/>
         <source>Cannot scrape a movie without an active scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="153"/>
         <source>Internal inconsistency: Cannot set language dropdown in movie search widget!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="175"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="314"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4734,112 +4699,112 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your movies. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Em baixo, pode ver os nomes de ficheiros usados para carregar e guardar os seus filmes. Pode editá-los à sua vontade, se quiser usar vários ficheiros separe-os com uma vírgula.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o de nome de ficheiro sem extensão.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="42"/>
         <source>Nfo</source>
-        <translation>Nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="49"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="56"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="63"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="70"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="77"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="216"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="223"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="281"/>
         <source>Movie outline</source>
-        <translation>Resumo do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="288"/>
         <source>Use plot when outline is not available</source>
-        <translation>Usar enredo quando não existir resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="295"/>
         <source>Movie Set Artwork</source>
-        <translation>Artwork de coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="21"/>
         <source>Artwork next to movies</source>
-        <translation>Artwork próxima dos filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="23"/>
         <source>Separate artwork directory</source>
-        <translation>Pasta separada de artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="305"/>
         <source>Movie Set Poster Filename</source>
-        <translation>Nome do ficheiro do cartaz da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="342"/>
         <source>Movie Set Fanart Filname</source>
-        <translation>Nome de ficheiro da fanart da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="379"/>
         <source>Artwork directory</source>
-        <translation>Pasta de artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="391"/>
         <source>Choose directory</source>
-        <translation>Escolher pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="400"/>
         <source>Movie Original Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="407"/>
         <source>Don&apos;t store the original title if it is the same as the normal title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="163"/>
         <source>Choose a directory where your movie set artwork is stored</source>
-        <translation>Escolher uma pasta onde a artwork da coleção de filmes está guardada</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4847,283 +4812,283 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="50"/>
         <source>Movie has changed. Click to revert changes.</source>
-        <translation>O filme foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="75"/>
         <source>Movie Name</source>
-        <translation>Nome do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="121"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="141"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1050"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="155"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="165"/>
         <source>Original Name</source>
-        <translation>Nome original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="175"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="185"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="211"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="228"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="235"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="245"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="255"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="275"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="282"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="317"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="347"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="350"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="353"/>
         <source>Not watched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="362"/>
         <source>Plot</source>
-        <translation>Enredo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="386"/>
         <source>Insert YouTube Dummy Link</source>
-        <translation>Inserir link falso do YouTube</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="405"/>
         <source>Download Trailer</source>
-        <translation>Descarregar trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="421"/>
         <source>Play local trailer</source>
-        <translation>Reproduzir trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="431"/>
         <source>Local trailer is available</source>
-        <translation>Está disponível um trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="434"/>
         <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="447"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="480"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="548"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="558"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="570"/>
         <source>Outline</source>
-        <translation>Resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="592"/>
         <source>Open movie on IMDb.com</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="595"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="631"/>
         <source>Go</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="618"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="628"/>
         <source>Open movie on TheMovieDB.org</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="663"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="695"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="786"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="705"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="717"/>
         <source>Support for extra fanarts is only available when your movies are stored in separate folders. Check the settings if you&apos;ve stored your movies in separate folders already.</source>
-        <translation>O recurso a fanarts extra só está disponível quando os seus filmes estão guardados em pastas separadas. Verifique as definições, caso já tenha guardado os seus filmes em pastas separadas.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="735"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="758"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="768"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="806"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="796"/>
         <source>Scantype</source>
-        <translation>Varrimento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="942"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="788"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="791"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="847"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="862"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="888"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="881"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="221"/>
         <source>Ratings</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="653"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="952"/>
         <source>Stereo Mode</source>
-        <translation>Modo de Estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="973"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1030"/>
         <source>External Subtitles</source>
-        <translation>Legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1060"/>
         <source>Forced</source>
-        <translation>Forçadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1216"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1256"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1238"/>
@@ -5134,103 +5099,103 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1502"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1549"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1263"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1303"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1310"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1350"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1386"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1426"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1433"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1473"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1480"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1520"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1527"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1567"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="88"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="89"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="93"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="94"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="98"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="99"/>
         <source>Add Country</source>
-        <translation>Adicionar país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="103"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="104"/>
         <source>Add Studio</source>
-        <translation>Adicionar estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="485"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="492"/>
         <source>Scraping...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="780"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="816"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1055"/>
@@ -5239,49 +5204,49 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="821"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="822"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="789"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="792"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="807"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="850"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="921"/>
         <source>Saving movie...</source>
-        <translation>A guardar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="926"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="902"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="950"/>
         <source>Saving movies...</source>
-        <translation>A guardar os filmes...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="919"/>
         <source>Movies Saved</source>
-        <translation>Filmes guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="971"/>
         <source>All Movies Saved</source>
-        <translation>Todos os filmes foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5289,12 +5254,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/file_search/MusicFileSearcher.cpp" line="44"/>
         <source>Searching for Music...</source>
-        <translation>A procurar por músia...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MusicFileSearcher.cpp" line="129"/>
         <source>Loading Music...</source>
-        <translation>A carregar a música...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5302,38 +5267,29 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="31"/>
         <source>Open Folder</source>
-        <translation>Abrir pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="32"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="25"/>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="155"/>
         <source>%n artists</source>
-        <translation>
-            <numerusform>%n artista</numerusform>
-            <numerusform>%n artistas</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="25"/>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="155"/>
         <source>%n albums</source>
-        <translation>
-            <numerusform>%n álbum</numerusform>
-            <numerusform>%n álbuns</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="158"/>
         <source>%1 of %n artists</source>
-        <translation>
-            <numerusform>%1 de %n artista</numerusform>
-            <numerusform>%1 de %n artistas</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5341,170 +5297,167 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="17"/>
         <source>Music Multi Scrape</source>
-        <translation>Extração múltipla de músicas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="39"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="48"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="61"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="74"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="87"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="100"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="113"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="126"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="139"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="152"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="165"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="178"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="191"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="204"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="217"/>
         <source>Moods</source>
-        <translation>Disposição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="230"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="243"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="256"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="269"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="282"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="295"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="308"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="321"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="334"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="347"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="369"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="395"/>
         <source>Scrape all albums of selected artists (and not only selected albums)</source>
-        <translation>Extrair todos os álbuns de artistas selecionados (e não apenas dos álbuns selecionados)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="402"/>
         <source>Automatically save each artist and album after scraping</source>
-        <translation>Guardar automaticamente cada artista e álbum após a extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="449"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="472"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="485"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.cpp" line="205"/>
         <source>Scraping of %n items has finished.</source>
-        <translation>
-            <numerusform>Terminou a extração de %n itens.</numerusform>
-            <numerusform>Terminou a extração de %n itens.</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5512,12 +5465,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5525,142 +5478,142 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="34"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="89"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="117"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="140"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="150"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="160"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="170"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="180"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="190"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="200"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="210"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="220"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="230"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="240"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="250"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="260"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="270"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="280"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="290"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="300"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="310"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="320"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="330"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="340"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="350"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="360"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="370"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="387"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5668,39 +5621,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your artists and albums. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Abaixo pode ver os nomes de ficheiros que são usados ​​para carregar e guardar os Artistas e Álbuns. Pode editá-los como quiser.
-Se quiser guardar o mesmo ficheiro com vários nomes, deve separar os nomes com uma vírgula.
-Por exemplo:  folder.jpg,cover.jpg</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="32"/>
         <source>Artist Thumbnail</source>
-        <translation>Miniatura de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="49"/>
         <source>Artist Fanart</source>
-        <translation>Fanart de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="66"/>
         <source>Artist Logo</source>
-        <translation>Logótipo de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="83"/>
         <source>Album Thumbnail</source>
-        <translation>Miniatura de álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="100"/>
         <source>Album Disc Art</source>
-        <translation>Capa do álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="117"/>
         <source>Download Extra Fanarts for Artists</source>
-        <translation>Descarregar Fanarts extras para artistas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5708,10 +5659,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message numerus="yes">
         <location filename="../../src/ui/small_widgets/MusicTreeView.cpp" line="105"/>
         <source>%n albums</source>
-        <translation>
-            <numerusform>%n album</numerusform>
-            <numerusform>%n álbuns</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5720,13 +5668,13 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="122"/>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="162"/>
         <source>Saving changed Artists and Albums</source>
-        <translation>A guardar alterações em artistas e álbuns</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="140"/>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="187"/>
         <source>All Artists and Albums Saved</source>
-        <translation>Todos os artistas e álbuns foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5734,150 +5682,150 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="53"/>
         <source>Album has changed. Click to revert changes.</source>
-        <translation>O álbum foi alterando. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="79"/>
         <source>Album Name</source>
-        <translation>Nome do álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="137"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="158"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="179"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="186"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="193"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="200"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="207"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="214"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="254"/>
         <source>MusicBrainz Album ID</source>
-        <translation>Identificador do álbum MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="268"/>
         <source>MusicBrainz Release Group ID</source>
-        <translation>Identificador do grupo de lançamento MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="285"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="326"/>
         <source>Booklet</source>
-        <translation>Brochura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="345"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="368"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="420"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="460"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="442"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="505"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="483"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="523"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="41"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="42"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="46"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="47"/>
         <source>Add Mood</source>
-        <translation>Adicionar estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="51"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="52"/>
         <source>Add Style</source>
-        <translation>Adicionar estilo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="186"/>
         <source>Saving Album...</source>
-        <translation>A guardar o álbum...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="192"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="524"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5885,182 +5833,182 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="53"/>
         <source>Artist has changed. Click to revert changes.</source>
-        <translation>O artista foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="79"/>
         <source>Artist Name</source>
-        <translation>Nome do artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="137"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="158"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="186"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="193"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="200"/>
         <source>Years active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="207"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="214"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="235"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="245"/>
         <source>MusicBrainz ID</source>
-        <translation>Identificador MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="262"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="303"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="325"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="330"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="340"/>
         <source>Add Album</source>
-        <translation>Adicionar álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="347"/>
         <source>Remove Album</source>
-        <translation>Remover álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="370"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="392"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="415"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="467"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="507"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="633"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="489"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="552"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="615"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="530"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="570"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="593"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="49"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="50"/>
         <source>Add Genre</source>
-        <translation>Adicionar Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="54"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="55"/>
         <source>Add Mood</source>
-        <translation>Adicionar estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="59"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="60"/>
         <source>Add Style</source>
-        <translation>Adicionar estilo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="196"/>
         <source>Saving Artist...</source>
-        <translation>A guardar o artista...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="202"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="501"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="586"/>
         <source>Unknown Album</source>
-        <translation>Álbum Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6068,87 +6016,87 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="38"/>
         <source>Scrape</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="58"/>
         <source>Save</source>
-        <translation>Guardar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="78"/>
         <source>Save All</source>
-        <translation>Guardar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="98"/>
         <source>Rename selected files</source>
-        <translation>Renomear ficheiros selecionados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="118"/>
         <source>Synchronize to Kodi</source>
-        <translation>Sincronizar com o Kodl</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="138"/>
         <source>Export Database</source>
-        <translation>Exportar base de Dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="161"/>
         <source>Reload</source>
-        <translation>Recarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="181"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="201"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="247"/>
         <source>Donate</source>
-        <translation>Fazer um donativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="17"/>
         <source>Scrape (%1)</source>
-        <translation>Extrair (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="20"/>
         <source>Save (%1)</source>
-        <translation>Guardar (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="24"/>
         <source>Save All (%1)</source>
-        <translation>Guardar todos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="28"/>
         <source>Reload all files (%1)</source>
-        <translation>Recarregar todos os ficheiros (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="32"/>
         <source>Export HTML</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="36"/>
         <source>Export CSV</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="43"/>
         <source>Export Database (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6156,7 +6104,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/scrapers/ScraperInterface.cpp" line="17"/>
         <source>Network Error</source>
-        <translation>Erro na rede</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6164,43 +6112,43 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="71"/>
         <source>Host</source>
-        <translation>Anfitrião</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="78"/>
         <source>Port</source>
-        <translation>Porta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="98"/>
         <source>Username</source>
-        <translation>Nome de utilizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="108"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="19"/>
         <source>Enable Proxy</source>
-        <translation>Ativar proxy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="64"/>
         <source>Type</source>
         <comment>Proxy Type</comment>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="51"/>
         <source>HTTP</source>
-        <translation>HTTP</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="36"/>
         <source>Use Proxy for Kodi</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6208,7 +6156,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/PlaceholderLineEdit.cpp" line="26"/>
         <source>Insert placeholder</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6216,183 +6164,183 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/main.cpp" line="36"/>
         <source>Logfile could not be openened</source>
-        <translation>Não foi possível abrir o ficheiro de registo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="37"/>
         <source>The logfile %1 could not be openend for writing.</source>
-        <translation>Não foi possível modificar o ficheiro de registo %1.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="76"/>
         <source>Stylesheet could not be opened!</source>
-        <translation>Não foi possível abrir a folha de estilo.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="78"/>
         <source>The default stylesheet could not be openend for reading.</source>
-        <translation>Não foi possível abrir a folha de estilos padrão para leitura.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="79"/>
         <source>The custom stylesheet could not be openend for reading. Using: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <source>No Label</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <source>Red</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <source>Orange</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <source>Yellow</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="392"/>
-        <source>No Label</source>
-        <translation>Sem etiqueta</translation>
+        <source>Green</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="393"/>
-        <source>Red</source>
-        <translation>Vermelho</translation>
+        <source>Blue</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="394"/>
-        <source>Orange</source>
-        <translation>Laranja</translation>
+        <source>Purple</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="395"/>
-        <source>Yellow</source>
-        <translation>Amarelo</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="396"/>
-        <source>Green</source>
-        <translation>Verde</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="397"/>
-        <source>Blue</source>
-        <translation>Azul</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="398"/>
-        <source>Purple</source>
-        <translation>Roxo</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
-        <translation>Cinzento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="12"/>
         <source>File not found:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="13"/>
         <source>Cannot open advancedsettings.xml in read-only mode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="14"/>
         <source>Couldn&apos;t find an &lt;advancedsettings&gt; tag!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="15"/>
         <source>Found unsupported xml tag:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="16"/>
         <source>Invalid value for xml tag:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
-        <translation>&lt;b&gt;Mover Ficheiro&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowCommonWidgets.cpp" line="59"/>
         <source>Aired order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowCommonWidgets.cpp" line="62"/>
         <source>DVD order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="8"/>
         <source>Timeout by MediaElch</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="9"/>
         <source>Content not found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="10"/>
         <source>Remote connection timed out</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="11"/>
         <source>SSL handshake failed</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="12"/>
         <source>Too many redirects</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="13"/>
         <source>Connection refused by host</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="14"/>
         <source>Host not found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="15"/>
         <source>Unknown network error</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="16"/>
         <source>Could not load the requested resource</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="18"/>
         <location filename="../../src/scrapers/ScraperError.cpp" line="25"/>
         <source>Network Error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="32"/>
         <source>The scraper&apos;s rate limit reached. Please wait ~10 seconds and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="37"/>
         <source>An unknown network error occurred. Are you connected to the internet?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="51"/>
         <source>The scraper did not respond with any data.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="55"/>
         <source>The scraper response could not be parsed.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media_center/kodi/ConcertXmlReader.cpp" line="29"/>
         <source>No valid musicvideo root entry found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6400,22 +6348,22 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="60"/>
         <source>QIODevice::Append is not supported for GZIP</source>
-        <translation>QIODevice::Append não é suportado pelo GZIP</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="66"/>
         <source>Opening gzip for both reading and writing is not supported</source>
-        <translation>A abertura do gzip para leitura e escrita não é suportada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="74"/>
         <source>You can open a gzip either for reading or for writing. Which is it?</source>
-        <translation>Pode abrir um gzip para ler ou gravar. Qual deles?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="80"/>
         <source>Could not gzopen() file</source>
-        <translation>Não foi possível abrir o ficheiro gzopen()</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6423,12 +6371,12 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quaziodevice.cpp" line="188"/>
         <source>QIODevice::Append is not supported for QuaZIODevice</source>
-        <translation>QIODevice::Append não é suportado pelo QuaZIODevice</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quaziodevice.cpp" line="193"/>
         <source>QIODevice::ReadWrite is not supported for QuaZIODevice</source>
-        <translation>QIODevice::ReadWrite não é suportado pelo QuaZIODevice</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6436,7 +6384,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quazipfile.cpp" line="251"/>
         <source>ZIP/UNZIP API error %1</source>
-        <translation>Erro da API ZIP/UNZIP %1</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6444,27 +6392,27 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="100"/>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="101"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="102"/>
         <source>Vote Count</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="103"/>
         <source>Min. Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="104"/>
         <source>Max. Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6472,17 +6420,17 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="14"/>
         <source>Form</source>
-        <translation>Formulário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="80"/>
         <source>Add rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="94"/>
         <source>Remove selected rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6490,145 +6438,133 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="17"/>
         <source>Renamer</source>
-        <translation>Alteração de nomes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="34"/>
         <source>Pattern</source>
-        <translation>Padrão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="75"/>
         <source>Use Season Directories</source>
-        <translation>Usar pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="85"/>
         <source>Multi-File Naming</source>
-        <translation>Alterar nome de vários ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="117"/>
         <source>Rename Directories</source>
-        <translation>Alterar nome de pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="127"/>
         <source>Rename Files</source>
-        <translation>Alterar nome de ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="162"/>
         <source>Directory Naming</source>
-        <translation>Alterar nome de pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="194"/>
         <source>File Naming</source>
-        <translation>Nomes dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="201"/>
         <source>Season Directory Naming</source>
-        <translation>Nomes das pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="208"/>
         <source>Season &lt;season&gt;</source>
-        <translation>Temporada &lt;season&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="249"/>
         <source>Results</source>
-        <translation>Resultados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="342"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="365"/>
         <source>Dry Run</source>
-        <translation>Operação &quot;a seco&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
         <source>Rename</source>
-        <translation>Alterar nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="38"/>
         <source>Please see %1 for help and examples on how to use the renamer.</source>
-        <translation>Veja a ajuda em %1. Temos exemplos de como usar o alterador de nomes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="58"/>
         <source>%n concerts will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="60"/>
         <source>%n movies will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="62"/>
         <source>%n TV shows and %1</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="63"/>
         <source>%n episodes will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
         <source>Finished</source>
-        <translation>Concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
         <source>Create dir</source>
-        <translation>Criar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
         <source>Move</source>
-        <translation>Mover</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6636,152 +6572,147 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="35"/>
         <source>Placeholders</source>
-        <translation>Marcadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
         <source>Placeholder</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
         <source>File extension</source>
-        <translation>Extensão de ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
         <source>Season Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
         <source>Part number of the current file</source>
-        <translation>Número da parte do ficheiro atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
-        <source>TMDb ID</source>
-        <translation type="unfinished">Identificador do TMDb</translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
         <source>Season Number</source>
-        <translation>Número da temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
         <source>Title of the show</source>
-        <translation>Título da série</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
         <source>Studio(s) (separated by a comma)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
         <source>Director(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
         <source>Audio Language(s) (separated by a minus)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
         <source>Episode Number</source>
-        <translation>Número do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
         <source>Resolution (1080p, 720p, ...)</source>
-        <translation>Resolução (1080p, 720p...)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
         <source>File/directory is BluRay</source>
-        <translation>Ficheiro ou pasta é BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
         <source>File/directory is DVD</source>
-        <translation>Ficheiro ou pasta é DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
         <source>File is 3D</source>
-        <translation>Ficheiro é 3D</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
         <source>Movie set name</source>
-        <translation>Nome da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
         <source>Video Codec</source>
-        <translation>Codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
         <source>Episode has a season name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
         <source>Audio Codec</source>
-        <translation>Codec de áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
         <source>Number of audio channels</source>
-        <translation>Número de canais de áudio</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6790,141 +6721,141 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="121"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="151"/>
         <source>Invalid</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="122"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="152"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="123"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="124"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="153"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="125"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="126"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="155"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="127"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="128"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="156"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="129"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="157"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="130"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="131"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="158"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="132"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="133"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="161"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="134"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="159"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="135"/>
         <source>Extra Art</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="136"/>
         <source>Season Backdrop</source>
-        <translation>Fundo de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="137"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="138"/>
         <source>Extra Fanart</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="139"/>
         <source>Show Thumbnail</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="140"/>
         <source>Season Thumbnail</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="141"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="142"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="145"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="165"/>
         <source>Unknown</source>
-        <translation>Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="160"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="154"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="162"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6933,162 +6864,162 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="21"/>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="138"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="57"/>
         <source>Enable adult movie scrapers</source>
-        <translation>Ativar extratores de filmes para adultos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="95"/>
         <source>Custom Movie Scraper</source>
-        <translation>Extrator de filmes personalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="101"/>
         <source>Combine multiple scrapers to your custom scraper. If you select other scrapers than IMDB, The Movie DB and Fanart.tv multiple searches may be necessary as only these three share an id.</source>
-        <translation>Combine vários extratores num único extrator personalizado. Se selecionar outros extratores além do IMDB, The Movie DB e Fanart.tv, poderão ser necessárias várias procuras, já que apenas estes três usam identificadores comuns.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="133"/>
         <source>Item</source>
-        <translation>Item</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="147"/>
         <source>TV Scraper</source>
-        <translation>Extrator de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="157"/>
         <source>Custom TV Scraper</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="172"/>
         <source>Don&apos;t use</source>
-        <translation>Não usar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="218"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="219"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="220"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="221"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="222"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="223"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="224"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="225"/>
         <source>Plot</source>
-        <translation>Enredo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="226"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="227"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="228"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="229"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="230"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="231"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="232"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="233"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="234"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="235"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="236"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="237"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="238"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="239"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="240"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="241"/>
         <source>Unsupported</source>
-        <translation>Incompatível</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7096,12 +7027,12 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/model/tv_show/SeasonModelItem.cpp" line="135"/>
         <source>Season %1 - %2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/tv_show/SeasonModelItem.cpp" line="137"/>
         <source>Season %1</source>
-        <translation>Temporada %1</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7109,59 +7040,59 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="61"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="88"/>
         <source>Set Name</source>
-        <translation>Nome da coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="122"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="127"/>
         <source>Sorttitle</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="150"/>
         <source>Add movie to set</source>
-        <translation>Adicionar filme à coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="153"/>
         <source>Add Movie</source>
-        <translation>Adicionar filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="160"/>
         <source>Remove selected movie from set</source>
-        <translation>Remover filme selecionado da coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="163"/>
         <source>Remove Movie</source>
-        <translation>Remover Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="182"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="204"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="276"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="225"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="300"/>
         <source>Full preview</source>
-        <translation>Pré-visualização inteira</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="239"/>
@@ -7169,32 +7100,32 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="314"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="317"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="254"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="56"/>
         <source>Add Movie Set</source>
-        <translation>Adicionar coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="57"/>
         <source>Delete Movie Set</source>
-        <translation>Eliminar coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="459"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="491"/>
         <source>New Movie Set</source>
-        <translation>Nova coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7202,79 +7133,79 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="20"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="184"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="162"/>
         <source>Kodi</source>
-        <translation>Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="206"/>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="209"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="220"/>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="223"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="62"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="69"/>
         <source>Save Settings</source>
-        <translation>Guardar definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="79"/>
         <source>toolBar</source>
-        <translation>barraFerramentas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="118"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="129"/>
         <source>TV Shows</source>
-        <translation>Séries TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="140"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="151"/>
         <source>Global</source>
-        <translation>Global</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="173"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="195"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.cpp" line="192"/>
         <source>Settings saved</source>
-        <translation>As definições foram guardadas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7282,32 +7213,32 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="17"/>
         <source>Support MediaElch</source>
-        <translation>Doações para o MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="30"/>
         <source>If you like MediaElch and wish to support it you have the chance to do so! You can donate as much as you like via PayPal.</source>
-        <translation>Se gosta do MediaElch e gostaria de apoiá-lo, tem a oportunidade de o fazer! Pode fazer uma doação da quantia que quiser através do PayPal.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="74"/>
         <source>MediaElch makes use of various movie and TV show databases. These databases also need your help to keep their services up and running for free. If you don&apos;t want to donate you can also contribute information and missing artwork if possible.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="127"/>
         <source>Thanks for your help and support!</source>
-        <translation>Obrigado pela sua ajuda e apoio!</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="149"/>
         <source>Hide donate button</source>
-        <translation>Ocultar botão para donativos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="172"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7315,7 +7246,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/TagCloud.ui" line="31"/>
         <source>Tag</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7323,115 +7254,115 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="17"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="47"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="87"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="110"/>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="206"/>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="369"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="166"/>
         <source>Preview</source>
-        <translation>Pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="171"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="176"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="186"/>
         <source>Back to Search Results</source>
-        <translation>Regressar aos resultados da busca</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="277"/>
         <source>URL</source>
-        <translation>Endereço</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="308"/>
         <source>Progress</source>
-        <translation>Progresso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="331"/>
         <source>Download</source>
-        <translation>Descarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="338"/>
         <source>Cancel Download</source>
-        <translation>Cancelar descarregamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="349"/>
         <source>Back to Trailers</source>
-        <translation>Regressar aos trailers</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="345"/>
         <source>Download Finished</source>
-        <translation>Descarregamento concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="356"/>
         <source>The file %1 already exists.</source>
-        <translation>O ficheiro %1 já existe.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="358"/>
         <source>Do you want to overwrite it?</source>
         <extracomment>&quot;it&quot; refers to the file</extracomment>
-        <translation>Quer substituí-lo?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="371"/>
         <source>Download Canceled</source>
-        <translation>Descarregamento cancelado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="375"/>
         <source>Download Not Found (404)</source>
-        <translation>Descarregamento não encontrado (404)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="379"/>
         <source>Download Error (%1)</source>
-        <translation>Erro no descarregamento (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="433"/>
         <source>Network Error</source>
-        <translation>Erro na rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="434"/>
         <source>Resource could not be played</source>
-        <translation>Não foi possível reproduzir o ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="435"/>
         <source>Video format error</source>
-        <translation>Erro de formato de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7439,92 +7370,92 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="36"/>
         <source>TV Scraper</source>
-        <translation>Extrator de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="88"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="107"/>
         <source>ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="114"/>
         <source>Internal TV scraper ID. Used as key in MediaElch&apos;s settings.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="124"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="169"/>
         <source>Website</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="179"/>
         <source>The scraper&apos;s main website.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="192"/>
         <source>Terms of Service</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="199"/>
         <source>Terms of service of the TV scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="212"/>
         <source>Privacy Policy</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="219"/>
         <source>Privacy Policy of the scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="232"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="239"/>
         <source>Where to get help for the TV scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="252"/>
         <source>Is the scraper initialized?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="255"/>
         <source>Is initialized?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="262"/>
         <source>Default Language</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.cpp" line="112"/>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.cpp" line="112"/>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7532,22 +7463,22 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="52"/>
         <source>Searching for TV Shows...</source>
-        <translation>A procurar séries de TV...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="58"/>
         <source>Loading TV Shows...</source>
-        <translation>A carregar séries de TV...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="87"/>
         <source>Searching for Episodes...</source>
-        <translation>A procurar episódios...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="126"/>
         <source>Loading Episodes...</source>
-        <translation>A carregar episódios...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7556,103 +7487,94 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="27"/>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="670"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="27"/>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="670"/>
         <source>%n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="466"/>
-        <source>You need to update the show once and load the show&apos;s TMDb ID to list missing episodes.
+        <source>You need to update the show once and load the show's TMDb ID to list missing episodes.
 Afterwards MediaElch will check automatically for new episodes on startup.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="470"/>
         <source>Don&apos;t show this hint again</source>
-        <translation>Não voltar a mostrar esta dica</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="674"/>
         <source>%1 of %n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="758"/>
         <source>Load Information</source>
-        <translation>Carregar informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="759"/>
         <source>Search for new episodes</source>
-        <translation>A procurar por novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="760"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="761"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="762"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="763"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="764"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="765"/>
         <source>Open TV Show Folder</source>
-        <translation>Abrir pasta da série de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="766"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="767"/>
         <source>Play episode</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="784"/>
         <source>Show missing episodes</source>
-        <translation>Mostrar episódios que faltam</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="787"/>
         <source>Hide specials in missing episodes</source>
-        <translation>Ocultar episódios especiais ao listar episódios em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="465"/>
         <source>Show update needed</source>
-        <translation>É necessário atualizar a série</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7660,42 +7582,42 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="91"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="92"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="93"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="94"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="95"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="96"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="97"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="98"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7703,303 +7625,297 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="20"/>
         <source>TV Show Multi Scrape</source>
-        <translation>Extrator múltiplo de episódios de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="30"/>
         <source>Please select the infos you want to be loaded. MediaElch will use the best result for each TV show and episode you selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="61"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="365"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="70"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="400"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="83"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="278"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="304"/>
         <source>Season Fanart</source>
-        <translation>Fanart de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="96"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="265"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="226"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="109"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="252"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="213"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="501"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="122"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="374"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="239"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="291"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="475"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="200"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="449"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="135"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="387"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="436"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="426"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="46"/>
         <source>Show Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="148"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="161"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="413"/>
         <source>First aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="174"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="488"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="187"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="317"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="339"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="526"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="350"/>
         <source>Episode Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="462"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="559"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="569"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="579"/>
         <source>Order for seasons</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="607"/>
         <source>Update only TV shows/episodes
 which have an ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="621"/>
         <source>Automatically save each TV show/
 episode after scraping</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="660"/>
         <source>1/20</source>
-        <translation>1/20</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="706"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="729"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="742"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="306"/>
         <source>Start scraping using &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="352"/>
         <source>Skipping show &quot;%1&quot; because it does not have a valid ID.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="371"/>
         <source>Search for TV show &quot;%1&quot; because no valid ID was found.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="378"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="475"/>
         <source>Scraping next TV show with ID &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="408"/>
         <source>Search for TV show &quot;%1&quot; because no valid show ID was found for the episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="417"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="493"/>
         <source>S%1E%2: Scraping next episode with show ID &quot;%3&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="463"/>
         <source>Error while searching for TV show: &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="468"/>
         <source>Did not find any results for search term &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="511"/>
         <source>Done.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="531"/>
         <source>%n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="532"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="534"/>
         <source>Scraping of %1 and %2 has finished.</source>
-        <translation>Terminou a extração de %1 e %2.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="536"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="538"/>
         <source>Scraping of %1 has finished.</source>
-        <translation>A extração de  %1 terminou.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="561"/>
         <source>Finished scraping details of TV show &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="570"/>
         <source>Start loading extra fanart from TheTvDb for TV show with ID &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="753"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="832"/>
         <source>Internal inconsistency: Cannot set language dropdown in TV show search widget!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="848"/>
         <source>S%2E%3: Finished scraping episode details. Title is: &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8007,12 +7923,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/search_dialog/TvShowScrapePreview.ui" line="43"/>
         <source>&lt;b&gt;Preview&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/search_dialog/TvShowScrapePreview.ui" line="83"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Description&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8020,17 +7936,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="58"/>
         <source>Scrape</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8038,219 +7954,216 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="19"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="29"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="134"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="179"/>
         <source>Show Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="210"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="519"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="220"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="230"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="539"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="240"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="549"/>
         <source>First aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="250"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="260"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="559"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="270"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="529"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="280"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="290"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="626"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="300"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="606"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="327"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="616"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="337"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="347"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="357"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="367"/>
         <source>Season Fanart</source>
-        <translation>Fanart de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="377"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="387"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="397"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="407"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="417"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="451"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="670"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="464"/>
         <source>No show details will be loaded because only episodes were selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="488"/>
         <source>Episode Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="586"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="596"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="636"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="682"/>
         <source>Season order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="697"/>
         <source>No episodes will be loaded. If you want to load episodes, change the update mode below.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="147"/>
         <source>Update TV Show only</source>
-        <translation>Atualizar apenas Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="152"/>
         <source>Update TV Show and new Episodes</source>
-        <translation>Atualizar séries de TV e novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="157"/>
         <source>Update TV Show and all Episodes</source>
-        <translation>Atualizar séries de TV e todos os episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="162"/>
         <source>Update new Episodes</source>
-        <translation>Atualizar novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="167"/>
         <source>Update all episodes</source>
-        <translation>Atualizar todos os episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="170"/>
         <source>The %1 scraper could not be initialized!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="148"/>
         <source>Please insert a search string!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="188"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="364"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8258,82 +8171,82 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your TV shows. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension and for season posters &lt;seasonNumber&gt; which is the season number.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o nome do ficheiro, sem extensão, e para cartazes de temporada &lt;seasonNumber&gt;, que é o número da temporada.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="42"/>
         <source>Show nfo</source>
-        <translation>Mostrar nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="49"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="56"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="63"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="70"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="77"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="84"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="91"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="98"/>
         <source>Season Backdrop</source>
-        <translation>Fundo de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="105"/>
         <source>Episode nfo</source>
-        <translation>Nfo do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="112"/>
         <source>Episode thumbnail</source>
-        <translation>Miniatura de episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="119"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="390"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="397"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8341,10 +8254,7 @@ episode after scraping</source>
     <message numerus="yes">
         <location filename="../../src/ui/small_widgets/TvShowTreeView.cpp" line="146"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -8352,7 +8262,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/TvShowUpdater.cpp" line="42"/>
         <source>Updating TV Shows</source>
-        <translation>A atualizar séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8361,22 +8271,22 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="161"/>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="218"/>
         <source>Saving changed TV Shows and Episodes</source>
-        <translation>A guardar alterações em séries de TV e episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="180"/>
         <source>Could not save episode S%1E%2 of show &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="193"/>
         <source>TV Shows and Episodes Saved</source>
-        <translation>Séries de TV e episódios guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="239"/>
         <source>All TV Shows and Episodes Saved</source>
-        <translation>Todas as séries TV e episódios foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8384,292 +8294,292 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="63"/>
         <source>Episode has changed. Click to revert changes.</source>
-        <translation>O episódio foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="82"/>
         <source>Episode Title</source>
-        <translation>Título do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="137"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="154"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="460"/>
         <source>TheTVDB ID</source>
-        <translation>Identificador TheTVDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="514"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="168"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="178"/>
         <source>Show Title</source>
-        <translation>Mostrar título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="188"/>
         <source>Season</source>
-        <translation>Temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="223"/>
         <source>Episode</source>
-        <translation>Episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="242"/>
         <source>Display Season</source>
-        <translation>Mostrar temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="302"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="350"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="367"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="377"/>
         <source>dd.MM.yyyy</source>
-        <translation>dd.MM.yyyy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="384"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="400"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="410"/>
         <source>dd.MM.yyyy HH:mm</source>
-        <translation>dd.MM.yyyy HH:mm</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="436"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="446"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="280"/>
         <source>Display Episode</source>
-        <translation>Mostrar episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="419"/>
         <source>Bookmark</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="313"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="477"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="548"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="558"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="595"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="663"/>
         <source>Directors</source>
-        <translation>Realizadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="691"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="701"/>
         <source>Add Director</source>
-        <translation>Adicionar Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="715"/>
         <source>Remove Director</source>
-        <translation>Remover Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="567"/>
         <source>Writers</source>
-        <translation>Argumentistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="605"/>
         <source>Add Writer</source>
-        <translation>Adicionar argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="619"/>
         <source>Remove Writer</source>
-        <translation>Remover Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="759"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="784"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="789"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="831"/>
         <source>Add Actor</source>
-        <translation>Adicionar Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="804"/>
         <source>Remove Actor</source>
-        <translation>Remover Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="878"/>
         <source>Click to change</source>
-        <translation>Clique para Alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="932"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="991"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="940"/>
         <source>Scantype</source>
-        <translation>TipoAnálise</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="894"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1081"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1106"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="525"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="528"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="981"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1096"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1045"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="429"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="959"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="924"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1116"/>
         <source>Stereo Mode</source>
-        <translation>Modo de Estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1137"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1211"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1233"/>
         <source>Click to Change</source>
-        <translation>Clique para Alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="115"/>
         <source>Episode missing</source>
-        <translation>Episódio em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="92"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="518"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="552"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="524"/>
@@ -8677,68 +8587,68 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="556"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="557"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="526"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="529"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="544"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="585"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="618"/>
         <source>Episode Saved</source>
-        <translation>O episódio foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="620"/>
         <source>Could not save episode S%1E%2 of show &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="666"/>
         <source>Scraping episode...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="800"/>
         <source>Unknown Director</source>
-        <translation>Realizador Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="850"/>
         <source>Unknown Writer</source>
-        <translation>Argumentista desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1107"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1108"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1171"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1171"/>
         <source>Images (*.jpg *.jpeg)</source>
-        <translation>Imagens (*.jpg *.jpeg)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8746,69 +8656,69 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="63"/>
         <source>Episode has changed. Click to revert changes.</source>
-        <translation>O episódio foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="83"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="138"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="149"/>
         <source>Season Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="171"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="232"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="193"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="254"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="298"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="276"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="320"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="342"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="119"/>
         <source>Season missing</source>
-        <translation>Temporada em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.cpp" line="111"/>
         <source>Season %1</source>
-        <translation>Temporada %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.cpp" line="188"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8816,208 +8726,208 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="50"/>
         <source>TV Show has changed. Click to revert changes.</source>
-        <translation>A série de TV foi alterada. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="70"/>
         <source>Show Title</source>
-        <translation>Mostrar título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="98"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="112"/>
         <source>Dir</source>
-        <translation>Dir</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="126"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="208"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="242"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="252"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="315"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="352"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="369"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="379"/>
         <source>dd.MM.yyyy</source>
-        <translation>dd.MM.yyyy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="406"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="460"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="416"/>
         <source>TV Tune</source>
-        <translation>Tema musical</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="425"/>
         <source>Existing</source>
-        <translation>Presente</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="432"/>
         <source>Missing</source>
-        <translation>Em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="448"/>
         <source>Download Theme</source>
-        <translation>Descarregar tema musical</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="386"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="396"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="505"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="201"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="522"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="533"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="558"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="563"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="605"/>
         <source>Add Actor</source>
-        <translation>Adicionar ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="578"/>
         <source>Remove Actor</source>
-        <translation>Remover ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="263"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="137"/>
         <source>TheTVDB ID</source>
-        <translation>Identificador TheTVDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="482"/>
         <source>Continuing</source>
-        <translation>Continuando</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="487"/>
         <source>Ended</source>
-        <translation>Finalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="495"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="154"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="512"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="652"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1221"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="668"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="717"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="739"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="762"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="906"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="928"/>
@@ -9027,92 +8937,92 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1133"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1177"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="950"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="994"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1199"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1067"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1111"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1155"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="78"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="79"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="83"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="84"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="456"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="497"/>
         <source>Please wait while your TV show is scraped</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="724"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="878"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="879"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="960"/>
         <source>Choose Image</source>
-        <translation>Escolher Imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="960"/>
         <source>Images (*.jpg *.jpeg)</source>
-        <translation>Imagens (*.jpg *.jpeg)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9120,53 +9030,53 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="17"/>
         <source>TV Tunes</source>
-        <translation>Temas musicais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="54"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="118"/>
         <source>Progress</source>
-        <translation>Progresso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="141"/>
         <source>Download</source>
-        <translation>Descarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="148"/>
         <source>Cancel Download</source>
-        <translation>Cancelar descarregamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="172"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="251"/>
         <source>Download Finished</source>
-        <translation>Descarregamento concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="256"/>
         <source>The file %1 already exists.</source>
-        <translation>O ficheiro %1 já existe.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="258"/>
         <source>Do you want to overwrite it?</source>
         <extracomment>&quot;it&quot; refers to the file</extracomment>
-        <translation>Quer substituí-lo?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="272"/>
         <source>Download Canceled</source>
-        <translation>Descarregamento cancelado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9174,47 +9084,47 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="45"/>
         <source>Cancel extraction</source>
-        <translation>Cancelar extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="65"/>
         <source>Extract without password</source>
-        <translation>Extrair sem palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="68"/>
         <source>Extract</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="75"/>
         <source>Extract with password</source>
-        <translation>Extrair com palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="95"/>
         <source>Delete this archive</source>
-        <translation>Eliminar este ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="50"/>
         <source>Extraction password</source>
-        <translation>Palavra-passe para extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="50"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="65"/>
         <source>Delete archive?</source>
-        <translation>Eliminar ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="66"/>
         <source>Do you really want to delete this archive?</source>
-        <translation>Quer mesmo eliminar este ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9222,17 +9132,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="63"/>
         <source>Updates available</source>
-        <translation>Atualizações disponíveis</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="64"/>
         <source>%1 is now available.&lt;br&gt;Get it now on %2</source>
-        <translation>%1 já está disponível.&lt;br&gt;Obtenha-o agora em %2</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="68"/>
         <source>Don&apos;t check for updates</source>
-        <translation>Não verificar atualizações</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9240,7 +9150,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/small_widgets/WebImageLabel.ui" line="47"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9248,33 +9158,33 @@ episode after scraping</source>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="28"/>
         <source>Could not get duration of file</source>
-        <translation>Não foi possível obter a duração do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="47"/>
         <source>Could not detect runtime of file</source>
-        <translation>Não foi possível detetar o tempo de reprodução do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="56"/>
         <location filename="../../src/media/ImageCapture.cpp" line="84"/>
         <source>Temporary output file could not be opened</source>
-        <translation>Não foi possível abrir o ficheiro de saída temporário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="71"/>
         <source>Could not start ffmpeg</source>
-        <translation>Não foi possível iniciar o ffmpeg</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="74"/>
         <source>Could not start ffmpeg. Please install it and make it available in your $PATH</source>
-        <translation>Não foi possível iniciar o ffmpeg. Por favor instale-o e torne-o disponível no seu $PATH</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="80"/>
         <source>ffmpeg did not finish</source>
-        <translation>ffmpeg não finalizou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9282,7 +9192,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/file_search/movie/MovieDirectorySearcher.cpp" line="391"/>
         <source>Storing movies in database...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9290,35 +9200,35 @@ episode after scraping</source>
     <message>
         <location filename="../../src/file_search/movie/MovieFileSearcher.cpp" line="58"/>
         <source>Searching for Movies...</source>
-        <translation>A procurar por filmes...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/movie/MovieFileSearcher.cpp" line="148"/>
         <source>Searching for movies...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
         <source>Straight</source>
-        <translation>Heterossexual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Gay</source>
-        <translation>Homossexual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9326,12 +9236,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/custom/CustomMovieScraper.cpp" line="20"/>
         <source>Custom Movie Scraper</source>
-        <translation>Extrator de filmes personalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/custom/CustomMovieScraper.cpp" line="178"/>
         <source>TMDb ID is invalid. Cannot scrape movie.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9339,12 +9249,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/custom/CustomTvScraper.cpp" line="28"/>
         <source>Custom TV scraper</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/custom/CustomTvScraper.cpp" line="33"/>
         <source>The custom TV scraper combines multiple scrapers so that details can be loaded from different sites in one step. It depends on TMDb for loading other scraper IDs.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9352,162 +9262,162 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="26"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="84"/>
         <source>Bulgarian</source>
-        <translation>Búlgaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="85"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="86"/>
         <source>Croatian</source>
-        <translation>Croata</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="87"/>
         <source>Czech</source>
-        <translation>Checo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="88"/>
         <source>Danish</source>
-        <translation>Dinamarquês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="89"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="90"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="91"/>
         <source>Finnish</source>
-        <translation>Finlandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="92"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="93"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="94"/>
         <source>Greek</source>
-        <translation>Grego</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="95"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="96"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="97"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="98"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="99"/>
         <source>Korean</source>
-        <translation>Coreano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="100"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="101"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="102"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="103"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="104"/>
         <source>Slovene</source>
-        <translation>Eslovaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="105"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="106"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="107"/>
         <source>Turkish</source>
-        <translation>Turco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="111"/>
         <source>Blu-ray</source>
-        <translation>BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="112"/>
         <source>DVD</source>
-        <translation>DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="115"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="117"/>
         <source>Preferred Disc Type</source>
-        <translation>Tipo de disco preferido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="119"/>
         <source>Personal API key</source>
-        <translation>Chave pessoal da API</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="356"/>
         <source>Movie not found on Fanart.tv</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="568"/>
         <source>TV show not found on Fanart.tv</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9515,7 +9425,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTvMusic.cpp" line="25"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9523,7 +9433,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTvMusicArtists.cpp" line="22"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9531,12 +9441,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/imdb/ImdbMovie.cpp" line="20"/>
         <source>IMDb is the world&apos;s most popular and authoritative source for movie, TV and celebrity content, designed to help fans explore the world of movies and shows and decide what to watch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/imdb/ImdbMovie.cpp" line="47"/>
         <source>Load all tags</source>
-        <translation>Carregar todas as etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9544,7 +9454,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTv.cpp" line="20"/>
         <source>IMDb is the world&apos;s most popular and authoritative source for movie, TV and celebrity content, designed to help fans explore the world of movies and shows and decide what to watch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9552,22 +9462,22 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="37"/>
         <source>Neither IMDb show ID nor episode ID are valid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="61"/>
         <source>IMDb ID could not be loaded from season page! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="76"/>
         <source>IMDb ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="90"/>
         <source>Loaded IMDb content is empty. Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9575,7 +9485,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing an IMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9583,17 +9493,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="92"/>
         <source>Could not extract JSON details from IMDb page!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="102"/>
         <source>Could not parse JSON from IMDb page!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="108"/>
         <source>Expected parsed IMDb JSON to be an object!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9601,7 +9511,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowScrapeJob.cpp" line="34"/>
         <source>Show is missing an IMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9609,12 +9519,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowSearchJob.cpp" line="20"/>
         <source>Loaded IMDb web page content is empty. Cannot scrape requested TV show.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowSearchJob.cpp" line="24"/>
         <source>Could not find result table in the scraped HTML. Please contact MediaElch&apos;s developers.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9622,7 +9532,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/TMDbImages.cpp" line="15"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9630,7 +9540,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDb.cpp" line="19"/>
         <source>TheTvDb is one of the most accurate sources for TV and film. Their information comes from fans like you, so create a free account on their website and help your favorite shows and movies. Everything added is shared not only with MediaElch but many other sites, mobile apps, and devices as well.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9638,7 +9548,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbEpisodeScrapeJob.cpp" line="65"/>
         <source>TheTvDb ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9646,7 +9556,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/TheTvDbImages.cpp" line="19"/>
         <source>TheTvDb is one of the most accurate sources for TV and film. Their information comes from fans like you, so create a free account on their website and help your favorite shows and movies. Everything added is shared not only with MediaElch but many other sites, mobile apps, and devices as well.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9654,7 +9564,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbSeasonScrapeJob.cpp" line="26"/>
         <source>Show is missing a TheTvDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9662,7 +9572,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbShowScrapeJob.cpp" line="46"/>
         <source>Show is missing a TheTvDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9670,12 +9580,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/concert/tmdb/TmdbConcert.cpp" line="28"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/concert/tmdb/TmdbConcert.cpp" line="132"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9683,12 +9593,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/tmdb/TmdbMovie.cpp" line="45"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/tmdb/TmdbMovie.cpp" line="158"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9696,7 +9606,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTv.cpp" line="20"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9704,7 +9614,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvEpisodeScrapeJob.cpp" line="26"/>
         <source>TMDb show ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9712,7 +9622,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9720,12 +9630,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp" line="41"/>
         <source>Continuing</source>
-        <translation>Continuando</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp" line="41"/>
         <source>Ended</source>
-        <translation>Finalizado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9733,7 +9643,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowScrapeJob.cpp" line="23"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9741,7 +9651,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMaze.cpp" line="19"/>
         <source>TVmaze is a collaborative site, which can be edited by any registered user. Find episode information for any show on any device. anytime, anywhere!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9749,12 +9659,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.cpp" line="39"/>
         <source>TVmaze show ID are valid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.cpp" line="66"/>
         <source>TVmaze ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9762,7 +9672,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9770,7 +9680,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeShowScrapeJob.cpp" line="29"/>
         <source>TV show is missing a TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9778,107 +9688,107 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="31"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="32"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="33"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="34"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="35"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="36"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="37"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="38"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="39"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="40"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="41"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="42"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="43"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="44"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="45"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="47"/>
         <source>The Audio DB</source>
-        <translation>The Audio DB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="48"/>
         <source>MusicBrainz</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="49"/>
         <source>AllMusic</source>
-        <translation>AllMusic</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="50"/>
         <source>Discogs</source>
-        <translation>Discogs</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="52"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="54"/>
         <source>Prefer</source>
-        <translation>Preferir</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9886,7 +9796,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/videobuster/VideoBuster.cpp" line="18"/>
         <source>VideoBuster is a German movie database.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/data/i18n/MediaElch_it.ts
+++ b/data/i18n/MediaElch_it.ts
@@ -4308,57 +4308,57 @@ Operazione cancellata</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation>Attori</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation>Extra Art</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation>Fanart Extra</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation>Dettagli Stream</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation>Trailer locale</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation>Sottotitoli</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation>Tag</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
@@ -6238,42 +6238,42 @@ Se vuoi cercare per un ID di TMDb inizia la stringa con &quot;id&quot;.</transla
         <translation>Lo stylesheet personalizzato non può essere aperto in lettura. Sto utilizzando: %1</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
         <source>No Label</source>
         <translation>Nessuna etichetta</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
         <source>Red</source>
         <translation>Rosso</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
         <source>Orange</source>
         <translation>Arancio</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
         <source>Yellow</source>
         <translation>Giallo</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
         <source>Green</source>
         <translation>Verde</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
         <source>Blue</source>
         <translation>Blu</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
         <source>Purple</source>
         <translation>Viola</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
         <translation>GRigio</translation>
     </message>
@@ -6303,7 +6303,7 @@ Se vuoi cercare per un ID di TMDb inizia la stringa con &quot;id&quot;.</transla
         <translation>Valore non valido per il tag xml:</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Muovi il File&lt;/b&gt; da &quot;%1&quot; a &quot;%2&quot;</translation>
     </message>
@@ -6553,7 +6553,7 @@ Se vuoi cercare per un ID di TMDb inizia la stringa con &quot;id&quot;.</transla
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation>Rinomina</translation>
     </message>
@@ -6595,37 +6595,37 @@ Se vuoi cercare per un ID di TMDb inizia la stringa con &quot;id&quot;.</transla
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation>Finito</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;Film&lt;/b&gt; &quot;%1&quot; non rinominato: è stato modificato ma non è stato salvato</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;Episodio&lt;/b&gt; &quot;%1&quot; non rinominato: è stato modificato ma non è stato salvato</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;Serie TV&lt;/b&gt; &quot;%1&quot; non rinominata: è stata modificata ma non è stata salvata</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;Concerto&lt;/b&gt; &quot;%1&quot; non rinominato: è stato modificato ma non è stato salvato</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation>Crea cartella</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation>Sposta</translation>
     </message>
@@ -6638,142 +6638,147 @@ Se vuoi cercare per un ID di TMDb inizia la stringa con &quot;id&quot;.</transla
         <translation>Segnaposto</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation>Segnaposto</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
         <source>Artist</source>
         <translation>Artista</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
         <source>File extension</source>
         <translation>Estensione file</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
         <source>Original Title</source>
         <translation>Titolo originale</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
         <source>Season Name</source>
         <translation>Nome Stagione</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
         <source>Part number of the current file</source>
         <translation>Numero parte del file corrente</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished">TMDb ID</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
         <source>Title</source>
         <translation>Titolo</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
         <source>Season Number</source>
         <translation>Numero stagione</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
         <source>Title of the show</source>
         <translation>Titolo</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
         <source>Year</source>
         <translation>Anno</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
         <source>Description</source>
         <translation>Descrizione</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
         <source>Studio(s) (separated by a comma)</source>
         <translation>Studio (separati da virgola)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
         <source>Sort Title</source>
         <translation>Titolo per ordinamento</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
         <source>Director(s)</source>
         <translation>Regista(i)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
         <source>Audio Language(s) (separated by a minus)</source>
         <translation>Lingue Audio (separate da trattino)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
         <source>Episode Number</source>
         <translation>Numero episodio</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation>Risoluzione (1080p, 720p, ...)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation>File/Cartella è un BluRay</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
         <translation>Lingue sottotitoli (separate da trattino)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation>File/Cartella è un DVD</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation>File è in 3D</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation>Nome del Gruppo di Film</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation>Codec Video</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
         <source>Episode has a season name</source>
         <translation>L&apos;episodio ha un nome di stagione</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation>Codec Audio</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation>Numero di canali audio</translation>
     </message>
@@ -9298,22 +9303,22 @@ Episodio dopo lo scraping</translation>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation>Etero</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation>Gay</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation>Lingua</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation>Genere</translation>
     </message>

--- a/data/i18n/MediaElch_ja.ts
+++ b/data/i18n/MediaElch_ja.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ja_JP">
+<TS version="2.1" language="ja">
 <context>
     <name>AboutDialog</name>
     <message>
@@ -81,12 +81,12 @@
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="304"/>
         <source>Movies</source>
-        <translation type="unfinished"></translation>
+        <translation>映画</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="337"/>
         <source>TV Shows</source>
-        <translation type="unfinished"></translation>
+        <translation>テレビ番組</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="370"/>
@@ -114,7 +114,7 @@
     <message>
         <location filename="../../src/model/ActorModel.cpp" line="83"/>
         <source>Actor</source>
-        <translation type="unfinished"></translation>
+        <translation>アクター</translation>
     </message>
     <message>
         <location filename="../../src/model/ActorModel.cpp" line="84"/>
@@ -132,12 +132,12 @@
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="46"/>
         <source>Remove Actor</source>
-        <translation type="unfinished"></translation>
+        <translation>アクター消す</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="73"/>
         <source>Add Actor</source>
-        <translation type="unfinished"></translation>
+        <translation>新アクター</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="107"/>
@@ -185,7 +185,7 @@
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="116"/>
         <source>Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>映画</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="139"/>
@@ -196,7 +196,7 @@
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="149"/>
         <source>Remove Current Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>この映画を消す</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="152"/>
@@ -231,7 +231,7 @@
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="286"/>
         <source>All Movies Saved</source>
-        <translation type="unfinished"></translation>
+        <translation>英語を</translation>
     </message>
 </context>
 <context>
@@ -348,7 +348,7 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="38"/>
         <source>Files</source>
-        <translation type="unfinished"></translation>
+        <translation>ファイル</translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="105"/>
@@ -363,12 +363,12 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="129"/>
         <source>Artist</source>
-        <translation type="unfinished"></translation>
+        <translation>アティスト</translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="139"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>アルバム</translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="149"/>
@@ -398,7 +398,7 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="237"/>
         <source> Minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>分</translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="247"/>
@@ -475,7 +475,7 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="41"/>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation>言語</translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="110"/>
@@ -530,7 +530,7 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="211"/>
         <source>Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター</translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="218"/>
@@ -540,7 +540,7 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="225"/>
         <source>Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="232"/>
@@ -600,7 +600,7 @@
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="71"/>
         <source>Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="100"/>
@@ -640,7 +640,7 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="76"/>
         <source>Video</source>
-        <translation type="unfinished"></translation>
+        <translation>ビデオ</translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="91"/>
@@ -694,7 +694,7 @@
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="163"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="164"/>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation>言語</translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="133"/>
@@ -753,7 +753,7 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="354"/>
         <source>Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター</translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="376"/>
@@ -787,7 +787,7 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="79"/>
         <source>Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="80"/>
@@ -797,7 +797,7 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="84"/>
         <source>Tags</source>
-        <translation type="unfinished"></translation>
+        <translation>タグ</translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="85"/>
@@ -807,7 +807,7 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="447"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt;がセーブしました。</translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="458"/>
@@ -836,13 +836,13 @@
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="35"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="242"/>
         <source>Movies</source>
-        <translation type="unfinished"></translation>
+        <translation>映画</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="40"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="252"/>
         <source>TV Shows</source>
-        <translation type="unfinished"></translation>
+        <translation>テレビ番組</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="45"/>
@@ -1176,7 +1176,7 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="436"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="469"/>
         <source>Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="308"/>
@@ -1193,7 +1193,7 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="355"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="437"/>
         <source>Tags</source>
-        <translation type="unfinished"></translation>
+        <translation>タグ</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="311"/>
@@ -1204,7 +1204,7 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="312"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="360"/>
         <source>Actors</source>
-        <translation type="unfinished"></translation>
+        <translation>アクター</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="313"/>
@@ -1292,12 +1292,12 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="427"/>
         <source>Artist</source>
-        <translation type="unfinished"></translation>
+        <translation>アティスト</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="428"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>アルバム</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
@@ -1312,7 +1312,7 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="468"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>名前</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="470"/>
@@ -1572,13 +1572,13 @@
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="94"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="215"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>名前</translation>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="99"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="220"/>
         <source>Files</source>
-        <translation type="unfinished"></translation>
+        <translation>ファイル</translation>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="104"/>
@@ -1654,7 +1654,7 @@
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="281"/>
         <source>Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>映画</translation>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="282"/>
@@ -1708,12 +1708,12 @@
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="68"/>
         <source>Movies</source>
-        <translation type="unfinished"></translation>
+        <translation>映画</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="78"/>
         <source>TV Shows</source>
-        <translation type="unfinished"></translation>
+        <translation>テレビ番組</translation>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="88"/>
@@ -1897,19 +1897,19 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="371"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>Genre</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="372"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>Studio</source>
-        <translation type="unfinished"></translation>
+        <translation>スタジオ</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="373"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>Country</source>
-        <translation type="unfinished"></translation>
+        <translation>国</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="384"/>
@@ -1919,7 +1919,7 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="384"/>
         <source>Year</source>
-        <translation type="unfinished"></translation>
+        <translation>年</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="378"/>
@@ -1940,12 +1940,12 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="374"/>
         <source>Set</source>
-        <translation type="unfinished"></translation>
+        <translation>セット</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="375"/>
         <source>Tag</source>
-        <translation type="unfinished"></translation>
+        <translation>タグ</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="376"/>
@@ -1975,7 +1975,7 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="439"/>
         <source>Filename</source>
-        <translation type="unfinished"></translation>
+        <translation>ファイル名前</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
@@ -2005,23 +2005,23 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="469"/>
         <source>Movie has Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター有</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="469"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>Movie has no Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター無</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>No Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター無</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="471"/>
@@ -2339,7 +2339,7 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="460"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>Actors</source>
-        <translation type="unfinished"></translation>
+        <translation>アクター</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
@@ -2404,7 +2404,7 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>Tags</source>
-        <translation type="unfinished"></translation>
+        <translation>タグ</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
@@ -2423,15 +2423,15 @@
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
+        <source>720p</source>
+        <translation>720p</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="494"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>Resolution</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
-        <source>720p</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2442,7 +2442,7 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="494"/>
         <source>1080p</source>
-        <translation type="unfinished"></translation>
+        <translation>1080p</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
@@ -2452,7 +2452,7 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <source>2160p</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">1080p {2160p?}</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
@@ -2462,7 +2462,7 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>SD</source>
-        <translation type="unfinished"></translation>
+        <translation>SD</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
@@ -2471,13 +2471,13 @@
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
-        <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
-        <source>Format</source>
-        <translation type="unfinished"></translation>
+        <source>DVD</source>
+        <translation>DVD</translation>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
-        <source>DVD</source>
+        <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
+        <source>Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2603,7 +2603,7 @@
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="52"/>
         <source>Genre</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="79"/>
@@ -2613,7 +2613,7 @@
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="116"/>
         <source>Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>映画</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="139"/>
@@ -2624,7 +2624,7 @@
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="149"/>
         <source>Remove Current Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>この映画を消す</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="152"/>
@@ -2659,7 +2659,7 @@
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="287"/>
         <source>All Movies Saved</source>
-        <translation type="unfinished"></translation>
+        <translation>英語を</translation>
     </message>
 </context>
 <context>
@@ -2724,7 +2724,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="137"/>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>消す</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="144"/>
@@ -2786,13 +2786,13 @@ The directories containing your music must contain subdirectories for each artis
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="42"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Movies</source>
-        <translation type="unfinished"></translation>
+        <translation>映画</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="43"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>TV Shows</source>
-        <translation type="unfinished"></translation>
+        <translation>テレビ番組</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="44"/>
@@ -2834,7 +2834,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Downloads</source>
-        <translation type="unfinished"></translation>
+        <translation>ダウンロッド</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="265"/>
@@ -2872,7 +2872,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="124"/>
         <source>Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>映画</translation>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="176"/>
@@ -2881,6 +2881,12 @@ The directories containing your music must contain subdirectories for each artis
         <location filename="../../src/ui/image/ImageDialog.ui" line="191"/>
         <location filename="../../src/ui/image/ImageDialog.ui" line="196"/>
         <source>Neue Spalte</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/image/ImageDialog.cpp" line="703"/>
+        <location filename="../../src/ui/image/ImageDialog.cpp" line="711"/>
+        <source>No images found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2941,12 +2947,6 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="523"/>
         <source>Images (*.jpg *.jpeg *.png)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/image/ImageDialog.cpp" line="703"/>
-        <location filename="../../src/ui/image/ImageDialog.cpp" line="711"/>
-        <source>No images found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3219,7 +3219,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="70"/>
         <source>127.0.0.1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">1080p {127.0.0.1?}</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="77"/>
@@ -3229,7 +3229,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="84"/>
         <source>8080</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">1080p {8080?}</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="91"/>
@@ -3479,7 +3479,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/data/Locale.cpp" line="48"/>
         <source>English</source>
-        <translation type="unfinished"></translation>
+        <translation>英語</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="49"/>
@@ -3515,7 +3515,7 @@ The directories containing your music must contain subdirectories for each artis
         <location filename="../../src/data/Locale.cpp" line="55"/>
         <location filename="../../src/data/Locale.cpp" line="56"/>
         <source>Spanish</source>
-        <translation type="unfinished"></translation>
+        <translation>スペイン語</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="57"/>
@@ -3547,7 +3547,7 @@ The directories containing your music must contain subdirectories for each artis
         <location filename="../../src/data/Locale.cpp" line="63"/>
         <location filename="../../src/data/Locale.cpp" line="65"/>
         <source>French</source>
-        <translation type="unfinished"></translation>
+        <translation>フランス語</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="64"/>
@@ -3599,13 +3599,13 @@ The directories containing your music must contain subdirectories for each artis
         <location filename="../../src/data/Locale.cpp" line="75"/>
         <location filename="../../src/data/Locale.cpp" line="76"/>
         <source>Italian</source>
-        <translation type="unfinished"></translation>
+        <translation>イタリア語</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="77"/>
         <location filename="../../src/data/Locale.cpp" line="78"/>
         <source>Japanese</source>
-        <translation type="unfinished"></translation>
+        <translation>日本語</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="79"/>
@@ -3626,7 +3626,7 @@ The directories containing your music must contain subdirectories for each artis
         <location filename="../../src/data/Locale.cpp" line="82"/>
         <location filename="../../src/data/Locale.cpp" line="83"/>
         <source>Korean</source>
-        <translation type="unfinished"></translation>
+        <translation>韓国語</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="84"/>
@@ -3700,7 +3700,7 @@ The directories containing your music must contain subdirectories for each artis
         <location filename="../../src/data/Locale.cpp" line="100"/>
         <location filename="../../src/data/Locale.cpp" line="101"/>
         <source>Russian</source>
-        <translation type="unfinished"></translation>
+        <translation>ロシア語</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="102"/>
@@ -3777,7 +3777,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/data/Locale.cpp" line="118"/>
         <source>Chinese</source>
-        <translation type="unfinished"></translation>
+        <translation>中国語</translation>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="119"/>
@@ -3816,7 +3816,7 @@ The directories containing your music must contain subdirectories for each artis
         <location filename="../../src/ui/main/MainWindow.ui" line="75"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="94"/>
         <source>Movies</source>
-        <translation type="unfinished"></translation>
+        <translation>映画</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="125"/>
@@ -3826,7 +3826,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="156"/>
         <source>Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="187"/>
@@ -3846,7 +3846,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="267"/>
         <source>TV Shows</source>
-        <translation type="unfinished"></translation>
+        <translation>テレビ番組</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="297"/>
@@ -4020,7 +4020,7 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="321"/>
         <source>Year</source>
-        <translation type="unfinished"></translation>
+        <translation>年</translation>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="338"/>
@@ -4178,7 +4178,7 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="160"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>名前</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="176"/>
@@ -4193,7 +4193,7 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="208"/>
         <source>Year</source>
-        <translation type="unfinished"></translation>
+        <translation>年</translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="30"/>
@@ -4297,57 +4297,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
-        <translation type="unfinished"></translation>
+        <translation>アクター</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
-        <translation type="unfinished"></translation>
+        <translation>タグ</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4375,73 +4375,8 @@ Main menu entry (tooltip)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="93"/>
-        <source>Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="103"/>
-        <source>Title</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="113"/>
-        <source>Rating</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="123"/>
-        <source>Overview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="133"/>
-        <source>Poster</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="143"/>
         <source>Countries</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="153"/>
-        <source>Runtime</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="163"/>
-        <source>Actors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="173"/>
-        <source>Certification</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="183"/>
-        <source>Trailer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="193"/>
-        <source>Tagline</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="203"/>
-        <source>Released</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="213"/>
-        <source>Writer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="223"/>
-        <source>Director</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4450,9 +4385,74 @@ Main menu entry (tooltip)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="163"/>
+        <source>Actors</source>
+        <translation>アクター</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="303"/>
+        <source>Logo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="223"/>
+        <source>Director</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="133"/>
+        <source>Poster</source>
+        <translation>ポスター</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="113"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="93"/>
+        <source>Set</source>
+        <translation>セット</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="103"/>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="173"/>
+        <source>Certification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="213"/>
+        <source>Writer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="203"/>
+        <source>Released</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="153"/>
+        <source>Runtime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="123"/>
+        <source>Overview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="183"/>
+        <source>Trailer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="243"/>
         <source>Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="253"/>
@@ -4460,18 +4460,8 @@ Main menu entry (tooltip)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="263"/>
-        <source>Thumb</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="273"/>
-        <source>Banner</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="283"/>
-        <source>CD Art</source>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="193"/>
+        <source>Tagline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4480,14 +4470,24 @@ Main menu entry (tooltip)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="303"/>
-        <source>Logo</source>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="283"/>
+        <source>CD Art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="273"/>
+        <source>Banner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="263"/>
+        <source>Thumb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="313"/>
         <source>Tags</source>
-        <translation type="unfinished"></translation>
+        <translation>タグ</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="332"/>
@@ -4507,12 +4507,12 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="380"/>
         <source>1/20</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">1080p {1/20?}</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="387"/>
         <source>Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>映画</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="412"/>
@@ -4560,7 +4560,7 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="41"/>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation>言語</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="70"/>
@@ -4581,7 +4581,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="170"/>
         <source>Set</source>
-        <translation type="unfinished"></translation>
+        <translation>セット</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="177"/>
@@ -4631,7 +4631,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="240"/>
         <source>Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="264"/>
@@ -4641,12 +4641,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="271"/>
         <source>Actors</source>
-        <translation type="unfinished"></translation>
+        <translation>アクター</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="278"/>
         <source>Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="285"/>
@@ -4661,7 +4661,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="299"/>
         <source>Tags</source>
-        <translation type="unfinished"></translation>
+        <translation>タグ</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="306"/>
@@ -4736,7 +4736,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="49"/>
         <source>Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="56"/>
@@ -4850,12 +4850,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/ui/movies/MovieWidget.ui" line="141"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1050"/>
         <source>Files</source>
-        <translation type="unfinished"></translation>
+        <translation>ファイル</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="155"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>名前</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="165"/>
@@ -4870,7 +4870,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="185"/>
         <source>Set</source>
-        <translation type="unfinished"></translation>
+        <translation>セット</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="211"/>
@@ -4959,8 +4959,8 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieWidget.ui" line="653"/>
-        <source>IMDb ID</source>
+        <location filename="../../src/ui/movies/MovieWidget.ui" line="480"/>
+        <source>User Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4969,14 +4969,9 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieWidget.ui" line="480"/>
-        <source>User Rating</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="558"/>
         <source> Minutes</source>
-        <translation type="unfinished"></translation>
+        <translation>分</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="570"/>
@@ -5012,7 +5007,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="695"/>
         <source>Actors</source>
-        <translation type="unfinished"></translation>
+        <translation>アクター</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="786"/>
@@ -5022,11 +5017,6 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="705"/>
         <source>Extra Fanarts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieWidget.ui" line="221"/>
-        <source>Ratings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5050,13 +5040,20 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/movies/MovieWidget.ui" line="806"/>
+        <source>Aspect Ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="796"/>
         <source>Scantype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieWidget.ui" line="806"/>
-        <source>Aspect Ratio</source>
+        <location filename="../../src/ui/movies/MovieWidget.ui" line="942"/>
+        <location filename="../../src/ui/movies/MovieWidget.cpp" line="788"/>
+        <location filename="../../src/ui/movies/MovieWidget.cpp" line="791"/>
+        <source>Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5067,6 +5064,11 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="862"/>
         <source>Video</source>
+        <translation>ビデオ</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieWidget.ui" line="888"/>
+        <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5075,15 +5077,13 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieWidget.ui" line="888"/>
-        <source>Duration</source>
+        <location filename="../../src/ui/movies/MovieWidget.ui" line="221"/>
+        <source>Ratings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieWidget.ui" line="942"/>
-        <location filename="../../src/ui/movies/MovieWidget.cpp" line="788"/>
-        <location filename="../../src/ui/movies/MovieWidget.cpp" line="791"/>
-        <source>Codec</source>
+        <location filename="../../src/ui/movies/MovieWidget.ui" line="653"/>
+        <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5102,15 +5102,6 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieWidget.ui" line="1055"/>
-        <location filename="../../src/ui/movies/MovieWidget.cpp" line="787"/>
-        <location filename="../../src/ui/movies/MovieWidget.cpp" line="790"/>
-        <location filename="../../src/ui/movies/MovieWidget.cpp" line="821"/>
-        <location filename="../../src/ui/movies/MovieWidget.cpp" line="822"/>
-        <source>Language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1060"/>
         <source>Forced</source>
         <translation type="unfinished"></translation>
@@ -5119,7 +5110,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1216"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1256"/>
         <source>Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1238"/>
@@ -5175,7 +5166,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="88"/>
         <source>Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="89"/>
@@ -5185,7 +5176,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="93"/>
         <source>Tags</source>
-        <translation type="unfinished"></translation>
+        <translation>タグ</translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="94"/>
@@ -5229,6 +5220,15 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/movies/MovieWidget.ui" line="1055"/>
+        <location filename="../../src/ui/movies/MovieWidget.cpp" line="787"/>
+        <location filename="../../src/ui/movies/MovieWidget.cpp" line="790"/>
+        <location filename="../../src/ui/movies/MovieWidget.cpp" line="821"/>
+        <location filename="../../src/ui/movies/MovieWidget.cpp" line="822"/>
+        <source>Language</source>
+        <translation>言語</translation>
+    </message>
+    <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="789"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="792"/>
         <source>Channels</source>
@@ -5245,6 +5245,16 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/movies/MovieWidget.cpp" line="921"/>
+        <source>Saving movie...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/movies/MovieWidget.cpp" line="926"/>
+        <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
+        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt;がセーブしました。</translation>
+    </message>
+    <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="902"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="950"/>
         <source>Saving movies...</source>
@@ -5256,19 +5266,9 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/movies/MovieWidget.cpp" line="921"/>
-        <source>Saving movie...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/movies/MovieWidget.cpp" line="926"/>
-        <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="971"/>
         <source>All Movies Saved</source>
-        <translation type="unfinished"></translation>
+        <translation>英語を</translation>
     </message>
 </context>
 <context>
@@ -5340,7 +5340,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="61"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>名前</translation>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="74"/>
@@ -5410,7 +5410,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="243"/>
         <source>Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="256"/>
@@ -5430,7 +5430,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="295"/>
         <source>Year</source>
-        <translation type="unfinished"></translation>
+        <translation>年</translation>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="308"/>
@@ -5440,7 +5440,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="321"/>
         <source>Artist</source>
-        <translation type="unfinished"></translation>
+        <translation>アティスト</translation>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="334"/>
@@ -5523,7 +5523,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="140"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>名前</translation>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="150"/>
@@ -5563,7 +5563,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="220"/>
         <source>Artist</source>
-        <translation type="unfinished"></translation>
+        <translation>アティスト</translation>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="230"/>
@@ -5578,7 +5578,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="250"/>
         <source>Year</source>
-        <translation type="unfinished"></translation>
+        <translation>年</translation>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="260"/>
@@ -5598,7 +5598,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="290"/>
         <source>Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="300"/>
@@ -5734,7 +5734,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="158"/>
         <source>Artist</source>
-        <translation type="unfinished"></translation>
+        <translation>アティスト</translation>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="179"/>
@@ -5754,7 +5754,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="200"/>
         <source>Year</source>
-        <translation type="unfinished"></translation>
+        <translation>年</translation>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="207"/>
@@ -5817,7 +5817,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="41"/>
         <source>Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="42"/>
@@ -5852,7 +5852,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="192"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt;がセーブしました。</translation>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="524"/>
@@ -5885,7 +5885,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="158"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>名前</translation>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="186"/>
@@ -5940,7 +5940,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="330"/>
         <source>Year</source>
-        <translation type="unfinished"></translation>
+        <translation>年</translation>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="340"/>
@@ -5995,7 +5995,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="49"/>
         <source>Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="50"/>
@@ -6030,7 +6030,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="202"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt;がセーブしました。</translation>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="501"/>
@@ -6194,46 +6194,6 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
-        <source>No Label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
-        <source>Red</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
-        <source>Orange</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
-        <source>Yellow</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
-        <source>Green</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
-        <source>Blue</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
-        <source>Purple</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
-        <source>Grey</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/main.cpp" line="36"/>
         <source>Logfile could not be openened</source>
         <translation type="unfinished"></translation>
@@ -6256,6 +6216,46 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/main.cpp" line="79"/>
         <source>The custom stylesheet could not be openend for reading. Using: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <source>No Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <source>Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <source>Orange</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <source>Yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
+        <source>Green</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
+        <source>Purple</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
+        <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6284,7 +6284,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6534,7 +6534,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6572,37 +6572,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6615,142 +6615,147 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
-        <source>Album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
-        <source>Season Number</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
-        <source>Director(s)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
-        <source>Title</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
-        <source>Season Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
-        <source>Part number of the current file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
-        <source>Episode has a season name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
-        <source>Original Title</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
-        <source>File extension</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
-        <source>Studio(s) (separated by a comma)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
-        <source>Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
-        <source>Year</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
-        <source>Title of the show</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
-        <source>Sort Title</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
-        <source>Audio Language(s) (separated by a minus)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
-        <source>Episode Number</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
-        <source>Artist</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
-        <source>Subtitle Language(s) (separated by a minus)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
+        <source>Artist</source>
+        <translation>アティスト</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
+        <source>File extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
+        <source>Original Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
+        <source>Season Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
+        <source>Part number of the current file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
+        <source>Album</source>
+        <translation>アルバム</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
+        <source>Season Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
+        <source>Title of the show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
+        <source>Year</source>
+        <translation>年</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
+        <source>Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
+        <source>Studio(s) (separated by a comma)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
+        <source>Sort Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
+        <source>Director(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
+        <source>Audio Language(s) (separated by a minus)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
+        <source>Episode Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
+        <source>Subtitle Language(s) (separated by a minus)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
+        <source>Episode has a season name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6767,7 +6772,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="122"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="152"/>
         <source>Actors</source>
-        <translation type="unfinished"></translation>
+        <translation>アクター</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="123"/>
@@ -6794,7 +6799,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="127"/>
         <source>Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="128"/>
@@ -6811,7 +6816,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="130"/>
         <source>Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="131"/>
@@ -6834,7 +6839,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="134"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="159"/>
         <source>Tags</source>
-        <translation type="unfinished"></translation>
+        <translation>タグ</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="135"/>
@@ -6984,7 +6989,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="226"/>
         <source>Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="227"/>
@@ -6994,12 +6999,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="228"/>
         <source>Actors</source>
-        <translation type="unfinished"></translation>
+        <translation>アクター</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="229"/>
         <source>Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="230"/>
@@ -7024,12 +7029,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="234"/>
         <source>Tags</source>
-        <translation type="unfinished"></translation>
+        <translation>タグ</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="235"/>
         <source>Set</source>
-        <translation type="unfinished"></translation>
+        <translation>セット</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="236"/>
@@ -7080,7 +7085,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="61"/>
         <source>Set</source>
-        <translation type="unfinished"></translation>
+        <translation>セット</translation>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="88"/>
@@ -7090,7 +7095,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="122"/>
         <source>Movie</source>
-        <translation type="unfinished"></translation>
+        <translation>映画</translation>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="127"/>
@@ -7120,7 +7125,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="182"/>
         <source>Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター</translation>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="204"/>
@@ -7160,7 +7165,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="459"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt;がセーブしました。</translation>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="491"/>
@@ -7181,6 +7186,23 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/settings/SettingsWindow.ui" line="162"/>
+        <source>Kodi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/settings/SettingsWindow.ui" line="206"/>
+        <location filename="../../src/ui/settings/SettingsWindow.ui" line="209"/>
+        <source>Import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/settings/SettingsWindow.ui" line="220"/>
+        <location filename="../../src/ui/settings/SettingsWindow.ui" line="223"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="62"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
@@ -7198,12 +7220,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="118"/>
         <source>Movies</source>
-        <translation type="unfinished"></translation>
+        <translation>映画</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="129"/>
         <source>TV Shows</source>
-        <translation type="unfinished"></translation>
+        <translation>テレビ番組</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="140"/>
@@ -7216,11 +7238,6 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/settings/SettingsWindow.ui" line="162"/>
-        <source>Kodi</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="173"/>
         <source>Network</source>
         <translation type="unfinished"></translation>
@@ -7228,18 +7245,6 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="195"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/settings/SettingsWindow.ui" line="206"/>
-        <location filename="../../src/ui/settings/SettingsWindow.ui" line="209"/>
-        <source>Import</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/settings/SettingsWindow.ui" line="220"/>
-        <location filename="../../src/ui/settings/SettingsWindow.ui" line="223"/>
-        <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7286,7 +7291,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/small_widgets/TagCloud.ui" line="31"/>
         <source>Tag</source>
-        <translation type="unfinished"></translation>
+        <translation>タグ</translation>
     </message>
 </context>
 <context>
@@ -7321,7 +7326,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="171"/>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation>言語</translation>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="176"/>
@@ -7415,7 +7420,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="88"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>名前</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="107"/>
@@ -7628,7 +7633,7 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="91"/>
         <source>Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター</translation>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="92"/>
@@ -7723,7 +7728,7 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="109"/>
         <source>Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="252"/>
@@ -7734,7 +7739,7 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="213"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="501"/>
         <source>Actors</source>
-        <translation type="unfinished"></translation>
+        <translation>アクター</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="122"/>
@@ -7745,13 +7750,13 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="239"/>
         <source>Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="291"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="475"/>
         <source>Tags</source>
-        <translation type="unfinished"></translation>
+        <translation>タグ</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="200"/>
@@ -7831,7 +7836,7 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="569"/>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation>言語</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="579"/>
@@ -7853,7 +7858,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="660"/>
         <source>1/20</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">1080p {1/20?}</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="706"/>
@@ -8009,7 +8014,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="29"/>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation>言語</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="134"/>
@@ -8064,13 +8069,13 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="280"/>
         <source>Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="290"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="626"/>
         <source>Tags</source>
-        <translation type="unfinished"></translation>
+        <translation>タグ</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="300"/>
@@ -8082,7 +8087,7 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="327"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="616"/>
         <source>Actors</source>
-        <translation type="unfinished"></translation>
+        <translation>アクター</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="337"/>
@@ -8092,7 +8097,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="347"/>
         <source>Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="357"/>
@@ -8238,7 +8243,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="49"/>
         <source>Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="56"/>
@@ -8356,11 +8361,6 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="115"/>
-        <source>Episode missing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="137"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
@@ -8368,12 +8368,22 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="154"/>
         <source>Files</source>
+        <translation>ファイル</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="460"/>
+        <source>TheTVDB ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="514"/>
+        <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="168"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>名前</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="178"/>
@@ -8421,9 +8431,19 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="400"/>
+        <source>Last Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="410"/>
+        <source>dd.MM.yyyy HH:mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="436"/>
         <source>Studio</source>
-        <translation type="unfinished"></translation>
+        <translation>スタジオ</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="446"/>
@@ -8436,34 +8456,8 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="400"/>
-        <source>Last Played</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="410"/>
-        <source>dd.MM.yyyy HH:mm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="419"/>
         <source>Bookmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="429"/>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="959"/>
-        <source>HH:mm:ss</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="460"/>
-        <source>TheTVDB ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="514"/>
-        <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8487,23 +8481,8 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="567"/>
-        <source>Writers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="595"/>
         <source>Writer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="605"/>
-        <source>Add Writer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="619"/>
-        <source>Remove Writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8527,14 +8506,29 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="567"/>
+        <source>Writers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="605"/>
+        <source>Add Writer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="619"/>
+        <source>Remove Writer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="759"/>
         <source>Actors</source>
-        <translation type="unfinished"></translation>
+        <translation>アクター</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="784"/>
         <source>Actor</source>
-        <translation type="unfinished"></translation>
+        <translation>アクター</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="789"/>
@@ -8542,18 +8536,33 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="804"/>
-        <source>Remove Actor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="831"/>
         <source>Add Actor</source>
-        <translation type="unfinished"></translation>
+        <translation>新アクター</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="804"/>
+        <source>Remove Actor</source>
+        <translation>アクター消す</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="878"/>
         <source>Click to change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="932"/>
+        <source>Streamdetails</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="991"/>
+        <source>Aspect Ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="940"/>
+        <source>Scantype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8563,18 +8572,10 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="924"/>
-        <source>Tags</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="932"/>
-        <source>Streamdetails</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="940"/>
-        <source>Scantype</source>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1106"/>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="525"/>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="528"/>
+        <source>Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8583,9 +8584,9 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="991"/>
-        <source>Aspect Ratio</source>
-        <translation type="unfinished"></translation>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1096"/>
+        <source>Video</source>
+        <translation>ビデオ</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1045"/>
@@ -8593,16 +8594,15 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1096"/>
-        <source>Video</source>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="429"/>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="959"/>
+        <source>HH:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1106"/>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="525"/>
-        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="528"/>
-        <source>Codec</source>
-        <translation type="unfinished"></translation>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="924"/>
+        <source>Tags</source>
+        <translation>タグ</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1116"/>
@@ -8625,6 +8625,11 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="115"/>
+        <source>Episode missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="92"/>
         <source>Add Tag</source>
         <translation type="unfinished"></translation>
@@ -8641,7 +8646,7 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="556"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="557"/>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation>言語</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="526"/>
@@ -8718,11 +8723,6 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="119"/>
-        <source>Season missing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="138"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
@@ -8738,15 +8738,15 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="232"/>
+        <source>Poster</source>
+        <translation>ポスター</translation>
+    </message>
+    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="193"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="254"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="298"/>
         <source>Click to Change</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="232"/>
-        <source>Poster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8762,6 +8762,11 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="342"/>
         <source>Click to change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="119"/>
+        <source>Season missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8798,14 +8803,19 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="242"/>
-        <source>Name</source>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="126"/>
+        <source>IDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="505"/>
-        <source>Sort Title</source>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="208"/>
+        <source>TVmaze ID</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="242"/>
+        <source>Name</source>
+        <translation>名前</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="252"/>
@@ -8815,11 +8825,6 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="315"/>
         <source>Top 250</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="263"/>
-        <source>User Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8838,18 +8843,13 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="386"/>
-        <source>Runtime</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="396"/>
-        <source> Minutes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="406"/>
         <source>Studio</source>
+        <translation>スタジオ</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="460"/>
+        <source>Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8873,8 +8873,58 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="460"/>
-        <source>Overview</source>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="386"/>
+        <source>Runtime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="396"/>
+        <source> Minutes</source>
+        <translation>分</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="505"/>
+        <source>Sort Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="201"/>
+        <source>IMDb ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="522"/>
+        <source>Extended</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="533"/>
+        <source>Actors</source>
+        <translation>アクター</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="558"/>
+        <source>Actor</source>
+        <translation>アクター</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="563"/>
+        <source>Role</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="605"/>
+        <source>Add Actor</source>
+        <translation>新アクター</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="578"/>
+        <source>Remove Actor</source>
+        <translation>アクター消す</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="263"/>
+        <source>User Rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8898,58 +8948,13 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="126"/>
-        <source>IDs</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="154"/>
         <source>TMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="201"/>
-        <source>IMDb ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="208"/>
-        <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="512"/>
         <source>Original Title</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="522"/>
-        <source>Extended</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="533"/>
-        <source>Actors</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="558"/>
-        <source>Actor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="563"/>
-        <source>Role</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="578"/>
-        <source>Remove Actor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="605"/>
-        <source>Add Actor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8981,7 +8986,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="906"/>
         <source>Poster</source>
-        <translation type="unfinished"></translation>
+        <translation>ポスター</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="928"/>
@@ -9004,6 +9009,11 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1199"/>
+        <source>Banner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1067"/>
         <source>Logo</source>
         <translation type="unfinished"></translation>
@@ -9019,14 +9029,9 @@ episode after scraping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1199"/>
-        <source>Banner</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="78"/>
         <source>Genres</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="79"/>
@@ -9036,7 +9041,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="83"/>
         <source>Tags</source>
-        <translation type="unfinished"></translation>
+        <translation>タグ</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="84"/>
@@ -9046,7 +9051,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="456"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt;がセーブしました。</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="497"/>
@@ -9265,24 +9270,24 @@ episode after scraping</source>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation>言語</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
-        <translation type="unfinished"></translation>
+        <translation>ジャンル</translation>
     </message>
 </context>
 <context>
@@ -9326,7 +9331,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="85"/>
         <source>Chinese</source>
-        <translation type="unfinished"></translation>
+        <translation>中国語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="86"/>
@@ -9351,7 +9356,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="90"/>
         <source>English</source>
-        <translation type="unfinished"></translation>
+        <translation>英語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="91"/>
@@ -9361,7 +9366,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="92"/>
         <source>French</source>
-        <translation type="unfinished"></translation>
+        <translation>フランス語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="93"/>
@@ -9386,17 +9391,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="97"/>
         <source>Italian</source>
-        <translation type="unfinished"></translation>
+        <translation>イタリア語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="98"/>
         <source>Japanese</source>
-        <translation type="unfinished"></translation>
+        <translation>日本語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="99"/>
         <source>Korean</source>
-        <translation type="unfinished"></translation>
+        <translation>韓国語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="100"/>
@@ -9416,7 +9421,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="103"/>
         <source>Russian</source>
-        <translation type="unfinished"></translation>
+        <translation>ロシア語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="104"/>
@@ -9426,7 +9431,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="105"/>
         <source>Spanish</source>
-        <translation type="unfinished"></translation>
+        <translation>スペイン語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="106"/>
@@ -9446,12 +9451,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="112"/>
         <source>DVD</source>
-        <translation type="unfinished"></translation>
+        <translation>DVD</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="115"/>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation>言語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="117"/>
@@ -9639,7 +9644,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/concert/tmdb/TmdbConcert.cpp" line="132"/>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation>言語</translation>
     </message>
 </context>
 <context>
@@ -9652,7 +9657,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/tmdb/TmdbMovie.cpp" line="158"/>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation>言語</translation>
     </message>
 </context>
 <context>
@@ -9742,7 +9747,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="31"/>
         <source>Chinese</source>
-        <translation type="unfinished"></translation>
+        <translation>中国語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="32"/>
@@ -9752,12 +9757,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="33"/>
         <source>English</source>
-        <translation type="unfinished"></translation>
+        <translation>英語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="34"/>
         <source>French</source>
-        <translation type="unfinished"></translation>
+        <translation>フランス語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="35"/>
@@ -9777,12 +9782,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="38"/>
         <source>Italian</source>
-        <translation type="unfinished"></translation>
+        <translation>イタリア語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="39"/>
         <source>Japanese</source>
-        <translation type="unfinished"></translation>
+        <translation>日本語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="40"/>
@@ -9802,12 +9807,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="43"/>
         <source>Russian</source>
-        <translation type="unfinished"></translation>
+        <translation>ロシア語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="44"/>
         <source>Spanish</source>
-        <translation type="unfinished"></translation>
+        <translation>スペイン語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="45"/>
@@ -9837,7 +9842,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="52"/>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation>言語</translation>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="54"/>

--- a/data/i18n/MediaElch_ko.ts
+++ b/data/i18n/MediaElch_ko.ts
@@ -4298,57 +4298,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation>배우</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation>추가 아트</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation>추가 팬아트</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation>팬아트</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation>포스터</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation>스트림 정보</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation>예고편</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation>로컬 예고편</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation>자막</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation>태그</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6220,42 +6220,42 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
         <source>No Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6285,7 +6285,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6535,7 +6535,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation>이름 변경</translation>
     </message>
@@ -6573,37 +6573,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation>완료</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6616,142 +6616,147 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
         <source>Artist</source>
         <translation>아티스트</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
         <source>File extension</source>
         <translation>파일 확장자</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
         <source>Original Title</source>
         <translation>원제목</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
         <source>Season Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
         <source>Part number of the current file</source>
         <translation>현재 파일의 파트 번호</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
         <source>Album</source>
         <translation>앨범</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
         <source>Title</source>
         <translation>제목</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
         <source>Season Number</source>
         <translation>시즌 번호</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
         <source>Title of the show</source>
         <translation>쇼 제목</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
         <source>Year</source>
         <translation>연도</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
         <source>Description</source>
         <translation>설명</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
         <source>Studio(s) (separated by a comma)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
         <source>Sort Title</source>
         <translation>정렬용 제목</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
         <source>Director(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
         <source>Audio Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
         <source>Episode Number</source>
         <translation>에피소드 번호</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
         <source>Episode has a season name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9266,22 +9271,22 @@ episode after scraping</source>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation>언어</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation>장르</translation>
     </message>

--- a/data/i18n/MediaElch_ku_IQ.ts
+++ b/data/i18n/MediaElch_ku_IQ.ts
@@ -1,112 +1,110 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="pt_PT">
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ku_IQ">
 <context>
     <name>AboutDialog</name>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="23"/>
         <source>About MediaElch</source>
-        <translation>Sobre o MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="44"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="112"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="155"/>
         <source>Icon Sets: Retina by &quot;The Working Group&quot; and &quot;Capital Suite&quot; by &quot;capital18 (Jugal Paryani)&quot;</source>
-        <translation>Conjuntos de ícones: Retina de &quot;The Working Group&quot; e &quot;Capital Suite&quot;, de &quot;capital18 (Jugal Paryani)&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="178"/>
         <source>MediaElch Icon by Kathrin Luckner</source>
-        <translation>Ícone do MediaElch por Kathrin Luckner</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="120"/>
         <source>MediaElch was built with &lt;a href=&quot;https://www.qt.io/&quot;&gt;Qt&lt;/a&gt;</source>
-        <translation>O MediaElch foi feito com o &lt;a href=&quot;https://www.qt.io/&quot;&gt;Qt&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="146"/>
         <source>About Qt</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="165"/>
         <source>&lt;a href=&quot;https://develop.kde.org/frameworks/breeze-icons/&quot; title=&quot;KDE Breeze Website&quot;&gt;Breeze icons&lt;/a&gt; copyright KDE and licenced under the GNU LGPL version 3 or later</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="188"/>
         <source>Stream Details detection with &lt;a href=&quot;https://www.mediaarea.net&quot;&gt;Media Info&lt;/a&gt;</source>
-        <translation>Deteção de detalhes da transmissão com &lt;a href=&quot;https://www.mediaarea.net&quot;&gt;Media Info&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="201"/>
         <source>&lt;a href=&quot;https://www.mediaelch.de/mediaelch/&quot;&gt;http://www.mediaelch.de&lt;/a&gt; powered by &lt;a href=&quot;https://www.kvibes.de&quot;&gt;k.vibes&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="211"/>
         <source>Bugs and wishes can be reported on &lt;a href=&quot;https://github.com/Komet/MediaElch/issues&quot;&gt;GitHub&lt;/a&gt; .</source>
-        <translation>Os erros e desejos podem ser reportados no &lt;a href=&quot;https://github.com/Komet/MediaElch/issues&quot;&gt;GitHub&lt;/a&gt; .</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="238"/>
         <source>Developer</source>
-        <translation>Programador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="244"/>
         <source>The information below is important for developers. Please provide if you need help.</source>
-        <translation>Os dados abaixo são importantes para os programadores. Por favor, inclua no seu pedido de ajuda.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="272"/>
         <source>Copy to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="295"/>
         <source>Your Collection</source>
-        <translation>A sua coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="304"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="337"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="370"/>
         <source>Episodes</source>
-        <translation>Episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="403"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="436"/>
         <source>Artists</source>
-        <translation>Artistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="466"/>
         <source>Albums</source>
-        <translation>Álbuns</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -114,12 +112,12 @@
     <message>
         <location filename="../../src/model/ActorModel.cpp" line="83"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/ActorModel.cpp" line="84"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -127,47 +125,47 @@
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="14"/>
         <source>Form</source>
-        <translation>Formulário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="46"/>
         <source>Remove Actor</source>
-        <translation>Remover ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="73"/>
         <source>Add Actor</source>
-        <translation>Adicionar ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="107"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="123"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="66"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="67"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="159"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="161"/>
         <source>Images (*.jpg *.jpeg *.png)</source>
-        <translation>Imagens (*.jpg *.jpeg *.png)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -175,63 +173,63 @@
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="52"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="79"/>
         <source>TextLabel</source>
-        <translation>EtiquetaTexto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="116"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="139"/>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="142"/>
         <source>Add Movie</source>
-        <translation>Adicionar Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="149"/>
         <source>Remove Current Movie</source>
-        <translation>Remover filme atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="152"/>
         <source>Remove Movie</source>
-        <translation>Remover Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="165"/>
         <source>Double click a certification to rename it, right click to delete. If you want to merge two certifications just give them the same name.</source>
-        <translation>Clique duas vezes numa certificação para lhe alterar o nome, clique com o botão direito para eliminá-la. Se quiser fundir duas classificações, basta colocar-lhes o mesmo nome.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="175"/>
         <source>Please keep in mind that the changes you make here (renaming or deleting certifications) will be made for every movie.</source>
-        <translation>Por favor, lembre-se que todas as alterações feitas aqui (alterar o nome ou eliminar certificações) serão feitas para todos os filmes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="28"/>
         <source>Add Certification</source>
-        <translation>Adicionar certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="29"/>
         <source>Delete Certification</source>
-        <translation>Eliminar certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="175"/>
         <source>New Certification</source>
-        <translation>Nova certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="286"/>
         <source>All Movies Saved</source>
-        <translation>Foram guardados todos os filmes</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -239,37 +237,37 @@
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="112"/>
         <source>Delete Image</source>
-        <translation>Eliminar imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="119"/>
         <source>Zoom Image</source>
-        <translation>Ampliar imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="125"/>
         <source>Capture random screenshot</source>
-        <translation>Capturar ecrã aleatório</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="131"/>
         <source>Select another image</source>
-        <translation>Selecionar outra imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="420"/>
         <source>Really delete image?</source>
-        <translation>Quer eliminar a imagem?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="421"/>
         <source>Are you sure you want to delete this image?</source>
-        <translation>Tem a certeza que quer eliminar esta imagem?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="423"/>
         <source>Do not ask again</source>
-        <translation>Não perguntar de novo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -277,12 +275,12 @@
     <message>
         <location filename="../../src/file_search/ConcertFileSearcher.cpp" line="53"/>
         <source>Searching for Concerts...</source>
-        <translation>A procurar concertos...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/ConcertFileSearcher.cpp" line="59"/>
         <source>Loading Concerts...</source>
-        <translation>A carregar concertos...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -291,58 +289,52 @@
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="22"/>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="363"/>
         <source>%n concerts</source>
-        <translation>
-            <numerusform>%n concerto</numerusform>
-            <numerusform>%n concertos</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="42"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="43"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="44"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="45"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="46"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="47"/>
         <source>Open Concert Folder</source>
-        <translation>Abrir pasta do concerto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="48"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="49"/>
         <source>Play concert</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="365"/>
         <source>%1 of %n concerts</source>
-        <translation>
-            <numerusform>%1 de %n concerto</numerusform>
-            <numerusform>%1 de %n concertos</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -350,108 +342,108 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="38"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="105"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="119"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="129"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="139"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="149"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="159"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="170"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="210"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="227"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="237"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="247"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="264"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="274"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="309"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="339"/>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="342"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="345"/>
         <source>Not watched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="354"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="52"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="63"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="94"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -459,12 +451,12 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -472,115 +464,112 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="31"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="41"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="110"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="132"/>
         <source>Infos to load</source>
-        <translation>Informações a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="155"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="162"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="169"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="176"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="183"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="190"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="197"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="204"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="211"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="218"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="225"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="232"/>
         <source>Logo, Clear Art, CD Art</source>
-        <translation>Logótipo, Clear Art, CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="235"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="249"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="106"/>
         <source>The %1 scraper could not be initialized!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="119"/>
         <source>Please insert a search string!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="141"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="226"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -588,42 +577,42 @@
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your concerts. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Em baixo, pode ver os nomes de ficheiros usados para carregar e guardar os seus concertos. Pode editá-los à sua vontade, se quiser usar vários ficheiros separe-os com uma vírgula.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o de nome de ficheiro sem extensão.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="42"/>
         <source>Nfo</source>
-        <translation>Nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="71"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="100"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="129"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="158"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="187"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -633,63 +622,63 @@
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="132"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="135"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="54"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="76"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="91"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="101"/>
         <source>Scantype</source>
-        <translation>Varrimento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="111"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="165"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="185"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="195"/>
         <source>Stereo Mode</source>
-        <translation>Modo de estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="212"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="71"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="125"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="159"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="131"/>
@@ -697,18 +686,18 @@
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="163"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="164"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="133"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="136"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="151"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -716,47 +705,47 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="50"/>
         <source>Concert has changed. Click to revert changes.</source>
-        <translation>O concerto foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="76"/>
         <source>Concert Name</source>
-        <translation>Nome do concerto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="127"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="153"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="175"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="198"/>
         <source>Add Images</source>
-        <translation>Adicionar Imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="208"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="354"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="376"/>
@@ -765,62 +754,62 @@
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="537"/>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="581"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="398"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="471"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="515"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="559"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="79"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="80"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="84"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="85"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="447"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="458"/>
         <source>Concerts Saved</source>
-        <translation>Concertos guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="485"/>
         <source>All Concerts Saved</source>
-        <translation>Todos os concertos guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -828,185 +817,185 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="14"/>
         <source>CSV Export</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="22"/>
         <source>CSV Columns</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="35"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="242"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="40"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="252"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="45"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="262"/>
         <source>TV Episodes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="50"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="272"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="55"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="282"/>
         <source>Music Artists</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="60"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="292"/>
         <source>Music Albums</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="225"/>
         <source>Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="233"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="304"/>
         <source>Separator</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="321"/>
         <source>Replacement</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="340"/>
         <source>Linebreaks will be replaced by &lt;code&gt;\n&lt;/code&gt;. </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="350"/>
         <source>If any text contains the separator, it will be replaced by the replacement set above.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="373"/>
         <source>&lt;b&gt;Tip:&lt;/b&gt; You can sort the items by Drag &amp;amp; Drop.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="390"/>
         <source>Export as CSV</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="29"/>
         <source>Tab</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="30"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="35"/>
         <source>Semicolon (;)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="31"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="36"/>
         <source>Comma (,)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="34"/>
         <source>Space</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="37"/>
         <source>Minus (-)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="52"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="112"/>
         <source>Export directory</source>
-        <translation>Exportar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="114"/>
         <source>Export aborted. No directory was selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="130"/>
         <source>Export movies...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="147"/>
         <source>Export TV shows...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="161"/>
         <source>Export TV episodes...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="179"/>
         <source>Export concerts...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="197"/>
         <source>Export artists...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="212"/>
         <source>Export albums...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="227"/>
         <source>Export completed in %1 seconds.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="319"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="399"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="444"/>
         <source>Streamdetails - Duration (in seconds)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="400"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="445"/>
         <source>Streamdetails - Video Aspect</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="321"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="401"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="446"/>
         <source>Streamdetails - Video Width</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="290"/>
@@ -1016,162 +1005,162 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="467"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="495"/>
         <source>Type</source>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="320"/>
         <source>Streamdetails - Video Aspect Ratio</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="322"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="402"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="447"/>
         <source>Streamdetails - Video Height</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="323"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="403"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="448"/>
         <source>Streamdetails - Video Codec</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="324"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="404"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="449"/>
         <source>Streamdetails - Audio Language(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="325"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="405"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="450"/>
         <source>Streamdetails - Audio Codec(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="326"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="406"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="451"/>
         <source>Streamdetails - Audio Channel(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="327"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="407"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="452"/>
         <source>Streamdetails - Subtitle Language(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="380"/>
         <source>TV Show - TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="379"/>
         <source>TV Show - IMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="291"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="345"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="425"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="292"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="344"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="424"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="293"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="348"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="423"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="294"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="350"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="426"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="295"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="349"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="296"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="361"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="429"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="297"/>
         <source>Outline</source>
-        <translation>Resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="298"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="299"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="359"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="431"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="300"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="358"/>
         <source>IMDb Top 250</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="301"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="432"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="302"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="433"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="303"/>
         <source>Runtime in minutes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="304"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="353"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="435"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="305"/>
         <source>Writers</source>
-        <translation>Argumentistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="306"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="307"/>
@@ -1179,51 +1168,51 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="436"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="469"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="308"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="309"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="310"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="355"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="437"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="311"/>
         <source>Trailers</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="312"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="360"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="313"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Playcount</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="314"/>
         <source>Last played</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="315"/>
         <source>Movie Set</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="316"/>
@@ -1231,301 +1220,301 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="442"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="480"/>
         <source>Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="443"/>
         <source>Filename(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="318"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="441"/>
         <source>Last Modified Date</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="346"/>
         <source>TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="347"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="351"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="352"/>
         <source>network</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="356"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="434"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="357"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="430"/>
         <source>Ratings</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="381"/>
         <source>TV Show - TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="382"/>
         <source>TV Show - TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="383"/>
         <source>TV Show - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="427"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="428"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Trailer URL</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="440"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="468"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="470"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="471"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="472"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="473"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="474"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="475"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="476"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="477"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="478"/>
         <source>MusicBrainz ID</source>
-        <translation>Identificador MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="479"/>
         <source>AllMusic ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="384"/>
         <source>Episode - Season</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="385"/>
         <source>Episode - Number</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="386"/>
         <source>Episode - IMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="387"/>
         <source>Episode - TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="388"/>
         <source>Episode - TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="389"/>
         <source>Episode - TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="390"/>
         <source>Episode - First Aired</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="391"/>
         <source>Episode - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="392"/>
         <source>Episode - Overview</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="393"/>
         <source>Episode - User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="394"/>
         <source>Episode - Directors</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <source>Episode - Writers</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <source>Episode - Actors</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="397"/>
         <source>Episode - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="398"/>
         <source>Episode - Filename(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="496"/>
         <source>Artist - Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="497"/>
         <source>Album - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="498"/>
         <source>Album - Artist Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="499"/>
         <source>Album - Genres</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="500"/>
         <source>Album - Styles</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="501"/>
         <source>Album - Moods</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="502"/>
         <source>Album - Review</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="503"/>
         <source>Album - Release Date</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="504"/>
         <source>Album - Label</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="505"/>
         <source>Album - Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="506"/>
         <source>Album - Year</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="507"/>
         <source>Album - MusicBrainz ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="508"/>
         <source>Album - MusicBrainz ReleaseGroup ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="509"/>
         <source>Album - AllMusic ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="510"/>
         <source>Album - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="550"/>
         <source>Export failed. Could not write to CSV file.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="540"/>
         <source>Export failed. File could not be opened for writing.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1533,35 +1522,35 @@
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="29"/>
         <source>Select which site you prefer for each element of a TV show and episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="43"/>
         <source>TV show details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="65"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="101"/>
         <source>Item</source>
-        <translation>Item</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="70"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="106"/>
         <source>Site</source>
-        <translation>Site</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="79"/>
         <source>Episode details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.cpp" line="149"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.cpp" line="183"/>
         <source>No Scraper Available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1569,65 +1558,62 @@
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="50"/>
         <source>Archives</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="94"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="215"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="99"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="220"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="104"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="225"/>
         <source>Size</source>
-        <translation>Tamanho</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="146"/>
         <source>Importable items</source>
-        <translation>Itens importáveis</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="172"/>
         <source>Import movie with MakeMKV</source>
-        <translation>Importar filme com o MakeMKV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="230"/>
         <source>Import Type</source>
         <extracomment>(e.g. movie, TV show, concert)</extracomment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="233"/>
         <source>Type of this file.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="238"/>
         <source>Import Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="241"/>
         <source>Where to store the file when importing it.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="126"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="268"/>
         <source>%n files</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="202"/>
@@ -1635,50 +1621,50 @@
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="209"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="221"/>
         <source>Extraction failed</source>
-        <translation>A extração falhou</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="203"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="206"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="209"/>
         <source>Extraction of %1 has failed: %2</source>
-        <translation>A extração de %1 falhou: %2</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="219"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="233"/>
         <source>Extraction finished</source>
-        <translation>A extração terminou</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="233"/>
         <source>Extraction of %1 finished</source>
-        <translation>A extração de %1 foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="281"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="282"/>
         <source>TV Show</source>
-        <translation>Série TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="283"/>
         <source>Concert</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="464"/>
         <source>makemkvcon missing</source>
-        <translation>makemkvcon não foi encontrado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="465"/>
         <source>Please set the correct path to makemkvcon in MediaElch&apos;s settings.</source>
-        <translation>Por favor defina o caminho para o makemkvcon.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1687,87 +1673,87 @@
         <location filename="../../src/ui/export/ExportDialog.ui" line="23"/>
         <location filename="../../src/ui/export/ExportDialog.ui" line="132"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="32"/>
         <source>Export your complete collection.</source>
-        <translation>Exportar a sua coleção completa.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="39"/>
         <source>Message</source>
-        <translation>Mensagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="51"/>
         <source>Theme</source>
-        <translation>Tema</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="61"/>
         <source>Items to export</source>
-        <translation>Itens para exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="68"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="78"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="88"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="109"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="36"/>
         <source>You need to install at least one theme.</source>
-        <translation>Tem de instalar pelo menos um tema.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="58"/>
         <source>You need to select at least one media type to export.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="68"/>
         <source>Export directory</source>
-        <translation>Exportar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="70"/>
         <source>Export aborted. No directory was selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="78"/>
         <source>Could not create export directory.</source>
-        <translation>Não foi possível criar a pasta para exportação.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="95"/>
         <source>Export canceled.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="98"/>
         <source>Export completed.</source>
-        <translation>Exportação concluída.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="145"/>
         <source>Selected theme not found! Try to restart MediaElch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1775,28 +1761,28 @@
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.ui" line="17"/>
         <source>Message</source>
-        <translation>Mensagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.ui" line="43"/>
         <source>Theme</source>
-        <translation>Tema</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="67"/>
         <source>Theme &quot;%1&quot; was successfully installed</source>
-        <translation>O tema &quot;%1&quot; foi instalado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="70"/>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="81"/>
         <source>There was an error while processing the theme &quot;%1&quot;</source>
-        <translation>Ocorreu um erro ao processar o tema &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="78"/>
         <source>Theme &quot;%1&quot; was successfully uninstalled</source>
-        <translation>O tema &quot;%1&quot; foi desinstalado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1805,47 +1791,47 @@
         <location filename="../../src/ui/settings/ExportTemplateWidget.ui" line="102"/>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="42"/>
         <source>Install</source>
-        <translation>Instalar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="25"/>
         <source>by %1</source>
-        <translation>de %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="30"/>
         <source>No website available.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="33"/>
         <source>Version %1</source>
-        <translation>Versão %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="36"/>
         <source>Update</source>
-        <translation>Atualizar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="39"/>
         <source>Uninstall</source>
-        <translation>Desinstalar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="52"/>
         <source>Updating...</source>
-        <translation>A atualizar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="56"/>
         <source>Installing...</source>
-        <translation>A instalar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="60"/>
         <source>Uninstalling...</source>
-        <translation>A desinstalar...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1853,12 +1839,12 @@
     <message>
         <location filename="../../src/import/Extractor.cpp" line="30"/>
         <source>No files to extract</source>
-        <translation>Não há ficheiros para extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/import/Extractor.cpp" line="40"/>
         <source>Unrar not found</source>
-        <translation>Unrar não foi encontrado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1866,7 +1852,7 @@
     <message>
         <location filename="../../src/ui/main/FileScannerDialog.ui" line="17"/>
         <source>File Scanner</source>
-        <translation>Analisador de ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1874,94 +1860,94 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.ui" line="17"/>
         <source>Filter</source>
-        <translation>Filtro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="117"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="214"/>
         <source>Title contains &quot;%1&quot;</source>
-        <translation>O título contém &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="127"/>
         <source>Filename contains &quot;%1&quot;</source>
-        <translation>O ficheiro contém &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="393"/>
         <source>Label &quot;%1&quot;</source>
-        <translation>Etiqueta &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="395"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="371"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="372"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="373"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>Country</source>
-        <translation>País</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="384"/>
         <source>Released %1</source>
-        <translation>Lançamento %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="384"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="378"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="122"/>
         <source>Original Title contains &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="137"/>
         <source>TMDb ID &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="374"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="375"/>
         <source>Tag</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="376"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="377"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>Video codec</source>
-        <translation>Codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="437"/>
@@ -1969,226 +1955,226 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="516"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="517"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="438"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="439"/>
         <source>Filename</source>
-        <translation>Nome do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>IMDb</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="442"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>Movie has no TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>No TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>TMDb</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="469"/>
         <source>Movie has Poster</source>
-        <translation>O filme tem cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="469"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>Movie has no Poster</source>
-        <translation>O filme não tem cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>No Poster</source>
-        <translation>Nenhum cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="471"/>
         <source>Movie has Extra Fanarts</source>
-        <translation>O filme tem fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="471"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>Movie has no Extra Fanarts</source>
-        <translation>O filme não tem fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>No Extra Fanarts</source>
-        <translation>Nenhuma fanart extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <source>Movie has Backdrop</source>
-        <translation>O filme tem fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Movie has no Backdrop</source>
-        <translation>O filme não tem fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>No Backdrop</source>
-        <translation>Nenhum fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>No Fanart</source>
-        <translation>Sem fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="475"/>
         <source>Movie has Logo</source>
-        <translation>O filme tem logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="475"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>Movie has no Logo</source>
-        <translation>O filme não tem logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>No Logo</source>
-        <translation>Nenhum logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="477"/>
         <source>Movie has Clear Art</source>
-        <translation>O filme tem Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="477"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>Movie has no Clear Art</source>
-        <translation>O filme não tem Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>No Clear Art</source>
-        <translation>Nenhuma Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="479"/>
         <source>Movie has Banner</source>
-        <translation>O filme tem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="479"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>Movie has no Banner</source>
-        <translation>O filme não tem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>No Banner</source>
-        <translation>Sem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="481"/>
         <source>Movie has Thumb</source>
-        <translation>O filme tem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="481"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>Movie has no Thumb</source>
-        <translation>O filme não tem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>No Thumb</source>
-        <translation>Sem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="483"/>
         <source>Movie has CD Art</source>
-        <translation>O filme tem CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="483"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>Movie has no CD Art</source>
-        <translation>O filme não tem CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>No CD Art</source>
-        <translation>Nenhuma CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="487"/>
         <source>Movie has Trailer</source>
-        <translation>O filme tem trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="487"/>
@@ -2196,239 +2182,239 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="488"/>
         <source>Movie has no Trailer</source>
-        <translation>O filme não tem trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="488"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>No Trailer</source>
-        <translation>Nenhum trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <source>Movie has local Trailer</source>
-        <translation>O filme tem um trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Movie has no local Trailer</source>
-        <translation>O filme não tem trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>No local Trailer</source>
-        <translation>Nenhum trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <source>Movie is Watched</source>
-        <translation>O filme foi visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Seen</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Movie is Unwatched</source>
-        <translation>O filme está por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Unwatched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Unseen</source>
-        <translation>Não visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>Movie has no Certification</source>
-        <translation>O filme não tem certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>No Certification</source>
-        <translation>Nenhuma certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>Movie has no Genre</source>
-        <translation>O filme não tem género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="132"/>
         <source>IMDb ID &quot;%1&quot;</source>
-        <translation>Identificador do IMDB &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="440"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>No Genre</source>
-        <translation>Nenhum género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="456"/>
         <source>Movie has Rating</source>
-        <translation>O filme tem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="456"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>Movie has no Rating</source>
-        <translation>O filme não tem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>No Rating</source>
-        <translation>Sem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="464"/>
         <source>Stream Details loaded</source>
-        <translation>Os detalhes da pista foram carregados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="464"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>Stream Details</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>Stream Details not loaded</source>
-        <translation>Os detalhes da pista não foram carregados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>No Stream Details</source>
-        <translation>Nenhuns detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="460"/>
         <source>Movie has Actors</source>
-        <translation>O filme tem atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="460"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>Movie has no Actors</source>
-        <translation>O filme não tem atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>No Actors</source>
-        <translation>Nenhuns atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>Movie has no Studio</source>
-        <translation>O filme não tem estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>No Studio</source>
-        <translation>Nenhum estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>Movie has no Country</source>
-        <translation>O filme não tem país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>No Country</source>
-        <translation>Nenhum país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>Movie has no Director</source>
-        <translation>O filme não tem realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>No Director</source>
-        <translation>Nenhum realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>No information about video codec</source>
-        <translation>Nenhuma informação sobre o codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>No video codec</source>
-        <translation>Sem codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>Movie has no Tags</source>
-        <translation>O filme não tem etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>No Tags</source>
-        <translation>Nenhumas etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>Movie has no IMDb ID</source>
-        <translation>Filme sem identificador IMDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>No IMDb ID</source>
-        <translation>Sem identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
         <source>Resolution 720p</source>
-        <translation>Resolução 720p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
         <source>720p</source>
-        <translation>720p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
@@ -2436,68 +2422,68 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="494"/>
         <source>Resolution 1080p</source>
-        <translation>Resolução 1080p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="494"/>
         <source>1080p</source>
-        <translation>1080p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <source>Resolution 2160p</source>
-        <translation>Resolução 2160p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <source>2160p</source>
-        <translation>2160p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>Resolution SD</source>
-        <translation>Resolução SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>SD</source>
-        <translation>SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <source>Format DVD</source>
-        <translation>Formato DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <source>DVD</source>
-        <translation>DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>Format</source>
-        <translation>Formato</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>BluRay Format</source>
-        <translation>Formato BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>BluRay</source>
-        <translation>BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
         <source>Channels 2.0</source>
-        <translation>Canais 2.0</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
@@ -2507,59 +2493,59 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="502"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="503"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="502"/>
         <source>Channels 5.1</source>
-        <translation>Canais 5.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="503"/>
         <source>Channels 7.1</source>
-        <translation>Canais 7.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="504"/>
         <source>Audio Quality HD</source>
-        <translation>Qualidade de áudio HD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="504"/>
         <source>HD Audio</source>
-        <translation>Áudio HD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <source>Audio Quality Normal</source>
-        <translation>Qualidade de áudio normal</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <source>Normal Audio</source>
-        <translation>Áudio normal</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>Audio Quality SD</source>
-        <translation>Qualidade de áudio SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>SD Audio</source>
-        <translation>Áudio SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="509"/>
         <source>Movie has Subtitle</source>
-        <translation>Filme com legenda</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="509"/>
@@ -2567,39 +2553,39 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>Subtitle</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="510"/>
         <source>Movie has no Subtitle</source>
-        <translation>O filme não tem legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="510"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>No Subtitle</source>
-        <translation>Sem legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <source>Movie has external Subtitle</source>
-        <translation>O filme tem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>External Subtitle</source>
-        <translation>Legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>Movie has no external Subtitle</source>
-        <translation>O filme não tem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>No External Subtitle</source>
-        <translation>Sem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2607,63 +2593,63 @@
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="52"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="79"/>
         <source>TextLabel</source>
-        <translation>EtiquetaTexto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="116"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="139"/>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="142"/>
         <source>Add Movie</source>
-        <translation>Adicionar filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="149"/>
         <source>Remove Current Movie</source>
-        <translation>Remover filme atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="152"/>
         <source>Remove Movie</source>
-        <translation>Remover filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="165"/>
         <source>Double click a genre to rename it, right click to delete. If you want to merge two genres just give them the same name.</source>
-        <translation>Clique duas vezes num género para lhe alterar o nome, clique com o botão direito para eliminá-lo. Se quiser fundir dois géneros, basta colocar-lhes o mesmo nome.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="175"/>
         <source>Please keep in mind that the changes you make here (renaming or deleting genres) will be made for every movie.</source>
-        <translation>Por favor, lembre-se que todas as alterações feitas aqui (alterar o nome ou eliminar géneros) serão feitas para todos os filmes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="28"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="29"/>
         <source>Delete Genre</source>
-        <translation>Eliminar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="172"/>
         <source>New Genre</source>
-        <translation>Novo género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="287"/>
         <source>All Movies Saved</source>
-        <translation>Todos os filmes foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2671,189 +2657,189 @@
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="21"/>
         <source>Directories</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="57"/>
         <source>Add one or more directories containing your movies, TV Shows, concerts, music or files to import.
 TV Show Episodes have to be in subfolders with the name of the show.
 The directories containing your music must contain subdirectories for each artist which contain directories of albums.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="91"/>
         <source>Type</source>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="96"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="101"/>
         <source>Sep. folders</source>
-        <translation>Pastas separadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="104"/>
         <source>Items are in separate folders</source>
-        <translation>Os itens estão em pastas separadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="109"/>
         <source>Reload On Start</source>
-        <translation>Recarregar ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="112"/>
         <source>Automatically reload contents on start</source>
-        <translation>Recarrega automaticamente os conteúdos ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="117"/>
         <source>Disabled</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="120"/>
         <source>Ignore this folder.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="130"/>
         <source>Add</source>
-        <translation>Adicionar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="137"/>
         <source>Remove</source>
-        <translation>Remover</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="144"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sort movies into separate directories&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ordenar filmes em pastas separadas&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="147"/>
         <source>Organize</source>
-        <translation>Organizar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="174"/>
         <source>Store trailer URLs in YouTube Plugin format</source>
-        <translation>Guardar endereços de trailers no formato YouTube Plugin</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="188"/>
         <source>Automatically load and save stream details from files</source>
-        <translation>Carregar e guardar automaticamente detalhes das pistas dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="202"/>
         <source>Ignore articles when sorting (&quot;The&quot;)</source>
-        <translation>Ignorar artigos iniciais ao ordenar (&quot;The&quot;)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="216"/>
         <source>Download actor images</source>
-        <translation>Descarregar imagens de atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="230"/>
         <source>Check for Updates on start</source>
-        <translation>Verificar se existem atualizações ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="244"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="263"/>
         <source>Words to exclude from media names (seperated by commas and non case-sensitive)</source>
-        <translation>Palavras a excluir dos nomes de média (separar com vírgulas e sem sensibilidade a maiúsculas)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="270"/>
         <source>Startup section</source>
-        <translation>Secção inicial</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="300"/>
         <source>Appearance</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="311"/>
         <source>Main Window Theme (changing it requires restart of MediaElch)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="42"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="43"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="44"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="45"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="46"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="48"/>
         <source>Auto</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="49"/>
         <source>Light</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="50"/>
         <source>Dark</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="66"/>
         <source>Choose a directory containing your movies, TV show or concerts</source>
-        <translation>Escolher uma pasta que contém os seus filmes, séries TV ou concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Downloads</source>
-        <translation>Descarregamentos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="265"/>
         <source>Organizing movies does only work on movies, not already sorted to separate folders.</source>
-        <translation>Organizar filmes funciona apenas em filmes, sem estarem já organizados em pastas separadas.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="273"/>
         <source>Are you sure?</source>
-        <translation>Tem a certeza?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="275"/>
         <source>This operation sorts all movies in this directory to separate sub-directories based on the file name. Click &quot;Ok&quot;, if that&apos;s, what you want to do. </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2861,22 +2847,22 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="17"/>
         <source>Choose an Image</source>
-        <translation>Escolher uma imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="31"/>
         <source>Enter a search term or URL</source>
-        <translation>Introduza um termo de busca ou um endereço</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="44"/>
         <source>Language to use when searching for a TV show by title.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="124"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="176"/>
@@ -2885,96 +2871,93 @@ The directories containing your music must contain subdirectories for each artis
         <location filename="../../src/ui/image/ImageDialog.ui" line="191"/>
         <location filename="../../src/ui/image/ImageDialog.ui" line="196"/>
         <source>Neue Spalte</source>
-        <translation>Nova coluna</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="703"/>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="711"/>
         <source>No images found</source>
-        <translation>Nenhumas imagens encontradas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="249"/>
         <source>Zoom out</source>
-        <translation>Diminuir ampliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="275"/>
         <source>Preview size</source>
-        <translation>Tamanho de pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="303"/>
         <source>Zoom in</source>
-        <translation>Aumentar ampliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="324"/>
         <source>Loading...</source>
-        <translation>A carregar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="347"/>
         <source>Choose Local Image</source>
-        <translation>Escolher imagem local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="360"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="367"/>
         <source>Accept Images</source>
-        <translation>Aceitar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="251"/>
         <source>Default</source>
-        <translation>Padrão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="158"/>
         <source>Neither an image provider nor previously scraped image URLs are available for the requested image type.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="360"/>
         <source>Error while downloading one or more images: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="523"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="523"/>
         <source>Images (*.jpg *.jpeg *.png)</source>
-        <translation>Imagens (*.jpg *.jpeg *.png)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="708"/>
         <source>Images provided by &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
-        <translation>Imagens fornecidas por  &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="712"/>
         <source>Contribute by uploading images to &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
-        <translation>Contribua enviando novas imagens para &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/image/ImageDialog.cpp" line="812"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="941"/>
         <source>Error while querying image provider: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2982,7 +2965,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/small_widgets/ImageLabel.ui" line="42"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2990,12 +2973,12 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/image/ImagePreviewDialog.ui" line="17"/>
         <source>Preview</source>
-        <translation>Pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImagePreviewDialog.ui" line="82"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3003,22 +2986,22 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/import/ImportActions.ui" line="23"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.ui" line="30"/>
         <source>Delete</source>
-        <translation>Eliminar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.cpp" line="128"/>
         <source>Delete file?</source>
-        <translation>Eliminar o ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.cpp" line="129"/>
         <source>Do you really want to delete this file?</source>
-        <translation>Quer mesmo eliminar este ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3026,144 +3009,141 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="17"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="40"/>
         <source>Loading</source>
-        <translation>A carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="47"/>
         <source>Success</source>
-        <translation>Sucesso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="54"/>
         <source>Loading movie...</source>
-        <translation>A carregar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="81"/>
         <source>Directory Naming</source>
-        <translation>Nomes das pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="91"/>
         <source>File Naming</source>
-        <translation>Nomes dos Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="108"/>
         <source>Use Season Directories</source>
-        <translation>Usar pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="115"/>
         <source>Season Directory Naming</source>
-        <translation>Nomes das pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="132"/>
         <source>Keep source files after import</source>
-        <translation>Manter ficheiros originais após importação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="175"/>
         <location filename="../../src/ui/import/ImportDialog.ui" line="185"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="205"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="274"/>
         <source>Loading movie information...</source>
-        <translation>A carregar a informação do filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="296"/>
         <source>Loading concert information...</source>
-        <translation>A carregar a informação do concerto...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="320"/>
         <source>Loading episode information...</source>
-        <translation>A carregar a informação do episódio...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="390"/>
         <source>Movie information was loaded</source>
-        <translation>A informação do filme foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="404"/>
         <source>Concert information was loaded</source>
-        <translation>A informação do concerto foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="423"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="442"/>
         <source>Episode information was loaded</source>
-        <translation>A informação do episódio foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="454"/>
         <source>Renaming not possible</source>
-        <translation>Não é possível alterar o nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="454"/>
         <source>Please enter all naming patterns</source>
-        <translation>Por favor, introduza todos os padrões de nomenclatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="484"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="577"/>
         <source>Creating destination directory failed</source>
-        <translation>Não foi possível criar a pasta de destino</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="485"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="578"/>
         <source>The destination directory %1 could not be created</source>
-        <translation>Não foi possível criar a pasta de destino %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="514"/>
         <source>Importing movie...</source>
-        <translation>A importar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="553"/>
         <source>Importing episode...</source>
-        <translation>A importar o episódio...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="605"/>
         <source>Importing concert...</source>
-        <translation>A importar o concerto...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="708"/>
         <source>Import finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/import/ImportDialog.cpp" line="709"/>
         <source>Import of %n files has finished</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="712"/>
         <source>Import has finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3171,33 +3151,33 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="19"/>
         <source>Automatically delete archives after extraction</source>
-        <translation>Eliminar ficheiros automaticamente após extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="33"/>
         <source>Path to unrar</source>
-        <translation>Localização do Unrar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="45"/>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="66"/>
         <source>Choose</source>
-        <translation>Escolher</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="54"/>
         <source>Path to makemkvcon</source>
-        <translation>Localização de makemkvcon</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.cpp" line="46"/>
         <source>Choose unrar</source>
-        <translation>Escolher Unrar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.cpp" line="54"/>
         <source>Choose makemkvcon</source>
-        <translation>Escolher makemkvco</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3205,49 +3185,47 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="17"/>
         <source>General Kodi Settings. MediaElch uses the Kodi version below for writing NFO files.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="29"/>
         <source>Kodi Version</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="48"/>
         <source>If you want to use the synchronization feature you need to enable the webserver within Kodi (Settings -&gt; Services -&gt; Webserver). Enter the port of the webserver here (usually 80 or 8080).</source>
-        <translation>Se quer usar o recurso de sincronização, deve antes ativar o servidor web dentro do Kodi.
-Veja em Kodi -&gt; Definições -&gt; Serviços -&gt; Servidor web. Anote os números de host (IP) e da porta.
-Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="63"/>
         <source>Host</source>
-        <translation>Anfitrião</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="70"/>
         <source>127.0.0.1</source>
-        <translation>127.0.0.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="77"/>
         <source>Port</source>
-        <translation>Porta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="84"/>
         <source>8080</source>
-        <translation>8080</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="91"/>
         <source>User</source>
-        <translation>Utilizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="98"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3255,68 +3233,68 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="23"/>
         <source>Kodi Synchronization</source>
-        <translation>Sincronização com Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="32"/>
         <source>Please make sure you have setup your sources in Kodi and that the webserver is enabled (Kodi -&gt; Settings -&gt; Services -&gt; Webserver).</source>
-        <translation>Por favor, certifique-se que configurou as suas fontes no Kodi e que o seu servidor web está ativado (Kodi -&gt; Definições -&gt; Serviços -&gt; Servidor web).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="42"/>
         <source>Update contents</source>
-        <translation>Atualizar conteúdos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="52"/>
         <source>This will tell Kodi to remove the changed movies, concerts or shows. Afterwards a Kodi library update is triggered and the removed items will be picked up again.</source>
-        <translation>Isto irá dizer ao Kodi para remover os filmes, concertos e séries com alterações. Após isso, o Kodi irá fazer uma atualização e os itens removidos serão novamente recolhidos e reinseridos.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="62"/>
         <source>Remove non-existent items from Kodis database (Clean library)</source>
-        <translation>Remover itens não existentes da base de dados do Kodi (limpar coleção).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="69"/>
         <source>Kodi will remove not longer existing items from your database.</source>
-        <translation>O Kodi irá remover os itens não localizados da sua base de dados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="76"/>
         <source>Retrieve watched status</source>
-        <translation>Obter estado de &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="83"/>
         <source>The fields last played and playcount will be retrieved from Kodi.</source>
-        <translation>Os campos Última Reprodução e Contador de Sessões virão do Kodi.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="113"/>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="120"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="138"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="161"/>
         <source>Start</source>
-        <translation>Iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="165"/>
         <source>Please fill in your Kodi host and port.</source>
-        <translation>Por favor introduza os dados de Host e Porta no menu Definições -&gt; Kodi.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="238"/>
         <source>Getting contents from Kodi</source>
-        <translation>A obter conteúdos do Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="254"/>
@@ -3324,52 +3302,52 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="318"/>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="350"/>
         <source>Network error</source>
-        <translation>Erro de rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="448"/>
         <source>Removing movies from database</source>
-        <translation>A remover filmes da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="463"/>
         <source>Removing concerts from database</source>
-        <translation>A remover concertos da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="478"/>
         <source>Removing TV shows from database</source>
-        <translation>A remover séries de TV da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="493"/>
         <source>Removing episodes from database</source>
-        <translation>A remover episódios da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="533"/>
         <source>Trigger scan for new items</source>
-        <translation>Requisitar busca de novos itens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="555"/>
         <source>Error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="560"/>
         <source>Finished. Kodi is now loading your updated items.</source>
-        <translation>Terminado. O Kodi está agora a carregar os seus itens atualizados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="582"/>
         <source>Finished. Kodi is now cleaning your database.</source>
-        <translation>Terminado. O Kodi está agora a limpar a sua base de dados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="627"/>
         <source>Finished. Your items play count and last played date have been updated.</source>
-        <translation>Concluído. O &quot;Nº de reproduções&quot; e a &quot;última reprodução&quot; dos seus itens foram atualizadas.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3377,7 +3355,7 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/small_widgets/LanguageCombo.cpp" line="37"/>
         <source>No language available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3385,17 +3363,17 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="23"/>
         <source>Loading Stream Details</source>
-        <translation>A carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="32"/>
         <source>Loading Stream Details...</source>
-        <translation>A carregar detalhes da pista...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="46"/>
         <source>File</source>
-        <translation>Ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3403,414 +3381,414 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/data/Locale.cpp" line="28"/>
         <source>Arabic</source>
-        <translation>Árabe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="29"/>
         <source>Arabic (U.A.E.)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="30"/>
         <source>Arabic (Saudi Arabia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="31"/>
         <source>Belarusian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="32"/>
         <location filename="../../src/data/Locale.cpp" line="33"/>
         <source>Bulgarian</source>
-        <translation>Búlgaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="34"/>
         <source>Bengali</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="35"/>
         <source>Catalan (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="36"/>
         <source>Chamorro (Guam)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="37"/>
         <source>Cantonese</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="38"/>
         <location filename="../../src/data/Locale.cpp" line="39"/>
         <source>Czech</source>
-        <translation>Checo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="40"/>
         <location filename="../../src/data/Locale.cpp" line="41"/>
         <source>Danish</source>
-        <translation>Dinamarquês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="42"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="43"/>
         <source>German (AT)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="44"/>
         <source>German (CH)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="45"/>
         <source>German (DE)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="46"/>
         <location filename="../../src/data/Locale.cpp" line="47"/>
         <source>Greek</source>
-        <translation>Grego</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="48"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="49"/>
         <source>English (Australia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="50"/>
         <source>English (Canada)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="51"/>
         <source>English (GB)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="52"/>
         <source>English (NZ)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="53"/>
         <source>English (US)</source>
-        <translation>Inglês (US)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="54"/>
         <source>Esperanto</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="55"/>
         <location filename="../../src/data/Locale.cpp" line="56"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="57"/>
         <source>Spanish (Mexico)</source>
-        <translation>Castelhano (México)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="58"/>
         <source>Estonian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="59"/>
         <source>Basque (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="60"/>
         <source>Persian (Iran)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="61"/>
         <location filename="../../src/data/Locale.cpp" line="62"/>
         <source>Finnish</source>
-        <translation>Finlandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="63"/>
         <location filename="../../src/data/Locale.cpp" line="65"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="64"/>
         <source>French (Canada)</source>
-        <translation>Francês (Canadá)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="66"/>
         <source>Galician (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="67"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="68"/>
         <source>Hebrew (Israel)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="69"/>
         <source>Hindi (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="70"/>
         <source>Croatian</source>
-        <translation>Croata</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="71"/>
         <source>Croatian (Croatia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="72"/>
         <location filename="../../src/data/Locale.cpp" line="73"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="74"/>
         <source>Indonesian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="75"/>
         <location filename="../../src/data/Locale.cpp" line="76"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="77"/>
         <location filename="../../src/data/Locale.cpp" line="78"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="79"/>
         <source>Georgian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="80"/>
         <source>Kazakh</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="81"/>
         <source>Kannada</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="82"/>
         <location filename="../../src/data/Locale.cpp" line="83"/>
         <source>Korean</source>
-        <translation>Coreano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="84"/>
         <source>Lithuanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="85"/>
         <source>Latvian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="86"/>
         <source>Malayalam</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="87"/>
         <source>Malay (Malaysia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="88"/>
         <source>Malay (Singapore)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="89"/>
         <source>Norwegian Bokmål</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="90"/>
         <location filename="../../src/data/Locale.cpp" line="91"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="92"/>
         <location filename="../../src/data/Locale.cpp" line="93"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="94"/>
         <location filename="../../src/data/Locale.cpp" line="95"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="96"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="97"/>
         <source>Portuguese (Brazil)</source>
-        <translation>Português (Brasil)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="98"/>
         <source>Portuguese (Portugal)</source>
-        <translation>Português (Portugal)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="99"/>
         <source>Romanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="100"/>
         <location filename="../../src/data/Locale.cpp" line="101"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="102"/>
         <source>Sinhalese (Sri Lanka)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="103"/>
         <source>Slovak</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="104"/>
         <source>Slovene</source>
-        <translation>Eslovaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="105"/>
         <source>Slovenian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="106"/>
         <source>Albanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="107"/>
         <source>Serbian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="108"/>
         <location filename="../../src/data/Locale.cpp" line="109"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="110"/>
         <source>Tamil (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="111"/>
         <source>Telugu (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="112"/>
         <source>Thai</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="113"/>
         <source>Tagalog (Philippines)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="114"/>
         <location filename="../../src/data/Locale.cpp" line="115"/>
         <source>Turkish</source>
-        <translation>Turco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="116"/>
         <source>Ukrainian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="117"/>
         <source>Vietnamese</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="118"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="119"/>
         <source>Chinese (PRC)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="120"/>
         <source>Chinese (Hong Kong)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="121"/>
         <source>Chinese (Taiwan)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="122"/>
         <source>Zulu</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="124"/>
         <source>No language available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3818,55 +3796,55 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="14"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="75"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="94"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="125"/>
         <source>Movie Sets</source>
-        <translation>Coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="156"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="187"/>
         <source>Certifications</source>
-        <translation>Certificações</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="218"/>
         <source>Duplicates</source>
-        <translation>Duplicados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="248"/>
         <source>Shows</source>
-        <translation>Séries</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="267"/>
         <source>TV Shows</source>
-        <translation>Séries TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="297"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="316"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="346"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="365"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="395"/>
@@ -3875,92 +3853,92 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
         <extracomment>Main menu entry
 ----------
 Main menu entry (tooltip)</extracomment>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="883"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="888"/>
         <source>Quit</source>
-        <translation>Sair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="893"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="52"/>
         <source>FAQ</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="53"/>
         <source>Troubleshooting</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="54"/>
         <source>Report Issue</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="56"/>
         <source>Release Notes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="57"/>
         <source>Documentation</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="58"/>
         <source>Blog</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="59"/>
         <source>Official Kodi Forum</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="61"/>
         <source>View License</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="340"/>
         <source>&amp;Quick Open</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="807"/>
         <source>Reload all Movies (%1)</source>
-        <translation>Recarregar todos os filmes (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="813"/>
         <source>Reload all TV Shows (%1)</source>
-        <translation>Recarregar todas as séries de TV (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="824"/>
         <source>Reload all Concerts (%1)</source>
-        <translation>Recarregar todos os Concertos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="840"/>
         <source>Reload all Downloads (%1)</source>
-        <translation>Recarregar todos os descarregamentos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="846"/>
         <source>Reload Music (%1)</source>
-        <translation>Recarregar música (%1)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3968,147 +3946,147 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="50"/>
         <source>Scan</source>
-        <translation>Análise</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="92"/>
         <source>Import Tracks</source>
-        <translation>Importar faixas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="118"/>
         <source>Backup Disc</source>
-        <translation>Disco de cópia de segurança</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="163"/>
         <source>Loading</source>
-        <translation>A carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="170"/>
         <source>Success</source>
-        <translation>Sucesso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="177"/>
         <source>Loading movie...</source>
-        <translation>A carregar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="199"/>
         <source>Placeholders</source>
-        <translation>Marcadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="207"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="236"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="259"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="282"/>
         <source>File extension</source>
-        <translation>Extensão de ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="298"/>
         <source>Placeholder</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="321"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="338"/>
         <source>Part number of the current file</source>
-        <translation>Número da parte do ficheiro atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="355"/>
         <source>Directory Naming</source>
-        <translation>Nomes das pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="365"/>
         <source>File Naming</source>
-        <translation>Nomes dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="375"/>
         <source>Multi-File Naming</source>
-        <translation>Renomear múltiplos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="385"/>
         <source>Import directory</source>
-        <translation>Pasta de importação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="429"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="452"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="207"/>
         <source>No tracks selected</source>
-        <translation>Não foram selecionadas faixas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="208"/>
         <source>Please select at least one track you want to import.</source>
-        <translation>Por favor, selecione pelo menos uma faixa para importar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="246"/>
         <source>Loading movie information...</source>
-        <translation>A carregar a informação do filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="274"/>
         <source>Movie information was loaded</source>
-        <translation>A informação de filme foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="297"/>
         <source>Creating destination directory failed</source>
-        <translation>Não foi possível criar a pasta de destino</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="298"/>
         <source>The destination directory %1 could not be created</source>
-        <translation>Não foi possível criar a pasta de destino %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="386"/>
         <source>MakeMKV import finished</source>
-        <translation>Importação MakeMKV foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="386"/>
         <source>Import with MakeMKV has finished</source>
-        <translation>A importação com o MakeMKV foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="389"/>
         <source>Import has finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4116,17 +4094,17 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="116"/>
         <source>Movie title</source>
-        <translation>Título do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="145"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="152"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4134,27 +4112,27 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.ui" line="67"/>
         <source>Detect duplicate movies</source>
-        <translation>Detetar filmes duplicados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="75"/>
         <source>Detecting duplicate movies...</source>
-        <translation>A detetar filmes duplicados...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="129"/>
         <source>Open Detail Page</source>
-        <translation>Abrir página de detalhes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="130"/>
         <source>Open Movie Folder</source>
-        <translation>Abrir pasta do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="131"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4162,19 +4140,18 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="25"/>
         <source>Source %1 is no directory</source>
-        <translation>A fonte %1 não é uma pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="83"/>
         <source>Operation not possible.</source>
-        <translation>Não foi possível efetuar a operação.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="84"/>
         <source>%1
  Operation Canceled.</source>
-        <translation>%1
- Operação Cancelada.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4182,99 +4159,93 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="144"/>
         <source>New</source>
-        <translation>Novo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="160"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="176"/>
         <source>Date Added</source>
-        <translation>Data de adição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="192"/>
         <source>Seen</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="208"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="30"/>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="562"/>
         <source>%n movies</source>
-        <translation>
-            <numerusform>%n filme</numerusform>
-            <numerusform>%n filmes</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="58"/>
         <source>Media Status Columns</source>
-        <translation>Colunas de estado do média</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="69"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="80"/>
         <source>Load Information</source>
-        <translation>Carregar informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="81"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="82"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="83"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="84"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="85"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="86"/>
         <source>Open Movie Folder</source>
-        <translation>Abrir pasta do Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="87"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="88"/>
         <source>Play movie</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="564"/>
         <source>%1 of %n movies</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -4282,85 +4253,85 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="17"/>
         <source>Choose a movie</source>
-        <translation>Escolher o filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="26"/>
         <source>Filter</source>
-        <translation>Filtro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="58"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="68"/>
         <source>Add selected movies</source>
-        <translation>Adicionar filmes selecionados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="88"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="326"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <source>Extra Arts</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <source>Extra Fanarts</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="329"/>
-        <source>Extra Arts</source>
-        <translation>Arts extras</translation>
+        <source>Fanart</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="330"/>
-        <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <source>Poster</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="331"/>
-        <source>Fanart</source>
-        <translation>Fanart</translation>
+        <source>Stream Details</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="332"/>
-        <source>Poster</source>
-        <translation>Cartaz</translation>
+        <source>Trailer</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="333"/>
-        <source>Stream Details</source>
-        <translation>Detalhes da pista</translation>
+        <source>Local Trailer</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="334"/>
-        <source>Trailer</source>
-        <translation>Trailer</translation>
+        <source>Subtitles</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="335"/>
-        <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <source>Tags</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="336"/>
-        <source>Subtitles</source>
-        <translation>Legendas</translation>
-    </message>
-    <message>
-        <location filename="../../src/model/MovieModel.cpp" line="337"/>
-        <source>Tags</source>
-        <translation>Etiquetas</translation>
-    </message>
-    <message>
-        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4368,185 +4339,182 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="23"/>
         <source>Movie Multi Scrape</source>
-        <translation>Extração múltipla de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="36"/>
         <source>Please select the scraper and the infos you want to be loaded. MediaElch will use the best result for each movie you selected.</source>
-        <translation>Por favor, escolha o extrator e as informações que pretende carregar. O MediaElch usará o melhor resultado para cada filme que selecionou.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="48"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="84"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="143"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="233"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="163"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="303"/>
         <source>Logo</source>
-        <translation>Logotipos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="223"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="133"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="113"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="93"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="103"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="173"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="213"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="203"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="153"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="123"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="183"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="243"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="253"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="193"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="293"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="283"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="273"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="263"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="313"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="332"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="358"/>
         <source>Automatically save each movie after scraping</source>
-        <translation>Guardar automaticamente cada filme após a extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="365"/>
         <source>Update only movies with IMDb ID/TMDb Id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="380"/>
         <source>1/20</source>
-        <translation>1/20</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="387"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="412"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="435"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="448"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.cpp" line="201"/>
         <source>Scraping of %n movies has finished.</source>
-        <translation>
-            <numerusform>A extração de %n filmes terminou.</numerusform>
-            <numerusform>A extração de %n filmes terminou.</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -4554,12 +4522,12 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4567,166 +4535,163 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="31"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="41"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="70"/>
         <source>When using IMDb you can also use the IMDb id as search query.
 If you want to search by an TMDb id please prefix it with &quot;id&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="128"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="163"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="170"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="177"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="184"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="191"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="198"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="205"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="212"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="219"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="226"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="233"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="240"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="264"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="271"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="278"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="285"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="292"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="299"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="306"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="313"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="320"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="327"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="334"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="365"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="77"/>
         <source>Cannot scrape a movie without an active scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="153"/>
         <source>Internal inconsistency: Cannot set language dropdown in movie search widget!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="175"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="314"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4734,112 +4699,112 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your movies. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Em baixo, pode ver os nomes de ficheiros usados para carregar e guardar os seus filmes. Pode editá-los à sua vontade, se quiser usar vários ficheiros separe-os com uma vírgula.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o de nome de ficheiro sem extensão.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="42"/>
         <source>Nfo</source>
-        <translation>Nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="49"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="56"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="63"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="70"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="77"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="216"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="223"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="281"/>
         <source>Movie outline</source>
-        <translation>Resumo do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="288"/>
         <source>Use plot when outline is not available</source>
-        <translation>Usar enredo quando não existir resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="295"/>
         <source>Movie Set Artwork</source>
-        <translation>Artwork de coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="21"/>
         <source>Artwork next to movies</source>
-        <translation>Artwork próxima dos filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="23"/>
         <source>Separate artwork directory</source>
-        <translation>Pasta separada de artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="305"/>
         <source>Movie Set Poster Filename</source>
-        <translation>Nome do ficheiro do cartaz da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="342"/>
         <source>Movie Set Fanart Filname</source>
-        <translation>Nome de ficheiro da fanart da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="379"/>
         <source>Artwork directory</source>
-        <translation>Pasta de artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="391"/>
         <source>Choose directory</source>
-        <translation>Escolher pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="400"/>
         <source>Movie Original Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="407"/>
         <source>Don&apos;t store the original title if it is the same as the normal title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="163"/>
         <source>Choose a directory where your movie set artwork is stored</source>
-        <translation>Escolher uma pasta onde a artwork da coleção de filmes está guardada</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4847,283 +4812,283 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="50"/>
         <source>Movie has changed. Click to revert changes.</source>
-        <translation>O filme foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="75"/>
         <source>Movie Name</source>
-        <translation>Nome do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="121"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="141"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1050"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="155"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="165"/>
         <source>Original Name</source>
-        <translation>Nome original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="175"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="185"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="211"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="228"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="235"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="245"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="255"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="275"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="282"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="317"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="347"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="350"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="353"/>
         <source>Not watched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="362"/>
         <source>Plot</source>
-        <translation>Enredo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="386"/>
         <source>Insert YouTube Dummy Link</source>
-        <translation>Inserir link falso do YouTube</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="405"/>
         <source>Download Trailer</source>
-        <translation>Descarregar trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="421"/>
         <source>Play local trailer</source>
-        <translation>Reproduzir trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="431"/>
         <source>Local trailer is available</source>
-        <translation>Está disponível um trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="434"/>
         <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="447"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="480"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="548"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="558"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="570"/>
         <source>Outline</source>
-        <translation>Resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="592"/>
         <source>Open movie on IMDb.com</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="595"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="631"/>
         <source>Go</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="618"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="628"/>
         <source>Open movie on TheMovieDB.org</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="663"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="695"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="786"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="705"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="717"/>
         <source>Support for extra fanarts is only available when your movies are stored in separate folders. Check the settings if you&apos;ve stored your movies in separate folders already.</source>
-        <translation>O recurso a fanarts extra só está disponível quando os seus filmes estão guardados em pastas separadas. Verifique as definições, caso já tenha guardado os seus filmes em pastas separadas.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="735"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="758"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="768"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="806"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="796"/>
         <source>Scantype</source>
-        <translation>Varrimento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="942"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="788"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="791"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="847"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="862"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="888"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="881"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="221"/>
         <source>Ratings</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="653"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="952"/>
         <source>Stereo Mode</source>
-        <translation>Modo de Estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="973"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1030"/>
         <source>External Subtitles</source>
-        <translation>Legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1060"/>
         <source>Forced</source>
-        <translation>Forçadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1216"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1256"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1238"/>
@@ -5134,103 +5099,103 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1502"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1549"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1263"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1303"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1310"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1350"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1386"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1426"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1433"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1473"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1480"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1520"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1527"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1567"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="88"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="89"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="93"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="94"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="98"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="99"/>
         <source>Add Country</source>
-        <translation>Adicionar país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="103"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="104"/>
         <source>Add Studio</source>
-        <translation>Adicionar estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="485"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="492"/>
         <source>Scraping...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="780"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="816"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1055"/>
@@ -5239,49 +5204,49 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="821"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="822"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="789"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="792"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="807"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="850"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="921"/>
         <source>Saving movie...</source>
-        <translation>A guardar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="926"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="902"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="950"/>
         <source>Saving movies...</source>
-        <translation>A guardar os filmes...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="919"/>
         <source>Movies Saved</source>
-        <translation>Filmes guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="971"/>
         <source>All Movies Saved</source>
-        <translation>Todos os filmes foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5289,12 +5254,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/file_search/MusicFileSearcher.cpp" line="44"/>
         <source>Searching for Music...</source>
-        <translation>A procurar por músia...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MusicFileSearcher.cpp" line="129"/>
         <source>Loading Music...</source>
-        <translation>A carregar a música...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5302,38 +5267,29 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="31"/>
         <source>Open Folder</source>
-        <translation>Abrir pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="32"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="25"/>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="155"/>
         <source>%n artists</source>
-        <translation>
-            <numerusform>%n artista</numerusform>
-            <numerusform>%n artistas</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="25"/>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="155"/>
         <source>%n albums</source>
-        <translation>
-            <numerusform>%n álbum</numerusform>
-            <numerusform>%n álbuns</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="158"/>
         <source>%1 of %n artists</source>
-        <translation>
-            <numerusform>%1 de %n artista</numerusform>
-            <numerusform>%1 de %n artistas</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5341,170 +5297,167 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="17"/>
         <source>Music Multi Scrape</source>
-        <translation>Extração múltipla de músicas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="39"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="48"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="61"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="74"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="87"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="100"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="113"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="126"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="139"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="152"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="165"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="178"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="191"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="204"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="217"/>
         <source>Moods</source>
-        <translation>Disposição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="230"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="243"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="256"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="269"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="282"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="295"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="308"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="321"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="334"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="347"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="369"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="395"/>
         <source>Scrape all albums of selected artists (and not only selected albums)</source>
-        <translation>Extrair todos os álbuns de artistas selecionados (e não apenas dos álbuns selecionados)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="402"/>
         <source>Automatically save each artist and album after scraping</source>
-        <translation>Guardar automaticamente cada artista e álbum após a extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="449"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="472"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="485"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.cpp" line="205"/>
         <source>Scraping of %n items has finished.</source>
-        <translation>
-            <numerusform>Terminou a extração de %n itens.</numerusform>
-            <numerusform>Terminou a extração de %n itens.</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5512,12 +5465,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5525,142 +5478,142 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="34"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="89"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="117"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="140"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="150"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="160"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="170"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="180"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="190"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="200"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="210"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="220"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="230"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="240"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="250"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="260"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="270"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="280"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="290"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="300"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="310"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="320"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="330"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="340"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="350"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="360"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="370"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="387"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5668,39 +5621,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your artists and albums. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Abaixo pode ver os nomes de ficheiros que são usados ​​para carregar e guardar os Artistas e Álbuns. Pode editá-los como quiser.
-Se quiser guardar o mesmo ficheiro com vários nomes, deve separar os nomes com uma vírgula.
-Por exemplo:  folder.jpg,cover.jpg</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="32"/>
         <source>Artist Thumbnail</source>
-        <translation>Miniatura de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="49"/>
         <source>Artist Fanart</source>
-        <translation>Fanart de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="66"/>
         <source>Artist Logo</source>
-        <translation>Logótipo de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="83"/>
         <source>Album Thumbnail</source>
-        <translation>Miniatura de álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="100"/>
         <source>Album Disc Art</source>
-        <translation>Capa do álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="117"/>
         <source>Download Extra Fanarts for Artists</source>
-        <translation>Descarregar Fanarts extras para artistas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5708,10 +5659,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message numerus="yes">
         <location filename="../../src/ui/small_widgets/MusicTreeView.cpp" line="105"/>
         <source>%n albums</source>
-        <translation>
-            <numerusform>%n album</numerusform>
-            <numerusform>%n álbuns</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5720,13 +5668,13 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="122"/>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="162"/>
         <source>Saving changed Artists and Albums</source>
-        <translation>A guardar alterações em artistas e álbuns</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="140"/>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="187"/>
         <source>All Artists and Albums Saved</source>
-        <translation>Todos os artistas e álbuns foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5734,150 +5682,150 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="53"/>
         <source>Album has changed. Click to revert changes.</source>
-        <translation>O álbum foi alterando. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="79"/>
         <source>Album Name</source>
-        <translation>Nome do álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="137"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="158"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="179"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="186"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="193"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="200"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="207"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="214"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="254"/>
         <source>MusicBrainz Album ID</source>
-        <translation>Identificador do álbum MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="268"/>
         <source>MusicBrainz Release Group ID</source>
-        <translation>Identificador do grupo de lançamento MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="285"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="326"/>
         <source>Booklet</source>
-        <translation>Brochura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="345"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="368"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="420"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="460"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="442"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="505"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="483"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="523"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="41"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="42"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="46"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="47"/>
         <source>Add Mood</source>
-        <translation>Adicionar estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="51"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="52"/>
         <source>Add Style</source>
-        <translation>Adicionar estilo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="186"/>
         <source>Saving Album...</source>
-        <translation>A guardar o álbum...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="192"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="524"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5885,182 +5833,182 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="53"/>
         <source>Artist has changed. Click to revert changes.</source>
-        <translation>O artista foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="79"/>
         <source>Artist Name</source>
-        <translation>Nome do artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="137"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="158"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="186"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="193"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="200"/>
         <source>Years active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="207"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="214"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="235"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="245"/>
         <source>MusicBrainz ID</source>
-        <translation>Identificador MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="262"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="303"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="325"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="330"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="340"/>
         <source>Add Album</source>
-        <translation>Adicionar álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="347"/>
         <source>Remove Album</source>
-        <translation>Remover álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="370"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="392"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="415"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="467"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="507"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="633"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="489"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="552"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="615"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="530"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="570"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="593"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="49"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="50"/>
         <source>Add Genre</source>
-        <translation>Adicionar Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="54"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="55"/>
         <source>Add Mood</source>
-        <translation>Adicionar estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="59"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="60"/>
         <source>Add Style</source>
-        <translation>Adicionar estilo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="196"/>
         <source>Saving Artist...</source>
-        <translation>A guardar o artista...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="202"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="501"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="586"/>
         <source>Unknown Album</source>
-        <translation>Álbum Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6068,87 +6016,87 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="38"/>
         <source>Scrape</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="58"/>
         <source>Save</source>
-        <translation>Guardar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="78"/>
         <source>Save All</source>
-        <translation>Guardar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="98"/>
         <source>Rename selected files</source>
-        <translation>Renomear ficheiros selecionados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="118"/>
         <source>Synchronize to Kodi</source>
-        <translation>Sincronizar com o Kodl</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="138"/>
         <source>Export Database</source>
-        <translation>Exportar base de Dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="161"/>
         <source>Reload</source>
-        <translation>Recarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="181"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="201"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="247"/>
         <source>Donate</source>
-        <translation>Fazer um donativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="17"/>
         <source>Scrape (%1)</source>
-        <translation>Extrair (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="20"/>
         <source>Save (%1)</source>
-        <translation>Guardar (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="24"/>
         <source>Save All (%1)</source>
-        <translation>Guardar todos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="28"/>
         <source>Reload all files (%1)</source>
-        <translation>Recarregar todos os ficheiros (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="32"/>
         <source>Export HTML</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="36"/>
         <source>Export CSV</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="43"/>
         <source>Export Database (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6156,7 +6104,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/scrapers/ScraperInterface.cpp" line="17"/>
         <source>Network Error</source>
-        <translation>Erro na rede</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6164,43 +6112,43 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="71"/>
         <source>Host</source>
-        <translation>Anfitrião</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="78"/>
         <source>Port</source>
-        <translation>Porta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="98"/>
         <source>Username</source>
-        <translation>Nome de utilizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="108"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="19"/>
         <source>Enable Proxy</source>
-        <translation>Ativar proxy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="64"/>
         <source>Type</source>
         <comment>Proxy Type</comment>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="51"/>
         <source>HTTP</source>
-        <translation>HTTP</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="36"/>
         <source>Use Proxy for Kodi</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6208,7 +6156,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/PlaceholderLineEdit.cpp" line="26"/>
         <source>Insert placeholder</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6216,183 +6164,183 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/main.cpp" line="36"/>
         <source>Logfile could not be openened</source>
-        <translation>Não foi possível abrir o ficheiro de registo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="37"/>
         <source>The logfile %1 could not be openend for writing.</source>
-        <translation>Não foi possível modificar o ficheiro de registo %1.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="76"/>
         <source>Stylesheet could not be opened!</source>
-        <translation>Não foi possível abrir a folha de estilo.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="78"/>
         <source>The default stylesheet could not be openend for reading.</source>
-        <translation>Não foi possível abrir a folha de estilos padrão para leitura.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="79"/>
         <source>The custom stylesheet could not be openend for reading. Using: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <source>No Label</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <source>Red</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <source>Orange</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <source>Yellow</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="392"/>
-        <source>No Label</source>
-        <translation>Sem etiqueta</translation>
+        <source>Green</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="393"/>
-        <source>Red</source>
-        <translation>Vermelho</translation>
+        <source>Blue</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="394"/>
-        <source>Orange</source>
-        <translation>Laranja</translation>
+        <source>Purple</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="395"/>
-        <source>Yellow</source>
-        <translation>Amarelo</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="396"/>
-        <source>Green</source>
-        <translation>Verde</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="397"/>
-        <source>Blue</source>
-        <translation>Azul</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="398"/>
-        <source>Purple</source>
-        <translation>Roxo</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
-        <translation>Cinzento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="12"/>
         <source>File not found:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="13"/>
         <source>Cannot open advancedsettings.xml in read-only mode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="14"/>
         <source>Couldn&apos;t find an &lt;advancedsettings&gt; tag!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="15"/>
         <source>Found unsupported xml tag:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="16"/>
         <source>Invalid value for xml tag:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
-        <translation>&lt;b&gt;Mover Ficheiro&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowCommonWidgets.cpp" line="59"/>
         <source>Aired order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowCommonWidgets.cpp" line="62"/>
         <source>DVD order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="8"/>
         <source>Timeout by MediaElch</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="9"/>
         <source>Content not found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="10"/>
         <source>Remote connection timed out</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="11"/>
         <source>SSL handshake failed</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="12"/>
         <source>Too many redirects</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="13"/>
         <source>Connection refused by host</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="14"/>
         <source>Host not found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="15"/>
         <source>Unknown network error</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="16"/>
         <source>Could not load the requested resource</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="18"/>
         <location filename="../../src/scrapers/ScraperError.cpp" line="25"/>
         <source>Network Error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="32"/>
         <source>The scraper&apos;s rate limit reached. Please wait ~10 seconds and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="37"/>
         <source>An unknown network error occurred. Are you connected to the internet?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="51"/>
         <source>The scraper did not respond with any data.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="55"/>
         <source>The scraper response could not be parsed.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media_center/kodi/ConcertXmlReader.cpp" line="29"/>
         <source>No valid musicvideo root entry found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6400,22 +6348,22 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="60"/>
         <source>QIODevice::Append is not supported for GZIP</source>
-        <translation>QIODevice::Append não é suportado pelo GZIP</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="66"/>
         <source>Opening gzip for both reading and writing is not supported</source>
-        <translation>A abertura do gzip para leitura e escrita não é suportada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="74"/>
         <source>You can open a gzip either for reading or for writing. Which is it?</source>
-        <translation>Pode abrir um gzip para ler ou gravar. Qual deles?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="80"/>
         <source>Could not gzopen() file</source>
-        <translation>Não foi possível abrir o ficheiro gzopen()</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6423,12 +6371,12 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quaziodevice.cpp" line="188"/>
         <source>QIODevice::Append is not supported for QuaZIODevice</source>
-        <translation>QIODevice::Append não é suportado pelo QuaZIODevice</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quaziodevice.cpp" line="193"/>
         <source>QIODevice::ReadWrite is not supported for QuaZIODevice</source>
-        <translation>QIODevice::ReadWrite não é suportado pelo QuaZIODevice</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6436,7 +6384,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quazipfile.cpp" line="251"/>
         <source>ZIP/UNZIP API error %1</source>
-        <translation>Erro da API ZIP/UNZIP %1</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6444,27 +6392,27 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="100"/>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="101"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="102"/>
         <source>Vote Count</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="103"/>
         <source>Min. Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="104"/>
         <source>Max. Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6472,17 +6420,17 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="14"/>
         <source>Form</source>
-        <translation>Formulário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="80"/>
         <source>Add rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="94"/>
         <source>Remove selected rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6490,145 +6438,133 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="17"/>
         <source>Renamer</source>
-        <translation>Alteração de nomes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="34"/>
         <source>Pattern</source>
-        <translation>Padrão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="75"/>
         <source>Use Season Directories</source>
-        <translation>Usar pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="85"/>
         <source>Multi-File Naming</source>
-        <translation>Alterar nome de vários ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="117"/>
         <source>Rename Directories</source>
-        <translation>Alterar nome de pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="127"/>
         <source>Rename Files</source>
-        <translation>Alterar nome de ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="162"/>
         <source>Directory Naming</source>
-        <translation>Alterar nome de pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="194"/>
         <source>File Naming</source>
-        <translation>Nomes dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="201"/>
         <source>Season Directory Naming</source>
-        <translation>Nomes das pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="208"/>
         <source>Season &lt;season&gt;</source>
-        <translation>Temporada &lt;season&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="249"/>
         <source>Results</source>
-        <translation>Resultados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="342"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="365"/>
         <source>Dry Run</source>
-        <translation>Operação &quot;a seco&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
         <source>Rename</source>
-        <translation>Alterar nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="38"/>
         <source>Please see %1 for help and examples on how to use the renamer.</source>
-        <translation>Veja a ajuda em %1. Temos exemplos de como usar o alterador de nomes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="58"/>
         <source>%n concerts will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="60"/>
         <source>%n movies will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="62"/>
         <source>%n TV shows and %1</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="63"/>
         <source>%n episodes will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
         <source>Finished</source>
-        <translation>Concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
         <source>Create dir</source>
-        <translation>Criar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
         <source>Move</source>
-        <translation>Mover</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6636,152 +6572,147 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="35"/>
         <source>Placeholders</source>
-        <translation>Marcadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
         <source>Placeholder</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
         <source>File extension</source>
-        <translation>Extensão de ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
         <source>Season Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
         <source>Part number of the current file</source>
-        <translation>Número da parte do ficheiro atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
-        <source>TMDb ID</source>
-        <translation type="unfinished">Identificador do TMDb</translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
         <source>Season Number</source>
-        <translation>Número da temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
         <source>Title of the show</source>
-        <translation>Título da série</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
         <source>Studio(s) (separated by a comma)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
         <source>Director(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
         <source>Audio Language(s) (separated by a minus)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
         <source>Episode Number</source>
-        <translation>Número do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
         <source>Resolution (1080p, 720p, ...)</source>
-        <translation>Resolução (1080p, 720p...)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
         <source>File/directory is BluRay</source>
-        <translation>Ficheiro ou pasta é BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
         <source>File/directory is DVD</source>
-        <translation>Ficheiro ou pasta é DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
         <source>File is 3D</source>
-        <translation>Ficheiro é 3D</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
         <source>Movie set name</source>
-        <translation>Nome da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
         <source>Video Codec</source>
-        <translation>Codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
         <source>Episode has a season name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
         <source>Audio Codec</source>
-        <translation>Codec de áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
         <source>Number of audio channels</source>
-        <translation>Número de canais de áudio</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6790,141 +6721,141 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="121"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="151"/>
         <source>Invalid</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="122"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="152"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="123"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="124"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="153"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="125"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="126"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="155"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="127"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="128"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="156"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="129"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="157"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="130"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="131"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="158"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="132"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="133"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="161"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="134"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="159"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="135"/>
         <source>Extra Art</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="136"/>
         <source>Season Backdrop</source>
-        <translation>Fundo de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="137"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="138"/>
         <source>Extra Fanart</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="139"/>
         <source>Show Thumbnail</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="140"/>
         <source>Season Thumbnail</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="141"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="142"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="145"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="165"/>
         <source>Unknown</source>
-        <translation>Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="160"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="154"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="162"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6933,162 +6864,162 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="21"/>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="138"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="57"/>
         <source>Enable adult movie scrapers</source>
-        <translation>Ativar extratores de filmes para adultos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="95"/>
         <source>Custom Movie Scraper</source>
-        <translation>Extrator de filmes personalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="101"/>
         <source>Combine multiple scrapers to your custom scraper. If you select other scrapers than IMDB, The Movie DB and Fanart.tv multiple searches may be necessary as only these three share an id.</source>
-        <translation>Combine vários extratores num único extrator personalizado. Se selecionar outros extratores além do IMDB, The Movie DB e Fanart.tv, poderão ser necessárias várias procuras, já que apenas estes três usam identificadores comuns.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="133"/>
         <source>Item</source>
-        <translation>Item</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="147"/>
         <source>TV Scraper</source>
-        <translation>Extrator de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="157"/>
         <source>Custom TV Scraper</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="172"/>
         <source>Don&apos;t use</source>
-        <translation>Não usar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="218"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="219"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="220"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="221"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="222"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="223"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="224"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="225"/>
         <source>Plot</source>
-        <translation>Enredo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="226"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="227"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="228"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="229"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="230"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="231"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="232"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="233"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="234"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="235"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="236"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="237"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="238"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="239"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="240"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="241"/>
         <source>Unsupported</source>
-        <translation>Incompatível</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7096,12 +7027,12 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/model/tv_show/SeasonModelItem.cpp" line="135"/>
         <source>Season %1 - %2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/tv_show/SeasonModelItem.cpp" line="137"/>
         <source>Season %1</source>
-        <translation>Temporada %1</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7109,59 +7040,59 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="61"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="88"/>
         <source>Set Name</source>
-        <translation>Nome da coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="122"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="127"/>
         <source>Sorttitle</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="150"/>
         <source>Add movie to set</source>
-        <translation>Adicionar filme à coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="153"/>
         <source>Add Movie</source>
-        <translation>Adicionar filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="160"/>
         <source>Remove selected movie from set</source>
-        <translation>Remover filme selecionado da coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="163"/>
         <source>Remove Movie</source>
-        <translation>Remover Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="182"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="204"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="276"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="225"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="300"/>
         <source>Full preview</source>
-        <translation>Pré-visualização inteira</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="239"/>
@@ -7169,32 +7100,32 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="314"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="317"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="254"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="56"/>
         <source>Add Movie Set</source>
-        <translation>Adicionar coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="57"/>
         <source>Delete Movie Set</source>
-        <translation>Eliminar coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="459"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="491"/>
         <source>New Movie Set</source>
-        <translation>Nova coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7202,79 +7133,79 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="20"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="184"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="162"/>
         <source>Kodi</source>
-        <translation>Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="206"/>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="209"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="220"/>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="223"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="62"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="69"/>
         <source>Save Settings</source>
-        <translation>Guardar definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="79"/>
         <source>toolBar</source>
-        <translation>barraFerramentas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="118"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="129"/>
         <source>TV Shows</source>
-        <translation>Séries TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="140"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="151"/>
         <source>Global</source>
-        <translation>Global</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="173"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="195"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.cpp" line="192"/>
         <source>Settings saved</source>
-        <translation>As definições foram guardadas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7282,32 +7213,32 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="17"/>
         <source>Support MediaElch</source>
-        <translation>Doações para o MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="30"/>
         <source>If you like MediaElch and wish to support it you have the chance to do so! You can donate as much as you like via PayPal.</source>
-        <translation>Se gosta do MediaElch e gostaria de apoiá-lo, tem a oportunidade de o fazer! Pode fazer uma doação da quantia que quiser através do PayPal.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="74"/>
         <source>MediaElch makes use of various movie and TV show databases. These databases also need your help to keep their services up and running for free. If you don&apos;t want to donate you can also contribute information and missing artwork if possible.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="127"/>
         <source>Thanks for your help and support!</source>
-        <translation>Obrigado pela sua ajuda e apoio!</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="149"/>
         <source>Hide donate button</source>
-        <translation>Ocultar botão para donativos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="172"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7315,7 +7246,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/TagCloud.ui" line="31"/>
         <source>Tag</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7323,115 +7254,115 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="17"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="47"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="87"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="110"/>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="206"/>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="369"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="166"/>
         <source>Preview</source>
-        <translation>Pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="171"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="176"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="186"/>
         <source>Back to Search Results</source>
-        <translation>Regressar aos resultados da busca</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="277"/>
         <source>URL</source>
-        <translation>Endereço</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="308"/>
         <source>Progress</source>
-        <translation>Progresso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="331"/>
         <source>Download</source>
-        <translation>Descarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="338"/>
         <source>Cancel Download</source>
-        <translation>Cancelar descarregamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="349"/>
         <source>Back to Trailers</source>
-        <translation>Regressar aos trailers</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="345"/>
         <source>Download Finished</source>
-        <translation>Descarregamento concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="356"/>
         <source>The file %1 already exists.</source>
-        <translation>O ficheiro %1 já existe.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="358"/>
         <source>Do you want to overwrite it?</source>
         <extracomment>&quot;it&quot; refers to the file</extracomment>
-        <translation>Quer substituí-lo?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="371"/>
         <source>Download Canceled</source>
-        <translation>Descarregamento cancelado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="375"/>
         <source>Download Not Found (404)</source>
-        <translation>Descarregamento não encontrado (404)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="379"/>
         <source>Download Error (%1)</source>
-        <translation>Erro no descarregamento (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="433"/>
         <source>Network Error</source>
-        <translation>Erro na rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="434"/>
         <source>Resource could not be played</source>
-        <translation>Não foi possível reproduzir o ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="435"/>
         <source>Video format error</source>
-        <translation>Erro de formato de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7439,92 +7370,92 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="36"/>
         <source>TV Scraper</source>
-        <translation>Extrator de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="88"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="107"/>
         <source>ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="114"/>
         <source>Internal TV scraper ID. Used as key in MediaElch&apos;s settings.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="124"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="169"/>
         <source>Website</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="179"/>
         <source>The scraper&apos;s main website.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="192"/>
         <source>Terms of Service</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="199"/>
         <source>Terms of service of the TV scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="212"/>
         <source>Privacy Policy</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="219"/>
         <source>Privacy Policy of the scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="232"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="239"/>
         <source>Where to get help for the TV scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="252"/>
         <source>Is the scraper initialized?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="255"/>
         <source>Is initialized?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="262"/>
         <source>Default Language</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.cpp" line="112"/>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.cpp" line="112"/>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7532,22 +7463,22 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="52"/>
         <source>Searching for TV Shows...</source>
-        <translation>A procurar séries de TV...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="58"/>
         <source>Loading TV Shows...</source>
-        <translation>A carregar séries de TV...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="87"/>
         <source>Searching for Episodes...</source>
-        <translation>A procurar episódios...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="126"/>
         <source>Loading Episodes...</source>
-        <translation>A carregar episódios...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7556,103 +7487,94 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="27"/>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="670"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="27"/>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="670"/>
         <source>%n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="466"/>
-        <source>You need to update the show once and load the show&apos;s TMDb ID to list missing episodes.
+        <source>You need to update the show once and load the show's TMDb ID to list missing episodes.
 Afterwards MediaElch will check automatically for new episodes on startup.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="470"/>
         <source>Don&apos;t show this hint again</source>
-        <translation>Não voltar a mostrar esta dica</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="674"/>
         <source>%1 of %n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="758"/>
         <source>Load Information</source>
-        <translation>Carregar informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="759"/>
         <source>Search for new episodes</source>
-        <translation>A procurar por novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="760"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="761"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="762"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="763"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="764"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="765"/>
         <source>Open TV Show Folder</source>
-        <translation>Abrir pasta da série de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="766"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="767"/>
         <source>Play episode</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="784"/>
         <source>Show missing episodes</source>
-        <translation>Mostrar episódios que faltam</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="787"/>
         <source>Hide specials in missing episodes</source>
-        <translation>Ocultar episódios especiais ao listar episódios em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="465"/>
         <source>Show update needed</source>
-        <translation>É necessário atualizar a série</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7660,42 +7582,42 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="91"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="92"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="93"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="94"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="95"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="96"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="97"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="98"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7703,303 +7625,297 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="20"/>
         <source>TV Show Multi Scrape</source>
-        <translation>Extrator múltiplo de episódios de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="30"/>
         <source>Please select the infos you want to be loaded. MediaElch will use the best result for each TV show and episode you selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="61"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="365"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="70"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="400"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="83"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="278"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="304"/>
         <source>Season Fanart</source>
-        <translation>Fanart de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="96"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="265"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="226"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="109"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="252"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="213"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="501"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="122"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="374"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="239"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="291"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="475"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="200"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="449"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="135"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="387"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="436"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="426"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="46"/>
         <source>Show Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="148"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="161"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="413"/>
         <source>First aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="174"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="488"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="187"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="317"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="339"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="526"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="350"/>
         <source>Episode Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="462"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="559"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="569"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="579"/>
         <source>Order for seasons</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="607"/>
         <source>Update only TV shows/episodes
 which have an ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="621"/>
         <source>Automatically save each TV show/
 episode after scraping</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="660"/>
         <source>1/20</source>
-        <translation>1/20</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="706"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="729"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="742"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="306"/>
         <source>Start scraping using &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="352"/>
         <source>Skipping show &quot;%1&quot; because it does not have a valid ID.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="371"/>
         <source>Search for TV show &quot;%1&quot; because no valid ID was found.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="378"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="475"/>
         <source>Scraping next TV show with ID &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="408"/>
         <source>Search for TV show &quot;%1&quot; because no valid show ID was found for the episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="417"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="493"/>
         <source>S%1E%2: Scraping next episode with show ID &quot;%3&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="463"/>
         <source>Error while searching for TV show: &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="468"/>
         <source>Did not find any results for search term &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="511"/>
         <source>Done.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="531"/>
         <source>%n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="532"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="534"/>
         <source>Scraping of %1 and %2 has finished.</source>
-        <translation>Terminou a extração de %1 e %2.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="536"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="538"/>
         <source>Scraping of %1 has finished.</source>
-        <translation>A extração de  %1 terminou.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="561"/>
         <source>Finished scraping details of TV show &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="570"/>
         <source>Start loading extra fanart from TheTvDb for TV show with ID &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="753"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="832"/>
         <source>Internal inconsistency: Cannot set language dropdown in TV show search widget!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="848"/>
         <source>S%2E%3: Finished scraping episode details. Title is: &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8007,12 +7923,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/search_dialog/TvShowScrapePreview.ui" line="43"/>
         <source>&lt;b&gt;Preview&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/search_dialog/TvShowScrapePreview.ui" line="83"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Description&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8020,17 +7936,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="58"/>
         <source>Scrape</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8038,219 +7954,216 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="19"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="29"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="134"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="179"/>
         <source>Show Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="210"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="519"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="220"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="230"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="539"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="240"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="549"/>
         <source>First aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="250"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="260"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="559"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="270"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="529"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="280"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="290"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="626"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="300"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="606"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="327"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="616"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="337"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="347"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="357"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="367"/>
         <source>Season Fanart</source>
-        <translation>Fanart de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="377"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="387"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="397"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="407"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="417"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="451"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="670"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="464"/>
         <source>No show details will be loaded because only episodes were selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="488"/>
         <source>Episode Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="586"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="596"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="636"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="682"/>
         <source>Season order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="697"/>
         <source>No episodes will be loaded. If you want to load episodes, change the update mode below.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="147"/>
         <source>Update TV Show only</source>
-        <translation>Atualizar apenas Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="152"/>
         <source>Update TV Show and new Episodes</source>
-        <translation>Atualizar séries de TV e novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="157"/>
         <source>Update TV Show and all Episodes</source>
-        <translation>Atualizar séries de TV e todos os episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="162"/>
         <source>Update new Episodes</source>
-        <translation>Atualizar novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="167"/>
         <source>Update all episodes</source>
-        <translation>Atualizar todos os episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="170"/>
         <source>The %1 scraper could not be initialized!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="148"/>
         <source>Please insert a search string!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="188"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="364"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8258,82 +8171,82 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your TV shows. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension and for season posters &lt;seasonNumber&gt; which is the season number.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o nome do ficheiro, sem extensão, e para cartazes de temporada &lt;seasonNumber&gt;, que é o número da temporada.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="42"/>
         <source>Show nfo</source>
-        <translation>Mostrar nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="49"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="56"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="63"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="70"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="77"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="84"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="91"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="98"/>
         <source>Season Backdrop</source>
-        <translation>Fundo de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="105"/>
         <source>Episode nfo</source>
-        <translation>Nfo do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="112"/>
         <source>Episode thumbnail</source>
-        <translation>Miniatura de episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="119"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="390"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="397"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8341,10 +8254,7 @@ episode after scraping</source>
     <message numerus="yes">
         <location filename="../../src/ui/small_widgets/TvShowTreeView.cpp" line="146"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -8352,7 +8262,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/TvShowUpdater.cpp" line="42"/>
         <source>Updating TV Shows</source>
-        <translation>A atualizar séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8361,22 +8271,22 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="161"/>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="218"/>
         <source>Saving changed TV Shows and Episodes</source>
-        <translation>A guardar alterações em séries de TV e episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="180"/>
         <source>Could not save episode S%1E%2 of show &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="193"/>
         <source>TV Shows and Episodes Saved</source>
-        <translation>Séries de TV e episódios guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="239"/>
         <source>All TV Shows and Episodes Saved</source>
-        <translation>Todas as séries TV e episódios foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8384,292 +8294,292 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="63"/>
         <source>Episode has changed. Click to revert changes.</source>
-        <translation>O episódio foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="82"/>
         <source>Episode Title</source>
-        <translation>Título do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="137"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="154"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="460"/>
         <source>TheTVDB ID</source>
-        <translation>Identificador TheTVDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="514"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="168"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="178"/>
         <source>Show Title</source>
-        <translation>Mostrar título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="188"/>
         <source>Season</source>
-        <translation>Temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="223"/>
         <source>Episode</source>
-        <translation>Episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="242"/>
         <source>Display Season</source>
-        <translation>Mostrar temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="302"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="350"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="367"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="377"/>
         <source>dd.MM.yyyy</source>
-        <translation>dd.MM.yyyy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="384"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="400"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="410"/>
         <source>dd.MM.yyyy HH:mm</source>
-        <translation>dd.MM.yyyy HH:mm</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="436"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="446"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="280"/>
         <source>Display Episode</source>
-        <translation>Mostrar episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="419"/>
         <source>Bookmark</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="313"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="477"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="548"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="558"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="595"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="663"/>
         <source>Directors</source>
-        <translation>Realizadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="691"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="701"/>
         <source>Add Director</source>
-        <translation>Adicionar Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="715"/>
         <source>Remove Director</source>
-        <translation>Remover Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="567"/>
         <source>Writers</source>
-        <translation>Argumentistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="605"/>
         <source>Add Writer</source>
-        <translation>Adicionar argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="619"/>
         <source>Remove Writer</source>
-        <translation>Remover Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="759"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="784"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="789"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="831"/>
         <source>Add Actor</source>
-        <translation>Adicionar Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="804"/>
         <source>Remove Actor</source>
-        <translation>Remover Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="878"/>
         <source>Click to change</source>
-        <translation>Clique para Alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="932"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="991"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="940"/>
         <source>Scantype</source>
-        <translation>TipoAnálise</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="894"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1081"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1106"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="525"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="528"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="981"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1096"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1045"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="429"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="959"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="924"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1116"/>
         <source>Stereo Mode</source>
-        <translation>Modo de Estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1137"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1211"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1233"/>
         <source>Click to Change</source>
-        <translation>Clique para Alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="115"/>
         <source>Episode missing</source>
-        <translation>Episódio em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="92"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="518"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="552"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="524"/>
@@ -8677,68 +8587,68 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="556"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="557"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="526"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="529"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="544"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="585"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="618"/>
         <source>Episode Saved</source>
-        <translation>O episódio foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="620"/>
         <source>Could not save episode S%1E%2 of show &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="666"/>
         <source>Scraping episode...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="800"/>
         <source>Unknown Director</source>
-        <translation>Realizador Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="850"/>
         <source>Unknown Writer</source>
-        <translation>Argumentista desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1107"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1108"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1171"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1171"/>
         <source>Images (*.jpg *.jpeg)</source>
-        <translation>Imagens (*.jpg *.jpeg)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8746,69 +8656,69 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="63"/>
         <source>Episode has changed. Click to revert changes.</source>
-        <translation>O episódio foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="83"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="138"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="149"/>
         <source>Season Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="171"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="232"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="193"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="254"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="298"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="276"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="320"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="342"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="119"/>
         <source>Season missing</source>
-        <translation>Temporada em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.cpp" line="111"/>
         <source>Season %1</source>
-        <translation>Temporada %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.cpp" line="188"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8816,208 +8726,208 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="50"/>
         <source>TV Show has changed. Click to revert changes.</source>
-        <translation>A série de TV foi alterada. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="70"/>
         <source>Show Title</source>
-        <translation>Mostrar título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="98"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="112"/>
         <source>Dir</source>
-        <translation>Dir</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="126"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="208"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="242"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="252"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="315"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="352"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="369"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="379"/>
         <source>dd.MM.yyyy</source>
-        <translation>dd.MM.yyyy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="406"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="460"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="416"/>
         <source>TV Tune</source>
-        <translation>Tema musical</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="425"/>
         <source>Existing</source>
-        <translation>Presente</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="432"/>
         <source>Missing</source>
-        <translation>Em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="448"/>
         <source>Download Theme</source>
-        <translation>Descarregar tema musical</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="386"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="396"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="505"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="201"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="522"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="533"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="558"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="563"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="605"/>
         <source>Add Actor</source>
-        <translation>Adicionar ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="578"/>
         <source>Remove Actor</source>
-        <translation>Remover ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="263"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="137"/>
         <source>TheTVDB ID</source>
-        <translation>Identificador TheTVDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="482"/>
         <source>Continuing</source>
-        <translation>Continuando</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="487"/>
         <source>Ended</source>
-        <translation>Finalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="495"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="154"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="512"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="652"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1221"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="668"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="717"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="739"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="762"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="906"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="928"/>
@@ -9027,92 +8937,92 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1133"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1177"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="950"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="994"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1199"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1067"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1111"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1155"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="78"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="79"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="83"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="84"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="456"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="497"/>
         <source>Please wait while your TV show is scraped</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="724"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="878"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="879"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="960"/>
         <source>Choose Image</source>
-        <translation>Escolher Imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="960"/>
         <source>Images (*.jpg *.jpeg)</source>
-        <translation>Imagens (*.jpg *.jpeg)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9120,53 +9030,53 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="17"/>
         <source>TV Tunes</source>
-        <translation>Temas musicais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="54"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="118"/>
         <source>Progress</source>
-        <translation>Progresso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="141"/>
         <source>Download</source>
-        <translation>Descarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="148"/>
         <source>Cancel Download</source>
-        <translation>Cancelar descarregamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="172"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="251"/>
         <source>Download Finished</source>
-        <translation>Descarregamento concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="256"/>
         <source>The file %1 already exists.</source>
-        <translation>O ficheiro %1 já existe.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="258"/>
         <source>Do you want to overwrite it?</source>
         <extracomment>&quot;it&quot; refers to the file</extracomment>
-        <translation>Quer substituí-lo?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="272"/>
         <source>Download Canceled</source>
-        <translation>Descarregamento cancelado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9174,47 +9084,47 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="45"/>
         <source>Cancel extraction</source>
-        <translation>Cancelar extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="65"/>
         <source>Extract without password</source>
-        <translation>Extrair sem palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="68"/>
         <source>Extract</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="75"/>
         <source>Extract with password</source>
-        <translation>Extrair com palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="95"/>
         <source>Delete this archive</source>
-        <translation>Eliminar este ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="50"/>
         <source>Extraction password</source>
-        <translation>Palavra-passe para extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="50"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="65"/>
         <source>Delete archive?</source>
-        <translation>Eliminar ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="66"/>
         <source>Do you really want to delete this archive?</source>
-        <translation>Quer mesmo eliminar este ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9222,17 +9132,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="63"/>
         <source>Updates available</source>
-        <translation>Atualizações disponíveis</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="64"/>
         <source>%1 is now available.&lt;br&gt;Get it now on %2</source>
-        <translation>%1 já está disponível.&lt;br&gt;Obtenha-o agora em %2</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="68"/>
         <source>Don&apos;t check for updates</source>
-        <translation>Não verificar atualizações</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9240,7 +9150,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/small_widgets/WebImageLabel.ui" line="47"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9248,33 +9158,33 @@ episode after scraping</source>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="28"/>
         <source>Could not get duration of file</source>
-        <translation>Não foi possível obter a duração do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="47"/>
         <source>Could not detect runtime of file</source>
-        <translation>Não foi possível detetar o tempo de reprodução do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="56"/>
         <location filename="../../src/media/ImageCapture.cpp" line="84"/>
         <source>Temporary output file could not be opened</source>
-        <translation>Não foi possível abrir o ficheiro de saída temporário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="71"/>
         <source>Could not start ffmpeg</source>
-        <translation>Não foi possível iniciar o ffmpeg</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="74"/>
         <source>Could not start ffmpeg. Please install it and make it available in your $PATH</source>
-        <translation>Não foi possível iniciar o ffmpeg. Por favor instale-o e torne-o disponível no seu $PATH</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="80"/>
         <source>ffmpeg did not finish</source>
-        <translation>ffmpeg não finalizou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9282,7 +9192,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/file_search/movie/MovieDirectorySearcher.cpp" line="391"/>
         <source>Storing movies in database...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9290,35 +9200,35 @@ episode after scraping</source>
     <message>
         <location filename="../../src/file_search/movie/MovieFileSearcher.cpp" line="58"/>
         <source>Searching for Movies...</source>
-        <translation>A procurar por filmes...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/movie/MovieFileSearcher.cpp" line="148"/>
         <source>Searching for movies...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
         <source>Straight</source>
-        <translation>Heterossexual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Gay</source>
-        <translation>Homossexual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9326,12 +9236,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/custom/CustomMovieScraper.cpp" line="20"/>
         <source>Custom Movie Scraper</source>
-        <translation>Extrator de filmes personalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/custom/CustomMovieScraper.cpp" line="178"/>
         <source>TMDb ID is invalid. Cannot scrape movie.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9339,12 +9249,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/custom/CustomTvScraper.cpp" line="28"/>
         <source>Custom TV scraper</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/custom/CustomTvScraper.cpp" line="33"/>
         <source>The custom TV scraper combines multiple scrapers so that details can be loaded from different sites in one step. It depends on TMDb for loading other scraper IDs.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9352,162 +9262,162 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="26"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="84"/>
         <source>Bulgarian</source>
-        <translation>Búlgaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="85"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="86"/>
         <source>Croatian</source>
-        <translation>Croata</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="87"/>
         <source>Czech</source>
-        <translation>Checo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="88"/>
         <source>Danish</source>
-        <translation>Dinamarquês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="89"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="90"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="91"/>
         <source>Finnish</source>
-        <translation>Finlandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="92"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="93"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="94"/>
         <source>Greek</source>
-        <translation>Grego</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="95"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="96"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="97"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="98"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="99"/>
         <source>Korean</source>
-        <translation>Coreano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="100"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="101"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="102"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="103"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="104"/>
         <source>Slovene</source>
-        <translation>Eslovaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="105"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="106"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="107"/>
         <source>Turkish</source>
-        <translation>Turco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="111"/>
         <source>Blu-ray</source>
-        <translation>BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="112"/>
         <source>DVD</source>
-        <translation>DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="115"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="117"/>
         <source>Preferred Disc Type</source>
-        <translation>Tipo de disco preferido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="119"/>
         <source>Personal API key</source>
-        <translation>Chave pessoal da API</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="356"/>
         <source>Movie not found on Fanart.tv</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="568"/>
         <source>TV show not found on Fanart.tv</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9515,7 +9425,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTvMusic.cpp" line="25"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9523,7 +9433,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTvMusicArtists.cpp" line="22"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9531,12 +9441,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/imdb/ImdbMovie.cpp" line="20"/>
         <source>IMDb is the world&apos;s most popular and authoritative source for movie, TV and celebrity content, designed to help fans explore the world of movies and shows and decide what to watch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/imdb/ImdbMovie.cpp" line="47"/>
         <source>Load all tags</source>
-        <translation>Carregar todas as etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9544,7 +9454,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTv.cpp" line="20"/>
         <source>IMDb is the world&apos;s most popular and authoritative source for movie, TV and celebrity content, designed to help fans explore the world of movies and shows and decide what to watch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9552,22 +9462,22 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="37"/>
         <source>Neither IMDb show ID nor episode ID are valid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="61"/>
         <source>IMDb ID could not be loaded from season page! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="76"/>
         <source>IMDb ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="90"/>
         <source>Loaded IMDb content is empty. Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9575,7 +9485,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing an IMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9583,17 +9493,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="92"/>
         <source>Could not extract JSON details from IMDb page!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="102"/>
         <source>Could not parse JSON from IMDb page!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="108"/>
         <source>Expected parsed IMDb JSON to be an object!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9601,7 +9511,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowScrapeJob.cpp" line="34"/>
         <source>Show is missing an IMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9609,12 +9519,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowSearchJob.cpp" line="20"/>
         <source>Loaded IMDb web page content is empty. Cannot scrape requested TV show.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowSearchJob.cpp" line="24"/>
         <source>Could not find result table in the scraped HTML. Please contact MediaElch&apos;s developers.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9622,7 +9532,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/TMDbImages.cpp" line="15"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9630,7 +9540,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDb.cpp" line="19"/>
         <source>TheTvDb is one of the most accurate sources for TV and film. Their information comes from fans like you, so create a free account on their website and help your favorite shows and movies. Everything added is shared not only with MediaElch but many other sites, mobile apps, and devices as well.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9638,7 +9548,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbEpisodeScrapeJob.cpp" line="65"/>
         <source>TheTvDb ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9646,7 +9556,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/TheTvDbImages.cpp" line="19"/>
         <source>TheTvDb is one of the most accurate sources for TV and film. Their information comes from fans like you, so create a free account on their website and help your favorite shows and movies. Everything added is shared not only with MediaElch but many other sites, mobile apps, and devices as well.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9654,7 +9564,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbSeasonScrapeJob.cpp" line="26"/>
         <source>Show is missing a TheTvDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9662,7 +9572,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbShowScrapeJob.cpp" line="46"/>
         <source>Show is missing a TheTvDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9670,12 +9580,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/concert/tmdb/TmdbConcert.cpp" line="28"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/concert/tmdb/TmdbConcert.cpp" line="132"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9683,12 +9593,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/tmdb/TmdbMovie.cpp" line="45"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/tmdb/TmdbMovie.cpp" line="158"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9696,7 +9606,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTv.cpp" line="20"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9704,7 +9614,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvEpisodeScrapeJob.cpp" line="26"/>
         <source>TMDb show ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9712,7 +9622,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9720,12 +9630,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp" line="41"/>
         <source>Continuing</source>
-        <translation>Continuando</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp" line="41"/>
         <source>Ended</source>
-        <translation>Finalizado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9733,7 +9643,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowScrapeJob.cpp" line="23"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9741,7 +9651,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMaze.cpp" line="19"/>
         <source>TVmaze is a collaborative site, which can be edited by any registered user. Find episode information for any show on any device. anytime, anywhere!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9749,12 +9659,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.cpp" line="39"/>
         <source>TVmaze show ID are valid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.cpp" line="66"/>
         <source>TVmaze ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9762,7 +9672,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9770,7 +9680,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeShowScrapeJob.cpp" line="29"/>
         <source>TV show is missing a TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9778,107 +9688,107 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="31"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="32"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="33"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="34"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="35"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="36"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="37"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="38"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="39"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="40"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="41"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="42"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="43"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="44"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="45"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="47"/>
         <source>The Audio DB</source>
-        <translation>The Audio DB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="48"/>
         <source>MusicBrainz</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="49"/>
         <source>AllMusic</source>
-        <translation>AllMusic</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="50"/>
         <source>Discogs</source>
-        <translation>Discogs</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="52"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="54"/>
         <source>Prefer</source>
-        <translation>Preferir</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9886,7 +9796,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/videobuster/VideoBuster.cpp" line="18"/>
         <source>VideoBuster is a German movie database.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/data/i18n/MediaElch_lt_LT.ts
+++ b/data/i18n/MediaElch_lt_LT.ts
@@ -1,112 +1,110 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="pt_PT">
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lt_LT">
 <context>
     <name>AboutDialog</name>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="23"/>
         <source>About MediaElch</source>
-        <translation>Sobre o MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="44"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="112"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="155"/>
         <source>Icon Sets: Retina by &quot;The Working Group&quot; and &quot;Capital Suite&quot; by &quot;capital18 (Jugal Paryani)&quot;</source>
-        <translation>Conjuntos de ícones: Retina de &quot;The Working Group&quot; e &quot;Capital Suite&quot;, de &quot;capital18 (Jugal Paryani)&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="178"/>
         <source>MediaElch Icon by Kathrin Luckner</source>
-        <translation>Ícone do MediaElch por Kathrin Luckner</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="120"/>
         <source>MediaElch was built with &lt;a href=&quot;https://www.qt.io/&quot;&gt;Qt&lt;/a&gt;</source>
-        <translation>O MediaElch foi feito com o &lt;a href=&quot;https://www.qt.io/&quot;&gt;Qt&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="146"/>
         <source>About Qt</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="165"/>
         <source>&lt;a href=&quot;https://develop.kde.org/frameworks/breeze-icons/&quot; title=&quot;KDE Breeze Website&quot;&gt;Breeze icons&lt;/a&gt; copyright KDE and licenced under the GNU LGPL version 3 or later</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="188"/>
         <source>Stream Details detection with &lt;a href=&quot;https://www.mediaarea.net&quot;&gt;Media Info&lt;/a&gt;</source>
-        <translation>Deteção de detalhes da transmissão com &lt;a href=&quot;https://www.mediaarea.net&quot;&gt;Media Info&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="201"/>
         <source>&lt;a href=&quot;https://www.mediaelch.de/mediaelch/&quot;&gt;http://www.mediaelch.de&lt;/a&gt; powered by &lt;a href=&quot;https://www.kvibes.de&quot;&gt;k.vibes&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="211"/>
         <source>Bugs and wishes can be reported on &lt;a href=&quot;https://github.com/Komet/MediaElch/issues&quot;&gt;GitHub&lt;/a&gt; .</source>
-        <translation>Os erros e desejos podem ser reportados no &lt;a href=&quot;https://github.com/Komet/MediaElch/issues&quot;&gt;GitHub&lt;/a&gt; .</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="238"/>
         <source>Developer</source>
-        <translation>Programador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="244"/>
         <source>The information below is important for developers. Please provide if you need help.</source>
-        <translation>Os dados abaixo são importantes para os programadores. Por favor, inclua no seu pedido de ajuda.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="272"/>
         <source>Copy to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="295"/>
         <source>Your Collection</source>
-        <translation>A sua coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="304"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="337"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="370"/>
         <source>Episodes</source>
-        <translation>Episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="403"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="436"/>
         <source>Artists</source>
-        <translation>Artistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="466"/>
         <source>Albums</source>
-        <translation>Álbuns</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -114,12 +112,12 @@
     <message>
         <location filename="../../src/model/ActorModel.cpp" line="83"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/ActorModel.cpp" line="84"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -127,47 +125,47 @@
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="14"/>
         <source>Form</source>
-        <translation>Formulário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="46"/>
         <source>Remove Actor</source>
-        <translation>Remover ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="73"/>
         <source>Add Actor</source>
-        <translation>Adicionar ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="107"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="123"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="66"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="67"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="159"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="161"/>
         <source>Images (*.jpg *.jpeg *.png)</source>
-        <translation>Imagens (*.jpg *.jpeg *.png)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -175,63 +173,63 @@
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="52"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="79"/>
         <source>TextLabel</source>
-        <translation>EtiquetaTexto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="116"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="139"/>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="142"/>
         <source>Add Movie</source>
-        <translation>Adicionar Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="149"/>
         <source>Remove Current Movie</source>
-        <translation>Remover filme atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="152"/>
         <source>Remove Movie</source>
-        <translation>Remover Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="165"/>
         <source>Double click a certification to rename it, right click to delete. If you want to merge two certifications just give them the same name.</source>
-        <translation>Clique duas vezes numa certificação para lhe alterar o nome, clique com o botão direito para eliminá-la. Se quiser fundir duas classificações, basta colocar-lhes o mesmo nome.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="175"/>
         <source>Please keep in mind that the changes you make here (renaming or deleting certifications) will be made for every movie.</source>
-        <translation>Por favor, lembre-se que todas as alterações feitas aqui (alterar o nome ou eliminar certificações) serão feitas para todos os filmes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="28"/>
         <source>Add Certification</source>
-        <translation>Adicionar certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="29"/>
         <source>Delete Certification</source>
-        <translation>Eliminar certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="175"/>
         <source>New Certification</source>
-        <translation>Nova certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="286"/>
         <source>All Movies Saved</source>
-        <translation>Foram guardados todos os filmes</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -239,37 +237,37 @@
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="112"/>
         <source>Delete Image</source>
-        <translation>Eliminar imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="119"/>
         <source>Zoom Image</source>
-        <translation>Ampliar imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="125"/>
         <source>Capture random screenshot</source>
-        <translation>Capturar ecrã aleatório</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="131"/>
         <source>Select another image</source>
-        <translation>Selecionar outra imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="420"/>
         <source>Really delete image?</source>
-        <translation>Quer eliminar a imagem?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="421"/>
         <source>Are you sure you want to delete this image?</source>
-        <translation>Tem a certeza que quer eliminar esta imagem?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="423"/>
         <source>Do not ask again</source>
-        <translation>Não perguntar de novo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -277,12 +275,12 @@
     <message>
         <location filename="../../src/file_search/ConcertFileSearcher.cpp" line="53"/>
         <source>Searching for Concerts...</source>
-        <translation>A procurar concertos...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/ConcertFileSearcher.cpp" line="59"/>
         <source>Loading Concerts...</source>
-        <translation>A carregar concertos...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -291,58 +289,52 @@
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="22"/>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="363"/>
         <source>%n concerts</source>
-        <translation>
-            <numerusform>%n concerto</numerusform>
-            <numerusform>%n concertos</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="42"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="43"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="44"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="45"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="46"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="47"/>
         <source>Open Concert Folder</source>
-        <translation>Abrir pasta do concerto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="48"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="49"/>
         <source>Play concert</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="365"/>
         <source>%1 of %n concerts</source>
-        <translation>
-            <numerusform>%1 de %n concerto</numerusform>
-            <numerusform>%1 de %n concertos</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -350,108 +342,108 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="38"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="105"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="119"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="129"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="139"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="149"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="159"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="170"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="210"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="227"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="237"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="247"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="264"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="274"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="309"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="339"/>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="342"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="345"/>
         <source>Not watched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="354"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="52"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="63"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="94"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -459,12 +451,12 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -472,115 +464,112 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="31"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="41"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="110"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="132"/>
         <source>Infos to load</source>
-        <translation>Informações a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="155"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="162"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="169"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="176"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="183"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="190"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="197"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="204"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="211"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="218"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="225"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="232"/>
         <source>Logo, Clear Art, CD Art</source>
-        <translation>Logótipo, Clear Art, CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="235"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="249"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="106"/>
         <source>The %1 scraper could not be initialized!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="119"/>
         <source>Please insert a search string!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="141"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="226"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -588,42 +577,42 @@
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your concerts. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Em baixo, pode ver os nomes de ficheiros usados para carregar e guardar os seus concertos. Pode editá-los à sua vontade, se quiser usar vários ficheiros separe-os com uma vírgula.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o de nome de ficheiro sem extensão.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="42"/>
         <source>Nfo</source>
-        <translation>Nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="71"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="100"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="129"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="158"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="187"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -633,63 +622,63 @@
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="132"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="135"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="54"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="76"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="91"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="101"/>
         <source>Scantype</source>
-        <translation>Varrimento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="111"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="165"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="185"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="195"/>
         <source>Stereo Mode</source>
-        <translation>Modo de estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="212"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="71"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="125"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="159"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="131"/>
@@ -697,18 +686,18 @@
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="163"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="164"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="133"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="136"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="151"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -716,47 +705,47 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="50"/>
         <source>Concert has changed. Click to revert changes.</source>
-        <translation>O concerto foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="76"/>
         <source>Concert Name</source>
-        <translation>Nome do concerto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="127"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="153"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="175"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="198"/>
         <source>Add Images</source>
-        <translation>Adicionar Imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="208"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="354"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="376"/>
@@ -765,62 +754,62 @@
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="537"/>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="581"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="398"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="471"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="515"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="559"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="79"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="80"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="84"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="85"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="447"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="458"/>
         <source>Concerts Saved</source>
-        <translation>Concertos guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="485"/>
         <source>All Concerts Saved</source>
-        <translation>Todos os concertos guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -828,185 +817,185 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="14"/>
         <source>CSV Export</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="22"/>
         <source>CSV Columns</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="35"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="242"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="40"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="252"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="45"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="262"/>
         <source>TV Episodes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="50"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="272"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="55"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="282"/>
         <source>Music Artists</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="60"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="292"/>
         <source>Music Albums</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="225"/>
         <source>Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="233"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="304"/>
         <source>Separator</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="321"/>
         <source>Replacement</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="340"/>
         <source>Linebreaks will be replaced by &lt;code&gt;\n&lt;/code&gt;. </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="350"/>
         <source>If any text contains the separator, it will be replaced by the replacement set above.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="373"/>
         <source>&lt;b&gt;Tip:&lt;/b&gt; You can sort the items by Drag &amp;amp; Drop.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="390"/>
         <source>Export as CSV</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="29"/>
         <source>Tab</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="30"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="35"/>
         <source>Semicolon (;)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="31"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="36"/>
         <source>Comma (,)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="34"/>
         <source>Space</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="37"/>
         <source>Minus (-)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="52"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="112"/>
         <source>Export directory</source>
-        <translation>Exportar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="114"/>
         <source>Export aborted. No directory was selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="130"/>
         <source>Export movies...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="147"/>
         <source>Export TV shows...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="161"/>
         <source>Export TV episodes...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="179"/>
         <source>Export concerts...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="197"/>
         <source>Export artists...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="212"/>
         <source>Export albums...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="227"/>
         <source>Export completed in %1 seconds.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="319"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="399"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="444"/>
         <source>Streamdetails - Duration (in seconds)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="400"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="445"/>
         <source>Streamdetails - Video Aspect</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="321"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="401"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="446"/>
         <source>Streamdetails - Video Width</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="290"/>
@@ -1016,162 +1005,162 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="467"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="495"/>
         <source>Type</source>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="320"/>
         <source>Streamdetails - Video Aspect Ratio</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="322"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="402"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="447"/>
         <source>Streamdetails - Video Height</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="323"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="403"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="448"/>
         <source>Streamdetails - Video Codec</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="324"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="404"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="449"/>
         <source>Streamdetails - Audio Language(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="325"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="405"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="450"/>
         <source>Streamdetails - Audio Codec(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="326"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="406"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="451"/>
         <source>Streamdetails - Audio Channel(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="327"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="407"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="452"/>
         <source>Streamdetails - Subtitle Language(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="380"/>
         <source>TV Show - TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="379"/>
         <source>TV Show - IMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="291"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="345"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="425"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="292"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="344"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="424"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="293"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="348"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="423"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="294"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="350"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="426"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="295"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="349"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="296"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="361"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="429"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="297"/>
         <source>Outline</source>
-        <translation>Resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="298"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="299"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="359"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="431"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="300"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="358"/>
         <source>IMDb Top 250</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="301"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="432"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="302"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="433"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="303"/>
         <source>Runtime in minutes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="304"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="353"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="435"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="305"/>
         <source>Writers</source>
-        <translation>Argumentistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="306"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="307"/>
@@ -1179,51 +1168,51 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="436"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="469"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="308"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="309"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="310"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="355"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="437"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="311"/>
         <source>Trailers</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="312"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="360"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="313"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Playcount</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="314"/>
         <source>Last played</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="315"/>
         <source>Movie Set</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="316"/>
@@ -1231,301 +1220,301 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="442"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="480"/>
         <source>Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="443"/>
         <source>Filename(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="318"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="441"/>
         <source>Last Modified Date</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="346"/>
         <source>TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="347"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="351"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="352"/>
         <source>network</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="356"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="434"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="357"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="430"/>
         <source>Ratings</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="381"/>
         <source>TV Show - TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="382"/>
         <source>TV Show - TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="383"/>
         <source>TV Show - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="427"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="428"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Trailer URL</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="440"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="468"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="470"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="471"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="472"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="473"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="474"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="475"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="476"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="477"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="478"/>
         <source>MusicBrainz ID</source>
-        <translation>Identificador MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="479"/>
         <source>AllMusic ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="384"/>
         <source>Episode - Season</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="385"/>
         <source>Episode - Number</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="386"/>
         <source>Episode - IMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="387"/>
         <source>Episode - TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="388"/>
         <source>Episode - TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="389"/>
         <source>Episode - TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="390"/>
         <source>Episode - First Aired</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="391"/>
         <source>Episode - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="392"/>
         <source>Episode - Overview</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="393"/>
         <source>Episode - User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="394"/>
         <source>Episode - Directors</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <source>Episode - Writers</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <source>Episode - Actors</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="397"/>
         <source>Episode - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="398"/>
         <source>Episode - Filename(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="496"/>
         <source>Artist - Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="497"/>
         <source>Album - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="498"/>
         <source>Album - Artist Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="499"/>
         <source>Album - Genres</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="500"/>
         <source>Album - Styles</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="501"/>
         <source>Album - Moods</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="502"/>
         <source>Album - Review</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="503"/>
         <source>Album - Release Date</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="504"/>
         <source>Album - Label</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="505"/>
         <source>Album - Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="506"/>
         <source>Album - Year</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="507"/>
         <source>Album - MusicBrainz ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="508"/>
         <source>Album - MusicBrainz ReleaseGroup ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="509"/>
         <source>Album - AllMusic ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="510"/>
         <source>Album - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="550"/>
         <source>Export failed. Could not write to CSV file.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="540"/>
         <source>Export failed. File could not be opened for writing.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1533,35 +1522,35 @@
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="29"/>
         <source>Select which site you prefer for each element of a TV show and episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="43"/>
         <source>TV show details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="65"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="101"/>
         <source>Item</source>
-        <translation>Item</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="70"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="106"/>
         <source>Site</source>
-        <translation>Site</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="79"/>
         <source>Episode details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.cpp" line="149"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.cpp" line="183"/>
         <source>No Scraper Available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1569,65 +1558,62 @@
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="50"/>
         <source>Archives</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="94"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="215"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="99"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="220"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="104"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="225"/>
         <source>Size</source>
-        <translation>Tamanho</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="146"/>
         <source>Importable items</source>
-        <translation>Itens importáveis</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="172"/>
         <source>Import movie with MakeMKV</source>
-        <translation>Importar filme com o MakeMKV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="230"/>
         <source>Import Type</source>
         <extracomment>(e.g. movie, TV show, concert)</extracomment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="233"/>
         <source>Type of this file.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="238"/>
         <source>Import Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="241"/>
         <source>Where to store the file when importing it.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="126"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="268"/>
         <source>%n files</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="202"/>
@@ -1635,50 +1621,50 @@
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="209"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="221"/>
         <source>Extraction failed</source>
-        <translation>A extração falhou</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="203"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="206"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="209"/>
         <source>Extraction of %1 has failed: %2</source>
-        <translation>A extração de %1 falhou: %2</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="219"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="233"/>
         <source>Extraction finished</source>
-        <translation>A extração terminou</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="233"/>
         <source>Extraction of %1 finished</source>
-        <translation>A extração de %1 foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="281"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="282"/>
         <source>TV Show</source>
-        <translation>Série TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="283"/>
         <source>Concert</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="464"/>
         <source>makemkvcon missing</source>
-        <translation>makemkvcon não foi encontrado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="465"/>
         <source>Please set the correct path to makemkvcon in MediaElch&apos;s settings.</source>
-        <translation>Por favor defina o caminho para o makemkvcon.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1687,87 +1673,87 @@
         <location filename="../../src/ui/export/ExportDialog.ui" line="23"/>
         <location filename="../../src/ui/export/ExportDialog.ui" line="132"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="32"/>
         <source>Export your complete collection.</source>
-        <translation>Exportar a sua coleção completa.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="39"/>
         <source>Message</source>
-        <translation>Mensagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="51"/>
         <source>Theme</source>
-        <translation>Tema</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="61"/>
         <source>Items to export</source>
-        <translation>Itens para exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="68"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="78"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="88"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="109"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="36"/>
         <source>You need to install at least one theme.</source>
-        <translation>Tem de instalar pelo menos um tema.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="58"/>
         <source>You need to select at least one media type to export.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="68"/>
         <source>Export directory</source>
-        <translation>Exportar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="70"/>
         <source>Export aborted. No directory was selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="78"/>
         <source>Could not create export directory.</source>
-        <translation>Não foi possível criar a pasta para exportação.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="95"/>
         <source>Export canceled.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="98"/>
         <source>Export completed.</source>
-        <translation>Exportação concluída.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="145"/>
         <source>Selected theme not found! Try to restart MediaElch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1775,28 +1761,28 @@
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.ui" line="17"/>
         <source>Message</source>
-        <translation>Mensagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.ui" line="43"/>
         <source>Theme</source>
-        <translation>Tema</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="67"/>
         <source>Theme &quot;%1&quot; was successfully installed</source>
-        <translation>O tema &quot;%1&quot; foi instalado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="70"/>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="81"/>
         <source>There was an error while processing the theme &quot;%1&quot;</source>
-        <translation>Ocorreu um erro ao processar o tema &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="78"/>
         <source>Theme &quot;%1&quot; was successfully uninstalled</source>
-        <translation>O tema &quot;%1&quot; foi desinstalado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1805,47 +1791,47 @@
         <location filename="../../src/ui/settings/ExportTemplateWidget.ui" line="102"/>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="42"/>
         <source>Install</source>
-        <translation>Instalar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="25"/>
         <source>by %1</source>
-        <translation>de %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="30"/>
         <source>No website available.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="33"/>
         <source>Version %1</source>
-        <translation>Versão %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="36"/>
         <source>Update</source>
-        <translation>Atualizar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="39"/>
         <source>Uninstall</source>
-        <translation>Desinstalar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="52"/>
         <source>Updating...</source>
-        <translation>A atualizar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="56"/>
         <source>Installing...</source>
-        <translation>A instalar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="60"/>
         <source>Uninstalling...</source>
-        <translation>A desinstalar...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1853,12 +1839,12 @@
     <message>
         <location filename="../../src/import/Extractor.cpp" line="30"/>
         <source>No files to extract</source>
-        <translation>Não há ficheiros para extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/import/Extractor.cpp" line="40"/>
         <source>Unrar not found</source>
-        <translation>Unrar não foi encontrado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1866,7 +1852,7 @@
     <message>
         <location filename="../../src/ui/main/FileScannerDialog.ui" line="17"/>
         <source>File Scanner</source>
-        <translation>Analisador de ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1874,94 +1860,94 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.ui" line="17"/>
         <source>Filter</source>
-        <translation>Filtro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="117"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="214"/>
         <source>Title contains &quot;%1&quot;</source>
-        <translation>O título contém &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="127"/>
         <source>Filename contains &quot;%1&quot;</source>
-        <translation>O ficheiro contém &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="393"/>
         <source>Label &quot;%1&quot;</source>
-        <translation>Etiqueta &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="395"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="371"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="372"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="373"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>Country</source>
-        <translation>País</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="384"/>
         <source>Released %1</source>
-        <translation>Lançamento %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="384"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="378"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="122"/>
         <source>Original Title contains &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="137"/>
         <source>TMDb ID &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="374"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="375"/>
         <source>Tag</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="376"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="377"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>Video codec</source>
-        <translation>Codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="437"/>
@@ -1969,226 +1955,226 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="516"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="517"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="438"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="439"/>
         <source>Filename</source>
-        <translation>Nome do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>IMDb</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="442"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>Movie has no TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>No TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>TMDb</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="469"/>
         <source>Movie has Poster</source>
-        <translation>O filme tem cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="469"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>Movie has no Poster</source>
-        <translation>O filme não tem cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>No Poster</source>
-        <translation>Nenhum cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="471"/>
         <source>Movie has Extra Fanarts</source>
-        <translation>O filme tem fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="471"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>Movie has no Extra Fanarts</source>
-        <translation>O filme não tem fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>No Extra Fanarts</source>
-        <translation>Nenhuma fanart extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <source>Movie has Backdrop</source>
-        <translation>O filme tem fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Movie has no Backdrop</source>
-        <translation>O filme não tem fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>No Backdrop</source>
-        <translation>Nenhum fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>No Fanart</source>
-        <translation>Sem fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="475"/>
         <source>Movie has Logo</source>
-        <translation>O filme tem logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="475"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>Movie has no Logo</source>
-        <translation>O filme não tem logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>No Logo</source>
-        <translation>Nenhum logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="477"/>
         <source>Movie has Clear Art</source>
-        <translation>O filme tem Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="477"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>Movie has no Clear Art</source>
-        <translation>O filme não tem Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>No Clear Art</source>
-        <translation>Nenhuma Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="479"/>
         <source>Movie has Banner</source>
-        <translation>O filme tem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="479"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>Movie has no Banner</source>
-        <translation>O filme não tem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>No Banner</source>
-        <translation>Sem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="481"/>
         <source>Movie has Thumb</source>
-        <translation>O filme tem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="481"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>Movie has no Thumb</source>
-        <translation>O filme não tem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>No Thumb</source>
-        <translation>Sem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="483"/>
         <source>Movie has CD Art</source>
-        <translation>O filme tem CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="483"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>Movie has no CD Art</source>
-        <translation>O filme não tem CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>No CD Art</source>
-        <translation>Nenhuma CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="487"/>
         <source>Movie has Trailer</source>
-        <translation>O filme tem trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="487"/>
@@ -2196,239 +2182,239 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="488"/>
         <source>Movie has no Trailer</source>
-        <translation>O filme não tem trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="488"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>No Trailer</source>
-        <translation>Nenhum trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <source>Movie has local Trailer</source>
-        <translation>O filme tem um trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Movie has no local Trailer</source>
-        <translation>O filme não tem trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>No local Trailer</source>
-        <translation>Nenhum trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <source>Movie is Watched</source>
-        <translation>O filme foi visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Seen</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Movie is Unwatched</source>
-        <translation>O filme está por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Unwatched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Unseen</source>
-        <translation>Não visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>Movie has no Certification</source>
-        <translation>O filme não tem certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>No Certification</source>
-        <translation>Nenhuma certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>Movie has no Genre</source>
-        <translation>O filme não tem género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="132"/>
         <source>IMDb ID &quot;%1&quot;</source>
-        <translation>Identificador do IMDB &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="440"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>No Genre</source>
-        <translation>Nenhum género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="456"/>
         <source>Movie has Rating</source>
-        <translation>O filme tem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="456"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>Movie has no Rating</source>
-        <translation>O filme não tem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>No Rating</source>
-        <translation>Sem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="464"/>
         <source>Stream Details loaded</source>
-        <translation>Os detalhes da pista foram carregados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="464"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>Stream Details</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>Stream Details not loaded</source>
-        <translation>Os detalhes da pista não foram carregados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>No Stream Details</source>
-        <translation>Nenhuns detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="460"/>
         <source>Movie has Actors</source>
-        <translation>O filme tem atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="460"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>Movie has no Actors</source>
-        <translation>O filme não tem atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>No Actors</source>
-        <translation>Nenhuns atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>Movie has no Studio</source>
-        <translation>O filme não tem estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>No Studio</source>
-        <translation>Nenhum estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>Movie has no Country</source>
-        <translation>O filme não tem país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>No Country</source>
-        <translation>Nenhum país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>Movie has no Director</source>
-        <translation>O filme não tem realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>No Director</source>
-        <translation>Nenhum realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>No information about video codec</source>
-        <translation>Nenhuma informação sobre o codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>No video codec</source>
-        <translation>Sem codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>Movie has no Tags</source>
-        <translation>O filme não tem etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>No Tags</source>
-        <translation>Nenhumas etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>Movie has no IMDb ID</source>
-        <translation>Filme sem identificador IMDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>No IMDb ID</source>
-        <translation>Sem identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
         <source>Resolution 720p</source>
-        <translation>Resolução 720p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
         <source>720p</source>
-        <translation>720p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
@@ -2436,68 +2422,68 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="494"/>
         <source>Resolution 1080p</source>
-        <translation>Resolução 1080p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="494"/>
         <source>1080p</source>
-        <translation>1080p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <source>Resolution 2160p</source>
-        <translation>Resolução 2160p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <source>2160p</source>
-        <translation>2160p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>Resolution SD</source>
-        <translation>Resolução SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>SD</source>
-        <translation>SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <source>Format DVD</source>
-        <translation>Formato DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <source>DVD</source>
-        <translation>DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>Format</source>
-        <translation>Formato</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>BluRay Format</source>
-        <translation>Formato BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>BluRay</source>
-        <translation>BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
         <source>Channels 2.0</source>
-        <translation>Canais 2.0</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
@@ -2507,59 +2493,59 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="502"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="503"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="502"/>
         <source>Channels 5.1</source>
-        <translation>Canais 5.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="503"/>
         <source>Channels 7.1</source>
-        <translation>Canais 7.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="504"/>
         <source>Audio Quality HD</source>
-        <translation>Qualidade de áudio HD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="504"/>
         <source>HD Audio</source>
-        <translation>Áudio HD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <source>Audio Quality Normal</source>
-        <translation>Qualidade de áudio normal</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <source>Normal Audio</source>
-        <translation>Áudio normal</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>Audio Quality SD</source>
-        <translation>Qualidade de áudio SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>SD Audio</source>
-        <translation>Áudio SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="509"/>
         <source>Movie has Subtitle</source>
-        <translation>Filme com legenda</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="509"/>
@@ -2567,39 +2553,39 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>Subtitle</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="510"/>
         <source>Movie has no Subtitle</source>
-        <translation>O filme não tem legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="510"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>No Subtitle</source>
-        <translation>Sem legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <source>Movie has external Subtitle</source>
-        <translation>O filme tem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>External Subtitle</source>
-        <translation>Legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>Movie has no external Subtitle</source>
-        <translation>O filme não tem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>No External Subtitle</source>
-        <translation>Sem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2607,63 +2593,63 @@
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="52"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="79"/>
         <source>TextLabel</source>
-        <translation>EtiquetaTexto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="116"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="139"/>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="142"/>
         <source>Add Movie</source>
-        <translation>Adicionar filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="149"/>
         <source>Remove Current Movie</source>
-        <translation>Remover filme atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="152"/>
         <source>Remove Movie</source>
-        <translation>Remover filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="165"/>
         <source>Double click a genre to rename it, right click to delete. If you want to merge two genres just give them the same name.</source>
-        <translation>Clique duas vezes num género para lhe alterar o nome, clique com o botão direito para eliminá-lo. Se quiser fundir dois géneros, basta colocar-lhes o mesmo nome.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="175"/>
         <source>Please keep in mind that the changes you make here (renaming or deleting genres) will be made for every movie.</source>
-        <translation>Por favor, lembre-se que todas as alterações feitas aqui (alterar o nome ou eliminar géneros) serão feitas para todos os filmes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="28"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="29"/>
         <source>Delete Genre</source>
-        <translation>Eliminar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="172"/>
         <source>New Genre</source>
-        <translation>Novo género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="287"/>
         <source>All Movies Saved</source>
-        <translation>Todos os filmes foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2671,189 +2657,189 @@
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="21"/>
         <source>Directories</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="57"/>
         <source>Add one or more directories containing your movies, TV Shows, concerts, music or files to import.
 TV Show Episodes have to be in subfolders with the name of the show.
 The directories containing your music must contain subdirectories for each artist which contain directories of albums.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="91"/>
         <source>Type</source>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="96"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="101"/>
         <source>Sep. folders</source>
-        <translation>Pastas separadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="104"/>
         <source>Items are in separate folders</source>
-        <translation>Os itens estão em pastas separadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="109"/>
         <source>Reload On Start</source>
-        <translation>Recarregar ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="112"/>
         <source>Automatically reload contents on start</source>
-        <translation>Recarrega automaticamente os conteúdos ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="117"/>
         <source>Disabled</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="120"/>
         <source>Ignore this folder.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="130"/>
         <source>Add</source>
-        <translation>Adicionar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="137"/>
         <source>Remove</source>
-        <translation>Remover</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="144"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sort movies into separate directories&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ordenar filmes em pastas separadas&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="147"/>
         <source>Organize</source>
-        <translation>Organizar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="174"/>
         <source>Store trailer URLs in YouTube Plugin format</source>
-        <translation>Guardar endereços de trailers no formato YouTube Plugin</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="188"/>
         <source>Automatically load and save stream details from files</source>
-        <translation>Carregar e guardar automaticamente detalhes das pistas dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="202"/>
         <source>Ignore articles when sorting (&quot;The&quot;)</source>
-        <translation>Ignorar artigos iniciais ao ordenar (&quot;The&quot;)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="216"/>
         <source>Download actor images</source>
-        <translation>Descarregar imagens de atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="230"/>
         <source>Check for Updates on start</source>
-        <translation>Verificar se existem atualizações ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="244"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="263"/>
         <source>Words to exclude from media names (seperated by commas and non case-sensitive)</source>
-        <translation>Palavras a excluir dos nomes de média (separar com vírgulas e sem sensibilidade a maiúsculas)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="270"/>
         <source>Startup section</source>
-        <translation>Secção inicial</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="300"/>
         <source>Appearance</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="311"/>
         <source>Main Window Theme (changing it requires restart of MediaElch)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="42"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="43"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="44"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="45"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="46"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="48"/>
         <source>Auto</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="49"/>
         <source>Light</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="50"/>
         <source>Dark</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="66"/>
         <source>Choose a directory containing your movies, TV show or concerts</source>
-        <translation>Escolher uma pasta que contém os seus filmes, séries TV ou concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Downloads</source>
-        <translation>Descarregamentos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="265"/>
         <source>Organizing movies does only work on movies, not already sorted to separate folders.</source>
-        <translation>Organizar filmes funciona apenas em filmes, sem estarem já organizados em pastas separadas.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="273"/>
         <source>Are you sure?</source>
-        <translation>Tem a certeza?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="275"/>
         <source>This operation sorts all movies in this directory to separate sub-directories based on the file name. Click &quot;Ok&quot;, if that&apos;s, what you want to do. </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2861,22 +2847,22 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="17"/>
         <source>Choose an Image</source>
-        <translation>Escolher uma imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="31"/>
         <source>Enter a search term or URL</source>
-        <translation>Introduza um termo de busca ou um endereço</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="44"/>
         <source>Language to use when searching for a TV show by title.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="124"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="176"/>
@@ -2885,96 +2871,93 @@ The directories containing your music must contain subdirectories for each artis
         <location filename="../../src/ui/image/ImageDialog.ui" line="191"/>
         <location filename="../../src/ui/image/ImageDialog.ui" line="196"/>
         <source>Neue Spalte</source>
-        <translation>Nova coluna</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="703"/>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="711"/>
         <source>No images found</source>
-        <translation>Nenhumas imagens encontradas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="249"/>
         <source>Zoom out</source>
-        <translation>Diminuir ampliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="275"/>
         <source>Preview size</source>
-        <translation>Tamanho de pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="303"/>
         <source>Zoom in</source>
-        <translation>Aumentar ampliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="324"/>
         <source>Loading...</source>
-        <translation>A carregar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="347"/>
         <source>Choose Local Image</source>
-        <translation>Escolher imagem local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="360"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="367"/>
         <source>Accept Images</source>
-        <translation>Aceitar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="251"/>
         <source>Default</source>
-        <translation>Padrão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="158"/>
         <source>Neither an image provider nor previously scraped image URLs are available for the requested image type.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="360"/>
         <source>Error while downloading one or more images: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="523"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="523"/>
         <source>Images (*.jpg *.jpeg *.png)</source>
-        <translation>Imagens (*.jpg *.jpeg *.png)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="708"/>
         <source>Images provided by &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
-        <translation>Imagens fornecidas por  &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="712"/>
         <source>Contribute by uploading images to &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
-        <translation>Contribua enviando novas imagens para &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/image/ImageDialog.cpp" line="812"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="941"/>
         <source>Error while querying image provider: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2982,7 +2965,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/small_widgets/ImageLabel.ui" line="42"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2990,12 +2973,12 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/image/ImagePreviewDialog.ui" line="17"/>
         <source>Preview</source>
-        <translation>Pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImagePreviewDialog.ui" line="82"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3003,22 +2986,22 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/import/ImportActions.ui" line="23"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.ui" line="30"/>
         <source>Delete</source>
-        <translation>Eliminar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.cpp" line="128"/>
         <source>Delete file?</source>
-        <translation>Eliminar o ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.cpp" line="129"/>
         <source>Do you really want to delete this file?</source>
-        <translation>Quer mesmo eliminar este ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3026,144 +3009,141 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="17"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="40"/>
         <source>Loading</source>
-        <translation>A carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="47"/>
         <source>Success</source>
-        <translation>Sucesso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="54"/>
         <source>Loading movie...</source>
-        <translation>A carregar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="81"/>
         <source>Directory Naming</source>
-        <translation>Nomes das pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="91"/>
         <source>File Naming</source>
-        <translation>Nomes dos Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="108"/>
         <source>Use Season Directories</source>
-        <translation>Usar pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="115"/>
         <source>Season Directory Naming</source>
-        <translation>Nomes das pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="132"/>
         <source>Keep source files after import</source>
-        <translation>Manter ficheiros originais após importação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="175"/>
         <location filename="../../src/ui/import/ImportDialog.ui" line="185"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="205"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="274"/>
         <source>Loading movie information...</source>
-        <translation>A carregar a informação do filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="296"/>
         <source>Loading concert information...</source>
-        <translation>A carregar a informação do concerto...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="320"/>
         <source>Loading episode information...</source>
-        <translation>A carregar a informação do episódio...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="390"/>
         <source>Movie information was loaded</source>
-        <translation>A informação do filme foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="404"/>
         <source>Concert information was loaded</source>
-        <translation>A informação do concerto foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="423"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="442"/>
         <source>Episode information was loaded</source>
-        <translation>A informação do episódio foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="454"/>
         <source>Renaming not possible</source>
-        <translation>Não é possível alterar o nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="454"/>
         <source>Please enter all naming patterns</source>
-        <translation>Por favor, introduza todos os padrões de nomenclatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="484"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="577"/>
         <source>Creating destination directory failed</source>
-        <translation>Não foi possível criar a pasta de destino</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="485"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="578"/>
         <source>The destination directory %1 could not be created</source>
-        <translation>Não foi possível criar a pasta de destino %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="514"/>
         <source>Importing movie...</source>
-        <translation>A importar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="553"/>
         <source>Importing episode...</source>
-        <translation>A importar o episódio...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="605"/>
         <source>Importing concert...</source>
-        <translation>A importar o concerto...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="708"/>
         <source>Import finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/import/ImportDialog.cpp" line="709"/>
         <source>Import of %n files has finished</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="712"/>
         <source>Import has finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3171,33 +3151,33 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="19"/>
         <source>Automatically delete archives after extraction</source>
-        <translation>Eliminar ficheiros automaticamente após extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="33"/>
         <source>Path to unrar</source>
-        <translation>Localização do Unrar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="45"/>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="66"/>
         <source>Choose</source>
-        <translation>Escolher</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="54"/>
         <source>Path to makemkvcon</source>
-        <translation>Localização de makemkvcon</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.cpp" line="46"/>
         <source>Choose unrar</source>
-        <translation>Escolher Unrar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.cpp" line="54"/>
         <source>Choose makemkvcon</source>
-        <translation>Escolher makemkvco</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3205,49 +3185,47 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="17"/>
         <source>General Kodi Settings. MediaElch uses the Kodi version below for writing NFO files.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="29"/>
         <source>Kodi Version</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="48"/>
         <source>If you want to use the synchronization feature you need to enable the webserver within Kodi (Settings -&gt; Services -&gt; Webserver). Enter the port of the webserver here (usually 80 or 8080).</source>
-        <translation>Se quer usar o recurso de sincronização, deve antes ativar o servidor web dentro do Kodi.
-Veja em Kodi -&gt; Definições -&gt; Serviços -&gt; Servidor web. Anote os números de host (IP) e da porta.
-Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="63"/>
         <source>Host</source>
-        <translation>Anfitrião</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="70"/>
         <source>127.0.0.1</source>
-        <translation>127.0.0.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="77"/>
         <source>Port</source>
-        <translation>Porta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="84"/>
         <source>8080</source>
-        <translation>8080</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="91"/>
         <source>User</source>
-        <translation>Utilizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="98"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3255,68 +3233,68 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="23"/>
         <source>Kodi Synchronization</source>
-        <translation>Sincronização com Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="32"/>
         <source>Please make sure you have setup your sources in Kodi and that the webserver is enabled (Kodi -&gt; Settings -&gt; Services -&gt; Webserver).</source>
-        <translation>Por favor, certifique-se que configurou as suas fontes no Kodi e que o seu servidor web está ativado (Kodi -&gt; Definições -&gt; Serviços -&gt; Servidor web).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="42"/>
         <source>Update contents</source>
-        <translation>Atualizar conteúdos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="52"/>
         <source>This will tell Kodi to remove the changed movies, concerts or shows. Afterwards a Kodi library update is triggered and the removed items will be picked up again.</source>
-        <translation>Isto irá dizer ao Kodi para remover os filmes, concertos e séries com alterações. Após isso, o Kodi irá fazer uma atualização e os itens removidos serão novamente recolhidos e reinseridos.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="62"/>
         <source>Remove non-existent items from Kodis database (Clean library)</source>
-        <translation>Remover itens não existentes da base de dados do Kodi (limpar coleção).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="69"/>
         <source>Kodi will remove not longer existing items from your database.</source>
-        <translation>O Kodi irá remover os itens não localizados da sua base de dados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="76"/>
         <source>Retrieve watched status</source>
-        <translation>Obter estado de &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="83"/>
         <source>The fields last played and playcount will be retrieved from Kodi.</source>
-        <translation>Os campos Última Reprodução e Contador de Sessões virão do Kodi.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="113"/>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="120"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="138"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="161"/>
         <source>Start</source>
-        <translation>Iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="165"/>
         <source>Please fill in your Kodi host and port.</source>
-        <translation>Por favor introduza os dados de Host e Porta no menu Definições -&gt; Kodi.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="238"/>
         <source>Getting contents from Kodi</source>
-        <translation>A obter conteúdos do Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="254"/>
@@ -3324,52 +3302,52 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="318"/>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="350"/>
         <source>Network error</source>
-        <translation>Erro de rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="448"/>
         <source>Removing movies from database</source>
-        <translation>A remover filmes da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="463"/>
         <source>Removing concerts from database</source>
-        <translation>A remover concertos da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="478"/>
         <source>Removing TV shows from database</source>
-        <translation>A remover séries de TV da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="493"/>
         <source>Removing episodes from database</source>
-        <translation>A remover episódios da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="533"/>
         <source>Trigger scan for new items</source>
-        <translation>Requisitar busca de novos itens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="555"/>
         <source>Error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="560"/>
         <source>Finished. Kodi is now loading your updated items.</source>
-        <translation>Terminado. O Kodi está agora a carregar os seus itens atualizados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="582"/>
         <source>Finished. Kodi is now cleaning your database.</source>
-        <translation>Terminado. O Kodi está agora a limpar a sua base de dados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="627"/>
         <source>Finished. Your items play count and last played date have been updated.</source>
-        <translation>Concluído. O &quot;Nº de reproduções&quot; e a &quot;última reprodução&quot; dos seus itens foram atualizadas.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3377,7 +3355,7 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/small_widgets/LanguageCombo.cpp" line="37"/>
         <source>No language available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3385,17 +3363,17 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="23"/>
         <source>Loading Stream Details</source>
-        <translation>A carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="32"/>
         <source>Loading Stream Details...</source>
-        <translation>A carregar detalhes da pista...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="46"/>
         <source>File</source>
-        <translation>Ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3403,414 +3381,414 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/data/Locale.cpp" line="28"/>
         <source>Arabic</source>
-        <translation>Árabe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="29"/>
         <source>Arabic (U.A.E.)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="30"/>
         <source>Arabic (Saudi Arabia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="31"/>
         <source>Belarusian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="32"/>
         <location filename="../../src/data/Locale.cpp" line="33"/>
         <source>Bulgarian</source>
-        <translation>Búlgaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="34"/>
         <source>Bengali</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="35"/>
         <source>Catalan (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="36"/>
         <source>Chamorro (Guam)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="37"/>
         <source>Cantonese</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="38"/>
         <location filename="../../src/data/Locale.cpp" line="39"/>
         <source>Czech</source>
-        <translation>Checo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="40"/>
         <location filename="../../src/data/Locale.cpp" line="41"/>
         <source>Danish</source>
-        <translation>Dinamarquês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="42"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="43"/>
         <source>German (AT)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="44"/>
         <source>German (CH)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="45"/>
         <source>German (DE)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="46"/>
         <location filename="../../src/data/Locale.cpp" line="47"/>
         <source>Greek</source>
-        <translation>Grego</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="48"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="49"/>
         <source>English (Australia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="50"/>
         <source>English (Canada)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="51"/>
         <source>English (GB)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="52"/>
         <source>English (NZ)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="53"/>
         <source>English (US)</source>
-        <translation>Inglês (US)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="54"/>
         <source>Esperanto</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="55"/>
         <location filename="../../src/data/Locale.cpp" line="56"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="57"/>
         <source>Spanish (Mexico)</source>
-        <translation>Castelhano (México)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="58"/>
         <source>Estonian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="59"/>
         <source>Basque (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="60"/>
         <source>Persian (Iran)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="61"/>
         <location filename="../../src/data/Locale.cpp" line="62"/>
         <source>Finnish</source>
-        <translation>Finlandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="63"/>
         <location filename="../../src/data/Locale.cpp" line="65"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="64"/>
         <source>French (Canada)</source>
-        <translation>Francês (Canadá)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="66"/>
         <source>Galician (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="67"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="68"/>
         <source>Hebrew (Israel)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="69"/>
         <source>Hindi (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="70"/>
         <source>Croatian</source>
-        <translation>Croata</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="71"/>
         <source>Croatian (Croatia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="72"/>
         <location filename="../../src/data/Locale.cpp" line="73"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="74"/>
         <source>Indonesian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="75"/>
         <location filename="../../src/data/Locale.cpp" line="76"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="77"/>
         <location filename="../../src/data/Locale.cpp" line="78"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="79"/>
         <source>Georgian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="80"/>
         <source>Kazakh</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="81"/>
         <source>Kannada</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="82"/>
         <location filename="../../src/data/Locale.cpp" line="83"/>
         <source>Korean</source>
-        <translation>Coreano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="84"/>
         <source>Lithuanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="85"/>
         <source>Latvian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="86"/>
         <source>Malayalam</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="87"/>
         <source>Malay (Malaysia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="88"/>
         <source>Malay (Singapore)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="89"/>
         <source>Norwegian Bokmål</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="90"/>
         <location filename="../../src/data/Locale.cpp" line="91"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="92"/>
         <location filename="../../src/data/Locale.cpp" line="93"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="94"/>
         <location filename="../../src/data/Locale.cpp" line="95"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="96"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="97"/>
         <source>Portuguese (Brazil)</source>
-        <translation>Português (Brasil)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="98"/>
         <source>Portuguese (Portugal)</source>
-        <translation>Português (Portugal)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="99"/>
         <source>Romanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="100"/>
         <location filename="../../src/data/Locale.cpp" line="101"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="102"/>
         <source>Sinhalese (Sri Lanka)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="103"/>
         <source>Slovak</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="104"/>
         <source>Slovene</source>
-        <translation>Eslovaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="105"/>
         <source>Slovenian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="106"/>
         <source>Albanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="107"/>
         <source>Serbian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="108"/>
         <location filename="../../src/data/Locale.cpp" line="109"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="110"/>
         <source>Tamil (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="111"/>
         <source>Telugu (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="112"/>
         <source>Thai</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="113"/>
         <source>Tagalog (Philippines)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="114"/>
         <location filename="../../src/data/Locale.cpp" line="115"/>
         <source>Turkish</source>
-        <translation>Turco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="116"/>
         <source>Ukrainian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="117"/>
         <source>Vietnamese</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="118"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="119"/>
         <source>Chinese (PRC)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="120"/>
         <source>Chinese (Hong Kong)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="121"/>
         <source>Chinese (Taiwan)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="122"/>
         <source>Zulu</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="124"/>
         <source>No language available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3818,55 +3796,55 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="14"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="75"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="94"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="125"/>
         <source>Movie Sets</source>
-        <translation>Coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="156"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="187"/>
         <source>Certifications</source>
-        <translation>Certificações</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="218"/>
         <source>Duplicates</source>
-        <translation>Duplicados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="248"/>
         <source>Shows</source>
-        <translation>Séries</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="267"/>
         <source>TV Shows</source>
-        <translation>Séries TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="297"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="316"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="346"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="365"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="395"/>
@@ -3875,92 +3853,92 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
         <extracomment>Main menu entry
 ----------
 Main menu entry (tooltip)</extracomment>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="883"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="888"/>
         <source>Quit</source>
-        <translation>Sair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="893"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="52"/>
         <source>FAQ</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="53"/>
         <source>Troubleshooting</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="54"/>
         <source>Report Issue</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="56"/>
         <source>Release Notes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="57"/>
         <source>Documentation</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="58"/>
         <source>Blog</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="59"/>
         <source>Official Kodi Forum</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="61"/>
         <source>View License</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="340"/>
         <source>&amp;Quick Open</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="807"/>
         <source>Reload all Movies (%1)</source>
-        <translation>Recarregar todos os filmes (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="813"/>
         <source>Reload all TV Shows (%1)</source>
-        <translation>Recarregar todas as séries de TV (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="824"/>
         <source>Reload all Concerts (%1)</source>
-        <translation>Recarregar todos os Concertos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="840"/>
         <source>Reload all Downloads (%1)</source>
-        <translation>Recarregar todos os descarregamentos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="846"/>
         <source>Reload Music (%1)</source>
-        <translation>Recarregar música (%1)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3968,147 +3946,147 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="50"/>
         <source>Scan</source>
-        <translation>Análise</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="92"/>
         <source>Import Tracks</source>
-        <translation>Importar faixas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="118"/>
         <source>Backup Disc</source>
-        <translation>Disco de cópia de segurança</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="163"/>
         <source>Loading</source>
-        <translation>A carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="170"/>
         <source>Success</source>
-        <translation>Sucesso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="177"/>
         <source>Loading movie...</source>
-        <translation>A carregar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="199"/>
         <source>Placeholders</source>
-        <translation>Marcadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="207"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="236"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="259"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="282"/>
         <source>File extension</source>
-        <translation>Extensão de ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="298"/>
         <source>Placeholder</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="321"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="338"/>
         <source>Part number of the current file</source>
-        <translation>Número da parte do ficheiro atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="355"/>
         <source>Directory Naming</source>
-        <translation>Nomes das pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="365"/>
         <source>File Naming</source>
-        <translation>Nomes dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="375"/>
         <source>Multi-File Naming</source>
-        <translation>Renomear múltiplos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="385"/>
         <source>Import directory</source>
-        <translation>Pasta de importação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="429"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="452"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="207"/>
         <source>No tracks selected</source>
-        <translation>Não foram selecionadas faixas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="208"/>
         <source>Please select at least one track you want to import.</source>
-        <translation>Por favor, selecione pelo menos uma faixa para importar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="246"/>
         <source>Loading movie information...</source>
-        <translation>A carregar a informação do filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="274"/>
         <source>Movie information was loaded</source>
-        <translation>A informação de filme foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="297"/>
         <source>Creating destination directory failed</source>
-        <translation>Não foi possível criar a pasta de destino</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="298"/>
         <source>The destination directory %1 could not be created</source>
-        <translation>Não foi possível criar a pasta de destino %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="386"/>
         <source>MakeMKV import finished</source>
-        <translation>Importação MakeMKV foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="386"/>
         <source>Import with MakeMKV has finished</source>
-        <translation>A importação com o MakeMKV foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="389"/>
         <source>Import has finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4116,17 +4094,17 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="116"/>
         <source>Movie title</source>
-        <translation>Título do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="145"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="152"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4134,27 +4112,27 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.ui" line="67"/>
         <source>Detect duplicate movies</source>
-        <translation>Detetar filmes duplicados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="75"/>
         <source>Detecting duplicate movies...</source>
-        <translation>A detetar filmes duplicados...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="129"/>
         <source>Open Detail Page</source>
-        <translation>Abrir página de detalhes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="130"/>
         <source>Open Movie Folder</source>
-        <translation>Abrir pasta do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="131"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4162,19 +4140,18 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="25"/>
         <source>Source %1 is no directory</source>
-        <translation>A fonte %1 não é uma pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="83"/>
         <source>Operation not possible.</source>
-        <translation>Não foi possível efetuar a operação.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="84"/>
         <source>%1
  Operation Canceled.</source>
-        <translation>%1
- Operação Cancelada.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4182,99 +4159,93 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="144"/>
         <source>New</source>
-        <translation>Novo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="160"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="176"/>
         <source>Date Added</source>
-        <translation>Data de adição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="192"/>
         <source>Seen</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="208"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="30"/>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="562"/>
         <source>%n movies</source>
-        <translation>
-            <numerusform>%n filme</numerusform>
-            <numerusform>%n filmes</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="58"/>
         <source>Media Status Columns</source>
-        <translation>Colunas de estado do média</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="69"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="80"/>
         <source>Load Information</source>
-        <translation>Carregar informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="81"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="82"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="83"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="84"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="85"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="86"/>
         <source>Open Movie Folder</source>
-        <translation>Abrir pasta do Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="87"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="88"/>
         <source>Play movie</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="564"/>
         <source>%1 of %n movies</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -4282,85 +4253,85 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="17"/>
         <source>Choose a movie</source>
-        <translation>Escolher o filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="26"/>
         <source>Filter</source>
-        <translation>Filtro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="58"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="68"/>
         <source>Add selected movies</source>
-        <translation>Adicionar filmes selecionados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="88"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="326"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <source>Extra Arts</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <source>Extra Fanarts</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="329"/>
-        <source>Extra Arts</source>
-        <translation>Arts extras</translation>
+        <source>Fanart</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="330"/>
-        <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <source>Poster</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="331"/>
-        <source>Fanart</source>
-        <translation>Fanart</translation>
+        <source>Stream Details</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="332"/>
-        <source>Poster</source>
-        <translation>Cartaz</translation>
+        <source>Trailer</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="333"/>
-        <source>Stream Details</source>
-        <translation>Detalhes da pista</translation>
+        <source>Local Trailer</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="334"/>
-        <source>Trailer</source>
-        <translation>Trailer</translation>
+        <source>Subtitles</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="335"/>
-        <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <source>Tags</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="336"/>
-        <source>Subtitles</source>
-        <translation>Legendas</translation>
-    </message>
-    <message>
-        <location filename="../../src/model/MovieModel.cpp" line="337"/>
-        <source>Tags</source>
-        <translation>Etiquetas</translation>
-    </message>
-    <message>
-        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4368,185 +4339,182 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="23"/>
         <source>Movie Multi Scrape</source>
-        <translation>Extração múltipla de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="36"/>
         <source>Please select the scraper and the infos you want to be loaded. MediaElch will use the best result for each movie you selected.</source>
-        <translation>Por favor, escolha o extrator e as informações que pretende carregar. O MediaElch usará o melhor resultado para cada filme que selecionou.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="48"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="84"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="143"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="233"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="163"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="303"/>
         <source>Logo</source>
-        <translation>Logotipos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="223"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="133"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="113"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="93"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="103"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="173"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="213"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="203"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="153"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="123"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="183"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="243"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="253"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="193"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="293"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="283"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="273"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="263"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="313"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="332"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="358"/>
         <source>Automatically save each movie after scraping</source>
-        <translation>Guardar automaticamente cada filme após a extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="365"/>
         <source>Update only movies with IMDb ID/TMDb Id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="380"/>
         <source>1/20</source>
-        <translation>1/20</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="387"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="412"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="435"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="448"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.cpp" line="201"/>
         <source>Scraping of %n movies has finished.</source>
-        <translation>
-            <numerusform>A extração de %n filmes terminou.</numerusform>
-            <numerusform>A extração de %n filmes terminou.</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -4554,12 +4522,12 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4567,166 +4535,163 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="31"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="41"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="70"/>
         <source>When using IMDb you can also use the IMDb id as search query.
 If you want to search by an TMDb id please prefix it with &quot;id&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="128"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="163"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="170"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="177"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="184"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="191"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="198"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="205"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="212"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="219"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="226"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="233"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="240"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="264"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="271"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="278"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="285"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="292"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="299"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="306"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="313"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="320"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="327"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="334"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="365"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="77"/>
         <source>Cannot scrape a movie without an active scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="153"/>
         <source>Internal inconsistency: Cannot set language dropdown in movie search widget!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="175"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="314"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4734,112 +4699,112 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your movies. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Em baixo, pode ver os nomes de ficheiros usados para carregar e guardar os seus filmes. Pode editá-los à sua vontade, se quiser usar vários ficheiros separe-os com uma vírgula.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o de nome de ficheiro sem extensão.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="42"/>
         <source>Nfo</source>
-        <translation>Nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="49"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="56"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="63"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="70"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="77"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="216"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="223"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="281"/>
         <source>Movie outline</source>
-        <translation>Resumo do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="288"/>
         <source>Use plot when outline is not available</source>
-        <translation>Usar enredo quando não existir resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="295"/>
         <source>Movie Set Artwork</source>
-        <translation>Artwork de coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="21"/>
         <source>Artwork next to movies</source>
-        <translation>Artwork próxima dos filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="23"/>
         <source>Separate artwork directory</source>
-        <translation>Pasta separada de artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="305"/>
         <source>Movie Set Poster Filename</source>
-        <translation>Nome do ficheiro do cartaz da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="342"/>
         <source>Movie Set Fanart Filname</source>
-        <translation>Nome de ficheiro da fanart da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="379"/>
         <source>Artwork directory</source>
-        <translation>Pasta de artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="391"/>
         <source>Choose directory</source>
-        <translation>Escolher pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="400"/>
         <source>Movie Original Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="407"/>
         <source>Don&apos;t store the original title if it is the same as the normal title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="163"/>
         <source>Choose a directory where your movie set artwork is stored</source>
-        <translation>Escolher uma pasta onde a artwork da coleção de filmes está guardada</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4847,283 +4812,283 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="50"/>
         <source>Movie has changed. Click to revert changes.</source>
-        <translation>O filme foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="75"/>
         <source>Movie Name</source>
-        <translation>Nome do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="121"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="141"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1050"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="155"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="165"/>
         <source>Original Name</source>
-        <translation>Nome original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="175"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="185"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="211"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="228"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="235"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="245"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="255"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="275"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="282"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="317"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="347"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="350"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="353"/>
         <source>Not watched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="362"/>
         <source>Plot</source>
-        <translation>Enredo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="386"/>
         <source>Insert YouTube Dummy Link</source>
-        <translation>Inserir link falso do YouTube</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="405"/>
         <source>Download Trailer</source>
-        <translation>Descarregar trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="421"/>
         <source>Play local trailer</source>
-        <translation>Reproduzir trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="431"/>
         <source>Local trailer is available</source>
-        <translation>Está disponível um trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="434"/>
         <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="447"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="480"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="548"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="558"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="570"/>
         <source>Outline</source>
-        <translation>Resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="592"/>
         <source>Open movie on IMDb.com</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="595"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="631"/>
         <source>Go</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="618"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="628"/>
         <source>Open movie on TheMovieDB.org</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="663"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="695"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="786"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="705"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="717"/>
         <source>Support for extra fanarts is only available when your movies are stored in separate folders. Check the settings if you&apos;ve stored your movies in separate folders already.</source>
-        <translation>O recurso a fanarts extra só está disponível quando os seus filmes estão guardados em pastas separadas. Verifique as definições, caso já tenha guardado os seus filmes em pastas separadas.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="735"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="758"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="768"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="806"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="796"/>
         <source>Scantype</source>
-        <translation>Varrimento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="942"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="788"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="791"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="847"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="862"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="888"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="881"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="221"/>
         <source>Ratings</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="653"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="952"/>
         <source>Stereo Mode</source>
-        <translation>Modo de Estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="973"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1030"/>
         <source>External Subtitles</source>
-        <translation>Legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1060"/>
         <source>Forced</source>
-        <translation>Forçadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1216"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1256"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1238"/>
@@ -5134,103 +5099,103 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1502"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1549"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1263"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1303"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1310"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1350"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1386"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1426"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1433"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1473"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1480"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1520"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1527"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1567"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="88"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="89"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="93"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="94"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="98"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="99"/>
         <source>Add Country</source>
-        <translation>Adicionar país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="103"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="104"/>
         <source>Add Studio</source>
-        <translation>Adicionar estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="485"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="492"/>
         <source>Scraping...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="780"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="816"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1055"/>
@@ -5239,49 +5204,49 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="821"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="822"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="789"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="792"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="807"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="850"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="921"/>
         <source>Saving movie...</source>
-        <translation>A guardar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="926"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="902"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="950"/>
         <source>Saving movies...</source>
-        <translation>A guardar os filmes...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="919"/>
         <source>Movies Saved</source>
-        <translation>Filmes guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="971"/>
         <source>All Movies Saved</source>
-        <translation>Todos os filmes foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5289,12 +5254,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/file_search/MusicFileSearcher.cpp" line="44"/>
         <source>Searching for Music...</source>
-        <translation>A procurar por músia...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MusicFileSearcher.cpp" line="129"/>
         <source>Loading Music...</source>
-        <translation>A carregar a música...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5302,38 +5267,29 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="31"/>
         <source>Open Folder</source>
-        <translation>Abrir pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="32"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="25"/>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="155"/>
         <source>%n artists</source>
-        <translation>
-            <numerusform>%n artista</numerusform>
-            <numerusform>%n artistas</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="25"/>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="155"/>
         <source>%n albums</source>
-        <translation>
-            <numerusform>%n álbum</numerusform>
-            <numerusform>%n álbuns</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="158"/>
         <source>%1 of %n artists</source>
-        <translation>
-            <numerusform>%1 de %n artista</numerusform>
-            <numerusform>%1 de %n artistas</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5341,170 +5297,167 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="17"/>
         <source>Music Multi Scrape</source>
-        <translation>Extração múltipla de músicas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="39"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="48"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="61"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="74"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="87"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="100"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="113"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="126"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="139"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="152"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="165"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="178"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="191"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="204"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="217"/>
         <source>Moods</source>
-        <translation>Disposição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="230"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="243"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="256"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="269"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="282"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="295"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="308"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="321"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="334"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="347"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="369"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="395"/>
         <source>Scrape all albums of selected artists (and not only selected albums)</source>
-        <translation>Extrair todos os álbuns de artistas selecionados (e não apenas dos álbuns selecionados)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="402"/>
         <source>Automatically save each artist and album after scraping</source>
-        <translation>Guardar automaticamente cada artista e álbum após a extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="449"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="472"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="485"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.cpp" line="205"/>
         <source>Scraping of %n items has finished.</source>
-        <translation>
-            <numerusform>Terminou a extração de %n itens.</numerusform>
-            <numerusform>Terminou a extração de %n itens.</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5512,12 +5465,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5525,142 +5478,142 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="34"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="89"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="117"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="140"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="150"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="160"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="170"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="180"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="190"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="200"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="210"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="220"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="230"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="240"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="250"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="260"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="270"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="280"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="290"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="300"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="310"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="320"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="330"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="340"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="350"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="360"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="370"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="387"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5668,39 +5621,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your artists and albums. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Abaixo pode ver os nomes de ficheiros que são usados ​​para carregar e guardar os Artistas e Álbuns. Pode editá-los como quiser.
-Se quiser guardar o mesmo ficheiro com vários nomes, deve separar os nomes com uma vírgula.
-Por exemplo:  folder.jpg,cover.jpg</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="32"/>
         <source>Artist Thumbnail</source>
-        <translation>Miniatura de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="49"/>
         <source>Artist Fanart</source>
-        <translation>Fanart de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="66"/>
         <source>Artist Logo</source>
-        <translation>Logótipo de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="83"/>
         <source>Album Thumbnail</source>
-        <translation>Miniatura de álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="100"/>
         <source>Album Disc Art</source>
-        <translation>Capa do álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="117"/>
         <source>Download Extra Fanarts for Artists</source>
-        <translation>Descarregar Fanarts extras para artistas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5708,10 +5659,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message numerus="yes">
         <location filename="../../src/ui/small_widgets/MusicTreeView.cpp" line="105"/>
         <source>%n albums</source>
-        <translation>
-            <numerusform>%n album</numerusform>
-            <numerusform>%n álbuns</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5720,13 +5668,13 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="122"/>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="162"/>
         <source>Saving changed Artists and Albums</source>
-        <translation>A guardar alterações em artistas e álbuns</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="140"/>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="187"/>
         <source>All Artists and Albums Saved</source>
-        <translation>Todos os artistas e álbuns foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5734,150 +5682,150 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="53"/>
         <source>Album has changed. Click to revert changes.</source>
-        <translation>O álbum foi alterando. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="79"/>
         <source>Album Name</source>
-        <translation>Nome do álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="137"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="158"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="179"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="186"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="193"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="200"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="207"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="214"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="254"/>
         <source>MusicBrainz Album ID</source>
-        <translation>Identificador do álbum MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="268"/>
         <source>MusicBrainz Release Group ID</source>
-        <translation>Identificador do grupo de lançamento MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="285"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="326"/>
         <source>Booklet</source>
-        <translation>Brochura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="345"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="368"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="420"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="460"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="442"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="505"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="483"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="523"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="41"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="42"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="46"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="47"/>
         <source>Add Mood</source>
-        <translation>Adicionar estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="51"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="52"/>
         <source>Add Style</source>
-        <translation>Adicionar estilo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="186"/>
         <source>Saving Album...</source>
-        <translation>A guardar o álbum...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="192"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="524"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5885,182 +5833,182 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="53"/>
         <source>Artist has changed. Click to revert changes.</source>
-        <translation>O artista foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="79"/>
         <source>Artist Name</source>
-        <translation>Nome do artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="137"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="158"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="186"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="193"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="200"/>
         <source>Years active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="207"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="214"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="235"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="245"/>
         <source>MusicBrainz ID</source>
-        <translation>Identificador MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="262"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="303"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="325"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="330"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="340"/>
         <source>Add Album</source>
-        <translation>Adicionar álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="347"/>
         <source>Remove Album</source>
-        <translation>Remover álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="370"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="392"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="415"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="467"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="507"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="633"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="489"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="552"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="615"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="530"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="570"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="593"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="49"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="50"/>
         <source>Add Genre</source>
-        <translation>Adicionar Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="54"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="55"/>
         <source>Add Mood</source>
-        <translation>Adicionar estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="59"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="60"/>
         <source>Add Style</source>
-        <translation>Adicionar estilo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="196"/>
         <source>Saving Artist...</source>
-        <translation>A guardar o artista...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="202"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="501"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="586"/>
         <source>Unknown Album</source>
-        <translation>Álbum Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6068,87 +6016,87 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="38"/>
         <source>Scrape</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="58"/>
         <source>Save</source>
-        <translation>Guardar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="78"/>
         <source>Save All</source>
-        <translation>Guardar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="98"/>
         <source>Rename selected files</source>
-        <translation>Renomear ficheiros selecionados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="118"/>
         <source>Synchronize to Kodi</source>
-        <translation>Sincronizar com o Kodl</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="138"/>
         <source>Export Database</source>
-        <translation>Exportar base de Dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="161"/>
         <source>Reload</source>
-        <translation>Recarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="181"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="201"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="247"/>
         <source>Donate</source>
-        <translation>Fazer um donativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="17"/>
         <source>Scrape (%1)</source>
-        <translation>Extrair (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="20"/>
         <source>Save (%1)</source>
-        <translation>Guardar (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="24"/>
         <source>Save All (%1)</source>
-        <translation>Guardar todos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="28"/>
         <source>Reload all files (%1)</source>
-        <translation>Recarregar todos os ficheiros (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="32"/>
         <source>Export HTML</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="36"/>
         <source>Export CSV</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="43"/>
         <source>Export Database (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6156,7 +6104,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/scrapers/ScraperInterface.cpp" line="17"/>
         <source>Network Error</source>
-        <translation>Erro na rede</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6164,43 +6112,43 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="71"/>
         <source>Host</source>
-        <translation>Anfitrião</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="78"/>
         <source>Port</source>
-        <translation>Porta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="98"/>
         <source>Username</source>
-        <translation>Nome de utilizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="108"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="19"/>
         <source>Enable Proxy</source>
-        <translation>Ativar proxy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="64"/>
         <source>Type</source>
         <comment>Proxy Type</comment>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="51"/>
         <source>HTTP</source>
-        <translation>HTTP</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="36"/>
         <source>Use Proxy for Kodi</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6208,7 +6156,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/PlaceholderLineEdit.cpp" line="26"/>
         <source>Insert placeholder</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6216,183 +6164,183 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/main.cpp" line="36"/>
         <source>Logfile could not be openened</source>
-        <translation>Não foi possível abrir o ficheiro de registo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="37"/>
         <source>The logfile %1 could not be openend for writing.</source>
-        <translation>Não foi possível modificar o ficheiro de registo %1.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="76"/>
         <source>Stylesheet could not be opened!</source>
-        <translation>Não foi possível abrir a folha de estilo.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="78"/>
         <source>The default stylesheet could not be openend for reading.</source>
-        <translation>Não foi possível abrir a folha de estilos padrão para leitura.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="79"/>
         <source>The custom stylesheet could not be openend for reading. Using: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <source>No Label</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <source>Red</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <source>Orange</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <source>Yellow</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="392"/>
-        <source>No Label</source>
-        <translation>Sem etiqueta</translation>
+        <source>Green</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="393"/>
-        <source>Red</source>
-        <translation>Vermelho</translation>
+        <source>Blue</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="394"/>
-        <source>Orange</source>
-        <translation>Laranja</translation>
+        <source>Purple</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="395"/>
-        <source>Yellow</source>
-        <translation>Amarelo</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="396"/>
-        <source>Green</source>
-        <translation>Verde</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="397"/>
-        <source>Blue</source>
-        <translation>Azul</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="398"/>
-        <source>Purple</source>
-        <translation>Roxo</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
-        <translation>Cinzento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="12"/>
         <source>File not found:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="13"/>
         <source>Cannot open advancedsettings.xml in read-only mode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="14"/>
         <source>Couldn&apos;t find an &lt;advancedsettings&gt; tag!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="15"/>
         <source>Found unsupported xml tag:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="16"/>
         <source>Invalid value for xml tag:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
-        <translation>&lt;b&gt;Mover Ficheiro&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowCommonWidgets.cpp" line="59"/>
         <source>Aired order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowCommonWidgets.cpp" line="62"/>
         <source>DVD order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="8"/>
         <source>Timeout by MediaElch</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="9"/>
         <source>Content not found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="10"/>
         <source>Remote connection timed out</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="11"/>
         <source>SSL handshake failed</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="12"/>
         <source>Too many redirects</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="13"/>
         <source>Connection refused by host</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="14"/>
         <source>Host not found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="15"/>
         <source>Unknown network error</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="16"/>
         <source>Could not load the requested resource</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="18"/>
         <location filename="../../src/scrapers/ScraperError.cpp" line="25"/>
         <source>Network Error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="32"/>
         <source>The scraper&apos;s rate limit reached. Please wait ~10 seconds and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="37"/>
         <source>An unknown network error occurred. Are you connected to the internet?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="51"/>
         <source>The scraper did not respond with any data.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="55"/>
         <source>The scraper response could not be parsed.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media_center/kodi/ConcertXmlReader.cpp" line="29"/>
         <source>No valid musicvideo root entry found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6400,22 +6348,22 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="60"/>
         <source>QIODevice::Append is not supported for GZIP</source>
-        <translation>QIODevice::Append não é suportado pelo GZIP</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="66"/>
         <source>Opening gzip for both reading and writing is not supported</source>
-        <translation>A abertura do gzip para leitura e escrita não é suportada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="74"/>
         <source>You can open a gzip either for reading or for writing. Which is it?</source>
-        <translation>Pode abrir um gzip para ler ou gravar. Qual deles?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="80"/>
         <source>Could not gzopen() file</source>
-        <translation>Não foi possível abrir o ficheiro gzopen()</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6423,12 +6371,12 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quaziodevice.cpp" line="188"/>
         <source>QIODevice::Append is not supported for QuaZIODevice</source>
-        <translation>QIODevice::Append não é suportado pelo QuaZIODevice</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quaziodevice.cpp" line="193"/>
         <source>QIODevice::ReadWrite is not supported for QuaZIODevice</source>
-        <translation>QIODevice::ReadWrite não é suportado pelo QuaZIODevice</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6436,7 +6384,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quazipfile.cpp" line="251"/>
         <source>ZIP/UNZIP API error %1</source>
-        <translation>Erro da API ZIP/UNZIP %1</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6444,27 +6392,27 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="100"/>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="101"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="102"/>
         <source>Vote Count</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="103"/>
         <source>Min. Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="104"/>
         <source>Max. Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6472,17 +6420,17 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="14"/>
         <source>Form</source>
-        <translation>Formulário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="80"/>
         <source>Add rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="94"/>
         <source>Remove selected rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6490,145 +6438,133 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="17"/>
         <source>Renamer</source>
-        <translation>Alteração de nomes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="34"/>
         <source>Pattern</source>
-        <translation>Padrão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="75"/>
         <source>Use Season Directories</source>
-        <translation>Usar pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="85"/>
         <source>Multi-File Naming</source>
-        <translation>Alterar nome de vários ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="117"/>
         <source>Rename Directories</source>
-        <translation>Alterar nome de pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="127"/>
         <source>Rename Files</source>
-        <translation>Alterar nome de ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="162"/>
         <source>Directory Naming</source>
-        <translation>Alterar nome de pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="194"/>
         <source>File Naming</source>
-        <translation>Nomes dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="201"/>
         <source>Season Directory Naming</source>
-        <translation>Nomes das pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="208"/>
         <source>Season &lt;season&gt;</source>
-        <translation>Temporada &lt;season&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="249"/>
         <source>Results</source>
-        <translation>Resultados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="342"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="365"/>
         <source>Dry Run</source>
-        <translation>Operação &quot;a seco&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
         <source>Rename</source>
-        <translation>Alterar nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="38"/>
         <source>Please see %1 for help and examples on how to use the renamer.</source>
-        <translation>Veja a ajuda em %1. Temos exemplos de como usar o alterador de nomes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="58"/>
         <source>%n concerts will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="60"/>
         <source>%n movies will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="62"/>
         <source>%n TV shows and %1</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="63"/>
         <source>%n episodes will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
         <source>Finished</source>
-        <translation>Concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
         <source>Create dir</source>
-        <translation>Criar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
         <source>Move</source>
-        <translation>Mover</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6636,152 +6572,147 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="35"/>
         <source>Placeholders</source>
-        <translation>Marcadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
         <source>Placeholder</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
         <source>File extension</source>
-        <translation>Extensão de ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
         <source>Season Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
         <source>Part number of the current file</source>
-        <translation>Número da parte do ficheiro atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
-        <source>TMDb ID</source>
-        <translation type="unfinished">Identificador do TMDb</translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
         <source>Season Number</source>
-        <translation>Número da temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
         <source>Title of the show</source>
-        <translation>Título da série</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
         <source>Studio(s) (separated by a comma)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
         <source>Director(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
         <source>Audio Language(s) (separated by a minus)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
         <source>Episode Number</source>
-        <translation>Número do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
         <source>Resolution (1080p, 720p, ...)</source>
-        <translation>Resolução (1080p, 720p...)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
         <source>File/directory is BluRay</source>
-        <translation>Ficheiro ou pasta é BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
         <source>File/directory is DVD</source>
-        <translation>Ficheiro ou pasta é DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
         <source>File is 3D</source>
-        <translation>Ficheiro é 3D</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
         <source>Movie set name</source>
-        <translation>Nome da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
         <source>Video Codec</source>
-        <translation>Codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
         <source>Episode has a season name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
         <source>Audio Codec</source>
-        <translation>Codec de áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
         <source>Number of audio channels</source>
-        <translation>Número de canais de áudio</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6790,141 +6721,141 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="121"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="151"/>
         <source>Invalid</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="122"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="152"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="123"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="124"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="153"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="125"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="126"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="155"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="127"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="128"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="156"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="129"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="157"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="130"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="131"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="158"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="132"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="133"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="161"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="134"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="159"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="135"/>
         <source>Extra Art</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="136"/>
         <source>Season Backdrop</source>
-        <translation>Fundo de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="137"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="138"/>
         <source>Extra Fanart</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="139"/>
         <source>Show Thumbnail</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="140"/>
         <source>Season Thumbnail</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="141"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="142"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="145"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="165"/>
         <source>Unknown</source>
-        <translation>Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="160"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="154"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="162"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6933,162 +6864,162 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="21"/>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="138"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="57"/>
         <source>Enable adult movie scrapers</source>
-        <translation>Ativar extratores de filmes para adultos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="95"/>
         <source>Custom Movie Scraper</source>
-        <translation>Extrator de filmes personalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="101"/>
         <source>Combine multiple scrapers to your custom scraper. If you select other scrapers than IMDB, The Movie DB and Fanart.tv multiple searches may be necessary as only these three share an id.</source>
-        <translation>Combine vários extratores num único extrator personalizado. Se selecionar outros extratores além do IMDB, The Movie DB e Fanart.tv, poderão ser necessárias várias procuras, já que apenas estes três usam identificadores comuns.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="133"/>
         <source>Item</source>
-        <translation>Item</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="147"/>
         <source>TV Scraper</source>
-        <translation>Extrator de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="157"/>
         <source>Custom TV Scraper</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="172"/>
         <source>Don&apos;t use</source>
-        <translation>Não usar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="218"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="219"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="220"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="221"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="222"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="223"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="224"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="225"/>
         <source>Plot</source>
-        <translation>Enredo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="226"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="227"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="228"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="229"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="230"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="231"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="232"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="233"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="234"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="235"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="236"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="237"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="238"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="239"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="240"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="241"/>
         <source>Unsupported</source>
-        <translation>Incompatível</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7096,12 +7027,12 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/model/tv_show/SeasonModelItem.cpp" line="135"/>
         <source>Season %1 - %2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/tv_show/SeasonModelItem.cpp" line="137"/>
         <source>Season %1</source>
-        <translation>Temporada %1</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7109,59 +7040,59 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="61"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="88"/>
         <source>Set Name</source>
-        <translation>Nome da coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="122"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="127"/>
         <source>Sorttitle</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="150"/>
         <source>Add movie to set</source>
-        <translation>Adicionar filme à coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="153"/>
         <source>Add Movie</source>
-        <translation>Adicionar filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="160"/>
         <source>Remove selected movie from set</source>
-        <translation>Remover filme selecionado da coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="163"/>
         <source>Remove Movie</source>
-        <translation>Remover Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="182"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="204"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="276"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="225"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="300"/>
         <source>Full preview</source>
-        <translation>Pré-visualização inteira</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="239"/>
@@ -7169,32 +7100,32 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="314"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="317"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="254"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="56"/>
         <source>Add Movie Set</source>
-        <translation>Adicionar coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="57"/>
         <source>Delete Movie Set</source>
-        <translation>Eliminar coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="459"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="491"/>
         <source>New Movie Set</source>
-        <translation>Nova coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7202,79 +7133,79 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="20"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="184"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="162"/>
         <source>Kodi</source>
-        <translation>Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="206"/>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="209"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="220"/>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="223"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="62"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="69"/>
         <source>Save Settings</source>
-        <translation>Guardar definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="79"/>
         <source>toolBar</source>
-        <translation>barraFerramentas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="118"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="129"/>
         <source>TV Shows</source>
-        <translation>Séries TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="140"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="151"/>
         <source>Global</source>
-        <translation>Global</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="173"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="195"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.cpp" line="192"/>
         <source>Settings saved</source>
-        <translation>As definições foram guardadas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7282,32 +7213,32 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="17"/>
         <source>Support MediaElch</source>
-        <translation>Doações para o MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="30"/>
         <source>If you like MediaElch and wish to support it you have the chance to do so! You can donate as much as you like via PayPal.</source>
-        <translation>Se gosta do MediaElch e gostaria de apoiá-lo, tem a oportunidade de o fazer! Pode fazer uma doação da quantia que quiser através do PayPal.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="74"/>
         <source>MediaElch makes use of various movie and TV show databases. These databases also need your help to keep their services up and running for free. If you don&apos;t want to donate you can also contribute information and missing artwork if possible.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="127"/>
         <source>Thanks for your help and support!</source>
-        <translation>Obrigado pela sua ajuda e apoio!</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="149"/>
         <source>Hide donate button</source>
-        <translation>Ocultar botão para donativos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="172"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7315,7 +7246,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/TagCloud.ui" line="31"/>
         <source>Tag</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7323,115 +7254,115 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="17"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="47"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="87"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="110"/>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="206"/>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="369"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="166"/>
         <source>Preview</source>
-        <translation>Pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="171"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="176"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="186"/>
         <source>Back to Search Results</source>
-        <translation>Regressar aos resultados da busca</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="277"/>
         <source>URL</source>
-        <translation>Endereço</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="308"/>
         <source>Progress</source>
-        <translation>Progresso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="331"/>
         <source>Download</source>
-        <translation>Descarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="338"/>
         <source>Cancel Download</source>
-        <translation>Cancelar descarregamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="349"/>
         <source>Back to Trailers</source>
-        <translation>Regressar aos trailers</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="345"/>
         <source>Download Finished</source>
-        <translation>Descarregamento concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="356"/>
         <source>The file %1 already exists.</source>
-        <translation>O ficheiro %1 já existe.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="358"/>
         <source>Do you want to overwrite it?</source>
         <extracomment>&quot;it&quot; refers to the file</extracomment>
-        <translation>Quer substituí-lo?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="371"/>
         <source>Download Canceled</source>
-        <translation>Descarregamento cancelado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="375"/>
         <source>Download Not Found (404)</source>
-        <translation>Descarregamento não encontrado (404)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="379"/>
         <source>Download Error (%1)</source>
-        <translation>Erro no descarregamento (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="433"/>
         <source>Network Error</source>
-        <translation>Erro na rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="434"/>
         <source>Resource could not be played</source>
-        <translation>Não foi possível reproduzir o ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="435"/>
         <source>Video format error</source>
-        <translation>Erro de formato de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7439,92 +7370,92 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="36"/>
         <source>TV Scraper</source>
-        <translation>Extrator de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="88"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="107"/>
         <source>ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="114"/>
         <source>Internal TV scraper ID. Used as key in MediaElch&apos;s settings.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="124"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="169"/>
         <source>Website</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="179"/>
         <source>The scraper&apos;s main website.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="192"/>
         <source>Terms of Service</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="199"/>
         <source>Terms of service of the TV scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="212"/>
         <source>Privacy Policy</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="219"/>
         <source>Privacy Policy of the scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="232"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="239"/>
         <source>Where to get help for the TV scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="252"/>
         <source>Is the scraper initialized?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="255"/>
         <source>Is initialized?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="262"/>
         <source>Default Language</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.cpp" line="112"/>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.cpp" line="112"/>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7532,22 +7463,22 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="52"/>
         <source>Searching for TV Shows...</source>
-        <translation>A procurar séries de TV...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="58"/>
         <source>Loading TV Shows...</source>
-        <translation>A carregar séries de TV...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="87"/>
         <source>Searching for Episodes...</source>
-        <translation>A procurar episódios...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="126"/>
         <source>Loading Episodes...</source>
-        <translation>A carregar episódios...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7556,103 +7487,94 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="27"/>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="670"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="27"/>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="670"/>
         <source>%n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="466"/>
-        <source>You need to update the show once and load the show&apos;s TMDb ID to list missing episodes.
+        <source>You need to update the show once and load the show's TMDb ID to list missing episodes.
 Afterwards MediaElch will check automatically for new episodes on startup.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="470"/>
         <source>Don&apos;t show this hint again</source>
-        <translation>Não voltar a mostrar esta dica</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="674"/>
         <source>%1 of %n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="758"/>
         <source>Load Information</source>
-        <translation>Carregar informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="759"/>
         <source>Search for new episodes</source>
-        <translation>A procurar por novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="760"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="761"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="762"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="763"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="764"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="765"/>
         <source>Open TV Show Folder</source>
-        <translation>Abrir pasta da série de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="766"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="767"/>
         <source>Play episode</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="784"/>
         <source>Show missing episodes</source>
-        <translation>Mostrar episódios que faltam</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="787"/>
         <source>Hide specials in missing episodes</source>
-        <translation>Ocultar episódios especiais ao listar episódios em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="465"/>
         <source>Show update needed</source>
-        <translation>É necessário atualizar a série</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7660,42 +7582,42 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="91"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="92"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="93"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="94"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="95"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="96"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="97"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="98"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7703,303 +7625,297 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="20"/>
         <source>TV Show Multi Scrape</source>
-        <translation>Extrator múltiplo de episódios de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="30"/>
         <source>Please select the infos you want to be loaded. MediaElch will use the best result for each TV show and episode you selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="61"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="365"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="70"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="400"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="83"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="278"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="304"/>
         <source>Season Fanart</source>
-        <translation>Fanart de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="96"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="265"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="226"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="109"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="252"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="213"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="501"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="122"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="374"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="239"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="291"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="475"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="200"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="449"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="135"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="387"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="436"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="426"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="46"/>
         <source>Show Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="148"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="161"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="413"/>
         <source>First aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="174"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="488"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="187"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="317"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="339"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="526"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="350"/>
         <source>Episode Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="462"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="559"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="569"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="579"/>
         <source>Order for seasons</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="607"/>
         <source>Update only TV shows/episodes
 which have an ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="621"/>
         <source>Automatically save each TV show/
 episode after scraping</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="660"/>
         <source>1/20</source>
-        <translation>1/20</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="706"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="729"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="742"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="306"/>
         <source>Start scraping using &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="352"/>
         <source>Skipping show &quot;%1&quot; because it does not have a valid ID.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="371"/>
         <source>Search for TV show &quot;%1&quot; because no valid ID was found.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="378"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="475"/>
         <source>Scraping next TV show with ID &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="408"/>
         <source>Search for TV show &quot;%1&quot; because no valid show ID was found for the episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="417"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="493"/>
         <source>S%1E%2: Scraping next episode with show ID &quot;%3&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="463"/>
         <source>Error while searching for TV show: &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="468"/>
         <source>Did not find any results for search term &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="511"/>
         <source>Done.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="531"/>
         <source>%n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="532"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="534"/>
         <source>Scraping of %1 and %2 has finished.</source>
-        <translation>Terminou a extração de %1 e %2.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="536"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="538"/>
         <source>Scraping of %1 has finished.</source>
-        <translation>A extração de  %1 terminou.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="561"/>
         <source>Finished scraping details of TV show &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="570"/>
         <source>Start loading extra fanart from TheTvDb for TV show with ID &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="753"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="832"/>
         <source>Internal inconsistency: Cannot set language dropdown in TV show search widget!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="848"/>
         <source>S%2E%3: Finished scraping episode details. Title is: &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8007,12 +7923,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/search_dialog/TvShowScrapePreview.ui" line="43"/>
         <source>&lt;b&gt;Preview&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/search_dialog/TvShowScrapePreview.ui" line="83"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Description&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8020,17 +7936,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="58"/>
         <source>Scrape</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8038,219 +7954,216 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="19"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="29"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="134"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="179"/>
         <source>Show Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="210"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="519"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="220"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="230"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="539"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="240"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="549"/>
         <source>First aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="250"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="260"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="559"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="270"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="529"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="280"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="290"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="626"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="300"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="606"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="327"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="616"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="337"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="347"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="357"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="367"/>
         <source>Season Fanart</source>
-        <translation>Fanart de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="377"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="387"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="397"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="407"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="417"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="451"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="670"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="464"/>
         <source>No show details will be loaded because only episodes were selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="488"/>
         <source>Episode Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="586"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="596"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="636"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="682"/>
         <source>Season order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="697"/>
         <source>No episodes will be loaded. If you want to load episodes, change the update mode below.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="147"/>
         <source>Update TV Show only</source>
-        <translation>Atualizar apenas Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="152"/>
         <source>Update TV Show and new Episodes</source>
-        <translation>Atualizar séries de TV e novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="157"/>
         <source>Update TV Show and all Episodes</source>
-        <translation>Atualizar séries de TV e todos os episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="162"/>
         <source>Update new Episodes</source>
-        <translation>Atualizar novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="167"/>
         <source>Update all episodes</source>
-        <translation>Atualizar todos os episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="170"/>
         <source>The %1 scraper could not be initialized!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="148"/>
         <source>Please insert a search string!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="188"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="364"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8258,82 +8171,82 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your TV shows. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension and for season posters &lt;seasonNumber&gt; which is the season number.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o nome do ficheiro, sem extensão, e para cartazes de temporada &lt;seasonNumber&gt;, que é o número da temporada.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="42"/>
         <source>Show nfo</source>
-        <translation>Mostrar nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="49"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="56"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="63"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="70"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="77"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="84"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="91"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="98"/>
         <source>Season Backdrop</source>
-        <translation>Fundo de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="105"/>
         <source>Episode nfo</source>
-        <translation>Nfo do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="112"/>
         <source>Episode thumbnail</source>
-        <translation>Miniatura de episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="119"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="390"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="397"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8341,10 +8254,7 @@ episode after scraping</source>
     <message numerus="yes">
         <location filename="../../src/ui/small_widgets/TvShowTreeView.cpp" line="146"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -8352,7 +8262,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/TvShowUpdater.cpp" line="42"/>
         <source>Updating TV Shows</source>
-        <translation>A atualizar séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8361,22 +8271,22 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="161"/>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="218"/>
         <source>Saving changed TV Shows and Episodes</source>
-        <translation>A guardar alterações em séries de TV e episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="180"/>
         <source>Could not save episode S%1E%2 of show &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="193"/>
         <source>TV Shows and Episodes Saved</source>
-        <translation>Séries de TV e episódios guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="239"/>
         <source>All TV Shows and Episodes Saved</source>
-        <translation>Todas as séries TV e episódios foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8384,292 +8294,292 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="63"/>
         <source>Episode has changed. Click to revert changes.</source>
-        <translation>O episódio foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="82"/>
         <source>Episode Title</source>
-        <translation>Título do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="137"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="154"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="460"/>
         <source>TheTVDB ID</source>
-        <translation>Identificador TheTVDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="514"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="168"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="178"/>
         <source>Show Title</source>
-        <translation>Mostrar título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="188"/>
         <source>Season</source>
-        <translation>Temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="223"/>
         <source>Episode</source>
-        <translation>Episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="242"/>
         <source>Display Season</source>
-        <translation>Mostrar temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="302"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="350"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="367"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="377"/>
         <source>dd.MM.yyyy</source>
-        <translation>dd.MM.yyyy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="384"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="400"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="410"/>
         <source>dd.MM.yyyy HH:mm</source>
-        <translation>dd.MM.yyyy HH:mm</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="436"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="446"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="280"/>
         <source>Display Episode</source>
-        <translation>Mostrar episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="419"/>
         <source>Bookmark</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="313"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="477"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="548"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="558"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="595"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="663"/>
         <source>Directors</source>
-        <translation>Realizadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="691"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="701"/>
         <source>Add Director</source>
-        <translation>Adicionar Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="715"/>
         <source>Remove Director</source>
-        <translation>Remover Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="567"/>
         <source>Writers</source>
-        <translation>Argumentistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="605"/>
         <source>Add Writer</source>
-        <translation>Adicionar argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="619"/>
         <source>Remove Writer</source>
-        <translation>Remover Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="759"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="784"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="789"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="831"/>
         <source>Add Actor</source>
-        <translation>Adicionar Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="804"/>
         <source>Remove Actor</source>
-        <translation>Remover Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="878"/>
         <source>Click to change</source>
-        <translation>Clique para Alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="932"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="991"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="940"/>
         <source>Scantype</source>
-        <translation>TipoAnálise</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="894"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1081"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1106"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="525"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="528"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="981"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1096"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1045"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="429"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="959"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="924"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1116"/>
         <source>Stereo Mode</source>
-        <translation>Modo de Estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1137"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1211"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1233"/>
         <source>Click to Change</source>
-        <translation>Clique para Alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="115"/>
         <source>Episode missing</source>
-        <translation>Episódio em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="92"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="518"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="552"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="524"/>
@@ -8677,68 +8587,68 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="556"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="557"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="526"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="529"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="544"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="585"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="618"/>
         <source>Episode Saved</source>
-        <translation>O episódio foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="620"/>
         <source>Could not save episode S%1E%2 of show &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="666"/>
         <source>Scraping episode...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="800"/>
         <source>Unknown Director</source>
-        <translation>Realizador Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="850"/>
         <source>Unknown Writer</source>
-        <translation>Argumentista desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1107"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1108"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1171"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1171"/>
         <source>Images (*.jpg *.jpeg)</source>
-        <translation>Imagens (*.jpg *.jpeg)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8746,69 +8656,69 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="63"/>
         <source>Episode has changed. Click to revert changes.</source>
-        <translation>O episódio foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="83"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="138"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="149"/>
         <source>Season Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="171"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="232"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="193"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="254"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="298"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="276"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="320"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="342"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="119"/>
         <source>Season missing</source>
-        <translation>Temporada em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.cpp" line="111"/>
         <source>Season %1</source>
-        <translation>Temporada %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.cpp" line="188"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8816,208 +8726,208 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="50"/>
         <source>TV Show has changed. Click to revert changes.</source>
-        <translation>A série de TV foi alterada. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="70"/>
         <source>Show Title</source>
-        <translation>Mostrar título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="98"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="112"/>
         <source>Dir</source>
-        <translation>Dir</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="126"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="208"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="242"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="252"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="315"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="352"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="369"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="379"/>
         <source>dd.MM.yyyy</source>
-        <translation>dd.MM.yyyy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="406"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="460"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="416"/>
         <source>TV Tune</source>
-        <translation>Tema musical</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="425"/>
         <source>Existing</source>
-        <translation>Presente</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="432"/>
         <source>Missing</source>
-        <translation>Em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="448"/>
         <source>Download Theme</source>
-        <translation>Descarregar tema musical</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="386"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="396"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="505"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="201"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="522"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="533"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="558"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="563"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="605"/>
         <source>Add Actor</source>
-        <translation>Adicionar ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="578"/>
         <source>Remove Actor</source>
-        <translation>Remover ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="263"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="137"/>
         <source>TheTVDB ID</source>
-        <translation>Identificador TheTVDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="482"/>
         <source>Continuing</source>
-        <translation>Continuando</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="487"/>
         <source>Ended</source>
-        <translation>Finalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="495"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="154"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="512"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="652"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1221"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="668"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="717"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="739"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="762"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="906"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="928"/>
@@ -9027,92 +8937,92 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1133"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1177"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="950"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="994"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1199"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1067"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1111"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1155"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="78"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="79"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="83"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="84"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="456"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="497"/>
         <source>Please wait while your TV show is scraped</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="724"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="878"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="879"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="960"/>
         <source>Choose Image</source>
-        <translation>Escolher Imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="960"/>
         <source>Images (*.jpg *.jpeg)</source>
-        <translation>Imagens (*.jpg *.jpeg)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9120,53 +9030,53 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="17"/>
         <source>TV Tunes</source>
-        <translation>Temas musicais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="54"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="118"/>
         <source>Progress</source>
-        <translation>Progresso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="141"/>
         <source>Download</source>
-        <translation>Descarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="148"/>
         <source>Cancel Download</source>
-        <translation>Cancelar descarregamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="172"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="251"/>
         <source>Download Finished</source>
-        <translation>Descarregamento concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="256"/>
         <source>The file %1 already exists.</source>
-        <translation>O ficheiro %1 já existe.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="258"/>
         <source>Do you want to overwrite it?</source>
         <extracomment>&quot;it&quot; refers to the file</extracomment>
-        <translation>Quer substituí-lo?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="272"/>
         <source>Download Canceled</source>
-        <translation>Descarregamento cancelado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9174,47 +9084,47 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="45"/>
         <source>Cancel extraction</source>
-        <translation>Cancelar extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="65"/>
         <source>Extract without password</source>
-        <translation>Extrair sem palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="68"/>
         <source>Extract</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="75"/>
         <source>Extract with password</source>
-        <translation>Extrair com palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="95"/>
         <source>Delete this archive</source>
-        <translation>Eliminar este ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="50"/>
         <source>Extraction password</source>
-        <translation>Palavra-passe para extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="50"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="65"/>
         <source>Delete archive?</source>
-        <translation>Eliminar ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="66"/>
         <source>Do you really want to delete this archive?</source>
-        <translation>Quer mesmo eliminar este ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9222,17 +9132,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="63"/>
         <source>Updates available</source>
-        <translation>Atualizações disponíveis</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="64"/>
         <source>%1 is now available.&lt;br&gt;Get it now on %2</source>
-        <translation>%1 já está disponível.&lt;br&gt;Obtenha-o agora em %2</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="68"/>
         <source>Don&apos;t check for updates</source>
-        <translation>Não verificar atualizações</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9240,7 +9150,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/small_widgets/WebImageLabel.ui" line="47"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9248,33 +9158,33 @@ episode after scraping</source>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="28"/>
         <source>Could not get duration of file</source>
-        <translation>Não foi possível obter a duração do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="47"/>
         <source>Could not detect runtime of file</source>
-        <translation>Não foi possível detetar o tempo de reprodução do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="56"/>
         <location filename="../../src/media/ImageCapture.cpp" line="84"/>
         <source>Temporary output file could not be opened</source>
-        <translation>Não foi possível abrir o ficheiro de saída temporário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="71"/>
         <source>Could not start ffmpeg</source>
-        <translation>Não foi possível iniciar o ffmpeg</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="74"/>
         <source>Could not start ffmpeg. Please install it and make it available in your $PATH</source>
-        <translation>Não foi possível iniciar o ffmpeg. Por favor instale-o e torne-o disponível no seu $PATH</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="80"/>
         <source>ffmpeg did not finish</source>
-        <translation>ffmpeg não finalizou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9282,7 +9192,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/file_search/movie/MovieDirectorySearcher.cpp" line="391"/>
         <source>Storing movies in database...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9290,35 +9200,35 @@ episode after scraping</source>
     <message>
         <location filename="../../src/file_search/movie/MovieFileSearcher.cpp" line="58"/>
         <source>Searching for Movies...</source>
-        <translation>A procurar por filmes...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/movie/MovieFileSearcher.cpp" line="148"/>
         <source>Searching for movies...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
         <source>Straight</source>
-        <translation>Heterossexual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Gay</source>
-        <translation>Homossexual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9326,12 +9236,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/custom/CustomMovieScraper.cpp" line="20"/>
         <source>Custom Movie Scraper</source>
-        <translation>Extrator de filmes personalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/custom/CustomMovieScraper.cpp" line="178"/>
         <source>TMDb ID is invalid. Cannot scrape movie.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9339,12 +9249,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/custom/CustomTvScraper.cpp" line="28"/>
         <source>Custom TV scraper</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/custom/CustomTvScraper.cpp" line="33"/>
         <source>The custom TV scraper combines multiple scrapers so that details can be loaded from different sites in one step. It depends on TMDb for loading other scraper IDs.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9352,162 +9262,162 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="26"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="84"/>
         <source>Bulgarian</source>
-        <translation>Búlgaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="85"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="86"/>
         <source>Croatian</source>
-        <translation>Croata</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="87"/>
         <source>Czech</source>
-        <translation>Checo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="88"/>
         <source>Danish</source>
-        <translation>Dinamarquês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="89"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="90"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="91"/>
         <source>Finnish</source>
-        <translation>Finlandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="92"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="93"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="94"/>
         <source>Greek</source>
-        <translation>Grego</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="95"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="96"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="97"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="98"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="99"/>
         <source>Korean</source>
-        <translation>Coreano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="100"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="101"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="102"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="103"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="104"/>
         <source>Slovene</source>
-        <translation>Eslovaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="105"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="106"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="107"/>
         <source>Turkish</source>
-        <translation>Turco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="111"/>
         <source>Blu-ray</source>
-        <translation>BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="112"/>
         <source>DVD</source>
-        <translation>DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="115"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="117"/>
         <source>Preferred Disc Type</source>
-        <translation>Tipo de disco preferido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="119"/>
         <source>Personal API key</source>
-        <translation>Chave pessoal da API</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="356"/>
         <source>Movie not found on Fanart.tv</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="568"/>
         <source>TV show not found on Fanart.tv</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9515,7 +9425,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTvMusic.cpp" line="25"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9523,7 +9433,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTvMusicArtists.cpp" line="22"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9531,12 +9441,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/imdb/ImdbMovie.cpp" line="20"/>
         <source>IMDb is the world&apos;s most popular and authoritative source for movie, TV and celebrity content, designed to help fans explore the world of movies and shows and decide what to watch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/imdb/ImdbMovie.cpp" line="47"/>
         <source>Load all tags</source>
-        <translation>Carregar todas as etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9544,7 +9454,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTv.cpp" line="20"/>
         <source>IMDb is the world&apos;s most popular and authoritative source for movie, TV and celebrity content, designed to help fans explore the world of movies and shows and decide what to watch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9552,22 +9462,22 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="37"/>
         <source>Neither IMDb show ID nor episode ID are valid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="61"/>
         <source>IMDb ID could not be loaded from season page! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="76"/>
         <source>IMDb ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="90"/>
         <source>Loaded IMDb content is empty. Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9575,7 +9485,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing an IMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9583,17 +9493,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="92"/>
         <source>Could not extract JSON details from IMDb page!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="102"/>
         <source>Could not parse JSON from IMDb page!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="108"/>
         <source>Expected parsed IMDb JSON to be an object!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9601,7 +9511,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowScrapeJob.cpp" line="34"/>
         <source>Show is missing an IMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9609,12 +9519,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowSearchJob.cpp" line="20"/>
         <source>Loaded IMDb web page content is empty. Cannot scrape requested TV show.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowSearchJob.cpp" line="24"/>
         <source>Could not find result table in the scraped HTML. Please contact MediaElch&apos;s developers.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9622,7 +9532,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/TMDbImages.cpp" line="15"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9630,7 +9540,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDb.cpp" line="19"/>
         <source>TheTvDb is one of the most accurate sources for TV and film. Their information comes from fans like you, so create a free account on their website and help your favorite shows and movies. Everything added is shared not only with MediaElch but many other sites, mobile apps, and devices as well.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9638,7 +9548,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbEpisodeScrapeJob.cpp" line="65"/>
         <source>TheTvDb ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9646,7 +9556,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/TheTvDbImages.cpp" line="19"/>
         <source>TheTvDb is one of the most accurate sources for TV and film. Their information comes from fans like you, so create a free account on their website and help your favorite shows and movies. Everything added is shared not only with MediaElch but many other sites, mobile apps, and devices as well.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9654,7 +9564,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbSeasonScrapeJob.cpp" line="26"/>
         <source>Show is missing a TheTvDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9662,7 +9572,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbShowScrapeJob.cpp" line="46"/>
         <source>Show is missing a TheTvDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9670,12 +9580,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/concert/tmdb/TmdbConcert.cpp" line="28"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/concert/tmdb/TmdbConcert.cpp" line="132"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9683,12 +9593,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/tmdb/TmdbMovie.cpp" line="45"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/tmdb/TmdbMovie.cpp" line="158"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9696,7 +9606,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTv.cpp" line="20"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9704,7 +9614,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvEpisodeScrapeJob.cpp" line="26"/>
         <source>TMDb show ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9712,7 +9622,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9720,12 +9630,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp" line="41"/>
         <source>Continuing</source>
-        <translation>Continuando</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp" line="41"/>
         <source>Ended</source>
-        <translation>Finalizado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9733,7 +9643,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowScrapeJob.cpp" line="23"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9741,7 +9651,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMaze.cpp" line="19"/>
         <source>TVmaze is a collaborative site, which can be edited by any registered user. Find episode information for any show on any device. anytime, anywhere!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9749,12 +9659,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.cpp" line="39"/>
         <source>TVmaze show ID are valid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.cpp" line="66"/>
         <source>TVmaze ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9762,7 +9672,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9770,7 +9680,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeShowScrapeJob.cpp" line="29"/>
         <source>TV show is missing a TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9778,107 +9688,107 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="31"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="32"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="33"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="34"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="35"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="36"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="37"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="38"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="39"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="40"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="41"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="42"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="43"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="44"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="45"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="47"/>
         <source>The Audio DB</source>
-        <translation>The Audio DB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="48"/>
         <source>MusicBrainz</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="49"/>
         <source>AllMusic</source>
-        <translation>AllMusic</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="50"/>
         <source>Discogs</source>
-        <translation>Discogs</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="52"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="54"/>
         <source>Prefer</source>
-        <translation>Preferir</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9886,7 +9796,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/videobuster/VideoBuster.cpp" line="18"/>
         <source>VideoBuster is a German movie database.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/data/i18n/MediaElch_my.ts
+++ b/data/i18n/MediaElch_my.ts
@@ -1,112 +1,110 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="pt_PT">
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="my">
 <context>
     <name>AboutDialog</name>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="23"/>
         <source>About MediaElch</source>
-        <translation>Sobre o MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="44"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="112"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="155"/>
         <source>Icon Sets: Retina by &quot;The Working Group&quot; and &quot;Capital Suite&quot; by &quot;capital18 (Jugal Paryani)&quot;</source>
-        <translation>Conjuntos de ícones: Retina de &quot;The Working Group&quot; e &quot;Capital Suite&quot;, de &quot;capital18 (Jugal Paryani)&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="178"/>
         <source>MediaElch Icon by Kathrin Luckner</source>
-        <translation>Ícone do MediaElch por Kathrin Luckner</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="120"/>
         <source>MediaElch was built with &lt;a href=&quot;https://www.qt.io/&quot;&gt;Qt&lt;/a&gt;</source>
-        <translation>O MediaElch foi feito com o &lt;a href=&quot;https://www.qt.io/&quot;&gt;Qt&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="146"/>
         <source>About Qt</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="165"/>
         <source>&lt;a href=&quot;https://develop.kde.org/frameworks/breeze-icons/&quot; title=&quot;KDE Breeze Website&quot;&gt;Breeze icons&lt;/a&gt; copyright KDE and licenced under the GNU LGPL version 3 or later</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="188"/>
         <source>Stream Details detection with &lt;a href=&quot;https://www.mediaarea.net&quot;&gt;Media Info&lt;/a&gt;</source>
-        <translation>Deteção de detalhes da transmissão com &lt;a href=&quot;https://www.mediaarea.net&quot;&gt;Media Info&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="201"/>
         <source>&lt;a href=&quot;https://www.mediaelch.de/mediaelch/&quot;&gt;http://www.mediaelch.de&lt;/a&gt; powered by &lt;a href=&quot;https://www.kvibes.de&quot;&gt;k.vibes&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="211"/>
         <source>Bugs and wishes can be reported on &lt;a href=&quot;https://github.com/Komet/MediaElch/issues&quot;&gt;GitHub&lt;/a&gt; .</source>
-        <translation>Os erros e desejos podem ser reportados no &lt;a href=&quot;https://github.com/Komet/MediaElch/issues&quot;&gt;GitHub&lt;/a&gt; .</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="238"/>
         <source>Developer</source>
-        <translation>Programador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="244"/>
         <source>The information below is important for developers. Please provide if you need help.</source>
-        <translation>Os dados abaixo são importantes para os programadores. Por favor, inclua no seu pedido de ajuda.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="272"/>
         <source>Copy to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="295"/>
         <source>Your Collection</source>
-        <translation>A sua coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="304"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="337"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="370"/>
         <source>Episodes</source>
-        <translation>Episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="403"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="436"/>
         <source>Artists</source>
-        <translation>Artistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="466"/>
         <source>Albums</source>
-        <translation>Álbuns</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -114,12 +112,12 @@
     <message>
         <location filename="../../src/model/ActorModel.cpp" line="83"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/ActorModel.cpp" line="84"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -127,47 +125,47 @@
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="14"/>
         <source>Form</source>
-        <translation>Formulário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="46"/>
         <source>Remove Actor</source>
-        <translation>Remover ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="73"/>
         <source>Add Actor</source>
-        <translation>Adicionar ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="107"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="123"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="66"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="67"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="159"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="161"/>
         <source>Images (*.jpg *.jpeg *.png)</source>
-        <translation>Imagens (*.jpg *.jpeg *.png)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -175,63 +173,63 @@
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="52"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="79"/>
         <source>TextLabel</source>
-        <translation>EtiquetaTexto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="116"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="139"/>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="142"/>
         <source>Add Movie</source>
-        <translation>Adicionar Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="149"/>
         <source>Remove Current Movie</source>
-        <translation>Remover filme atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="152"/>
         <source>Remove Movie</source>
-        <translation>Remover Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="165"/>
         <source>Double click a certification to rename it, right click to delete. If you want to merge two certifications just give them the same name.</source>
-        <translation>Clique duas vezes numa certificação para lhe alterar o nome, clique com o botão direito para eliminá-la. Se quiser fundir duas classificações, basta colocar-lhes o mesmo nome.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="175"/>
         <source>Please keep in mind that the changes you make here (renaming or deleting certifications) will be made for every movie.</source>
-        <translation>Por favor, lembre-se que todas as alterações feitas aqui (alterar o nome ou eliminar certificações) serão feitas para todos os filmes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="28"/>
         <source>Add Certification</source>
-        <translation>Adicionar certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="29"/>
         <source>Delete Certification</source>
-        <translation>Eliminar certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="175"/>
         <source>New Certification</source>
-        <translation>Nova certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="286"/>
         <source>All Movies Saved</source>
-        <translation>Foram guardados todos os filmes</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -239,37 +237,37 @@
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="112"/>
         <source>Delete Image</source>
-        <translation>Eliminar imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="119"/>
         <source>Zoom Image</source>
-        <translation>Ampliar imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="125"/>
         <source>Capture random screenshot</source>
-        <translation>Capturar ecrã aleatório</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="131"/>
         <source>Select another image</source>
-        <translation>Selecionar outra imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="420"/>
         <source>Really delete image?</source>
-        <translation>Quer eliminar a imagem?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="421"/>
         <source>Are you sure you want to delete this image?</source>
-        <translation>Tem a certeza que quer eliminar esta imagem?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="423"/>
         <source>Do not ask again</source>
-        <translation>Não perguntar de novo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -277,12 +275,12 @@
     <message>
         <location filename="../../src/file_search/ConcertFileSearcher.cpp" line="53"/>
         <source>Searching for Concerts...</source>
-        <translation>A procurar concertos...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/ConcertFileSearcher.cpp" line="59"/>
         <source>Loading Concerts...</source>
-        <translation>A carregar concertos...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -291,58 +289,52 @@
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="22"/>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="363"/>
         <source>%n concerts</source>
-        <translation>
-            <numerusform>%n concerto</numerusform>
-            <numerusform>%n concertos</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="42"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="43"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="44"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="45"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="46"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="47"/>
         <source>Open Concert Folder</source>
-        <translation>Abrir pasta do concerto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="48"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="49"/>
         <source>Play concert</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="365"/>
         <source>%1 of %n concerts</source>
-        <translation>
-            <numerusform>%1 de %n concerto</numerusform>
-            <numerusform>%1 de %n concertos</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -350,108 +342,108 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="38"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="105"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="119"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="129"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="139"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="149"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="159"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="170"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="210"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="227"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="237"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="247"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="264"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="274"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="309"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="339"/>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="342"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="345"/>
         <source>Not watched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="354"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="52"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="63"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="94"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -459,12 +451,12 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -472,115 +464,112 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="31"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="41"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="110"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="132"/>
         <source>Infos to load</source>
-        <translation>Informações a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="155"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="162"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="169"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="176"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="183"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="190"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="197"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="204"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="211"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="218"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="225"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="232"/>
         <source>Logo, Clear Art, CD Art</source>
-        <translation>Logótipo, Clear Art, CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="235"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="249"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="106"/>
         <source>The %1 scraper could not be initialized!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="119"/>
         <source>Please insert a search string!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="141"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="226"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -588,42 +577,42 @@
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your concerts. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Em baixo, pode ver os nomes de ficheiros usados para carregar e guardar os seus concertos. Pode editá-los à sua vontade, se quiser usar vários ficheiros separe-os com uma vírgula.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o de nome de ficheiro sem extensão.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="42"/>
         <source>Nfo</source>
-        <translation>Nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="71"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="100"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="129"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="158"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="187"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -633,63 +622,63 @@
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="132"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="135"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="54"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="76"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="91"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="101"/>
         <source>Scantype</source>
-        <translation>Varrimento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="111"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="165"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="185"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="195"/>
         <source>Stereo Mode</source>
-        <translation>Modo de estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="212"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="71"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="125"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="159"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="131"/>
@@ -697,18 +686,18 @@
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="163"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="164"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="133"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="136"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="151"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -716,47 +705,47 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="50"/>
         <source>Concert has changed. Click to revert changes.</source>
-        <translation>O concerto foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="76"/>
         <source>Concert Name</source>
-        <translation>Nome do concerto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="127"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="153"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="175"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="198"/>
         <source>Add Images</source>
-        <translation>Adicionar Imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="208"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="354"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="376"/>
@@ -765,62 +754,62 @@
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="537"/>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="581"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="398"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="471"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="515"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="559"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="79"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="80"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="84"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="85"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="447"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="458"/>
         <source>Concerts Saved</source>
-        <translation>Concertos guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="485"/>
         <source>All Concerts Saved</source>
-        <translation>Todos os concertos guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -828,185 +817,185 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="14"/>
         <source>CSV Export</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="22"/>
         <source>CSV Columns</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="35"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="242"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="40"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="252"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="45"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="262"/>
         <source>TV Episodes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="50"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="272"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="55"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="282"/>
         <source>Music Artists</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="60"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="292"/>
         <source>Music Albums</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="225"/>
         <source>Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="233"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="304"/>
         <source>Separator</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="321"/>
         <source>Replacement</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="340"/>
         <source>Linebreaks will be replaced by &lt;code&gt;\n&lt;/code&gt;. </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="350"/>
         <source>If any text contains the separator, it will be replaced by the replacement set above.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="373"/>
         <source>&lt;b&gt;Tip:&lt;/b&gt; You can sort the items by Drag &amp;amp; Drop.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="390"/>
         <source>Export as CSV</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="29"/>
         <source>Tab</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="30"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="35"/>
         <source>Semicolon (;)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="31"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="36"/>
         <source>Comma (,)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="34"/>
         <source>Space</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="37"/>
         <source>Minus (-)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="52"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="112"/>
         <source>Export directory</source>
-        <translation>Exportar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="114"/>
         <source>Export aborted. No directory was selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="130"/>
         <source>Export movies...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="147"/>
         <source>Export TV shows...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="161"/>
         <source>Export TV episodes...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="179"/>
         <source>Export concerts...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="197"/>
         <source>Export artists...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="212"/>
         <source>Export albums...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="227"/>
         <source>Export completed in %1 seconds.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="319"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="399"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="444"/>
         <source>Streamdetails - Duration (in seconds)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="400"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="445"/>
         <source>Streamdetails - Video Aspect</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="321"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="401"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="446"/>
         <source>Streamdetails - Video Width</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="290"/>
@@ -1016,162 +1005,162 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="467"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="495"/>
         <source>Type</source>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="320"/>
         <source>Streamdetails - Video Aspect Ratio</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="322"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="402"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="447"/>
         <source>Streamdetails - Video Height</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="323"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="403"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="448"/>
         <source>Streamdetails - Video Codec</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="324"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="404"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="449"/>
         <source>Streamdetails - Audio Language(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="325"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="405"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="450"/>
         <source>Streamdetails - Audio Codec(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="326"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="406"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="451"/>
         <source>Streamdetails - Audio Channel(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="327"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="407"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="452"/>
         <source>Streamdetails - Subtitle Language(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="380"/>
         <source>TV Show - TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="379"/>
         <source>TV Show - IMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="291"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="345"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="425"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="292"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="344"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="424"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="293"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="348"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="423"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="294"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="350"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="426"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="295"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="349"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="296"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="361"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="429"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="297"/>
         <source>Outline</source>
-        <translation>Resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="298"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="299"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="359"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="431"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="300"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="358"/>
         <source>IMDb Top 250</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="301"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="432"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="302"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="433"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="303"/>
         <source>Runtime in minutes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="304"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="353"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="435"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="305"/>
         <source>Writers</source>
-        <translation>Argumentistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="306"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="307"/>
@@ -1179,51 +1168,51 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="436"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="469"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="308"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="309"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="310"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="355"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="437"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="311"/>
         <source>Trailers</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="312"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="360"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="313"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Playcount</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="314"/>
         <source>Last played</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="315"/>
         <source>Movie Set</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="316"/>
@@ -1231,301 +1220,301 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="442"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="480"/>
         <source>Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="443"/>
         <source>Filename(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="318"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="441"/>
         <source>Last Modified Date</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="346"/>
         <source>TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="347"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="351"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="352"/>
         <source>network</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="356"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="434"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="357"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="430"/>
         <source>Ratings</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="381"/>
         <source>TV Show - TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="382"/>
         <source>TV Show - TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="383"/>
         <source>TV Show - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="427"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="428"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Trailer URL</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="440"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="468"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="470"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="471"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="472"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="473"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="474"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="475"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="476"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="477"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="478"/>
         <source>MusicBrainz ID</source>
-        <translation>Identificador MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="479"/>
         <source>AllMusic ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="384"/>
         <source>Episode - Season</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="385"/>
         <source>Episode - Number</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="386"/>
         <source>Episode - IMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="387"/>
         <source>Episode - TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="388"/>
         <source>Episode - TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="389"/>
         <source>Episode - TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="390"/>
         <source>Episode - First Aired</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="391"/>
         <source>Episode - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="392"/>
         <source>Episode - Overview</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="393"/>
         <source>Episode - User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="394"/>
         <source>Episode - Directors</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <source>Episode - Writers</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <source>Episode - Actors</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="397"/>
         <source>Episode - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="398"/>
         <source>Episode - Filename(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="496"/>
         <source>Artist - Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="497"/>
         <source>Album - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="498"/>
         <source>Album - Artist Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="499"/>
         <source>Album - Genres</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="500"/>
         <source>Album - Styles</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="501"/>
         <source>Album - Moods</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="502"/>
         <source>Album - Review</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="503"/>
         <source>Album - Release Date</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="504"/>
         <source>Album - Label</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="505"/>
         <source>Album - Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="506"/>
         <source>Album - Year</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="507"/>
         <source>Album - MusicBrainz ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="508"/>
         <source>Album - MusicBrainz ReleaseGroup ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="509"/>
         <source>Album - AllMusic ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="510"/>
         <source>Album - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="550"/>
         <source>Export failed. Could not write to CSV file.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="540"/>
         <source>Export failed. File could not be opened for writing.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1533,35 +1522,35 @@
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="29"/>
         <source>Select which site you prefer for each element of a TV show and episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="43"/>
         <source>TV show details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="65"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="101"/>
         <source>Item</source>
-        <translation>Item</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="70"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="106"/>
         <source>Site</source>
-        <translation>Site</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="79"/>
         <source>Episode details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.cpp" line="149"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.cpp" line="183"/>
         <source>No Scraper Available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1569,65 +1558,62 @@
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="50"/>
         <source>Archives</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="94"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="215"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="99"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="220"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="104"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="225"/>
         <source>Size</source>
-        <translation>Tamanho</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="146"/>
         <source>Importable items</source>
-        <translation>Itens importáveis</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="172"/>
         <source>Import movie with MakeMKV</source>
-        <translation>Importar filme com o MakeMKV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="230"/>
         <source>Import Type</source>
         <extracomment>(e.g. movie, TV show, concert)</extracomment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="233"/>
         <source>Type of this file.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="238"/>
         <source>Import Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="241"/>
         <source>Where to store the file when importing it.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="126"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="268"/>
         <source>%n files</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="202"/>
@@ -1635,50 +1621,50 @@
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="209"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="221"/>
         <source>Extraction failed</source>
-        <translation>A extração falhou</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="203"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="206"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="209"/>
         <source>Extraction of %1 has failed: %2</source>
-        <translation>A extração de %1 falhou: %2</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="219"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="233"/>
         <source>Extraction finished</source>
-        <translation>A extração terminou</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="233"/>
         <source>Extraction of %1 finished</source>
-        <translation>A extração de %1 foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="281"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="282"/>
         <source>TV Show</source>
-        <translation>Série TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="283"/>
         <source>Concert</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="464"/>
         <source>makemkvcon missing</source>
-        <translation>makemkvcon não foi encontrado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="465"/>
         <source>Please set the correct path to makemkvcon in MediaElch&apos;s settings.</source>
-        <translation>Por favor defina o caminho para o makemkvcon.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1687,87 +1673,87 @@
         <location filename="../../src/ui/export/ExportDialog.ui" line="23"/>
         <location filename="../../src/ui/export/ExportDialog.ui" line="132"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="32"/>
         <source>Export your complete collection.</source>
-        <translation>Exportar a sua coleção completa.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="39"/>
         <source>Message</source>
-        <translation>Mensagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="51"/>
         <source>Theme</source>
-        <translation>Tema</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="61"/>
         <source>Items to export</source>
-        <translation>Itens para exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="68"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="78"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="88"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="109"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="36"/>
         <source>You need to install at least one theme.</source>
-        <translation>Tem de instalar pelo menos um tema.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="58"/>
         <source>You need to select at least one media type to export.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="68"/>
         <source>Export directory</source>
-        <translation>Exportar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="70"/>
         <source>Export aborted. No directory was selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="78"/>
         <source>Could not create export directory.</source>
-        <translation>Não foi possível criar a pasta para exportação.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="95"/>
         <source>Export canceled.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="98"/>
         <source>Export completed.</source>
-        <translation>Exportação concluída.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="145"/>
         <source>Selected theme not found! Try to restart MediaElch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1775,28 +1761,28 @@
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.ui" line="17"/>
         <source>Message</source>
-        <translation>Mensagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.ui" line="43"/>
         <source>Theme</source>
-        <translation>Tema</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="67"/>
         <source>Theme &quot;%1&quot; was successfully installed</source>
-        <translation>O tema &quot;%1&quot; foi instalado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="70"/>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="81"/>
         <source>There was an error while processing the theme &quot;%1&quot;</source>
-        <translation>Ocorreu um erro ao processar o tema &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="78"/>
         <source>Theme &quot;%1&quot; was successfully uninstalled</source>
-        <translation>O tema &quot;%1&quot; foi desinstalado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1805,47 +1791,47 @@
         <location filename="../../src/ui/settings/ExportTemplateWidget.ui" line="102"/>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="42"/>
         <source>Install</source>
-        <translation>Instalar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="25"/>
         <source>by %1</source>
-        <translation>de %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="30"/>
         <source>No website available.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="33"/>
         <source>Version %1</source>
-        <translation>Versão %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="36"/>
         <source>Update</source>
-        <translation>Atualizar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="39"/>
         <source>Uninstall</source>
-        <translation>Desinstalar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="52"/>
         <source>Updating...</source>
-        <translation>A atualizar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="56"/>
         <source>Installing...</source>
-        <translation>A instalar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="60"/>
         <source>Uninstalling...</source>
-        <translation>A desinstalar...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1853,12 +1839,12 @@
     <message>
         <location filename="../../src/import/Extractor.cpp" line="30"/>
         <source>No files to extract</source>
-        <translation>Não há ficheiros para extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/import/Extractor.cpp" line="40"/>
         <source>Unrar not found</source>
-        <translation>Unrar não foi encontrado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1866,7 +1852,7 @@
     <message>
         <location filename="../../src/ui/main/FileScannerDialog.ui" line="17"/>
         <source>File Scanner</source>
-        <translation>Analisador de ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1874,94 +1860,94 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.ui" line="17"/>
         <source>Filter</source>
-        <translation>Filtro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="117"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="214"/>
         <source>Title contains &quot;%1&quot;</source>
-        <translation>O título contém &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="127"/>
         <source>Filename contains &quot;%1&quot;</source>
-        <translation>O ficheiro contém &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="393"/>
         <source>Label &quot;%1&quot;</source>
-        <translation>Etiqueta &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="395"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="371"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="372"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="373"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>Country</source>
-        <translation>País</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="384"/>
         <source>Released %1</source>
-        <translation>Lançamento %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="384"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="378"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="122"/>
         <source>Original Title contains &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="137"/>
         <source>TMDb ID &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="374"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="375"/>
         <source>Tag</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="376"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="377"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>Video codec</source>
-        <translation>Codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="437"/>
@@ -1969,226 +1955,226 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="516"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="517"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="438"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="439"/>
         <source>Filename</source>
-        <translation>Nome do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>IMDb</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="442"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>Movie has no TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>No TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>TMDb</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="469"/>
         <source>Movie has Poster</source>
-        <translation>O filme tem cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="469"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>Movie has no Poster</source>
-        <translation>O filme não tem cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>No Poster</source>
-        <translation>Nenhum cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="471"/>
         <source>Movie has Extra Fanarts</source>
-        <translation>O filme tem fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="471"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>Movie has no Extra Fanarts</source>
-        <translation>O filme não tem fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>No Extra Fanarts</source>
-        <translation>Nenhuma fanart extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <source>Movie has Backdrop</source>
-        <translation>O filme tem fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Movie has no Backdrop</source>
-        <translation>O filme não tem fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>No Backdrop</source>
-        <translation>Nenhum fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>No Fanart</source>
-        <translation>Sem fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="475"/>
         <source>Movie has Logo</source>
-        <translation>O filme tem logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="475"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>Movie has no Logo</source>
-        <translation>O filme não tem logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>No Logo</source>
-        <translation>Nenhum logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="477"/>
         <source>Movie has Clear Art</source>
-        <translation>O filme tem Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="477"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>Movie has no Clear Art</source>
-        <translation>O filme não tem Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>No Clear Art</source>
-        <translation>Nenhuma Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="479"/>
         <source>Movie has Banner</source>
-        <translation>O filme tem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="479"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>Movie has no Banner</source>
-        <translation>O filme não tem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>No Banner</source>
-        <translation>Sem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="481"/>
         <source>Movie has Thumb</source>
-        <translation>O filme tem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="481"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>Movie has no Thumb</source>
-        <translation>O filme não tem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>No Thumb</source>
-        <translation>Sem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="483"/>
         <source>Movie has CD Art</source>
-        <translation>O filme tem CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="483"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>Movie has no CD Art</source>
-        <translation>O filme não tem CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>No CD Art</source>
-        <translation>Nenhuma CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="487"/>
         <source>Movie has Trailer</source>
-        <translation>O filme tem trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="487"/>
@@ -2196,239 +2182,239 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="488"/>
         <source>Movie has no Trailer</source>
-        <translation>O filme não tem trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="488"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>No Trailer</source>
-        <translation>Nenhum trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <source>Movie has local Trailer</source>
-        <translation>O filme tem um trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Movie has no local Trailer</source>
-        <translation>O filme não tem trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>No local Trailer</source>
-        <translation>Nenhum trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <source>Movie is Watched</source>
-        <translation>O filme foi visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Seen</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Movie is Unwatched</source>
-        <translation>O filme está por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Unwatched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Unseen</source>
-        <translation>Não visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>Movie has no Certification</source>
-        <translation>O filme não tem certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>No Certification</source>
-        <translation>Nenhuma certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>Movie has no Genre</source>
-        <translation>O filme não tem género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="132"/>
         <source>IMDb ID &quot;%1&quot;</source>
-        <translation>Identificador do IMDB &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="440"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>No Genre</source>
-        <translation>Nenhum género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="456"/>
         <source>Movie has Rating</source>
-        <translation>O filme tem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="456"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>Movie has no Rating</source>
-        <translation>O filme não tem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>No Rating</source>
-        <translation>Sem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="464"/>
         <source>Stream Details loaded</source>
-        <translation>Os detalhes da pista foram carregados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="464"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>Stream Details</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>Stream Details not loaded</source>
-        <translation>Os detalhes da pista não foram carregados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>No Stream Details</source>
-        <translation>Nenhuns detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="460"/>
         <source>Movie has Actors</source>
-        <translation>O filme tem atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="460"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>Movie has no Actors</source>
-        <translation>O filme não tem atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>No Actors</source>
-        <translation>Nenhuns atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>Movie has no Studio</source>
-        <translation>O filme não tem estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>No Studio</source>
-        <translation>Nenhum estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>Movie has no Country</source>
-        <translation>O filme não tem país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>No Country</source>
-        <translation>Nenhum país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>Movie has no Director</source>
-        <translation>O filme não tem realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>No Director</source>
-        <translation>Nenhum realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>No information about video codec</source>
-        <translation>Nenhuma informação sobre o codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>No video codec</source>
-        <translation>Sem codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>Movie has no Tags</source>
-        <translation>O filme não tem etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>No Tags</source>
-        <translation>Nenhumas etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>Movie has no IMDb ID</source>
-        <translation>Filme sem identificador IMDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>No IMDb ID</source>
-        <translation>Sem identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
         <source>Resolution 720p</source>
-        <translation>Resolução 720p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
         <source>720p</source>
-        <translation>720p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
@@ -2436,68 +2422,68 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="494"/>
         <source>Resolution 1080p</source>
-        <translation>Resolução 1080p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="494"/>
         <source>1080p</source>
-        <translation>1080p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <source>Resolution 2160p</source>
-        <translation>Resolução 2160p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <source>2160p</source>
-        <translation>2160p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>Resolution SD</source>
-        <translation>Resolução SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>SD</source>
-        <translation>SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <source>Format DVD</source>
-        <translation>Formato DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <source>DVD</source>
-        <translation>DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>Format</source>
-        <translation>Formato</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>BluRay Format</source>
-        <translation>Formato BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>BluRay</source>
-        <translation>BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
         <source>Channels 2.0</source>
-        <translation>Canais 2.0</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
@@ -2507,59 +2493,59 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="502"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="503"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="502"/>
         <source>Channels 5.1</source>
-        <translation>Canais 5.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="503"/>
         <source>Channels 7.1</source>
-        <translation>Canais 7.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="504"/>
         <source>Audio Quality HD</source>
-        <translation>Qualidade de áudio HD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="504"/>
         <source>HD Audio</source>
-        <translation>Áudio HD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <source>Audio Quality Normal</source>
-        <translation>Qualidade de áudio normal</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <source>Normal Audio</source>
-        <translation>Áudio normal</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>Audio Quality SD</source>
-        <translation>Qualidade de áudio SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>SD Audio</source>
-        <translation>Áudio SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="509"/>
         <source>Movie has Subtitle</source>
-        <translation>Filme com legenda</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="509"/>
@@ -2567,39 +2553,39 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>Subtitle</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="510"/>
         <source>Movie has no Subtitle</source>
-        <translation>O filme não tem legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="510"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>No Subtitle</source>
-        <translation>Sem legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <source>Movie has external Subtitle</source>
-        <translation>O filme tem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>External Subtitle</source>
-        <translation>Legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>Movie has no external Subtitle</source>
-        <translation>O filme não tem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>No External Subtitle</source>
-        <translation>Sem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2607,63 +2593,63 @@
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="52"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="79"/>
         <source>TextLabel</source>
-        <translation>EtiquetaTexto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="116"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="139"/>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="142"/>
         <source>Add Movie</source>
-        <translation>Adicionar filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="149"/>
         <source>Remove Current Movie</source>
-        <translation>Remover filme atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="152"/>
         <source>Remove Movie</source>
-        <translation>Remover filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="165"/>
         <source>Double click a genre to rename it, right click to delete. If you want to merge two genres just give them the same name.</source>
-        <translation>Clique duas vezes num género para lhe alterar o nome, clique com o botão direito para eliminá-lo. Se quiser fundir dois géneros, basta colocar-lhes o mesmo nome.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="175"/>
         <source>Please keep in mind that the changes you make here (renaming or deleting genres) will be made for every movie.</source>
-        <translation>Por favor, lembre-se que todas as alterações feitas aqui (alterar o nome ou eliminar géneros) serão feitas para todos os filmes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="28"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="29"/>
         <source>Delete Genre</source>
-        <translation>Eliminar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="172"/>
         <source>New Genre</source>
-        <translation>Novo género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="287"/>
         <source>All Movies Saved</source>
-        <translation>Todos os filmes foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2671,189 +2657,189 @@
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="21"/>
         <source>Directories</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="57"/>
         <source>Add one or more directories containing your movies, TV Shows, concerts, music or files to import.
 TV Show Episodes have to be in subfolders with the name of the show.
 The directories containing your music must contain subdirectories for each artist which contain directories of albums.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="91"/>
         <source>Type</source>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="96"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="101"/>
         <source>Sep. folders</source>
-        <translation>Pastas separadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="104"/>
         <source>Items are in separate folders</source>
-        <translation>Os itens estão em pastas separadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="109"/>
         <source>Reload On Start</source>
-        <translation>Recarregar ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="112"/>
         <source>Automatically reload contents on start</source>
-        <translation>Recarrega automaticamente os conteúdos ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="117"/>
         <source>Disabled</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="120"/>
         <source>Ignore this folder.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="130"/>
         <source>Add</source>
-        <translation>Adicionar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="137"/>
         <source>Remove</source>
-        <translation>Remover</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="144"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sort movies into separate directories&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ordenar filmes em pastas separadas&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="147"/>
         <source>Organize</source>
-        <translation>Organizar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="174"/>
         <source>Store trailer URLs in YouTube Plugin format</source>
-        <translation>Guardar endereços de trailers no formato YouTube Plugin</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="188"/>
         <source>Automatically load and save stream details from files</source>
-        <translation>Carregar e guardar automaticamente detalhes das pistas dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="202"/>
         <source>Ignore articles when sorting (&quot;The&quot;)</source>
-        <translation>Ignorar artigos iniciais ao ordenar (&quot;The&quot;)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="216"/>
         <source>Download actor images</source>
-        <translation>Descarregar imagens de atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="230"/>
         <source>Check for Updates on start</source>
-        <translation>Verificar se existem atualizações ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="244"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="263"/>
         <source>Words to exclude from media names (seperated by commas and non case-sensitive)</source>
-        <translation>Palavras a excluir dos nomes de média (separar com vírgulas e sem sensibilidade a maiúsculas)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="270"/>
         <source>Startup section</source>
-        <translation>Secção inicial</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="300"/>
         <source>Appearance</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="311"/>
         <source>Main Window Theme (changing it requires restart of MediaElch)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="42"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="43"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="44"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="45"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="46"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="48"/>
         <source>Auto</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="49"/>
         <source>Light</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="50"/>
         <source>Dark</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="66"/>
         <source>Choose a directory containing your movies, TV show or concerts</source>
-        <translation>Escolher uma pasta que contém os seus filmes, séries TV ou concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Downloads</source>
-        <translation>Descarregamentos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="265"/>
         <source>Organizing movies does only work on movies, not already sorted to separate folders.</source>
-        <translation>Organizar filmes funciona apenas em filmes, sem estarem já organizados em pastas separadas.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="273"/>
         <source>Are you sure?</source>
-        <translation>Tem a certeza?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="275"/>
         <source>This operation sorts all movies in this directory to separate sub-directories based on the file name. Click &quot;Ok&quot;, if that&apos;s, what you want to do. </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2861,22 +2847,22 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="17"/>
         <source>Choose an Image</source>
-        <translation>Escolher uma imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="31"/>
         <source>Enter a search term or URL</source>
-        <translation>Introduza um termo de busca ou um endereço</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="44"/>
         <source>Language to use when searching for a TV show by title.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="124"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="176"/>
@@ -2885,96 +2871,93 @@ The directories containing your music must contain subdirectories for each artis
         <location filename="../../src/ui/image/ImageDialog.ui" line="191"/>
         <location filename="../../src/ui/image/ImageDialog.ui" line="196"/>
         <source>Neue Spalte</source>
-        <translation>Nova coluna</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="703"/>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="711"/>
         <source>No images found</source>
-        <translation>Nenhumas imagens encontradas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="249"/>
         <source>Zoom out</source>
-        <translation>Diminuir ampliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="275"/>
         <source>Preview size</source>
-        <translation>Tamanho de pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="303"/>
         <source>Zoom in</source>
-        <translation>Aumentar ampliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="324"/>
         <source>Loading...</source>
-        <translation>A carregar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="347"/>
         <source>Choose Local Image</source>
-        <translation>Escolher imagem local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="360"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="367"/>
         <source>Accept Images</source>
-        <translation>Aceitar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="251"/>
         <source>Default</source>
-        <translation>Padrão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="158"/>
         <source>Neither an image provider nor previously scraped image URLs are available for the requested image type.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="360"/>
         <source>Error while downloading one or more images: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="523"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="523"/>
         <source>Images (*.jpg *.jpeg *.png)</source>
-        <translation>Imagens (*.jpg *.jpeg *.png)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="708"/>
         <source>Images provided by &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
-        <translation>Imagens fornecidas por  &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="712"/>
         <source>Contribute by uploading images to &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
-        <translation>Contribua enviando novas imagens para &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/image/ImageDialog.cpp" line="812"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="941"/>
         <source>Error while querying image provider: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2982,7 +2965,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/small_widgets/ImageLabel.ui" line="42"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2990,12 +2973,12 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/image/ImagePreviewDialog.ui" line="17"/>
         <source>Preview</source>
-        <translation>Pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImagePreviewDialog.ui" line="82"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3003,22 +2986,22 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/import/ImportActions.ui" line="23"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.ui" line="30"/>
         <source>Delete</source>
-        <translation>Eliminar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.cpp" line="128"/>
         <source>Delete file?</source>
-        <translation>Eliminar o ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.cpp" line="129"/>
         <source>Do you really want to delete this file?</source>
-        <translation>Quer mesmo eliminar este ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3026,144 +3009,141 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="17"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="40"/>
         <source>Loading</source>
-        <translation>A carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="47"/>
         <source>Success</source>
-        <translation>Sucesso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="54"/>
         <source>Loading movie...</source>
-        <translation>A carregar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="81"/>
         <source>Directory Naming</source>
-        <translation>Nomes das pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="91"/>
         <source>File Naming</source>
-        <translation>Nomes dos Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="108"/>
         <source>Use Season Directories</source>
-        <translation>Usar pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="115"/>
         <source>Season Directory Naming</source>
-        <translation>Nomes das pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="132"/>
         <source>Keep source files after import</source>
-        <translation>Manter ficheiros originais após importação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="175"/>
         <location filename="../../src/ui/import/ImportDialog.ui" line="185"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="205"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="274"/>
         <source>Loading movie information...</source>
-        <translation>A carregar a informação do filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="296"/>
         <source>Loading concert information...</source>
-        <translation>A carregar a informação do concerto...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="320"/>
         <source>Loading episode information...</source>
-        <translation>A carregar a informação do episódio...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="390"/>
         <source>Movie information was loaded</source>
-        <translation>A informação do filme foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="404"/>
         <source>Concert information was loaded</source>
-        <translation>A informação do concerto foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="423"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="442"/>
         <source>Episode information was loaded</source>
-        <translation>A informação do episódio foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="454"/>
         <source>Renaming not possible</source>
-        <translation>Não é possível alterar o nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="454"/>
         <source>Please enter all naming patterns</source>
-        <translation>Por favor, introduza todos os padrões de nomenclatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="484"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="577"/>
         <source>Creating destination directory failed</source>
-        <translation>Não foi possível criar a pasta de destino</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="485"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="578"/>
         <source>The destination directory %1 could not be created</source>
-        <translation>Não foi possível criar a pasta de destino %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="514"/>
         <source>Importing movie...</source>
-        <translation>A importar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="553"/>
         <source>Importing episode...</source>
-        <translation>A importar o episódio...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="605"/>
         <source>Importing concert...</source>
-        <translation>A importar o concerto...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="708"/>
         <source>Import finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/import/ImportDialog.cpp" line="709"/>
         <source>Import of %n files has finished</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="712"/>
         <source>Import has finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3171,33 +3151,33 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="19"/>
         <source>Automatically delete archives after extraction</source>
-        <translation>Eliminar ficheiros automaticamente após extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="33"/>
         <source>Path to unrar</source>
-        <translation>Localização do Unrar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="45"/>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="66"/>
         <source>Choose</source>
-        <translation>Escolher</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="54"/>
         <source>Path to makemkvcon</source>
-        <translation>Localização de makemkvcon</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.cpp" line="46"/>
         <source>Choose unrar</source>
-        <translation>Escolher Unrar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.cpp" line="54"/>
         <source>Choose makemkvcon</source>
-        <translation>Escolher makemkvco</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3205,49 +3185,47 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="17"/>
         <source>General Kodi Settings. MediaElch uses the Kodi version below for writing NFO files.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="29"/>
         <source>Kodi Version</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="48"/>
         <source>If you want to use the synchronization feature you need to enable the webserver within Kodi (Settings -&gt; Services -&gt; Webserver). Enter the port of the webserver here (usually 80 or 8080).</source>
-        <translation>Se quer usar o recurso de sincronização, deve antes ativar o servidor web dentro do Kodi.
-Veja em Kodi -&gt; Definições -&gt; Serviços -&gt; Servidor web. Anote os números de host (IP) e da porta.
-Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="63"/>
         <source>Host</source>
-        <translation>Anfitrião</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="70"/>
         <source>127.0.0.1</source>
-        <translation>127.0.0.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="77"/>
         <source>Port</source>
-        <translation>Porta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="84"/>
         <source>8080</source>
-        <translation>8080</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="91"/>
         <source>User</source>
-        <translation>Utilizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="98"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3255,68 +3233,68 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="23"/>
         <source>Kodi Synchronization</source>
-        <translation>Sincronização com Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="32"/>
         <source>Please make sure you have setup your sources in Kodi and that the webserver is enabled (Kodi -&gt; Settings -&gt; Services -&gt; Webserver).</source>
-        <translation>Por favor, certifique-se que configurou as suas fontes no Kodi e que o seu servidor web está ativado (Kodi -&gt; Definições -&gt; Serviços -&gt; Servidor web).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="42"/>
         <source>Update contents</source>
-        <translation>Atualizar conteúdos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="52"/>
         <source>This will tell Kodi to remove the changed movies, concerts or shows. Afterwards a Kodi library update is triggered and the removed items will be picked up again.</source>
-        <translation>Isto irá dizer ao Kodi para remover os filmes, concertos e séries com alterações. Após isso, o Kodi irá fazer uma atualização e os itens removidos serão novamente recolhidos e reinseridos.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="62"/>
         <source>Remove non-existent items from Kodis database (Clean library)</source>
-        <translation>Remover itens não existentes da base de dados do Kodi (limpar coleção).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="69"/>
         <source>Kodi will remove not longer existing items from your database.</source>
-        <translation>O Kodi irá remover os itens não localizados da sua base de dados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="76"/>
         <source>Retrieve watched status</source>
-        <translation>Obter estado de &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="83"/>
         <source>The fields last played and playcount will be retrieved from Kodi.</source>
-        <translation>Os campos Última Reprodução e Contador de Sessões virão do Kodi.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="113"/>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="120"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="138"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="161"/>
         <source>Start</source>
-        <translation>Iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="165"/>
         <source>Please fill in your Kodi host and port.</source>
-        <translation>Por favor introduza os dados de Host e Porta no menu Definições -&gt; Kodi.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="238"/>
         <source>Getting contents from Kodi</source>
-        <translation>A obter conteúdos do Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="254"/>
@@ -3324,52 +3302,52 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="318"/>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="350"/>
         <source>Network error</source>
-        <translation>Erro de rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="448"/>
         <source>Removing movies from database</source>
-        <translation>A remover filmes da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="463"/>
         <source>Removing concerts from database</source>
-        <translation>A remover concertos da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="478"/>
         <source>Removing TV shows from database</source>
-        <translation>A remover séries de TV da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="493"/>
         <source>Removing episodes from database</source>
-        <translation>A remover episódios da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="533"/>
         <source>Trigger scan for new items</source>
-        <translation>Requisitar busca de novos itens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="555"/>
         <source>Error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="560"/>
         <source>Finished. Kodi is now loading your updated items.</source>
-        <translation>Terminado. O Kodi está agora a carregar os seus itens atualizados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="582"/>
         <source>Finished. Kodi is now cleaning your database.</source>
-        <translation>Terminado. O Kodi está agora a limpar a sua base de dados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="627"/>
         <source>Finished. Your items play count and last played date have been updated.</source>
-        <translation>Concluído. O &quot;Nº de reproduções&quot; e a &quot;última reprodução&quot; dos seus itens foram atualizadas.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3377,7 +3355,7 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/small_widgets/LanguageCombo.cpp" line="37"/>
         <source>No language available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3385,17 +3363,17 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="23"/>
         <source>Loading Stream Details</source>
-        <translation>A carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="32"/>
         <source>Loading Stream Details...</source>
-        <translation>A carregar detalhes da pista...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="46"/>
         <source>File</source>
-        <translation>Ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3403,414 +3381,414 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/data/Locale.cpp" line="28"/>
         <source>Arabic</source>
-        <translation>Árabe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="29"/>
         <source>Arabic (U.A.E.)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="30"/>
         <source>Arabic (Saudi Arabia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="31"/>
         <source>Belarusian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="32"/>
         <location filename="../../src/data/Locale.cpp" line="33"/>
         <source>Bulgarian</source>
-        <translation>Búlgaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="34"/>
         <source>Bengali</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="35"/>
         <source>Catalan (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="36"/>
         <source>Chamorro (Guam)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="37"/>
         <source>Cantonese</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="38"/>
         <location filename="../../src/data/Locale.cpp" line="39"/>
         <source>Czech</source>
-        <translation>Checo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="40"/>
         <location filename="../../src/data/Locale.cpp" line="41"/>
         <source>Danish</source>
-        <translation>Dinamarquês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="42"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="43"/>
         <source>German (AT)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="44"/>
         <source>German (CH)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="45"/>
         <source>German (DE)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="46"/>
         <location filename="../../src/data/Locale.cpp" line="47"/>
         <source>Greek</source>
-        <translation>Grego</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="48"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="49"/>
         <source>English (Australia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="50"/>
         <source>English (Canada)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="51"/>
         <source>English (GB)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="52"/>
         <source>English (NZ)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="53"/>
         <source>English (US)</source>
-        <translation>Inglês (US)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="54"/>
         <source>Esperanto</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="55"/>
         <location filename="../../src/data/Locale.cpp" line="56"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="57"/>
         <source>Spanish (Mexico)</source>
-        <translation>Castelhano (México)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="58"/>
         <source>Estonian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="59"/>
         <source>Basque (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="60"/>
         <source>Persian (Iran)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="61"/>
         <location filename="../../src/data/Locale.cpp" line="62"/>
         <source>Finnish</source>
-        <translation>Finlandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="63"/>
         <location filename="../../src/data/Locale.cpp" line="65"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="64"/>
         <source>French (Canada)</source>
-        <translation>Francês (Canadá)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="66"/>
         <source>Galician (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="67"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="68"/>
         <source>Hebrew (Israel)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="69"/>
         <source>Hindi (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="70"/>
         <source>Croatian</source>
-        <translation>Croata</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="71"/>
         <source>Croatian (Croatia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="72"/>
         <location filename="../../src/data/Locale.cpp" line="73"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="74"/>
         <source>Indonesian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="75"/>
         <location filename="../../src/data/Locale.cpp" line="76"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="77"/>
         <location filename="../../src/data/Locale.cpp" line="78"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="79"/>
         <source>Georgian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="80"/>
         <source>Kazakh</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="81"/>
         <source>Kannada</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="82"/>
         <location filename="../../src/data/Locale.cpp" line="83"/>
         <source>Korean</source>
-        <translation>Coreano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="84"/>
         <source>Lithuanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="85"/>
         <source>Latvian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="86"/>
         <source>Malayalam</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="87"/>
         <source>Malay (Malaysia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="88"/>
         <source>Malay (Singapore)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="89"/>
         <source>Norwegian Bokmål</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="90"/>
         <location filename="../../src/data/Locale.cpp" line="91"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="92"/>
         <location filename="../../src/data/Locale.cpp" line="93"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="94"/>
         <location filename="../../src/data/Locale.cpp" line="95"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="96"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="97"/>
         <source>Portuguese (Brazil)</source>
-        <translation>Português (Brasil)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="98"/>
         <source>Portuguese (Portugal)</source>
-        <translation>Português (Portugal)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="99"/>
         <source>Romanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="100"/>
         <location filename="../../src/data/Locale.cpp" line="101"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="102"/>
         <source>Sinhalese (Sri Lanka)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="103"/>
         <source>Slovak</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="104"/>
         <source>Slovene</source>
-        <translation>Eslovaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="105"/>
         <source>Slovenian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="106"/>
         <source>Albanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="107"/>
         <source>Serbian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="108"/>
         <location filename="../../src/data/Locale.cpp" line="109"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="110"/>
         <source>Tamil (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="111"/>
         <source>Telugu (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="112"/>
         <source>Thai</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="113"/>
         <source>Tagalog (Philippines)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="114"/>
         <location filename="../../src/data/Locale.cpp" line="115"/>
         <source>Turkish</source>
-        <translation>Turco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="116"/>
         <source>Ukrainian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="117"/>
         <source>Vietnamese</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="118"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="119"/>
         <source>Chinese (PRC)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="120"/>
         <source>Chinese (Hong Kong)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="121"/>
         <source>Chinese (Taiwan)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="122"/>
         <source>Zulu</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="124"/>
         <source>No language available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3818,55 +3796,55 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="14"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="75"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="94"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="125"/>
         <source>Movie Sets</source>
-        <translation>Coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="156"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="187"/>
         <source>Certifications</source>
-        <translation>Certificações</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="218"/>
         <source>Duplicates</source>
-        <translation>Duplicados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="248"/>
         <source>Shows</source>
-        <translation>Séries</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="267"/>
         <source>TV Shows</source>
-        <translation>Séries TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="297"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="316"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="346"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="365"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="395"/>
@@ -3875,92 +3853,92 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
         <extracomment>Main menu entry
 ----------
 Main menu entry (tooltip)</extracomment>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="883"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="888"/>
         <source>Quit</source>
-        <translation>Sair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="893"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="52"/>
         <source>FAQ</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="53"/>
         <source>Troubleshooting</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="54"/>
         <source>Report Issue</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="56"/>
         <source>Release Notes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="57"/>
         <source>Documentation</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="58"/>
         <source>Blog</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="59"/>
         <source>Official Kodi Forum</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="61"/>
         <source>View License</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="340"/>
         <source>&amp;Quick Open</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="807"/>
         <source>Reload all Movies (%1)</source>
-        <translation>Recarregar todos os filmes (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="813"/>
         <source>Reload all TV Shows (%1)</source>
-        <translation>Recarregar todas as séries de TV (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="824"/>
         <source>Reload all Concerts (%1)</source>
-        <translation>Recarregar todos os Concertos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="840"/>
         <source>Reload all Downloads (%1)</source>
-        <translation>Recarregar todos os descarregamentos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="846"/>
         <source>Reload Music (%1)</source>
-        <translation>Recarregar música (%1)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3968,147 +3946,147 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="50"/>
         <source>Scan</source>
-        <translation>Análise</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="92"/>
         <source>Import Tracks</source>
-        <translation>Importar faixas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="118"/>
         <source>Backup Disc</source>
-        <translation>Disco de cópia de segurança</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="163"/>
         <source>Loading</source>
-        <translation>A carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="170"/>
         <source>Success</source>
-        <translation>Sucesso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="177"/>
         <source>Loading movie...</source>
-        <translation>A carregar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="199"/>
         <source>Placeholders</source>
-        <translation>Marcadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="207"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="236"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="259"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="282"/>
         <source>File extension</source>
-        <translation>Extensão de ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="298"/>
         <source>Placeholder</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="321"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="338"/>
         <source>Part number of the current file</source>
-        <translation>Número da parte do ficheiro atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="355"/>
         <source>Directory Naming</source>
-        <translation>Nomes das pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="365"/>
         <source>File Naming</source>
-        <translation>Nomes dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="375"/>
         <source>Multi-File Naming</source>
-        <translation>Renomear múltiplos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="385"/>
         <source>Import directory</source>
-        <translation>Pasta de importação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="429"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="452"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="207"/>
         <source>No tracks selected</source>
-        <translation>Não foram selecionadas faixas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="208"/>
         <source>Please select at least one track you want to import.</source>
-        <translation>Por favor, selecione pelo menos uma faixa para importar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="246"/>
         <source>Loading movie information...</source>
-        <translation>A carregar a informação do filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="274"/>
         <source>Movie information was loaded</source>
-        <translation>A informação de filme foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="297"/>
         <source>Creating destination directory failed</source>
-        <translation>Não foi possível criar a pasta de destino</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="298"/>
         <source>The destination directory %1 could not be created</source>
-        <translation>Não foi possível criar a pasta de destino %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="386"/>
         <source>MakeMKV import finished</source>
-        <translation>Importação MakeMKV foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="386"/>
         <source>Import with MakeMKV has finished</source>
-        <translation>A importação com o MakeMKV foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="389"/>
         <source>Import has finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4116,17 +4094,17 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="116"/>
         <source>Movie title</source>
-        <translation>Título do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="145"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="152"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4134,27 +4112,27 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.ui" line="67"/>
         <source>Detect duplicate movies</source>
-        <translation>Detetar filmes duplicados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="75"/>
         <source>Detecting duplicate movies...</source>
-        <translation>A detetar filmes duplicados...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="129"/>
         <source>Open Detail Page</source>
-        <translation>Abrir página de detalhes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="130"/>
         <source>Open Movie Folder</source>
-        <translation>Abrir pasta do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="131"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4162,19 +4140,18 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="25"/>
         <source>Source %1 is no directory</source>
-        <translation>A fonte %1 não é uma pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="83"/>
         <source>Operation not possible.</source>
-        <translation>Não foi possível efetuar a operação.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="84"/>
         <source>%1
  Operation Canceled.</source>
-        <translation>%1
- Operação Cancelada.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4182,99 +4159,93 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="144"/>
         <source>New</source>
-        <translation>Novo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="160"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="176"/>
         <source>Date Added</source>
-        <translation>Data de adição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="192"/>
         <source>Seen</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="208"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="30"/>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="562"/>
         <source>%n movies</source>
-        <translation>
-            <numerusform>%n filme</numerusform>
-            <numerusform>%n filmes</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="58"/>
         <source>Media Status Columns</source>
-        <translation>Colunas de estado do média</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="69"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="80"/>
         <source>Load Information</source>
-        <translation>Carregar informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="81"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="82"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="83"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="84"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="85"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="86"/>
         <source>Open Movie Folder</source>
-        <translation>Abrir pasta do Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="87"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="88"/>
         <source>Play movie</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="564"/>
         <source>%1 of %n movies</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -4282,85 +4253,85 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="17"/>
         <source>Choose a movie</source>
-        <translation>Escolher o filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="26"/>
         <source>Filter</source>
-        <translation>Filtro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="58"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="68"/>
         <source>Add selected movies</source>
-        <translation>Adicionar filmes selecionados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="88"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="326"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <source>Extra Arts</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <source>Extra Fanarts</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="329"/>
-        <source>Extra Arts</source>
-        <translation>Arts extras</translation>
+        <source>Fanart</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="330"/>
-        <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <source>Poster</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="331"/>
-        <source>Fanart</source>
-        <translation>Fanart</translation>
+        <source>Stream Details</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="332"/>
-        <source>Poster</source>
-        <translation>Cartaz</translation>
+        <source>Trailer</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="333"/>
-        <source>Stream Details</source>
-        <translation>Detalhes da pista</translation>
+        <source>Local Trailer</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="334"/>
-        <source>Trailer</source>
-        <translation>Trailer</translation>
+        <source>Subtitles</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="335"/>
-        <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <source>Tags</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="336"/>
-        <source>Subtitles</source>
-        <translation>Legendas</translation>
-    </message>
-    <message>
-        <location filename="../../src/model/MovieModel.cpp" line="337"/>
-        <source>Tags</source>
-        <translation>Etiquetas</translation>
-    </message>
-    <message>
-        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4368,185 +4339,182 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="23"/>
         <source>Movie Multi Scrape</source>
-        <translation>Extração múltipla de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="36"/>
         <source>Please select the scraper and the infos you want to be loaded. MediaElch will use the best result for each movie you selected.</source>
-        <translation>Por favor, escolha o extrator e as informações que pretende carregar. O MediaElch usará o melhor resultado para cada filme que selecionou.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="48"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="84"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="143"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="233"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="163"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="303"/>
         <source>Logo</source>
-        <translation>Logotipos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="223"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="133"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="113"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="93"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="103"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="173"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="213"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="203"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="153"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="123"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="183"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="243"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="253"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="193"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="293"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="283"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="273"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="263"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="313"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="332"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="358"/>
         <source>Automatically save each movie after scraping</source>
-        <translation>Guardar automaticamente cada filme após a extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="365"/>
         <source>Update only movies with IMDb ID/TMDb Id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="380"/>
         <source>1/20</source>
-        <translation>1/20</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="387"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="412"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="435"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="448"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.cpp" line="201"/>
         <source>Scraping of %n movies has finished.</source>
-        <translation>
-            <numerusform>A extração de %n filmes terminou.</numerusform>
-            <numerusform>A extração de %n filmes terminou.</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -4554,12 +4522,12 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4567,166 +4535,163 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="31"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="41"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="70"/>
         <source>When using IMDb you can also use the IMDb id as search query.
 If you want to search by an TMDb id please prefix it with &quot;id&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="128"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="163"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="170"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="177"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="184"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="191"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="198"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="205"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="212"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="219"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="226"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="233"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="240"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="264"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="271"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="278"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="285"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="292"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="299"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="306"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="313"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="320"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="327"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="334"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="365"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="77"/>
         <source>Cannot scrape a movie without an active scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="153"/>
         <source>Internal inconsistency: Cannot set language dropdown in movie search widget!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="175"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="314"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4734,112 +4699,112 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your movies. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Em baixo, pode ver os nomes de ficheiros usados para carregar e guardar os seus filmes. Pode editá-los à sua vontade, se quiser usar vários ficheiros separe-os com uma vírgula.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o de nome de ficheiro sem extensão.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="42"/>
         <source>Nfo</source>
-        <translation>Nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="49"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="56"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="63"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="70"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="77"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="216"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="223"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="281"/>
         <source>Movie outline</source>
-        <translation>Resumo do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="288"/>
         <source>Use plot when outline is not available</source>
-        <translation>Usar enredo quando não existir resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="295"/>
         <source>Movie Set Artwork</source>
-        <translation>Artwork de coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="21"/>
         <source>Artwork next to movies</source>
-        <translation>Artwork próxima dos filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="23"/>
         <source>Separate artwork directory</source>
-        <translation>Pasta separada de artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="305"/>
         <source>Movie Set Poster Filename</source>
-        <translation>Nome do ficheiro do cartaz da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="342"/>
         <source>Movie Set Fanart Filname</source>
-        <translation>Nome de ficheiro da fanart da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="379"/>
         <source>Artwork directory</source>
-        <translation>Pasta de artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="391"/>
         <source>Choose directory</source>
-        <translation>Escolher pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="400"/>
         <source>Movie Original Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="407"/>
         <source>Don&apos;t store the original title if it is the same as the normal title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="163"/>
         <source>Choose a directory where your movie set artwork is stored</source>
-        <translation>Escolher uma pasta onde a artwork da coleção de filmes está guardada</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4847,283 +4812,283 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="50"/>
         <source>Movie has changed. Click to revert changes.</source>
-        <translation>O filme foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="75"/>
         <source>Movie Name</source>
-        <translation>Nome do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="121"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="141"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1050"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="155"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="165"/>
         <source>Original Name</source>
-        <translation>Nome original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="175"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="185"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="211"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="228"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="235"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="245"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="255"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="275"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="282"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="317"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="347"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="350"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="353"/>
         <source>Not watched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="362"/>
         <source>Plot</source>
-        <translation>Enredo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="386"/>
         <source>Insert YouTube Dummy Link</source>
-        <translation>Inserir link falso do YouTube</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="405"/>
         <source>Download Trailer</source>
-        <translation>Descarregar trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="421"/>
         <source>Play local trailer</source>
-        <translation>Reproduzir trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="431"/>
         <source>Local trailer is available</source>
-        <translation>Está disponível um trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="434"/>
         <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="447"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="480"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="548"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="558"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="570"/>
         <source>Outline</source>
-        <translation>Resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="592"/>
         <source>Open movie on IMDb.com</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="595"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="631"/>
         <source>Go</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="618"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="628"/>
         <source>Open movie on TheMovieDB.org</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="663"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="695"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="786"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="705"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="717"/>
         <source>Support for extra fanarts is only available when your movies are stored in separate folders. Check the settings if you&apos;ve stored your movies in separate folders already.</source>
-        <translation>O recurso a fanarts extra só está disponível quando os seus filmes estão guardados em pastas separadas. Verifique as definições, caso já tenha guardado os seus filmes em pastas separadas.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="735"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="758"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="768"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="806"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="796"/>
         <source>Scantype</source>
-        <translation>Varrimento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="942"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="788"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="791"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="847"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="862"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="888"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="881"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="221"/>
         <source>Ratings</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="653"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="952"/>
         <source>Stereo Mode</source>
-        <translation>Modo de Estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="973"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1030"/>
         <source>External Subtitles</source>
-        <translation>Legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1060"/>
         <source>Forced</source>
-        <translation>Forçadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1216"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1256"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1238"/>
@@ -5134,103 +5099,103 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1502"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1549"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1263"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1303"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1310"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1350"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1386"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1426"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1433"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1473"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1480"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1520"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1527"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1567"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="88"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="89"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="93"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="94"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="98"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="99"/>
         <source>Add Country</source>
-        <translation>Adicionar país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="103"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="104"/>
         <source>Add Studio</source>
-        <translation>Adicionar estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="485"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="492"/>
         <source>Scraping...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="780"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="816"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1055"/>
@@ -5239,49 +5204,49 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="821"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="822"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="789"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="792"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="807"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="850"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="921"/>
         <source>Saving movie...</source>
-        <translation>A guardar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="926"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="902"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="950"/>
         <source>Saving movies...</source>
-        <translation>A guardar os filmes...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="919"/>
         <source>Movies Saved</source>
-        <translation>Filmes guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="971"/>
         <source>All Movies Saved</source>
-        <translation>Todos os filmes foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5289,12 +5254,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/file_search/MusicFileSearcher.cpp" line="44"/>
         <source>Searching for Music...</source>
-        <translation>A procurar por músia...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MusicFileSearcher.cpp" line="129"/>
         <source>Loading Music...</source>
-        <translation>A carregar a música...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5302,38 +5267,29 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="31"/>
         <source>Open Folder</source>
-        <translation>Abrir pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="32"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="25"/>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="155"/>
         <source>%n artists</source>
-        <translation>
-            <numerusform>%n artista</numerusform>
-            <numerusform>%n artistas</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="25"/>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="155"/>
         <source>%n albums</source>
-        <translation>
-            <numerusform>%n álbum</numerusform>
-            <numerusform>%n álbuns</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="158"/>
         <source>%1 of %n artists</source>
-        <translation>
-            <numerusform>%1 de %n artista</numerusform>
-            <numerusform>%1 de %n artistas</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5341,170 +5297,167 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="17"/>
         <source>Music Multi Scrape</source>
-        <translation>Extração múltipla de músicas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="39"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="48"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="61"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="74"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="87"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="100"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="113"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="126"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="139"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="152"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="165"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="178"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="191"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="204"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="217"/>
         <source>Moods</source>
-        <translation>Disposição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="230"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="243"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="256"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="269"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="282"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="295"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="308"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="321"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="334"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="347"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="369"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="395"/>
         <source>Scrape all albums of selected artists (and not only selected albums)</source>
-        <translation>Extrair todos os álbuns de artistas selecionados (e não apenas dos álbuns selecionados)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="402"/>
         <source>Automatically save each artist and album after scraping</source>
-        <translation>Guardar automaticamente cada artista e álbum após a extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="449"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="472"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="485"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.cpp" line="205"/>
         <source>Scraping of %n items has finished.</source>
-        <translation>
-            <numerusform>Terminou a extração de %n itens.</numerusform>
-            <numerusform>Terminou a extração de %n itens.</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5512,12 +5465,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5525,142 +5478,142 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="34"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="89"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="117"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="140"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="150"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="160"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="170"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="180"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="190"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="200"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="210"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="220"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="230"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="240"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="250"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="260"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="270"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="280"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="290"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="300"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="310"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="320"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="330"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="340"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="350"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="360"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="370"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="387"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5668,39 +5621,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your artists and albums. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Abaixo pode ver os nomes de ficheiros que são usados ​​para carregar e guardar os Artistas e Álbuns. Pode editá-los como quiser.
-Se quiser guardar o mesmo ficheiro com vários nomes, deve separar os nomes com uma vírgula.
-Por exemplo:  folder.jpg,cover.jpg</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="32"/>
         <source>Artist Thumbnail</source>
-        <translation>Miniatura de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="49"/>
         <source>Artist Fanart</source>
-        <translation>Fanart de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="66"/>
         <source>Artist Logo</source>
-        <translation>Logótipo de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="83"/>
         <source>Album Thumbnail</source>
-        <translation>Miniatura de álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="100"/>
         <source>Album Disc Art</source>
-        <translation>Capa do álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="117"/>
         <source>Download Extra Fanarts for Artists</source>
-        <translation>Descarregar Fanarts extras para artistas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5708,10 +5659,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message numerus="yes">
         <location filename="../../src/ui/small_widgets/MusicTreeView.cpp" line="105"/>
         <source>%n albums</source>
-        <translation>
-            <numerusform>%n album</numerusform>
-            <numerusform>%n álbuns</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5720,13 +5668,13 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="122"/>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="162"/>
         <source>Saving changed Artists and Albums</source>
-        <translation>A guardar alterações em artistas e álbuns</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="140"/>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="187"/>
         <source>All Artists and Albums Saved</source>
-        <translation>Todos os artistas e álbuns foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5734,150 +5682,150 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="53"/>
         <source>Album has changed. Click to revert changes.</source>
-        <translation>O álbum foi alterando. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="79"/>
         <source>Album Name</source>
-        <translation>Nome do álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="137"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="158"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="179"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="186"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="193"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="200"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="207"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="214"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="254"/>
         <source>MusicBrainz Album ID</source>
-        <translation>Identificador do álbum MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="268"/>
         <source>MusicBrainz Release Group ID</source>
-        <translation>Identificador do grupo de lançamento MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="285"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="326"/>
         <source>Booklet</source>
-        <translation>Brochura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="345"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="368"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="420"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="460"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="442"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="505"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="483"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="523"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="41"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="42"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="46"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="47"/>
         <source>Add Mood</source>
-        <translation>Adicionar estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="51"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="52"/>
         <source>Add Style</source>
-        <translation>Adicionar estilo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="186"/>
         <source>Saving Album...</source>
-        <translation>A guardar o álbum...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="192"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="524"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5885,182 +5833,182 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="53"/>
         <source>Artist has changed. Click to revert changes.</source>
-        <translation>O artista foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="79"/>
         <source>Artist Name</source>
-        <translation>Nome do artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="137"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="158"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="186"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="193"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="200"/>
         <source>Years active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="207"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="214"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="235"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="245"/>
         <source>MusicBrainz ID</source>
-        <translation>Identificador MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="262"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="303"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="325"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="330"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="340"/>
         <source>Add Album</source>
-        <translation>Adicionar álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="347"/>
         <source>Remove Album</source>
-        <translation>Remover álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="370"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="392"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="415"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="467"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="507"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="633"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="489"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="552"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="615"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="530"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="570"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="593"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="49"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="50"/>
         <source>Add Genre</source>
-        <translation>Adicionar Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="54"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="55"/>
         <source>Add Mood</source>
-        <translation>Adicionar estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="59"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="60"/>
         <source>Add Style</source>
-        <translation>Adicionar estilo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="196"/>
         <source>Saving Artist...</source>
-        <translation>A guardar o artista...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="202"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="501"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="586"/>
         <source>Unknown Album</source>
-        <translation>Álbum Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6068,87 +6016,87 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="38"/>
         <source>Scrape</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="58"/>
         <source>Save</source>
-        <translation>Guardar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="78"/>
         <source>Save All</source>
-        <translation>Guardar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="98"/>
         <source>Rename selected files</source>
-        <translation>Renomear ficheiros selecionados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="118"/>
         <source>Synchronize to Kodi</source>
-        <translation>Sincronizar com o Kodl</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="138"/>
         <source>Export Database</source>
-        <translation>Exportar base de Dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="161"/>
         <source>Reload</source>
-        <translation>Recarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="181"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="201"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="247"/>
         <source>Donate</source>
-        <translation>Fazer um donativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="17"/>
         <source>Scrape (%1)</source>
-        <translation>Extrair (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="20"/>
         <source>Save (%1)</source>
-        <translation>Guardar (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="24"/>
         <source>Save All (%1)</source>
-        <translation>Guardar todos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="28"/>
         <source>Reload all files (%1)</source>
-        <translation>Recarregar todos os ficheiros (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="32"/>
         <source>Export HTML</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="36"/>
         <source>Export CSV</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="43"/>
         <source>Export Database (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6156,7 +6104,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/scrapers/ScraperInterface.cpp" line="17"/>
         <source>Network Error</source>
-        <translation>Erro na rede</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6164,43 +6112,43 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="71"/>
         <source>Host</source>
-        <translation>Anfitrião</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="78"/>
         <source>Port</source>
-        <translation>Porta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="98"/>
         <source>Username</source>
-        <translation>Nome de utilizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="108"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="19"/>
         <source>Enable Proxy</source>
-        <translation>Ativar proxy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="64"/>
         <source>Type</source>
         <comment>Proxy Type</comment>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="51"/>
         <source>HTTP</source>
-        <translation>HTTP</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="36"/>
         <source>Use Proxy for Kodi</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6208,7 +6156,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/PlaceholderLineEdit.cpp" line="26"/>
         <source>Insert placeholder</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6216,183 +6164,183 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/main.cpp" line="36"/>
         <source>Logfile could not be openened</source>
-        <translation>Não foi possível abrir o ficheiro de registo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="37"/>
         <source>The logfile %1 could not be openend for writing.</source>
-        <translation>Não foi possível modificar o ficheiro de registo %1.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="76"/>
         <source>Stylesheet could not be opened!</source>
-        <translation>Não foi possível abrir a folha de estilo.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="78"/>
         <source>The default stylesheet could not be openend for reading.</source>
-        <translation>Não foi possível abrir a folha de estilos padrão para leitura.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="79"/>
         <source>The custom stylesheet could not be openend for reading. Using: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <source>No Label</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <source>Red</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <source>Orange</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <source>Yellow</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="392"/>
-        <source>No Label</source>
-        <translation>Sem etiqueta</translation>
+        <source>Green</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="393"/>
-        <source>Red</source>
-        <translation>Vermelho</translation>
+        <source>Blue</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="394"/>
-        <source>Orange</source>
-        <translation>Laranja</translation>
+        <source>Purple</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="395"/>
-        <source>Yellow</source>
-        <translation>Amarelo</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="396"/>
-        <source>Green</source>
-        <translation>Verde</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="397"/>
-        <source>Blue</source>
-        <translation>Azul</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="398"/>
-        <source>Purple</source>
-        <translation>Roxo</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
-        <translation>Cinzento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="12"/>
         <source>File not found:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="13"/>
         <source>Cannot open advancedsettings.xml in read-only mode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="14"/>
         <source>Couldn&apos;t find an &lt;advancedsettings&gt; tag!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="15"/>
         <source>Found unsupported xml tag:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="16"/>
         <source>Invalid value for xml tag:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
-        <translation>&lt;b&gt;Mover Ficheiro&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowCommonWidgets.cpp" line="59"/>
         <source>Aired order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowCommonWidgets.cpp" line="62"/>
         <source>DVD order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="8"/>
         <source>Timeout by MediaElch</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="9"/>
         <source>Content not found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="10"/>
         <source>Remote connection timed out</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="11"/>
         <source>SSL handshake failed</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="12"/>
         <source>Too many redirects</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="13"/>
         <source>Connection refused by host</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="14"/>
         <source>Host not found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="15"/>
         <source>Unknown network error</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="16"/>
         <source>Could not load the requested resource</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="18"/>
         <location filename="../../src/scrapers/ScraperError.cpp" line="25"/>
         <source>Network Error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="32"/>
         <source>The scraper&apos;s rate limit reached. Please wait ~10 seconds and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="37"/>
         <source>An unknown network error occurred. Are you connected to the internet?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="51"/>
         <source>The scraper did not respond with any data.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="55"/>
         <source>The scraper response could not be parsed.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media_center/kodi/ConcertXmlReader.cpp" line="29"/>
         <source>No valid musicvideo root entry found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6400,22 +6348,22 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="60"/>
         <source>QIODevice::Append is not supported for GZIP</source>
-        <translation>QIODevice::Append não é suportado pelo GZIP</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="66"/>
         <source>Opening gzip for both reading and writing is not supported</source>
-        <translation>A abertura do gzip para leitura e escrita não é suportada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="74"/>
         <source>You can open a gzip either for reading or for writing. Which is it?</source>
-        <translation>Pode abrir um gzip para ler ou gravar. Qual deles?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="80"/>
         <source>Could not gzopen() file</source>
-        <translation>Não foi possível abrir o ficheiro gzopen()</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6423,12 +6371,12 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quaziodevice.cpp" line="188"/>
         <source>QIODevice::Append is not supported for QuaZIODevice</source>
-        <translation>QIODevice::Append não é suportado pelo QuaZIODevice</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quaziodevice.cpp" line="193"/>
         <source>QIODevice::ReadWrite is not supported for QuaZIODevice</source>
-        <translation>QIODevice::ReadWrite não é suportado pelo QuaZIODevice</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6436,7 +6384,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quazipfile.cpp" line="251"/>
         <source>ZIP/UNZIP API error %1</source>
-        <translation>Erro da API ZIP/UNZIP %1</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6444,27 +6392,27 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="100"/>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="101"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="102"/>
         <source>Vote Count</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="103"/>
         <source>Min. Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="104"/>
         <source>Max. Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6472,17 +6420,17 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="14"/>
         <source>Form</source>
-        <translation>Formulário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="80"/>
         <source>Add rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="94"/>
         <source>Remove selected rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6490,145 +6438,133 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="17"/>
         <source>Renamer</source>
-        <translation>Alteração de nomes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="34"/>
         <source>Pattern</source>
-        <translation>Padrão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="75"/>
         <source>Use Season Directories</source>
-        <translation>Usar pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="85"/>
         <source>Multi-File Naming</source>
-        <translation>Alterar nome de vários ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="117"/>
         <source>Rename Directories</source>
-        <translation>Alterar nome de pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="127"/>
         <source>Rename Files</source>
-        <translation>Alterar nome de ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="162"/>
         <source>Directory Naming</source>
-        <translation>Alterar nome de pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="194"/>
         <source>File Naming</source>
-        <translation>Nomes dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="201"/>
         <source>Season Directory Naming</source>
-        <translation>Nomes das pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="208"/>
         <source>Season &lt;season&gt;</source>
-        <translation>Temporada &lt;season&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="249"/>
         <source>Results</source>
-        <translation>Resultados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="342"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="365"/>
         <source>Dry Run</source>
-        <translation>Operação &quot;a seco&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
         <source>Rename</source>
-        <translation>Alterar nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="38"/>
         <source>Please see %1 for help and examples on how to use the renamer.</source>
-        <translation>Veja a ajuda em %1. Temos exemplos de como usar o alterador de nomes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="58"/>
         <source>%n concerts will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="60"/>
         <source>%n movies will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="62"/>
         <source>%n TV shows and %1</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="63"/>
         <source>%n episodes will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
         <source>Finished</source>
-        <translation>Concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
         <source>Create dir</source>
-        <translation>Criar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
         <source>Move</source>
-        <translation>Mover</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6636,152 +6572,147 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="35"/>
         <source>Placeholders</source>
-        <translation>Marcadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
         <source>Placeholder</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
         <source>File extension</source>
-        <translation>Extensão de ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
         <source>Season Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
         <source>Part number of the current file</source>
-        <translation>Número da parte do ficheiro atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
-        <source>TMDb ID</source>
-        <translation type="unfinished">Identificador do TMDb</translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
         <source>Season Number</source>
-        <translation>Número da temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
         <source>Title of the show</source>
-        <translation>Título da série</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
         <source>Studio(s) (separated by a comma)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
         <source>Director(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
         <source>Audio Language(s) (separated by a minus)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
         <source>Episode Number</source>
-        <translation>Número do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
         <source>Resolution (1080p, 720p, ...)</source>
-        <translation>Resolução (1080p, 720p...)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
         <source>File/directory is BluRay</source>
-        <translation>Ficheiro ou pasta é BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
         <source>File/directory is DVD</source>
-        <translation>Ficheiro ou pasta é DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
         <source>File is 3D</source>
-        <translation>Ficheiro é 3D</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
         <source>Movie set name</source>
-        <translation>Nome da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
         <source>Video Codec</source>
-        <translation>Codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
         <source>Episode has a season name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
         <source>Audio Codec</source>
-        <translation>Codec de áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
         <source>Number of audio channels</source>
-        <translation>Número de canais de áudio</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6790,141 +6721,141 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="121"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="151"/>
         <source>Invalid</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="122"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="152"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="123"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="124"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="153"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="125"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="126"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="155"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="127"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="128"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="156"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="129"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="157"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="130"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="131"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="158"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="132"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="133"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="161"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="134"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="159"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="135"/>
         <source>Extra Art</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="136"/>
         <source>Season Backdrop</source>
-        <translation>Fundo de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="137"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="138"/>
         <source>Extra Fanart</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="139"/>
         <source>Show Thumbnail</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="140"/>
         <source>Season Thumbnail</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="141"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="142"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="145"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="165"/>
         <source>Unknown</source>
-        <translation>Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="160"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="154"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="162"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6933,162 +6864,162 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="21"/>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="138"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="57"/>
         <source>Enable adult movie scrapers</source>
-        <translation>Ativar extratores de filmes para adultos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="95"/>
         <source>Custom Movie Scraper</source>
-        <translation>Extrator de filmes personalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="101"/>
         <source>Combine multiple scrapers to your custom scraper. If you select other scrapers than IMDB, The Movie DB and Fanart.tv multiple searches may be necessary as only these three share an id.</source>
-        <translation>Combine vários extratores num único extrator personalizado. Se selecionar outros extratores além do IMDB, The Movie DB e Fanart.tv, poderão ser necessárias várias procuras, já que apenas estes três usam identificadores comuns.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="133"/>
         <source>Item</source>
-        <translation>Item</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="147"/>
         <source>TV Scraper</source>
-        <translation>Extrator de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="157"/>
         <source>Custom TV Scraper</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="172"/>
         <source>Don&apos;t use</source>
-        <translation>Não usar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="218"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="219"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="220"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="221"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="222"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="223"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="224"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="225"/>
         <source>Plot</source>
-        <translation>Enredo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="226"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="227"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="228"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="229"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="230"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="231"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="232"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="233"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="234"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="235"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="236"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="237"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="238"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="239"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="240"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="241"/>
         <source>Unsupported</source>
-        <translation>Incompatível</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7096,12 +7027,12 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/model/tv_show/SeasonModelItem.cpp" line="135"/>
         <source>Season %1 - %2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/tv_show/SeasonModelItem.cpp" line="137"/>
         <source>Season %1</source>
-        <translation>Temporada %1</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7109,59 +7040,59 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="61"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="88"/>
         <source>Set Name</source>
-        <translation>Nome da coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="122"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="127"/>
         <source>Sorttitle</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="150"/>
         <source>Add movie to set</source>
-        <translation>Adicionar filme à coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="153"/>
         <source>Add Movie</source>
-        <translation>Adicionar filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="160"/>
         <source>Remove selected movie from set</source>
-        <translation>Remover filme selecionado da coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="163"/>
         <source>Remove Movie</source>
-        <translation>Remover Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="182"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="204"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="276"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="225"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="300"/>
         <source>Full preview</source>
-        <translation>Pré-visualização inteira</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="239"/>
@@ -7169,32 +7100,32 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="314"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="317"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="254"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="56"/>
         <source>Add Movie Set</source>
-        <translation>Adicionar coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="57"/>
         <source>Delete Movie Set</source>
-        <translation>Eliminar coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="459"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="491"/>
         <source>New Movie Set</source>
-        <translation>Nova coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7202,79 +7133,79 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="20"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="184"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="162"/>
         <source>Kodi</source>
-        <translation>Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="206"/>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="209"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="220"/>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="223"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="62"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="69"/>
         <source>Save Settings</source>
-        <translation>Guardar definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="79"/>
         <source>toolBar</source>
-        <translation>barraFerramentas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="118"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="129"/>
         <source>TV Shows</source>
-        <translation>Séries TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="140"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="151"/>
         <source>Global</source>
-        <translation>Global</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="173"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="195"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.cpp" line="192"/>
         <source>Settings saved</source>
-        <translation>As definições foram guardadas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7282,32 +7213,32 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="17"/>
         <source>Support MediaElch</source>
-        <translation>Doações para o MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="30"/>
         <source>If you like MediaElch and wish to support it you have the chance to do so! You can donate as much as you like via PayPal.</source>
-        <translation>Se gosta do MediaElch e gostaria de apoiá-lo, tem a oportunidade de o fazer! Pode fazer uma doação da quantia que quiser através do PayPal.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="74"/>
         <source>MediaElch makes use of various movie and TV show databases. These databases also need your help to keep their services up and running for free. If you don&apos;t want to donate you can also contribute information and missing artwork if possible.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="127"/>
         <source>Thanks for your help and support!</source>
-        <translation>Obrigado pela sua ajuda e apoio!</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="149"/>
         <source>Hide donate button</source>
-        <translation>Ocultar botão para donativos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="172"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7315,7 +7246,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/TagCloud.ui" line="31"/>
         <source>Tag</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7323,115 +7254,115 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="17"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="47"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="87"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="110"/>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="206"/>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="369"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="166"/>
         <source>Preview</source>
-        <translation>Pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="171"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="176"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="186"/>
         <source>Back to Search Results</source>
-        <translation>Regressar aos resultados da busca</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="277"/>
         <source>URL</source>
-        <translation>Endereço</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="308"/>
         <source>Progress</source>
-        <translation>Progresso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="331"/>
         <source>Download</source>
-        <translation>Descarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="338"/>
         <source>Cancel Download</source>
-        <translation>Cancelar descarregamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="349"/>
         <source>Back to Trailers</source>
-        <translation>Regressar aos trailers</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="345"/>
         <source>Download Finished</source>
-        <translation>Descarregamento concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="356"/>
         <source>The file %1 already exists.</source>
-        <translation>O ficheiro %1 já existe.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="358"/>
         <source>Do you want to overwrite it?</source>
         <extracomment>&quot;it&quot; refers to the file</extracomment>
-        <translation>Quer substituí-lo?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="371"/>
         <source>Download Canceled</source>
-        <translation>Descarregamento cancelado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="375"/>
         <source>Download Not Found (404)</source>
-        <translation>Descarregamento não encontrado (404)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="379"/>
         <source>Download Error (%1)</source>
-        <translation>Erro no descarregamento (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="433"/>
         <source>Network Error</source>
-        <translation>Erro na rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="434"/>
         <source>Resource could not be played</source>
-        <translation>Não foi possível reproduzir o ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="435"/>
         <source>Video format error</source>
-        <translation>Erro de formato de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7439,92 +7370,92 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="36"/>
         <source>TV Scraper</source>
-        <translation>Extrator de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="88"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="107"/>
         <source>ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="114"/>
         <source>Internal TV scraper ID. Used as key in MediaElch&apos;s settings.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="124"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="169"/>
         <source>Website</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="179"/>
         <source>The scraper&apos;s main website.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="192"/>
         <source>Terms of Service</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="199"/>
         <source>Terms of service of the TV scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="212"/>
         <source>Privacy Policy</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="219"/>
         <source>Privacy Policy of the scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="232"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="239"/>
         <source>Where to get help for the TV scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="252"/>
         <source>Is the scraper initialized?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="255"/>
         <source>Is initialized?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="262"/>
         <source>Default Language</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.cpp" line="112"/>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.cpp" line="112"/>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7532,22 +7463,22 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="52"/>
         <source>Searching for TV Shows...</source>
-        <translation>A procurar séries de TV...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="58"/>
         <source>Loading TV Shows...</source>
-        <translation>A carregar séries de TV...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="87"/>
         <source>Searching for Episodes...</source>
-        <translation>A procurar episódios...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="126"/>
         <source>Loading Episodes...</source>
-        <translation>A carregar episódios...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7556,103 +7487,94 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="27"/>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="670"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="27"/>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="670"/>
         <source>%n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="466"/>
-        <source>You need to update the show once and load the show&apos;s TMDb ID to list missing episodes.
+        <source>You need to update the show once and load the show's TMDb ID to list missing episodes.
 Afterwards MediaElch will check automatically for new episodes on startup.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="470"/>
         <source>Don&apos;t show this hint again</source>
-        <translation>Não voltar a mostrar esta dica</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="674"/>
         <source>%1 of %n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="758"/>
         <source>Load Information</source>
-        <translation>Carregar informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="759"/>
         <source>Search for new episodes</source>
-        <translation>A procurar por novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="760"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="761"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="762"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="763"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="764"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="765"/>
         <source>Open TV Show Folder</source>
-        <translation>Abrir pasta da série de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="766"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="767"/>
         <source>Play episode</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="784"/>
         <source>Show missing episodes</source>
-        <translation>Mostrar episódios que faltam</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="787"/>
         <source>Hide specials in missing episodes</source>
-        <translation>Ocultar episódios especiais ao listar episódios em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="465"/>
         <source>Show update needed</source>
-        <translation>É necessário atualizar a série</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7660,42 +7582,42 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="91"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="92"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="93"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="94"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="95"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="96"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="97"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="98"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7703,303 +7625,297 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="20"/>
         <source>TV Show Multi Scrape</source>
-        <translation>Extrator múltiplo de episódios de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="30"/>
         <source>Please select the infos you want to be loaded. MediaElch will use the best result for each TV show and episode you selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="61"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="365"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="70"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="400"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="83"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="278"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="304"/>
         <source>Season Fanart</source>
-        <translation>Fanart de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="96"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="265"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="226"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="109"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="252"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="213"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="501"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="122"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="374"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="239"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="291"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="475"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="200"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="449"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="135"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="387"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="436"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="426"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="46"/>
         <source>Show Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="148"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="161"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="413"/>
         <source>First aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="174"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="488"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="187"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="317"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="339"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="526"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="350"/>
         <source>Episode Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="462"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="559"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="569"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="579"/>
         <source>Order for seasons</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="607"/>
         <source>Update only TV shows/episodes
 which have an ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="621"/>
         <source>Automatically save each TV show/
 episode after scraping</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="660"/>
         <source>1/20</source>
-        <translation>1/20</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="706"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="729"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="742"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="306"/>
         <source>Start scraping using &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="352"/>
         <source>Skipping show &quot;%1&quot; because it does not have a valid ID.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="371"/>
         <source>Search for TV show &quot;%1&quot; because no valid ID was found.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="378"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="475"/>
         <source>Scraping next TV show with ID &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="408"/>
         <source>Search for TV show &quot;%1&quot; because no valid show ID was found for the episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="417"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="493"/>
         <source>S%1E%2: Scraping next episode with show ID &quot;%3&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="463"/>
         <source>Error while searching for TV show: &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="468"/>
         <source>Did not find any results for search term &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="511"/>
         <source>Done.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="531"/>
         <source>%n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="532"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="534"/>
         <source>Scraping of %1 and %2 has finished.</source>
-        <translation>Terminou a extração de %1 e %2.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="536"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="538"/>
         <source>Scraping of %1 has finished.</source>
-        <translation>A extração de  %1 terminou.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="561"/>
         <source>Finished scraping details of TV show &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="570"/>
         <source>Start loading extra fanart from TheTvDb for TV show with ID &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="753"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="832"/>
         <source>Internal inconsistency: Cannot set language dropdown in TV show search widget!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="848"/>
         <source>S%2E%3: Finished scraping episode details. Title is: &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8007,12 +7923,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/search_dialog/TvShowScrapePreview.ui" line="43"/>
         <source>&lt;b&gt;Preview&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/search_dialog/TvShowScrapePreview.ui" line="83"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Description&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8020,17 +7936,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="58"/>
         <source>Scrape</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8038,219 +7954,216 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="19"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="29"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="134"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="179"/>
         <source>Show Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="210"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="519"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="220"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="230"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="539"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="240"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="549"/>
         <source>First aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="250"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="260"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="559"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="270"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="529"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="280"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="290"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="626"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="300"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="606"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="327"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="616"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="337"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="347"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="357"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="367"/>
         <source>Season Fanart</source>
-        <translation>Fanart de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="377"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="387"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="397"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="407"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="417"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="451"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="670"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="464"/>
         <source>No show details will be loaded because only episodes were selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="488"/>
         <source>Episode Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="586"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="596"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="636"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="682"/>
         <source>Season order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="697"/>
         <source>No episodes will be loaded. If you want to load episodes, change the update mode below.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="147"/>
         <source>Update TV Show only</source>
-        <translation>Atualizar apenas Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="152"/>
         <source>Update TV Show and new Episodes</source>
-        <translation>Atualizar séries de TV e novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="157"/>
         <source>Update TV Show and all Episodes</source>
-        <translation>Atualizar séries de TV e todos os episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="162"/>
         <source>Update new Episodes</source>
-        <translation>Atualizar novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="167"/>
         <source>Update all episodes</source>
-        <translation>Atualizar todos os episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="170"/>
         <source>The %1 scraper could not be initialized!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="148"/>
         <source>Please insert a search string!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="188"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="364"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8258,82 +8171,82 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your TV shows. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension and for season posters &lt;seasonNumber&gt; which is the season number.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o nome do ficheiro, sem extensão, e para cartazes de temporada &lt;seasonNumber&gt;, que é o número da temporada.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="42"/>
         <source>Show nfo</source>
-        <translation>Mostrar nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="49"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="56"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="63"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="70"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="77"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="84"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="91"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="98"/>
         <source>Season Backdrop</source>
-        <translation>Fundo de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="105"/>
         <source>Episode nfo</source>
-        <translation>Nfo do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="112"/>
         <source>Episode thumbnail</source>
-        <translation>Miniatura de episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="119"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="390"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="397"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8341,10 +8254,7 @@ episode after scraping</source>
     <message numerus="yes">
         <location filename="../../src/ui/small_widgets/TvShowTreeView.cpp" line="146"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -8352,7 +8262,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/TvShowUpdater.cpp" line="42"/>
         <source>Updating TV Shows</source>
-        <translation>A atualizar séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8361,22 +8271,22 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="161"/>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="218"/>
         <source>Saving changed TV Shows and Episodes</source>
-        <translation>A guardar alterações em séries de TV e episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="180"/>
         <source>Could not save episode S%1E%2 of show &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="193"/>
         <source>TV Shows and Episodes Saved</source>
-        <translation>Séries de TV e episódios guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="239"/>
         <source>All TV Shows and Episodes Saved</source>
-        <translation>Todas as séries TV e episódios foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8384,292 +8294,292 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="63"/>
         <source>Episode has changed. Click to revert changes.</source>
-        <translation>O episódio foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="82"/>
         <source>Episode Title</source>
-        <translation>Título do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="137"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="154"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="460"/>
         <source>TheTVDB ID</source>
-        <translation>Identificador TheTVDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="514"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="168"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="178"/>
         <source>Show Title</source>
-        <translation>Mostrar título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="188"/>
         <source>Season</source>
-        <translation>Temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="223"/>
         <source>Episode</source>
-        <translation>Episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="242"/>
         <source>Display Season</source>
-        <translation>Mostrar temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="302"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="350"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="367"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="377"/>
         <source>dd.MM.yyyy</source>
-        <translation>dd.MM.yyyy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="384"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="400"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="410"/>
         <source>dd.MM.yyyy HH:mm</source>
-        <translation>dd.MM.yyyy HH:mm</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="436"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="446"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="280"/>
         <source>Display Episode</source>
-        <translation>Mostrar episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="419"/>
         <source>Bookmark</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="313"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="477"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="548"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="558"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="595"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="663"/>
         <source>Directors</source>
-        <translation>Realizadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="691"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="701"/>
         <source>Add Director</source>
-        <translation>Adicionar Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="715"/>
         <source>Remove Director</source>
-        <translation>Remover Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="567"/>
         <source>Writers</source>
-        <translation>Argumentistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="605"/>
         <source>Add Writer</source>
-        <translation>Adicionar argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="619"/>
         <source>Remove Writer</source>
-        <translation>Remover Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="759"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="784"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="789"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="831"/>
         <source>Add Actor</source>
-        <translation>Adicionar Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="804"/>
         <source>Remove Actor</source>
-        <translation>Remover Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="878"/>
         <source>Click to change</source>
-        <translation>Clique para Alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="932"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="991"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="940"/>
         <source>Scantype</source>
-        <translation>TipoAnálise</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="894"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1081"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1106"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="525"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="528"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="981"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1096"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1045"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="429"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="959"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="924"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1116"/>
         <source>Stereo Mode</source>
-        <translation>Modo de Estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1137"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1211"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1233"/>
         <source>Click to Change</source>
-        <translation>Clique para Alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="115"/>
         <source>Episode missing</source>
-        <translation>Episódio em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="92"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="518"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="552"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="524"/>
@@ -8677,68 +8587,68 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="556"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="557"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="526"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="529"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="544"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="585"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="618"/>
         <source>Episode Saved</source>
-        <translation>O episódio foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="620"/>
         <source>Could not save episode S%1E%2 of show &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="666"/>
         <source>Scraping episode...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="800"/>
         <source>Unknown Director</source>
-        <translation>Realizador Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="850"/>
         <source>Unknown Writer</source>
-        <translation>Argumentista desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1107"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1108"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1171"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1171"/>
         <source>Images (*.jpg *.jpeg)</source>
-        <translation>Imagens (*.jpg *.jpeg)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8746,69 +8656,69 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="63"/>
         <source>Episode has changed. Click to revert changes.</source>
-        <translation>O episódio foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="83"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="138"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="149"/>
         <source>Season Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="171"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="232"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="193"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="254"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="298"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="276"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="320"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="342"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="119"/>
         <source>Season missing</source>
-        <translation>Temporada em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.cpp" line="111"/>
         <source>Season %1</source>
-        <translation>Temporada %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.cpp" line="188"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8816,208 +8726,208 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="50"/>
         <source>TV Show has changed. Click to revert changes.</source>
-        <translation>A série de TV foi alterada. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="70"/>
         <source>Show Title</source>
-        <translation>Mostrar título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="98"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="112"/>
         <source>Dir</source>
-        <translation>Dir</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="126"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="208"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="242"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="252"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="315"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="352"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="369"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="379"/>
         <source>dd.MM.yyyy</source>
-        <translation>dd.MM.yyyy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="406"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="460"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="416"/>
         <source>TV Tune</source>
-        <translation>Tema musical</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="425"/>
         <source>Existing</source>
-        <translation>Presente</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="432"/>
         <source>Missing</source>
-        <translation>Em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="448"/>
         <source>Download Theme</source>
-        <translation>Descarregar tema musical</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="386"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="396"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="505"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="201"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="522"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="533"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="558"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="563"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="605"/>
         <source>Add Actor</source>
-        <translation>Adicionar ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="578"/>
         <source>Remove Actor</source>
-        <translation>Remover ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="263"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="137"/>
         <source>TheTVDB ID</source>
-        <translation>Identificador TheTVDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="482"/>
         <source>Continuing</source>
-        <translation>Continuando</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="487"/>
         <source>Ended</source>
-        <translation>Finalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="495"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="154"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="512"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="652"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1221"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="668"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="717"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="739"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="762"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="906"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="928"/>
@@ -9027,92 +8937,92 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1133"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1177"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="950"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="994"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1199"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1067"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1111"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1155"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="78"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="79"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="83"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="84"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="456"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="497"/>
         <source>Please wait while your TV show is scraped</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="724"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="878"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="879"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="960"/>
         <source>Choose Image</source>
-        <translation>Escolher Imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="960"/>
         <source>Images (*.jpg *.jpeg)</source>
-        <translation>Imagens (*.jpg *.jpeg)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9120,53 +9030,53 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="17"/>
         <source>TV Tunes</source>
-        <translation>Temas musicais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="54"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="118"/>
         <source>Progress</source>
-        <translation>Progresso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="141"/>
         <source>Download</source>
-        <translation>Descarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="148"/>
         <source>Cancel Download</source>
-        <translation>Cancelar descarregamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="172"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="251"/>
         <source>Download Finished</source>
-        <translation>Descarregamento concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="256"/>
         <source>The file %1 already exists.</source>
-        <translation>O ficheiro %1 já existe.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="258"/>
         <source>Do you want to overwrite it?</source>
         <extracomment>&quot;it&quot; refers to the file</extracomment>
-        <translation>Quer substituí-lo?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="272"/>
         <source>Download Canceled</source>
-        <translation>Descarregamento cancelado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9174,47 +9084,47 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="45"/>
         <source>Cancel extraction</source>
-        <translation>Cancelar extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="65"/>
         <source>Extract without password</source>
-        <translation>Extrair sem palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="68"/>
         <source>Extract</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="75"/>
         <source>Extract with password</source>
-        <translation>Extrair com palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="95"/>
         <source>Delete this archive</source>
-        <translation>Eliminar este ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="50"/>
         <source>Extraction password</source>
-        <translation>Palavra-passe para extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="50"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="65"/>
         <source>Delete archive?</source>
-        <translation>Eliminar ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="66"/>
         <source>Do you really want to delete this archive?</source>
-        <translation>Quer mesmo eliminar este ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9222,17 +9132,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="63"/>
         <source>Updates available</source>
-        <translation>Atualizações disponíveis</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="64"/>
         <source>%1 is now available.&lt;br&gt;Get it now on %2</source>
-        <translation>%1 já está disponível.&lt;br&gt;Obtenha-o agora em %2</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="68"/>
         <source>Don&apos;t check for updates</source>
-        <translation>Não verificar atualizações</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9240,7 +9150,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/small_widgets/WebImageLabel.ui" line="47"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9248,33 +9158,33 @@ episode after scraping</source>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="28"/>
         <source>Could not get duration of file</source>
-        <translation>Não foi possível obter a duração do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="47"/>
         <source>Could not detect runtime of file</source>
-        <translation>Não foi possível detetar o tempo de reprodução do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="56"/>
         <location filename="../../src/media/ImageCapture.cpp" line="84"/>
         <source>Temporary output file could not be opened</source>
-        <translation>Não foi possível abrir o ficheiro de saída temporário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="71"/>
         <source>Could not start ffmpeg</source>
-        <translation>Não foi possível iniciar o ffmpeg</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="74"/>
         <source>Could not start ffmpeg. Please install it and make it available in your $PATH</source>
-        <translation>Não foi possível iniciar o ffmpeg. Por favor instale-o e torne-o disponível no seu $PATH</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="80"/>
         <source>ffmpeg did not finish</source>
-        <translation>ffmpeg não finalizou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9282,7 +9192,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/file_search/movie/MovieDirectorySearcher.cpp" line="391"/>
         <source>Storing movies in database...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9290,35 +9200,35 @@ episode after scraping</source>
     <message>
         <location filename="../../src/file_search/movie/MovieFileSearcher.cpp" line="58"/>
         <source>Searching for Movies...</source>
-        <translation>A procurar por filmes...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/movie/MovieFileSearcher.cpp" line="148"/>
         <source>Searching for movies...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
         <source>Straight</source>
-        <translation>Heterossexual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Gay</source>
-        <translation>Homossexual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9326,12 +9236,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/custom/CustomMovieScraper.cpp" line="20"/>
         <source>Custom Movie Scraper</source>
-        <translation>Extrator de filmes personalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/custom/CustomMovieScraper.cpp" line="178"/>
         <source>TMDb ID is invalid. Cannot scrape movie.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9339,12 +9249,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/custom/CustomTvScraper.cpp" line="28"/>
         <source>Custom TV scraper</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/custom/CustomTvScraper.cpp" line="33"/>
         <source>The custom TV scraper combines multiple scrapers so that details can be loaded from different sites in one step. It depends on TMDb for loading other scraper IDs.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9352,162 +9262,162 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="26"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="84"/>
         <source>Bulgarian</source>
-        <translation>Búlgaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="85"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="86"/>
         <source>Croatian</source>
-        <translation>Croata</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="87"/>
         <source>Czech</source>
-        <translation>Checo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="88"/>
         <source>Danish</source>
-        <translation>Dinamarquês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="89"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="90"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="91"/>
         <source>Finnish</source>
-        <translation>Finlandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="92"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="93"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="94"/>
         <source>Greek</source>
-        <translation>Grego</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="95"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="96"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="97"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="98"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="99"/>
         <source>Korean</source>
-        <translation>Coreano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="100"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="101"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="102"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="103"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="104"/>
         <source>Slovene</source>
-        <translation>Eslovaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="105"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="106"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="107"/>
         <source>Turkish</source>
-        <translation>Turco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="111"/>
         <source>Blu-ray</source>
-        <translation>BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="112"/>
         <source>DVD</source>
-        <translation>DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="115"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="117"/>
         <source>Preferred Disc Type</source>
-        <translation>Tipo de disco preferido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="119"/>
         <source>Personal API key</source>
-        <translation>Chave pessoal da API</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="356"/>
         <source>Movie not found on Fanart.tv</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="568"/>
         <source>TV show not found on Fanart.tv</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9515,7 +9425,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTvMusic.cpp" line="25"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9523,7 +9433,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTvMusicArtists.cpp" line="22"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9531,12 +9441,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/imdb/ImdbMovie.cpp" line="20"/>
         <source>IMDb is the world&apos;s most popular and authoritative source for movie, TV and celebrity content, designed to help fans explore the world of movies and shows and decide what to watch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/imdb/ImdbMovie.cpp" line="47"/>
         <source>Load all tags</source>
-        <translation>Carregar todas as etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9544,7 +9454,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTv.cpp" line="20"/>
         <source>IMDb is the world&apos;s most popular and authoritative source for movie, TV and celebrity content, designed to help fans explore the world of movies and shows and decide what to watch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9552,22 +9462,22 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="37"/>
         <source>Neither IMDb show ID nor episode ID are valid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="61"/>
         <source>IMDb ID could not be loaded from season page! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="76"/>
         <source>IMDb ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="90"/>
         <source>Loaded IMDb content is empty. Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9575,7 +9485,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing an IMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9583,17 +9493,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="92"/>
         <source>Could not extract JSON details from IMDb page!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="102"/>
         <source>Could not parse JSON from IMDb page!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="108"/>
         <source>Expected parsed IMDb JSON to be an object!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9601,7 +9511,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowScrapeJob.cpp" line="34"/>
         <source>Show is missing an IMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9609,12 +9519,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowSearchJob.cpp" line="20"/>
         <source>Loaded IMDb web page content is empty. Cannot scrape requested TV show.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowSearchJob.cpp" line="24"/>
         <source>Could not find result table in the scraped HTML. Please contact MediaElch&apos;s developers.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9622,7 +9532,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/TMDbImages.cpp" line="15"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9630,7 +9540,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDb.cpp" line="19"/>
         <source>TheTvDb is one of the most accurate sources for TV and film. Their information comes from fans like you, so create a free account on their website and help your favorite shows and movies. Everything added is shared not only with MediaElch but many other sites, mobile apps, and devices as well.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9638,7 +9548,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbEpisodeScrapeJob.cpp" line="65"/>
         <source>TheTvDb ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9646,7 +9556,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/TheTvDbImages.cpp" line="19"/>
         <source>TheTvDb is one of the most accurate sources for TV and film. Their information comes from fans like you, so create a free account on their website and help your favorite shows and movies. Everything added is shared not only with MediaElch but many other sites, mobile apps, and devices as well.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9654,7 +9564,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbSeasonScrapeJob.cpp" line="26"/>
         <source>Show is missing a TheTvDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9662,7 +9572,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbShowScrapeJob.cpp" line="46"/>
         <source>Show is missing a TheTvDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9670,12 +9580,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/concert/tmdb/TmdbConcert.cpp" line="28"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/concert/tmdb/TmdbConcert.cpp" line="132"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9683,12 +9593,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/tmdb/TmdbMovie.cpp" line="45"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/tmdb/TmdbMovie.cpp" line="158"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9696,7 +9606,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTv.cpp" line="20"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9704,7 +9614,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvEpisodeScrapeJob.cpp" line="26"/>
         <source>TMDb show ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9712,7 +9622,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9720,12 +9630,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp" line="41"/>
         <source>Continuing</source>
-        <translation>Continuando</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp" line="41"/>
         <source>Ended</source>
-        <translation>Finalizado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9733,7 +9643,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowScrapeJob.cpp" line="23"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9741,7 +9651,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMaze.cpp" line="19"/>
         <source>TVmaze is a collaborative site, which can be edited by any registered user. Find episode information for any show on any device. anytime, anywhere!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9749,12 +9659,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.cpp" line="39"/>
         <source>TVmaze show ID are valid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.cpp" line="66"/>
         <source>TVmaze ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9762,7 +9672,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9770,7 +9680,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeShowScrapeJob.cpp" line="29"/>
         <source>TV show is missing a TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9778,107 +9688,107 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="31"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="32"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="33"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="34"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="35"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="36"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="37"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="38"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="39"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="40"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="41"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="42"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="43"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="44"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="45"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="47"/>
         <source>The Audio DB</source>
-        <translation>The Audio DB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="48"/>
         <source>MusicBrainz</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="49"/>
         <source>AllMusic</source>
-        <translation>AllMusic</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="50"/>
         <source>Discogs</source>
-        <translation>Discogs</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="52"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="54"/>
         <source>Prefer</source>
-        <translation>Preferir</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9886,7 +9796,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/videobuster/VideoBuster.cpp" line="18"/>
         <source>VideoBuster is a German movie database.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/data/i18n/MediaElch_nl_NL.ts
+++ b/data/i18n/MediaElch_nl_NL.ts
@@ -4306,57 +4306,57 @@ Opdracht geannuleerd.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation>Acteurs</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation>Extra Arts</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation>Extra Fanarts</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation>Stream Details</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation>Lokale Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation>Ondertitels</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation>Tags</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation>IMDB ID</translation>
     </message>
@@ -6235,42 +6235,42 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
         <source>No Label</source>
         <translation>Geen Label</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
         <source>Red</source>
         <translation>Rood</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
         <source>Orange</source>
         <translation>Oranje</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
         <source>Yellow</source>
         <translation>Geel</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
         <source>Green</source>
         <translation>Groen</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
         <source>Blue</source>
         <translation>Blauw</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
         <source>Purple</source>
         <translation>Paars</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
         <translation>Grijs</translation>
     </message>
@@ -6300,7 +6300,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6550,7 +6550,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation>Hernoemen</translation>
     </message>
@@ -6592,37 +6592,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation>Klaar</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation>Maak folder</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation>Verplaats</translation>
     </message>
@@ -6635,142 +6635,147 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation>Placeholders</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation>Placeholder</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
         <source>Artist</source>
         <translation>Artiest</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
         <source>File extension</source>
         <translation>Bestandsextensie</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
         <source>Original Title</source>
         <translation>Originele titel</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
         <source>Season Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
         <source>Part number of the current file</source>
         <translation>Nummer onderdeel van het huidige bestand</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished">IMDB ID</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
         <source>Title</source>
         <translation>Titel</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
         <source>Season Number</source>
         <translation>Seizoen nummer</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
         <source>Title of the show</source>
         <translation>Titel van de show</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
         <source>Year</source>
         <translation>Jaar</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
         <source>Description</source>
         <translation>Omschrijving</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
         <source>Studio(s) (separated by a comma)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
         <source>Sort Title</source>
         <translation>Sorteertitel</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
         <source>Director(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
         <source>Audio Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
         <source>Episode Number</source>
         <translation>Aflevering nummer</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation>Resolutie (1080p, 720p, ...)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation>Bestand/folder is BluRay</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation>Bestand/folder is DVD</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation>Bestand is 3D</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation>Film reeks naam</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation>IMDB ID</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation>Video Codec</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
         <source>Episode has a season name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation>Audio Codec</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation>Aantal audio kanalen</translation>
     </message>
@@ -9292,22 +9297,22 @@ episode after scraping</source>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation>Hetero</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation>Gay</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation>Genre</translation>
     </message>

--- a/data/i18n/MediaElch_no.ts
+++ b/data/i18n/MediaElch_no.ts
@@ -4306,57 +4306,57 @@ Operasjon kansellert.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation>Skuespillere</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation>Ekstra arts</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation>Ekstra fanarts</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation>Stream detaljer</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation type="unfinished">Lokale Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation>Undertekster</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation>Tags</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6235,42 +6235,42 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
         <source>No Label</source>
         <translation>Ingen etikett</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
         <source>Red</source>
         <translation>Rød</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
         <source>Orange</source>
         <translation>Orange</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
         <source>Yellow</source>
         <translation>Gul</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
         <source>Green</source>
         <translation>Grønn</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
         <source>Blue</source>
         <translation>Blå</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
         <source>Purple</source>
         <translation>Lilla</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
         <translation>Grå</translation>
     </message>
@@ -6300,7 +6300,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6550,7 +6550,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation>Endre navn</translation>
     </message>
@@ -6592,37 +6592,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation>Ferdig</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6635,142 +6635,147 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation>Plassholdere</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation>Plassholder</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
         <source>Artist</source>
         <translation>Kunstner</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
         <source>File extension</source>
         <translation>Filtype</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
         <source>Original Title</source>
         <translation>Orginaltittel</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
         <source>Season Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
         <source>Part number of the current file</source>
         <translation>Delenummer for den gjeldende filen</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
         <source>Title</source>
         <translation>Tittel</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
         <source>Season Number</source>
         <translation>Sesong nummer</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
         <source>Title of the show</source>
         <translation>Tittelen på showet</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
         <source>Year</source>
         <translation>År</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
         <source>Description</source>
         <translation>Beskrivelse</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
         <source>Studio(s) (separated by a comma)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
         <source>Sort Title</source>
         <translation>Tittel til sortering</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
         <source>Director(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
         <source>Audio Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
         <source>Episode Number</source>
         <translation>Episode nummer</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation>Oppløsning (1080p, 720p, ...)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation>Filen/mappen er en BluRay</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation>Filen/mappen er en DVD</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation>Filen er 3D</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation>Filmsetnavn</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
         <source>Episode has a season name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9292,22 +9297,22 @@ episode after scraping</source>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation>Språk</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation>Sjanger</translation>
     </message>

--- a/data/i18n/MediaElch_pl.ts
+++ b/data/i18n/MediaElch_pl.ts
@@ -4315,57 +4315,57 @@ Operacja anulowana.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation>Obsada</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation>Dodatkowe grafiki</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation>Fototapety</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation>Fotoapeta</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation>Plakat</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation>Ścieżki</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation>Zwiastun</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation>Lokalny zwiastun</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation>Napisy</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation>Znaczniki</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation>Identyfikator IMDb</translation>
     </message>
@@ -6251,42 +6251,42 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
         <source>No Label</source>
         <translation>Brak etykiety</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
         <source>Red</source>
         <translation>Czerwień</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
         <source>Orange</source>
         <translation>Pomarańcz</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
         <source>Yellow</source>
         <translation>Żółć</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
         <source>Green</source>
         <translation>Zieleń</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
         <source>Blue</source>
         <translation>Błękit</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
         <source>Purple</source>
         <translation>Purpura</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
         <translation>Szarość</translation>
     </message>
@@ -6316,7 +6316,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Przenieś plik&lt;/b&gt; z &quot;%1&quot; do &quot;%2&quot;</translation>
     </message>
@@ -6566,7 +6566,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation>Uruchom</translation>
     </message>
@@ -6612,37 +6612,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation>Zakończono</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation>Utwórz folder</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation>Przenieś</translation>
     </message>
@@ -6655,142 +6655,147 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation>Wypełniacze</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation>Wypełniacz</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
         <source>Artist</source>
         <translation>Wykonawca</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
         <source>File extension</source>
         <translation>Rozszerzenie pliku</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
         <source>Original Title</source>
         <translation>Tytuł oryginalny</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
         <source>Season Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
         <source>Part number of the current file</source>
         <translation>Numer części aktualnego pliku</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished">Identyfikator TMDb</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
         <source>Title</source>
         <translation>Tytuł</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
         <source>Season Number</source>
         <translation>Numer sezonu</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
         <source>Title of the show</source>
         <translation>Tytuł serialu</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
         <source>Year</source>
         <translation>Rok</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
         <source>Description</source>
         <translation>Opis</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
         <source>Studio(s) (separated by a comma)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
         <source>Sort Title</source>
         <translation>Tytuł sortowania</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
         <source>Director(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
         <source>Audio Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
         <source>Episode Number</source>
         <translation>Numer odcinka</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation>Rozdzielczość (1080p, 720p, ...)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation>Plik/folder ma strukturę dysku BluRay</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation>Plik/folder ma strukturę dysku DVD</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation>Plik wideo 3D</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation>Nazwa serii filmowej</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation>Identyfikator IMDb</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation>Kodek wideo</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
         <source>Episode has a season name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation>Kodek dźwięku</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation>Liczba kanałów</translation>
     </message>
@@ -9319,22 +9324,22 @@ episode after scraping</source>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation>Język</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation>Gatunek</translation>
     </message>

--- a/data/i18n/MediaElch_pt_BR.ts
+++ b/data/i18n/MediaElch_pt_BR.ts
@@ -36,7 +36,7 @@
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="146"/>
         <source>About Qt</source>
-        <translation type="unfinished"></translation>
+        <translation>Sobre Qt</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="165"/>
@@ -51,7 +51,7 @@
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="201"/>
         <source>&lt;a href=&quot;https://www.mediaelch.de/mediaelch/&quot;&gt;http://www.mediaelch.de&lt;/a&gt; powered by &lt;a href=&quot;https://www.kvibes.de&quot;&gt;k.vibes&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;a href=&quot;https://www.mediaelch.de/mediaelch/&quot;&gt;http://www.mediaelch.de&lt;/a&gt; powered by &lt;a href=&quot;https://www.kvibes.de&quot;&gt;k.vibes&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="211"/>
@@ -2681,7 +2681,7 @@ Você precisa ir na lista completa de filmes e clicar em Salvar Tudo ou salvar c
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="21"/>
         <source>Directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Diretórios</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="57"/>
@@ -2795,12 +2795,12 @@ e o arquivo será movido para dentro da nova Pasta</translation>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="300"/>
         <source>Appearance</source>
-        <translation type="unfinished"></translation>
+        <translation>Aparência</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="311"/>
         <source>Main Window Theme (changing it requires restart of MediaElch)</source>
-        <translation type="unfinished"></translation>
+        <translation>Tema da janela principal (alterar requer a reinicialização do MediaElch)</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="42"/>
@@ -2834,17 +2834,17 @@ e o arquivo será movido para dentro da nova Pasta</translation>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="48"/>
         <source>Auto</source>
-        <translation type="unfinished"></translation>
+        <translation>Automático</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="49"/>
         <source>Light</source>
-        <translation type="unfinished"></translation>
+        <translation>Claro</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="50"/>
         <source>Dark</source>
-        <translation type="unfinished"></translation>
+        <translation>Escuro</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="66"/>
@@ -4327,57 +4327,57 @@ Operação Cancelada.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation>Elenco</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation>Artes Extras</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation>Extra Fanarts</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation>Dados de Mídia</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation>Trailer Local</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation>Legendas</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation>Etiquetas</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation>IMDB ID</translation>
     </message>
@@ -6264,42 +6264,42 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <translation>O arquivo stylesheet customizado não pode ser aberto para leitura. Usando: %1</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
         <source>No Label</source>
         <translation>Sem Rótulo</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
         <source>Red</source>
         <translation>Vermelho</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
         <source>Orange</source>
         <translation>Laranja</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
         <source>Yellow</source>
         <translation>Amarelo</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
         <source>Green</source>
         <translation>Verde</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
         <source>Blue</source>
         <translation>Azul</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
         <source>Purple</source>
         <translation>Roxo</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
         <translation>Cinza</translation>
     </message>
@@ -6329,7 +6329,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <translation>Valor inválido para Tag xml:</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Mover Arquivo&lt;/b&gt; &quot;%1&quot; para &quot;%2&quot;</translation>
     </message>
@@ -6579,7 +6579,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation>Renomear</translation>
     </message>
@@ -6621,37 +6621,37 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation>Finalizado</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;Filme&lt;/b&gt; &quot;%1&quot; não renomeado: Foi editado mas não foi salvo</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;Episodio&lt;/b&gt; &quot;%1&quot; não renomeado: Foi editado mas não foi salvo</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;Série&lt;/b&gt; &quot;%1&quot; não renomeado: Foi editado mas não foi salvo</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;Concerto&lt;/b&gt; &quot;%1&quot; não renomeado: Foi editado mas não foi salvo</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation>Criar dir</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
@@ -6664,142 +6664,147 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <translation>Marcadores</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation>Marcador</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
         <source>Artist</source>
         <translation>Artista</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
         <source>File extension</source>
         <translation>Extensão do Arquivo</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
         <source>Original Title</source>
         <translation>Título Original</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
         <source>Season Name</source>
         <translation>Título da Temporada</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
         <source>Part number of the current file</source>
         <translation>Número da parte do arquivo atual</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished">TMDb ID</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
         <source>Album</source>
         <translation>Álbum</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
         <source>Title</source>
         <translation>Título Local</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
         <source>Season Number</source>
         <translation>Número da Temporada</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
         <source>Title of the show</source>
         <translation>Título da Série</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
         <source>Year</source>
         <translation>Ano</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
         <source>Description</source>
         <translation>Descrição</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
         <source>Studio(s) (separated by a comma)</source>
         <translation>Estúdio(s) (Separados por Vírgula)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
         <source>Sort Title</source>
         <translation>Título Ordem</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
         <source>Director(s)</source>
         <translation>Direção</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
         <source>Audio Language(s) (separated by a minus)</source>
         <translation>Áudio Idioma(s) (separados por um traço)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
         <source>Episode Number</source>
         <translation>Episódio Número</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation>Resolução (1080p, 720p, ...)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation>Arquivo/diretório é BluRay</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
         <translation>Legenda Idioma(s) (separados por um traço)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation>Arquivo/diretório é DVD</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation>Arquivo é 3D</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation>Nome da Coleção do Filme</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation>IMDB ID</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation>Codec de Vídeo</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
         <source>Episode has a season name</source>
         <translation>Episódio tem um Nome de Temporada</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation>Codec de Áudio</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation>Número de canais de áudio</translation>
     </message>
@@ -8033,12 +8038,12 @@ Episódio após scraping</translation>
     <message>
         <location filename="../../src/ui/tv_show/search_dialog/TvShowScrapePreview.ui" line="43"/>
         <source>&lt;b&gt;Preview&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Preview&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/search_dialog/TvShowScrapePreview.ui" line="83"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Description&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Descrição&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>
@@ -8395,7 +8400,7 @@ Para as artes de temporada use o placeholder &lt;seasonNumber&gt; que é o núme
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="180"/>
         <source>Could not save episode S%1E%2 of show &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Não foi possível salvar o Episódio S%1E%2 da Série &quot;%3&quot;</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="193"/>
@@ -8732,7 +8737,7 @@ Para as artes de temporada use o placeholder &lt;seasonNumber&gt; que é o núme
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="620"/>
         <source>Could not save episode S%1E%2 of show &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>Não foi possível salvar o Episódio S%1E%2 da Série &quot;%3&quot;</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="666"/>
@@ -9330,22 +9335,22 @@ Para as artes de temporada use o placeholder &lt;seasonNumber&gt; que é o núme
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation>Hétero</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation>Gay</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation>Gênero</translation>
     </message>

--- a/data/i18n/MediaElch_ru.ts
+++ b/data/i18n/MediaElch_ru.ts
@@ -4320,57 +4320,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation>Актёры</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation>Дополнительные обложки</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation>Фан-арты</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation>Фон</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation>Постер</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation>Информация о потоке</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation>Трейлер</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation>Локальный трейлер</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation>Субтитры</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation>Теги</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
@@ -6261,42 +6261,42 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation>Не возможно открыть личную таблицу стилей. Используется: %1</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
         <source>No Label</source>
         <translation>Нет метки</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
         <source>Red</source>
         <translation>Красный</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
         <source>Orange</source>
         <translation>Оранжевый</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
         <source>Yellow</source>
         <translation>Желтый</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
         <source>Green</source>
         <translation>Зелёный</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
         <source>Blue</source>
         <translation>Синий</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
         <source>Purple</source>
         <translation>Пурпурный</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
         <translation>Серый</translation>
     </message>
@@ -6326,7 +6326,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation>Недопустимое значение для XML-тега:</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;Файл фильма&lt;/b&gt; &quot;%1&quot; в &quot;%2&quot;</translation>
     </message>
@@ -6576,7 +6576,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation>Переименовать</translation>
     </message>
@@ -6622,37 +6622,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation>Закончено</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;Фильм&lt;/b&gt; &quot;%1&quot; не переименован: был изменён, но не сохранён</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;Серия&lt;/b&gt; &quot;%1&quot; не переименована: была изменена, но не сохранена</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;Сериал&lt;/b&gt; &quot;%1&quot; не переименован: был изменён, но не сохранён</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;Концерт&lt;/b&gt; &quot;%1&quot; не переименован: был изменён, но не сохранён</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation>Создать папку</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation>Переместить</translation>
     </message>
@@ -6665,142 +6665,147 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation>Атрибуты</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation>Атрибут</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
         <source>Artist</source>
         <translation>Артист</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
         <source>File extension</source>
         <translation>Расширение файла</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
         <source>Original Title</source>
         <translation>Оригинальное название</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
         <source>Season Name</source>
         <translation>Название сезона</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
         <source>Part number of the current file</source>
         <translation>Номер части файла</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished">TMDb ID</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
         <source>Album</source>
         <translation>Альбом</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
         <source>Title</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
         <source>Season Number</source>
         <translation>Номер сезона</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
         <source>Title of the show</source>
         <translation>Название сериала</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
         <source>Year</source>
         <translation>Год</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
         <source>Description</source>
         <translation>Описание</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
         <source>Studio(s) (separated by a comma)</source>
         <translation>Студия(и) (разделение запятой)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
         <source>Sort Title</source>
         <translation>Название по сортировке</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
         <source>Director(s)</source>
         <translation>Режиссёр(ы)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
         <source>Audio Language(s) (separated by a minus)</source>
         <translation>Язык(языки) аудио (через знак минус)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
         <source>Episode Number</source>
         <translation>Номер серии</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation>Разрешение (1080p, 720p, ...)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation>BluRay папка</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
         <translation>Язык(языки) субтитров (через знак минус)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation>DVD папка</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation>Файл 3D фильма</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation>Название коллекции</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation>Видео кодек</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
         <source>Episode has a season name</source>
         <translation>У серии название сезона</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation>Аудио кодек</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation>Количество каналов звука</translation>
     </message>
@@ -9337,22 +9342,22 @@ episode after scraping</source>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation>Straight</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation>Gay</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation>Язык</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation>Жанр</translation>
     </message>

--- a/data/i18n/MediaElch_sv.ts
+++ b/data/i18n/MediaElch_sv.ts
@@ -4306,57 +4306,57 @@ Processen avbruten.</translation>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation>Skådespelare</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation>Extra Art</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation>Extra Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation>Fanart</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation>Poster</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation>Ströminfo</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation>Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation type="unfinished">Lokal Trailer</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation>Undertexter</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation>Taggar</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6235,42 +6235,42 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
         <source>No Label</source>
         <translation>Ingen etikett</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
         <source>Red</source>
         <translation>Röd</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
         <source>Orange</source>
         <translation>Orange</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
         <source>Yellow</source>
         <translation>Gul</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
         <source>Green</source>
         <translation>Grön</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
         <source>Blue</source>
         <translation>Blå</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
         <source>Purple</source>
         <translation>Lila</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
         <translation>Grå</translation>
     </message>
@@ -6300,7 +6300,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6550,7 +6550,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation>Ändra namn</translation>
     </message>
@@ -6592,37 +6592,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation>Slutförd</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6635,142 +6635,147 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation>Behållare</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation>Behållare</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
         <source>Artist</source>
         <translation>Artist</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
         <source>File extension</source>
         <translation>Filändelse</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
         <source>Original Title</source>
         <translation>Originaltitel</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
         <source>Season Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
         <source>Part number of the current file</source>
         <translation>Delnummer av aktuell fil</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
         <source>Title</source>
         <translation>Titel</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
         <source>Season Number</source>
         <translation>Säsongsnummer</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
         <source>Title of the show</source>
         <translation>Titel på serien</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
         <source>Year</source>
         <translation>År</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
         <source>Description</source>
         <translation>Beskrivning</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
         <source>Studio(s) (separated by a comma)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
         <source>Sort Title</source>
         <translation>Sorteringstitel</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
         <source>Director(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
         <source>Audio Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
         <source>Episode Number</source>
         <translation>Avsnittsnummer</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation>Upplösning (1080p, 720p, ...)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation>Fil/katalog är BluRay</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation>Fil/Katalog är DVD</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation>Fil är 3D</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation>Filmsamlingsnamn</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
         <source>Episode has a season name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9292,22 +9297,22 @@ episode after scraping</source>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation>Språk</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation>Genre</translation>
     </message>

--- a/data/i18n/MediaElch_tr_TR.ts
+++ b/data/i18n/MediaElch_tr_TR.ts
@@ -1,112 +1,110 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="pt_PT">
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="tr_TR">
 <context>
     <name>AboutDialog</name>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="23"/>
         <source>About MediaElch</source>
-        <translation>Sobre o MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="44"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="112"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="155"/>
         <source>Icon Sets: Retina by &quot;The Working Group&quot; and &quot;Capital Suite&quot; by &quot;capital18 (Jugal Paryani)&quot;</source>
-        <translation>Conjuntos de ícones: Retina de &quot;The Working Group&quot; e &quot;Capital Suite&quot;, de &quot;capital18 (Jugal Paryani)&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="178"/>
         <source>MediaElch Icon by Kathrin Luckner</source>
-        <translation>Ícone do MediaElch por Kathrin Luckner</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="120"/>
         <source>MediaElch was built with &lt;a href=&quot;https://www.qt.io/&quot;&gt;Qt&lt;/a&gt;</source>
-        <translation>O MediaElch foi feito com o &lt;a href=&quot;https://www.qt.io/&quot;&gt;Qt&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="146"/>
         <source>About Qt</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="165"/>
         <source>&lt;a href=&quot;https://develop.kde.org/frameworks/breeze-icons/&quot; title=&quot;KDE Breeze Website&quot;&gt;Breeze icons&lt;/a&gt; copyright KDE and licenced under the GNU LGPL version 3 or later</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="188"/>
         <source>Stream Details detection with &lt;a href=&quot;https://www.mediaarea.net&quot;&gt;Media Info&lt;/a&gt;</source>
-        <translation>Deteção de detalhes da transmissão com &lt;a href=&quot;https://www.mediaarea.net&quot;&gt;Media Info&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="201"/>
         <source>&lt;a href=&quot;https://www.mediaelch.de/mediaelch/&quot;&gt;http://www.mediaelch.de&lt;/a&gt; powered by &lt;a href=&quot;https://www.kvibes.de&quot;&gt;k.vibes&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="211"/>
         <source>Bugs and wishes can be reported on &lt;a href=&quot;https://github.com/Komet/MediaElch/issues&quot;&gt;GitHub&lt;/a&gt; .</source>
-        <translation>Os erros e desejos podem ser reportados no &lt;a href=&quot;https://github.com/Komet/MediaElch/issues&quot;&gt;GitHub&lt;/a&gt; .</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="238"/>
         <source>Developer</source>
-        <translation>Programador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="244"/>
         <source>The information below is important for developers. Please provide if you need help.</source>
-        <translation>Os dados abaixo são importantes para os programadores. Por favor, inclua no seu pedido de ajuda.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="272"/>
         <source>Copy to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="295"/>
         <source>Your Collection</source>
-        <translation>A sua coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="304"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="337"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="370"/>
         <source>Episodes</source>
-        <translation>Episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="403"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="436"/>
         <source>Artists</source>
-        <translation>Artistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="466"/>
         <source>Albums</source>
-        <translation>Álbuns</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -114,12 +112,12 @@
     <message>
         <location filename="../../src/model/ActorModel.cpp" line="83"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/ActorModel.cpp" line="84"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -127,47 +125,47 @@
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="14"/>
         <source>Form</source>
-        <translation>Formulário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="46"/>
         <source>Remove Actor</source>
-        <translation>Remover ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="73"/>
         <source>Add Actor</source>
-        <translation>Adicionar ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="107"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.ui" line="123"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="66"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="67"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="159"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ActorsWidget.cpp" line="161"/>
         <source>Images (*.jpg *.jpeg *.png)</source>
-        <translation>Imagens (*.jpg *.jpeg *.png)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -175,63 +173,63 @@
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="52"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="79"/>
         <source>TextLabel</source>
-        <translation>EtiquetaTexto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="116"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="139"/>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="142"/>
         <source>Add Movie</source>
-        <translation>Adicionar Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="149"/>
         <source>Remove Current Movie</source>
-        <translation>Remover filme atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="152"/>
         <source>Remove Movie</source>
-        <translation>Remover Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="165"/>
         <source>Double click a certification to rename it, right click to delete. If you want to merge two certifications just give them the same name.</source>
-        <translation>Clique duas vezes numa certificação para lhe alterar o nome, clique com o botão direito para eliminá-la. Se quiser fundir duas classificações, basta colocar-lhes o mesmo nome.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.ui" line="175"/>
         <source>Please keep in mind that the changes you make here (renaming or deleting certifications) will be made for every movie.</source>
-        <translation>Por favor, lembre-se que todas as alterações feitas aqui (alterar o nome ou eliminar certificações) serão feitas para todos os filmes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="28"/>
         <source>Add Certification</source>
-        <translation>Adicionar certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="29"/>
         <source>Delete Certification</source>
-        <translation>Eliminar certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="175"/>
         <source>New Certification</source>
-        <translation>Nova certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/CertificationWidget.cpp" line="286"/>
         <source>All Movies Saved</source>
-        <translation>Foram guardados todos os filmes</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -239,37 +237,37 @@
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="112"/>
         <source>Delete Image</source>
-        <translation>Eliminar imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="119"/>
         <source>Zoom Image</source>
-        <translation>Ampliar imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="125"/>
         <source>Capture random screenshot</source>
-        <translation>Capturar ecrã aleatório</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="131"/>
         <source>Select another image</source>
-        <translation>Selecionar outra imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="420"/>
         <source>Really delete image?</source>
-        <translation>Quer eliminar a imagem?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="421"/>
         <source>Are you sure you want to delete this image?</source>
-        <translation>Tem a certeza que quer eliminar esta imagem?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/ClosableImage.cpp" line="423"/>
         <source>Do not ask again</source>
-        <translation>Não perguntar de novo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -277,12 +275,12 @@
     <message>
         <location filename="../../src/file_search/ConcertFileSearcher.cpp" line="53"/>
         <source>Searching for Concerts...</source>
-        <translation>A procurar concertos...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/ConcertFileSearcher.cpp" line="59"/>
         <source>Loading Concerts...</source>
-        <translation>A carregar concertos...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -291,58 +289,52 @@
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="22"/>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="363"/>
         <source>%n concerts</source>
-        <translation>
-            <numerusform>%n concerto</numerusform>
-            <numerusform>%n concertos</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="42"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="43"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="44"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="45"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="46"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="47"/>
         <source>Open Concert Folder</source>
-        <translation>Abrir pasta do concerto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="48"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="49"/>
         <source>Play concert</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/concerts/ConcertFilesWidget.cpp" line="365"/>
         <source>%1 of %n concerts</source>
-        <translation>
-            <numerusform>%1 de %n concerto</numerusform>
-            <numerusform>%1 de %n concertos</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -350,108 +342,108 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="38"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="105"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="119"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="129"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="139"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="149"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="159"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="170"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="210"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="227"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="237"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="247"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="264"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="274"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="309"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="339"/>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="342"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="345"/>
         <source>Not watched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="354"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="52"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="63"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertInfoWidget.ui" line="94"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -459,12 +451,12 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -472,115 +464,112 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="31"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="41"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="110"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="132"/>
         <source>Infos to load</source>
-        <translation>Informações a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="155"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="162"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="169"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="176"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="183"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="190"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="197"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="204"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="211"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="218"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="225"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="232"/>
         <source>Logo, Clear Art, CD Art</source>
-        <translation>Logótipo, Clear Art, CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="235"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.ui" line="249"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="106"/>
         <source>The %1 scraper could not be initialized!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="119"/>
         <source>Please insert a search string!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="141"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertSearchWidget.cpp" line="226"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -588,42 +577,42 @@
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your concerts. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Em baixo, pode ver os nomes de ficheiros usados para carregar e guardar os seus concertos. Pode editá-los à sua vontade, se quiser usar vários ficheiros separe-os com uma vírgula.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o de nome de ficheiro sem extensão.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="42"/>
         <source>Nfo</source>
-        <translation>Nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="71"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="100"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="129"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="158"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ConcertSettingsWidget.ui" line="187"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -633,63 +622,63 @@
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="132"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="135"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="54"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="76"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="91"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="101"/>
         <source>Scantype</source>
-        <translation>Varrimento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="111"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="165"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="185"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="195"/>
         <source>Stereo Mode</source>
-        <translation>Modo de estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.ui" line="212"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="71"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="125"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="159"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="131"/>
@@ -697,18 +686,18 @@
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="163"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="164"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="133"/>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="136"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertStreamDetailsWidget.cpp" line="151"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -716,47 +705,47 @@
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="50"/>
         <source>Concert has changed. Click to revert changes.</source>
-        <translation>O concerto foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="76"/>
         <source>Concert Name</source>
-        <translation>Nome do concerto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="127"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="153"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="175"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="198"/>
         <source>Add Images</source>
-        <translation>Adicionar Imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="208"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="354"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="376"/>
@@ -765,62 +754,62 @@
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="537"/>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="581"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="398"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="471"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="515"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.ui" line="559"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="79"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="80"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="84"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="85"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="447"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="458"/>
         <source>Concerts Saved</source>
-        <translation>Concertos guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/concerts/ConcertWidget.cpp" line="485"/>
         <source>All Concerts Saved</source>
-        <translation>Todos os concertos guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -828,185 +817,185 @@
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="14"/>
         <source>CSV Export</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="22"/>
         <source>CSV Columns</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="35"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="242"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="40"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="252"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="45"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="262"/>
         <source>TV Episodes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="50"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="272"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="55"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="282"/>
         <source>Music Artists</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="60"/>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="292"/>
         <source>Music Albums</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="225"/>
         <source>Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="233"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="304"/>
         <source>Separator</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="321"/>
         <source>Replacement</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="340"/>
         <source>Linebreaks will be replaced by &lt;code&gt;\n&lt;/code&gt;. </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="350"/>
         <source>If any text contains the separator, it will be replaced by the replacement set above.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="373"/>
         <source>&lt;b&gt;Tip:&lt;/b&gt; You can sort the items by Drag &amp;amp; Drop.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.ui" line="390"/>
         <source>Export as CSV</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="29"/>
         <source>Tab</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="30"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="35"/>
         <source>Semicolon (;)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="31"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="36"/>
         <source>Comma (,)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="34"/>
         <source>Space</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="37"/>
         <source>Minus (-)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="52"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="112"/>
         <source>Export directory</source>
-        <translation>Exportar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="114"/>
         <source>Export aborted. No directory was selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="130"/>
         <source>Export movies...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="147"/>
         <source>Export TV shows...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="161"/>
         <source>Export TV episodes...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="179"/>
         <source>Export concerts...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="197"/>
         <source>Export artists...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="212"/>
         <source>Export albums...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="227"/>
         <source>Export completed in %1 seconds.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="319"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="399"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="444"/>
         <source>Streamdetails - Duration (in seconds)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="400"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="445"/>
         <source>Streamdetails - Video Aspect</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="321"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="401"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="446"/>
         <source>Streamdetails - Video Width</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="290"/>
@@ -1016,162 +1005,162 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="467"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="495"/>
         <source>Type</source>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="320"/>
         <source>Streamdetails - Video Aspect Ratio</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="322"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="402"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="447"/>
         <source>Streamdetails - Video Height</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="323"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="403"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="448"/>
         <source>Streamdetails - Video Codec</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="324"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="404"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="449"/>
         <source>Streamdetails - Audio Language(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="325"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="405"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="450"/>
         <source>Streamdetails - Audio Codec(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="326"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="406"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="451"/>
         <source>Streamdetails - Audio Channel(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="327"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="407"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="452"/>
         <source>Streamdetails - Subtitle Language(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="380"/>
         <source>TV Show - TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="379"/>
         <source>TV Show - IMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="291"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="345"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="425"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="292"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="344"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="424"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="293"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="348"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="423"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="294"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="350"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="426"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="295"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="349"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="296"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="361"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="429"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="297"/>
         <source>Outline</source>
-        <translation>Resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="298"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="299"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="359"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="431"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="300"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="358"/>
         <source>IMDb Top 250</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="301"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="432"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="302"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="433"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="303"/>
         <source>Runtime in minutes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="304"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="353"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="435"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="305"/>
         <source>Writers</source>
-        <translation>Argumentistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="306"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="307"/>
@@ -1179,51 +1168,51 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="436"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="469"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="308"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="309"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="310"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="355"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="437"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="311"/>
         <source>Trailers</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="312"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="360"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="313"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="439"/>
         <source>Playcount</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="314"/>
         <source>Last played</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="315"/>
         <source>Movie Set</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="316"/>
@@ -1231,301 +1220,301 @@
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="442"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="480"/>
         <source>Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="317"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="443"/>
         <source>Filename(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="318"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="441"/>
         <source>Last Modified Date</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="346"/>
         <source>TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="347"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="351"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="352"/>
         <source>network</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="356"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="434"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="357"/>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="430"/>
         <source>Ratings</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="381"/>
         <source>TV Show - TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="382"/>
         <source>TV Show - TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="383"/>
         <source>TV Show - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="427"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="428"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="438"/>
         <source>Trailer URL</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="440"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="468"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="470"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="471"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="472"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="473"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="474"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="475"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="476"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="477"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="478"/>
         <source>MusicBrainz ID</source>
-        <translation>Identificador MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="479"/>
         <source>AllMusic ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="384"/>
         <source>Episode - Season</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="385"/>
         <source>Episode - Number</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="386"/>
         <source>Episode - IMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="387"/>
         <source>Episode - TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="388"/>
         <source>Episode - TheTvDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="389"/>
         <source>Episode - TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="390"/>
         <source>Episode - First Aired</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="391"/>
         <source>Episode - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="392"/>
         <source>Episode - Overview</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="393"/>
         <source>Episode - User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="394"/>
         <source>Episode - Directors</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="395"/>
         <source>Episode - Writers</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="396"/>
         <source>Episode - Actors</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="397"/>
         <source>Episode - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="398"/>
         <source>Episode - Filename(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="496"/>
         <source>Artist - Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="497"/>
         <source>Album - Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="498"/>
         <source>Album - Artist Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="499"/>
         <source>Album - Genres</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="500"/>
         <source>Album - Styles</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="501"/>
         <source>Album - Moods</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="502"/>
         <source>Album - Review</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="503"/>
         <source>Album - Release Date</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="504"/>
         <source>Album - Label</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="505"/>
         <source>Album - Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="506"/>
         <source>Album - Year</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="507"/>
         <source>Album - MusicBrainz ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="508"/>
         <source>Album - MusicBrainz ReleaseGroup ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="509"/>
         <source>Album - AllMusic ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="510"/>
         <source>Album - Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="550"/>
         <source>Export failed. Could not write to CSV file.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/CsvExportDialog.cpp" line="540"/>
         <source>Export failed. File could not be opened for writing.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1533,35 +1522,35 @@
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="29"/>
         <source>Select which site you prefer for each element of a TV show and episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="43"/>
         <source>TV show details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="65"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="101"/>
         <source>Item</source>
-        <translation>Item</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="70"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="106"/>
         <source>Site</source>
-        <translation>Site</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.ui" line="79"/>
         <source>Episode details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.cpp" line="149"/>
         <location filename="../../src/ui/settings/CustomTvScraperSettingsWidget.cpp" line="183"/>
         <source>No Scraper Available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1569,65 +1558,62 @@
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="50"/>
         <source>Archives</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="94"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="215"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="99"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="220"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="104"/>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="225"/>
         <source>Size</source>
-        <translation>Tamanho</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="146"/>
         <source>Importable items</source>
-        <translation>Itens importáveis</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="172"/>
         <source>Import movie with MakeMKV</source>
-        <translation>Importar filme com o MakeMKV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="230"/>
         <source>Import Type</source>
         <extracomment>(e.g. movie, TV show, concert)</extracomment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="233"/>
         <source>Type of this file.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="238"/>
         <source>Import Directory</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.ui" line="241"/>
         <source>Where to store the file when importing it.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="126"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="268"/>
         <source>%n files</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="202"/>
@@ -1635,50 +1621,50 @@
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="209"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="221"/>
         <source>Extraction failed</source>
-        <translation>A extração falhou</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="203"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="206"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="209"/>
         <source>Extraction of %1 has failed: %2</source>
-        <translation>A extração de %1 falhou: %2</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="219"/>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="233"/>
         <source>Extraction finished</source>
-        <translation>A extração terminou</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="233"/>
         <source>Extraction of %1 finished</source>
-        <translation>A extração de %1 foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="281"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="282"/>
         <source>TV Show</source>
-        <translation>Série TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="283"/>
         <source>Concert</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="464"/>
         <source>makemkvcon missing</source>
-        <translation>makemkvcon não foi encontrado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/DownloadsWidget.cpp" line="465"/>
         <source>Please set the correct path to makemkvcon in MediaElch&apos;s settings.</source>
-        <translation>Por favor defina o caminho para o makemkvcon.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1687,87 +1673,87 @@
         <location filename="../../src/ui/export/ExportDialog.ui" line="23"/>
         <location filename="../../src/ui/export/ExportDialog.ui" line="132"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="32"/>
         <source>Export your complete collection.</source>
-        <translation>Exportar a sua coleção completa.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="39"/>
         <source>Message</source>
-        <translation>Mensagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="51"/>
         <source>Theme</source>
-        <translation>Tema</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="61"/>
         <source>Items to export</source>
-        <translation>Itens para exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="68"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="78"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="88"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.ui" line="109"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="36"/>
         <source>You need to install at least one theme.</source>
-        <translation>Tem de instalar pelo menos um tema.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="58"/>
         <source>You need to select at least one media type to export.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="68"/>
         <source>Export directory</source>
-        <translation>Exportar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="70"/>
         <source>Export aborted. No directory was selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="78"/>
         <source>Could not create export directory.</source>
-        <translation>Não foi possível criar a pasta para exportação.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="95"/>
         <source>Export canceled.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="98"/>
         <source>Export completed.</source>
-        <translation>Exportação concluída.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/export/ExportDialog.cpp" line="145"/>
         <source>Selected theme not found! Try to restart MediaElch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1775,28 +1761,28 @@
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.ui" line="17"/>
         <source>Message</source>
-        <translation>Mensagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.ui" line="43"/>
         <source>Theme</source>
-        <translation>Tema</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="67"/>
         <source>Theme &quot;%1&quot; was successfully installed</source>
-        <translation>O tema &quot;%1&quot; foi instalado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="70"/>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="81"/>
         <source>There was an error while processing the theme &quot;%1&quot;</source>
-        <translation>Ocorreu um erro ao processar o tema &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportSettingsWidget.cpp" line="78"/>
         <source>Theme &quot;%1&quot; was successfully uninstalled</source>
-        <translation>O tema &quot;%1&quot; foi desinstalado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1805,47 +1791,47 @@
         <location filename="../../src/ui/settings/ExportTemplateWidget.ui" line="102"/>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="42"/>
         <source>Install</source>
-        <translation>Instalar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="25"/>
         <source>by %1</source>
-        <translation>de %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="30"/>
         <source>No website available.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="33"/>
         <source>Version %1</source>
-        <translation>Versão %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="36"/>
         <source>Update</source>
-        <translation>Atualizar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="39"/>
         <source>Uninstall</source>
-        <translation>Desinstalar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="52"/>
         <source>Updating...</source>
-        <translation>A atualizar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="56"/>
         <source>Installing...</source>
-        <translation>A instalar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ExportTemplateWidget.cpp" line="60"/>
         <source>Uninstalling...</source>
-        <translation>A desinstalar...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1853,12 +1839,12 @@
     <message>
         <location filename="../../src/import/Extractor.cpp" line="30"/>
         <source>No files to extract</source>
-        <translation>Não há ficheiros para extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/import/Extractor.cpp" line="40"/>
         <source>Unrar not found</source>
-        <translation>Unrar não foi encontrado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1866,7 +1852,7 @@
     <message>
         <location filename="../../src/ui/main/FileScannerDialog.ui" line="17"/>
         <source>File Scanner</source>
-        <translation>Analisador de ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1874,94 +1860,94 @@
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.ui" line="17"/>
         <source>Filter</source>
-        <translation>Filtro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="117"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="214"/>
         <source>Title contains &quot;%1&quot;</source>
-        <translation>O título contém &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="127"/>
         <source>Filename contains &quot;%1&quot;</source>
-        <translation>O ficheiro contém &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="393"/>
         <source>Label &quot;%1&quot;</source>
-        <translation>Etiqueta &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="395"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="371"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="372"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="373"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>Country</source>
-        <translation>País</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="384"/>
         <source>Released %1</source>
-        <translation>Lançamento %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="384"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="378"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="122"/>
         <source>Original Title contains &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="137"/>
         <source>TMDb ID &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="374"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="375"/>
         <source>Tag</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="376"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="377"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>Video codec</source>
-        <translation>Codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="437"/>
@@ -1969,226 +1955,226 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="516"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="517"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="438"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="439"/>
         <source>Filename</source>
-        <translation>Nome do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>IMDb</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="442"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>Movie has no TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>No TMDb ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="443"/>
         <source>TMDb</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="469"/>
         <source>Movie has Poster</source>
-        <translation>O filme tem cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="469"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>Movie has no Poster</source>
-        <translation>O filme não tem cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="470"/>
         <source>No Poster</source>
-        <translation>Nenhum cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="471"/>
         <source>Movie has Extra Fanarts</source>
-        <translation>O filme tem fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="471"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>Movie has no Extra Fanarts</source>
-        <translation>O filme não tem fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="472"/>
         <source>No Extra Fanarts</source>
-        <translation>Nenhuma fanart extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <source>Movie has Backdrop</source>
-        <translation>O filme tem fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="473"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>Movie has no Backdrop</source>
-        <translation>O filme não tem fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>No Backdrop</source>
-        <translation>Nenhum fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="474"/>
         <source>No Fanart</source>
-        <translation>Sem fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="475"/>
         <source>Movie has Logo</source>
-        <translation>O filme tem logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="475"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>Movie has no Logo</source>
-        <translation>O filme não tem logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="476"/>
         <source>No Logo</source>
-        <translation>Nenhum logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="477"/>
         <source>Movie has Clear Art</source>
-        <translation>O filme tem Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="477"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>Movie has no Clear Art</source>
-        <translation>O filme não tem Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="478"/>
         <source>No Clear Art</source>
-        <translation>Nenhuma Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="479"/>
         <source>Movie has Banner</source>
-        <translation>O filme tem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="479"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>Movie has no Banner</source>
-        <translation>O filme não tem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="480"/>
         <source>No Banner</source>
-        <translation>Sem faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="481"/>
         <source>Movie has Thumb</source>
-        <translation>O filme tem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="481"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>Movie has no Thumb</source>
-        <translation>O filme não tem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="482"/>
         <source>No Thumb</source>
-        <translation>Sem miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="483"/>
         <source>Movie has CD Art</source>
-        <translation>O filme tem CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="483"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>Movie has no CD Art</source>
-        <translation>O filme não tem CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="484"/>
         <source>No CD Art</source>
-        <translation>Nenhuma CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="487"/>
         <source>Movie has Trailer</source>
-        <translation>O filme tem trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="487"/>
@@ -2196,239 +2182,239 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="488"/>
         <source>Movie has no Trailer</source>
-        <translation>O filme não tem trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="488"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>No Trailer</source>
-        <translation>Nenhum trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <source>Movie has local Trailer</source>
-        <translation>O filme tem um trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="489"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>Movie has no local Trailer</source>
-        <translation>O filme não tem trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="490"/>
         <source>No local Trailer</source>
-        <translation>Nenhum trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <source>Movie is Watched</source>
-        <translation>O filme foi visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="454"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Seen</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Movie is Unwatched</source>
-        <translation>O filme está por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Unwatched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="455"/>
         <source>Unseen</source>
-        <translation>Não visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>Movie has no Certification</source>
-        <translation>O filme não tem certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="451"/>
         <source>No Certification</source>
-        <translation>Nenhuma certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>Movie has no Genre</source>
-        <translation>O filme não tem género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="132"/>
         <source>IMDb ID &quot;%1&quot;</source>
-        <translation>Identificador do IMDB &quot;%1&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="440"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="449"/>
         <source>No Genre</source>
-        <translation>Nenhum género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="456"/>
         <source>Movie has Rating</source>
-        <translation>O filme tem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="456"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>Movie has no Rating</source>
-        <translation>O filme não tem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="457"/>
         <source>No Rating</source>
-        <translation>Sem avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="464"/>
         <source>Stream Details loaded</source>
-        <translation>Os detalhes da pista foram carregados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="464"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>Stream Details</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>Stream Details not loaded</source>
-        <translation>Os detalhes da pista não foram carregados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="465"/>
         <source>No Stream Details</source>
-        <translation>Nenhuns detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="460"/>
         <source>Movie has Actors</source>
-        <translation>O filme tem atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="460"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>Movie has no Actors</source>
-        <translation>O filme não tem atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="461"/>
         <source>No Actors</source>
-        <translation>Nenhuns atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>Movie has no Studio</source>
-        <translation>O filme não tem estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="446"/>
         <source>No Studio</source>
-        <translation>Nenhum estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>Movie has no Country</source>
-        <translation>O filme não tem país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="447"/>
         <source>No Country</source>
-        <translation>Nenhum país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>Movie has no Director</source>
-        <translation>O filme não tem realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="448"/>
         <source>No Director</source>
-        <translation>Nenhum realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>No information about video codec</source>
-        <translation>Nenhuma informação sobre o codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="466"/>
         <source>No video codec</source>
-        <translation>Sem codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>Movie has no Tags</source>
-        <translation>O filme não tem etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>No Tags</source>
-        <translation>Nenhumas etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="450"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>Movie has no IMDb ID</source>
-        <translation>Filme sem identificador IMDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="441"/>
         <source>No IMDb ID</source>
-        <translation>Sem identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
         <source>Resolution 720p</source>
-        <translation>Resolução 720p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
         <source>720p</source>
-        <translation>720p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="493"/>
@@ -2436,68 +2422,68 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="494"/>
         <source>Resolution 1080p</source>
-        <translation>Resolução 1080p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="494"/>
         <source>1080p</source>
-        <translation>1080p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <source>Resolution 2160p</source>
-        <translation>Resolução 2160p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="495"/>
         <source>2160p</source>
-        <translation>2160p</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>Resolution SD</source>
-        <translation>Resolução SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="496"/>
         <source>SD</source>
-        <translation>SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <source>Format DVD</source>
-        <translation>Formato DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <source>DVD</source>
-        <translation>DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="497"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>Format</source>
-        <translation>Formato</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>BluRay Format</source>
-        <translation>Formato BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="498"/>
         <source>BluRay</source>
-        <translation>BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
         <source>Channels 2.0</source>
-        <translation>Canais 2.0</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
@@ -2507,59 +2493,59 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="501"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="502"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="503"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="502"/>
         <source>Channels 5.1</source>
-        <translation>Canais 5.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="503"/>
         <source>Channels 7.1</source>
-        <translation>Canais 7.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="504"/>
         <source>Audio Quality HD</source>
-        <translation>Qualidade de áudio HD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="504"/>
         <source>HD Audio</source>
-        <translation>Áudio HD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <source>Audio Quality Normal</source>
-        <translation>Qualidade de áudio normal</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="505"/>
         <source>Normal Audio</source>
-        <translation>Áudio normal</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>Audio Quality SD</source>
-        <translation>Qualidade de áudio SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="506"/>
         <source>SD Audio</source>
-        <translation>Áudio SD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="509"/>
         <source>Movie has Subtitle</source>
-        <translation>Filme com legenda</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="509"/>
@@ -2567,39 +2553,39 @@
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>Subtitle</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="510"/>
         <source>Movie has no Subtitle</source>
-        <translation>O filme não tem legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="510"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>No Subtitle</source>
-        <translation>Sem legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <source>Movie has external Subtitle</source>
-        <translation>O filme tem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="511"/>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>External Subtitle</source>
-        <translation>Legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>Movie has no external Subtitle</source>
-        <translation>O filme não tem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/FilterWidget.cpp" line="512"/>
         <source>No External Subtitle</source>
-        <translation>Sem legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2607,63 +2593,63 @@
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="52"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="79"/>
         <source>TextLabel</source>
-        <translation>EtiquetaTexto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="116"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="139"/>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="142"/>
         <source>Add Movie</source>
-        <translation>Adicionar filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="149"/>
         <source>Remove Current Movie</source>
-        <translation>Remover filme atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="152"/>
         <source>Remove Movie</source>
-        <translation>Remover filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="165"/>
         <source>Double click a genre to rename it, right click to delete. If you want to merge two genres just give them the same name.</source>
-        <translation>Clique duas vezes num género para lhe alterar o nome, clique com o botão direito para eliminá-lo. Se quiser fundir dois géneros, basta colocar-lhes o mesmo nome.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.ui" line="175"/>
         <source>Please keep in mind that the changes you make here (renaming or deleting genres) will be made for every movie.</source>
-        <translation>Por favor, lembre-se que todas as alterações feitas aqui (alterar o nome ou eliminar géneros) serão feitas para todos os filmes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="28"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="29"/>
         <source>Delete Genre</source>
-        <translation>Eliminar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="172"/>
         <source>New Genre</source>
-        <translation>Novo género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/GenreWidget.cpp" line="287"/>
         <source>All Movies Saved</source>
-        <translation>Todos os filmes foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2671,189 +2657,189 @@
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="21"/>
         <source>Directories</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="57"/>
         <source>Add one or more directories containing your movies, TV Shows, concerts, music or files to import.
 TV Show Episodes have to be in subfolders with the name of the show.
 The directories containing your music must contain subdirectories for each artist which contain directories of albums.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="91"/>
         <source>Type</source>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="96"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="101"/>
         <source>Sep. folders</source>
-        <translation>Pastas separadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="104"/>
         <source>Items are in separate folders</source>
-        <translation>Os itens estão em pastas separadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="109"/>
         <source>Reload On Start</source>
-        <translation>Recarregar ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="112"/>
         <source>Automatically reload contents on start</source>
-        <translation>Recarrega automaticamente os conteúdos ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="117"/>
         <source>Disabled</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="120"/>
         <source>Ignore this folder.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="130"/>
         <source>Add</source>
-        <translation>Adicionar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="137"/>
         <source>Remove</source>
-        <translation>Remover</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="144"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sort movies into separate directories&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ordenar filmes em pastas separadas&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="147"/>
         <source>Organize</source>
-        <translation>Organizar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="174"/>
         <source>Store trailer URLs in YouTube Plugin format</source>
-        <translation>Guardar endereços de trailers no formato YouTube Plugin</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="188"/>
         <source>Automatically load and save stream details from files</source>
-        <translation>Carregar e guardar automaticamente detalhes das pistas dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="202"/>
         <source>Ignore articles when sorting (&quot;The&quot;)</source>
-        <translation>Ignorar artigos iniciais ao ordenar (&quot;The&quot;)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="216"/>
         <source>Download actor images</source>
-        <translation>Descarregar imagens de atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="230"/>
         <source>Check for Updates on start</source>
-        <translation>Verificar se existem atualizações ao iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="244"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="263"/>
         <source>Words to exclude from media names (seperated by commas and non case-sensitive)</source>
-        <translation>Palavras a excluir dos nomes de média (separar com vírgulas e sem sensibilidade a maiúsculas)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="270"/>
         <source>Startup section</source>
-        <translation>Secção inicial</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="300"/>
         <source>Appearance</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="311"/>
         <source>Main Window Theme (changing it requires restart of MediaElch)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="42"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="43"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>TV Shows</source>
-        <translation>Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="44"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="45"/>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="46"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="48"/>
         <source>Auto</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="49"/>
         <source>Light</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="50"/>
         <source>Dark</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="66"/>
         <source>Choose a directory containing your movies, TV show or concerts</source>
-        <translation>Escolher uma pasta que contém os seus filmes, séries TV ou concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="219"/>
         <source>Downloads</source>
-        <translation>Descarregamentos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="265"/>
         <source>Organizing movies does only work on movies, not already sorted to separate folders.</source>
-        <translation>Organizar filmes funciona apenas em filmes, sem estarem já organizados em pastas separadas.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="273"/>
         <source>Are you sure?</source>
-        <translation>Tem a certeza?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="275"/>
         <source>This operation sorts all movies in this directory to separate sub-directories based on the file name. Click &quot;Ok&quot;, if that&apos;s, what you want to do. </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2861,22 +2847,22 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="17"/>
         <source>Choose an Image</source>
-        <translation>Escolher uma imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="31"/>
         <source>Enter a search term or URL</source>
-        <translation>Introduza um termo de busca ou um endereço</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="44"/>
         <source>Language to use when searching for a TV show by title.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="124"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="176"/>
@@ -2885,96 +2871,93 @@ The directories containing your music must contain subdirectories for each artis
         <location filename="../../src/ui/image/ImageDialog.ui" line="191"/>
         <location filename="../../src/ui/image/ImageDialog.ui" line="196"/>
         <source>Neue Spalte</source>
-        <translation>Nova coluna</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="703"/>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="711"/>
         <source>No images found</source>
-        <translation>Nenhumas imagens encontradas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="249"/>
         <source>Zoom out</source>
-        <translation>Diminuir ampliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="275"/>
         <source>Preview size</source>
-        <translation>Tamanho de pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="303"/>
         <source>Zoom in</source>
-        <translation>Aumentar ampliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="324"/>
         <source>Loading...</source>
-        <translation>A carregar...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="347"/>
         <source>Choose Local Image</source>
-        <translation>Escolher imagem local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="360"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.ui" line="367"/>
         <source>Accept Images</source>
-        <translation>Aceitar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="251"/>
         <source>Default</source>
-        <translation>Padrão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="158"/>
         <source>Neither an image provider nor previously scraped image URLs are available for the requested image type.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="360"/>
         <source>Error while downloading one or more images: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="523"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="523"/>
         <source>Images (*.jpg *.jpeg *.png)</source>
-        <translation>Imagens (*.jpg *.jpeg *.png)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="708"/>
         <source>Images provided by &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
-        <translation>Imagens fornecidas por  &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="712"/>
         <source>Contribute by uploading images to &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</source>
-        <translation>Contribua enviando novas imagens para &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/image/ImageDialog.cpp" line="812"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/image/ImageDialog.cpp" line="941"/>
         <source>Error while querying image provider: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2982,7 +2965,7 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/small_widgets/ImageLabel.ui" line="42"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -2990,12 +2973,12 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/image/ImagePreviewDialog.ui" line="17"/>
         <source>Preview</source>
-        <translation>Pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/image/ImagePreviewDialog.ui" line="82"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3003,22 +2986,22 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/import/ImportActions.ui" line="23"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.ui" line="30"/>
         <source>Delete</source>
-        <translation>Eliminar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.cpp" line="128"/>
         <source>Delete file?</source>
-        <translation>Eliminar o ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportActions.cpp" line="129"/>
         <source>Do you really want to delete this file?</source>
-        <translation>Quer mesmo eliminar este ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3026,144 +3009,141 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="17"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="40"/>
         <source>Loading</source>
-        <translation>A carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="47"/>
         <source>Success</source>
-        <translation>Sucesso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="54"/>
         <source>Loading movie...</source>
-        <translation>A carregar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="81"/>
         <source>Directory Naming</source>
-        <translation>Nomes das pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="91"/>
         <source>File Naming</source>
-        <translation>Nomes dos Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="108"/>
         <source>Use Season Directories</source>
-        <translation>Usar pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="115"/>
         <source>Season Directory Naming</source>
-        <translation>Nomes das pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="132"/>
         <source>Keep source files after import</source>
-        <translation>Manter ficheiros originais após importação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="175"/>
         <location filename="../../src/ui/import/ImportDialog.ui" line="185"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.ui" line="205"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="274"/>
         <source>Loading movie information...</source>
-        <translation>A carregar a informação do filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="296"/>
         <source>Loading concert information...</source>
-        <translation>A carregar a informação do concerto...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="320"/>
         <source>Loading episode information...</source>
-        <translation>A carregar a informação do episódio...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="390"/>
         <source>Movie information was loaded</source>
-        <translation>A informação do filme foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="404"/>
         <source>Concert information was loaded</source>
-        <translation>A informação do concerto foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="423"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="442"/>
         <source>Episode information was loaded</source>
-        <translation>A informação do episódio foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="454"/>
         <source>Renaming not possible</source>
-        <translation>Não é possível alterar o nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="454"/>
         <source>Please enter all naming patterns</source>
-        <translation>Por favor, introduza todos os padrões de nomenclatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="484"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="577"/>
         <source>Creating destination directory failed</source>
-        <translation>Não foi possível criar a pasta de destino</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="485"/>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="578"/>
         <source>The destination directory %1 could not be created</source>
-        <translation>Não foi possível criar a pasta de destino %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="514"/>
         <source>Importing movie...</source>
-        <translation>A importar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="553"/>
         <source>Importing episode...</source>
-        <translation>A importar o episódio...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="605"/>
         <source>Importing concert...</source>
-        <translation>A importar o concerto...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="708"/>
         <source>Import finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/import/ImportDialog.cpp" line="709"/>
         <source>Import of %n files has finished</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/import/ImportDialog.cpp" line="712"/>
         <source>Import has finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3171,33 +3151,33 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="19"/>
         <source>Automatically delete archives after extraction</source>
-        <translation>Eliminar ficheiros automaticamente após extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="33"/>
         <source>Path to unrar</source>
-        <translation>Localização do Unrar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="45"/>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="66"/>
         <source>Choose</source>
-        <translation>Escolher</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.ui" line="54"/>
         <source>Path to makemkvcon</source>
-        <translation>Localização de makemkvcon</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.cpp" line="46"/>
         <source>Choose unrar</source>
-        <translation>Escolher Unrar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ImportSettingsWidget.cpp" line="54"/>
         <source>Choose makemkvcon</source>
-        <translation>Escolher makemkvco</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3205,49 +3185,47 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="17"/>
         <source>General Kodi Settings. MediaElch uses the Kodi version below for writing NFO files.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="29"/>
         <source>Kodi Version</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="48"/>
         <source>If you want to use the synchronization feature you need to enable the webserver within Kodi (Settings -&gt; Services -&gt; Webserver). Enter the port of the webserver here (usually 80 or 8080).</source>
-        <translation>Se quer usar o recurso de sincronização, deve antes ativar o servidor web dentro do Kodi.
-Veja em Kodi -&gt; Definições -&gt; Serviços -&gt; Servidor web. Anote os números de host (IP) e da porta.
-Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="63"/>
         <source>Host</source>
-        <translation>Anfitrião</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="70"/>
         <source>127.0.0.1</source>
-        <translation>127.0.0.1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="77"/>
         <source>Port</source>
-        <translation>Porta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="84"/>
         <source>8080</source>
-        <translation>8080</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="91"/>
         <source>User</source>
-        <translation>Utilizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/KodiSettingsWidget.ui" line="98"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3255,68 +3233,68 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="23"/>
         <source>Kodi Synchronization</source>
-        <translation>Sincronização com Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="32"/>
         <source>Please make sure you have setup your sources in Kodi and that the webserver is enabled (Kodi -&gt; Settings -&gt; Services -&gt; Webserver).</source>
-        <translation>Por favor, certifique-se que configurou as suas fontes no Kodi e que o seu servidor web está ativado (Kodi -&gt; Definições -&gt; Serviços -&gt; Servidor web).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="42"/>
         <source>Update contents</source>
-        <translation>Atualizar conteúdos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="52"/>
         <source>This will tell Kodi to remove the changed movies, concerts or shows. Afterwards a Kodi library update is triggered and the removed items will be picked up again.</source>
-        <translation>Isto irá dizer ao Kodi para remover os filmes, concertos e séries com alterações. Após isso, o Kodi irá fazer uma atualização e os itens removidos serão novamente recolhidos e reinseridos.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="62"/>
         <source>Remove non-existent items from Kodis database (Clean library)</source>
-        <translation>Remover itens não existentes da base de dados do Kodi (limpar coleção).</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="69"/>
         <source>Kodi will remove not longer existing items from your database.</source>
-        <translation>O Kodi irá remover os itens não localizados da sua base de dados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="76"/>
         <source>Retrieve watched status</source>
-        <translation>Obter estado de &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="83"/>
         <source>The fields last played and playcount will be retrieved from Kodi.</source>
-        <translation>Os campos Última Reprodução e Contador de Sessões virão do Kodi.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="113"/>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="120"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="138"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.ui" line="161"/>
         <source>Start</source>
-        <translation>Iniciar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="165"/>
         <source>Please fill in your Kodi host and port.</source>
-        <translation>Por favor introduza os dados de Host e Porta no menu Definições -&gt; Kodi.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="238"/>
         <source>Getting contents from Kodi</source>
-        <translation>A obter conteúdos do Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="254"/>
@@ -3324,52 +3302,52 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="318"/>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="350"/>
         <source>Network error</source>
-        <translation>Erro de rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="448"/>
         <source>Removing movies from database</source>
-        <translation>A remover filmes da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="463"/>
         <source>Removing concerts from database</source>
-        <translation>A remover concertos da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="478"/>
         <source>Removing TV shows from database</source>
-        <translation>A remover séries de TV da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="493"/>
         <source>Removing episodes from database</source>
-        <translation>A remover episódios da base de dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="533"/>
         <source>Trigger scan for new items</source>
-        <translation>Requisitar busca de novos itens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="555"/>
         <source>Error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="560"/>
         <source>Finished. Kodi is now loading your updated items.</source>
-        <translation>Terminado. O Kodi está agora a carregar os seus itens atualizados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="582"/>
         <source>Finished. Kodi is now cleaning your database.</source>
-        <translation>Terminado. O Kodi está agora a limpar a sua base de dados.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/media_center/KodiSync.cpp" line="627"/>
         <source>Finished. Your items play count and last played date have been updated.</source>
-        <translation>Concluído. O &quot;Nº de reproduções&quot; e a &quot;última reprodução&quot; dos seus itens foram atualizadas.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3377,7 +3355,7 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/small_widgets/LanguageCombo.cpp" line="37"/>
         <source>No language available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3385,17 +3363,17 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="23"/>
         <source>Loading Stream Details</source>
-        <translation>A carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="32"/>
         <source>Loading Stream Details...</source>
-        <translation>A carregar detalhes da pista...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/LoadingStreamDetails.ui" line="46"/>
         <source>File</source>
-        <translation>Ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3403,414 +3381,414 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/data/Locale.cpp" line="28"/>
         <source>Arabic</source>
-        <translation>Árabe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="29"/>
         <source>Arabic (U.A.E.)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="30"/>
         <source>Arabic (Saudi Arabia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="31"/>
         <source>Belarusian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="32"/>
         <location filename="../../src/data/Locale.cpp" line="33"/>
         <source>Bulgarian</source>
-        <translation>Búlgaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="34"/>
         <source>Bengali</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="35"/>
         <source>Catalan (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="36"/>
         <source>Chamorro (Guam)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="37"/>
         <source>Cantonese</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="38"/>
         <location filename="../../src/data/Locale.cpp" line="39"/>
         <source>Czech</source>
-        <translation>Checo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="40"/>
         <location filename="../../src/data/Locale.cpp" line="41"/>
         <source>Danish</source>
-        <translation>Dinamarquês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="42"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="43"/>
         <source>German (AT)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="44"/>
         <source>German (CH)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="45"/>
         <source>German (DE)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="46"/>
         <location filename="../../src/data/Locale.cpp" line="47"/>
         <source>Greek</source>
-        <translation>Grego</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="48"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="49"/>
         <source>English (Australia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="50"/>
         <source>English (Canada)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="51"/>
         <source>English (GB)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="52"/>
         <source>English (NZ)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="53"/>
         <source>English (US)</source>
-        <translation>Inglês (US)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="54"/>
         <source>Esperanto</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="55"/>
         <location filename="../../src/data/Locale.cpp" line="56"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="57"/>
         <source>Spanish (Mexico)</source>
-        <translation>Castelhano (México)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="58"/>
         <source>Estonian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="59"/>
         <source>Basque (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="60"/>
         <source>Persian (Iran)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="61"/>
         <location filename="../../src/data/Locale.cpp" line="62"/>
         <source>Finnish</source>
-        <translation>Finlandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="63"/>
         <location filename="../../src/data/Locale.cpp" line="65"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="64"/>
         <source>French (Canada)</source>
-        <translation>Francês (Canadá)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="66"/>
         <source>Galician (Spain)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="67"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="68"/>
         <source>Hebrew (Israel)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="69"/>
         <source>Hindi (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="70"/>
         <source>Croatian</source>
-        <translation>Croata</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="71"/>
         <source>Croatian (Croatia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="72"/>
         <location filename="../../src/data/Locale.cpp" line="73"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="74"/>
         <source>Indonesian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="75"/>
         <location filename="../../src/data/Locale.cpp" line="76"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="77"/>
         <location filename="../../src/data/Locale.cpp" line="78"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="79"/>
         <source>Georgian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="80"/>
         <source>Kazakh</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="81"/>
         <source>Kannada</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="82"/>
         <location filename="../../src/data/Locale.cpp" line="83"/>
         <source>Korean</source>
-        <translation>Coreano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="84"/>
         <source>Lithuanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="85"/>
         <source>Latvian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="86"/>
         <source>Malayalam</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="87"/>
         <source>Malay (Malaysia)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="88"/>
         <source>Malay (Singapore)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="89"/>
         <source>Norwegian Bokmål</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="90"/>
         <location filename="../../src/data/Locale.cpp" line="91"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="92"/>
         <location filename="../../src/data/Locale.cpp" line="93"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="94"/>
         <location filename="../../src/data/Locale.cpp" line="95"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="96"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="97"/>
         <source>Portuguese (Brazil)</source>
-        <translation>Português (Brasil)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="98"/>
         <source>Portuguese (Portugal)</source>
-        <translation>Português (Portugal)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="99"/>
         <source>Romanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="100"/>
         <location filename="../../src/data/Locale.cpp" line="101"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="102"/>
         <source>Sinhalese (Sri Lanka)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="103"/>
         <source>Slovak</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="104"/>
         <source>Slovene</source>
-        <translation>Eslovaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="105"/>
         <source>Slovenian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="106"/>
         <source>Albanian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="107"/>
         <source>Serbian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="108"/>
         <location filename="../../src/data/Locale.cpp" line="109"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="110"/>
         <source>Tamil (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="111"/>
         <source>Telugu (India)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="112"/>
         <source>Thai</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="113"/>
         <source>Tagalog (Philippines)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="114"/>
         <location filename="../../src/data/Locale.cpp" line="115"/>
         <source>Turkish</source>
-        <translation>Turco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="116"/>
         <source>Ukrainian</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="117"/>
         <source>Vietnamese</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="118"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="119"/>
         <source>Chinese (PRC)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="120"/>
         <source>Chinese (Hong Kong)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="121"/>
         <source>Chinese (Taiwan)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="122"/>
         <source>Zulu</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/data/Locale.cpp" line="124"/>
         <source>No language available</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3818,55 +3796,55 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="14"/>
         <source>MediaElch</source>
-        <translation>MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="75"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="94"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="125"/>
         <source>Movie Sets</source>
-        <translation>Coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="156"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="187"/>
         <source>Certifications</source>
-        <translation>Certificações</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="218"/>
         <source>Duplicates</source>
-        <translation>Duplicados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="248"/>
         <source>Shows</source>
-        <translation>Séries</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="267"/>
         <source>TV Shows</source>
-        <translation>Séries TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="297"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="316"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="346"/>
         <location filename="../../src/ui/main/MainWindow.ui" line="365"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="395"/>
@@ -3875,92 +3853,92 @@ Introduza abaixo o host (IP) e a porta do servidor web (normalmente 80 ou 8080).
         <extracomment>Main menu entry
 ----------
 Main menu entry (tooltip)</extracomment>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="883"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="888"/>
         <source>Quit</source>
-        <translation>Sair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.ui" line="893"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="52"/>
         <source>FAQ</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="53"/>
         <source>Troubleshooting</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="54"/>
         <source>Report Issue</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="56"/>
         <source>Release Notes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="57"/>
         <source>Documentation</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="58"/>
         <source>Blog</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="59"/>
         <source>Official Kodi Forum</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="61"/>
         <source>View License</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="340"/>
         <source>&amp;Quick Open</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="807"/>
         <source>Reload all Movies (%1)</source>
-        <translation>Recarregar todos os filmes (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="813"/>
         <source>Reload all TV Shows (%1)</source>
-        <translation>Recarregar todas as séries de TV (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="824"/>
         <source>Reload all Concerts (%1)</source>
-        <translation>Recarregar todos os Concertos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="840"/>
         <source>Reload all Downloads (%1)</source>
-        <translation>Recarregar todos os descarregamentos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/MainWindow.cpp" line="846"/>
         <source>Reload Music (%1)</source>
-        <translation>Recarregar música (%1)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -3968,147 +3946,147 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="50"/>
         <source>Scan</source>
-        <translation>Análise</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="92"/>
         <source>Import Tracks</source>
-        <translation>Importar faixas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="118"/>
         <source>Backup Disc</source>
-        <translation>Disco de cópia de segurança</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="163"/>
         <source>Loading</source>
-        <translation>A carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="170"/>
         <source>Success</source>
-        <translation>Sucesso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="177"/>
         <source>Loading movie...</source>
-        <translation>A carregar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="199"/>
         <source>Placeholders</source>
-        <translation>Marcadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="207"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="236"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="259"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="282"/>
         <source>File extension</source>
-        <translation>Extensão de ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="298"/>
         <source>Placeholder</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="321"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="338"/>
         <source>Part number of the current file</source>
-        <translation>Número da parte do ficheiro atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="355"/>
         <source>Directory Naming</source>
-        <translation>Nomes das pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="365"/>
         <source>File Naming</source>
-        <translation>Nomes dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="375"/>
         <source>Multi-File Naming</source>
-        <translation>Renomear múltiplos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="385"/>
         <source>Import directory</source>
-        <translation>Pasta de importação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="429"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.ui" line="452"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="207"/>
         <source>No tracks selected</source>
-        <translation>Não foram selecionadas faixas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="208"/>
         <source>Please select at least one track you want to import.</source>
-        <translation>Por favor, selecione pelo menos uma faixa para importar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="246"/>
         <source>Loading movie information...</source>
-        <translation>A carregar a informação do filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="274"/>
         <source>Movie information was loaded</source>
-        <translation>A informação de filme foi carregada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="297"/>
         <source>Creating destination directory failed</source>
-        <translation>Não foi possível criar a pasta de destino</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="298"/>
         <source>The destination directory %1 could not be created</source>
-        <translation>Não foi possível criar a pasta de destino %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="386"/>
         <source>MakeMKV import finished</source>
-        <translation>Importação MakeMKV foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="386"/>
         <source>Import with MakeMKV has finished</source>
-        <translation>A importação com o MakeMKV foi concluída</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/MakeMkvDialog.cpp" line="389"/>
         <source>Import has finished</source>
-        <translation>A importação terminou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4116,17 +4094,17 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="116"/>
         <source>Movie title</source>
-        <translation>Título do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="145"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicateItem.ui" line="152"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4134,27 +4112,27 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.ui" line="67"/>
         <source>Detect duplicate movies</source>
-        <translation>Detetar filmes duplicados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="75"/>
         <source>Detecting duplicate movies...</source>
-        <translation>A detetar filmes duplicados...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="129"/>
         <source>Open Detail Page</source>
-        <translation>Abrir página de detalhes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="130"/>
         <source>Open Movie Folder</source>
-        <translation>Abrir pasta do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieDuplicates.cpp" line="131"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4162,19 +4140,18 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="25"/>
         <source>Source %1 is no directory</source>
-        <translation>A fonte %1 não é uma pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="83"/>
         <source>Operation not possible.</source>
-        <translation>Não foi possível efetuar a operação.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MovieFilesOrganizer.cpp" line="84"/>
         <source>%1
  Operation Canceled.</source>
-        <translation>%1
- Operação Cancelada.</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4182,99 +4159,93 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="144"/>
         <source>New</source>
-        <translation>Novo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="160"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="176"/>
         <source>Date Added</source>
-        <translation>Data de adição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="192"/>
         <source>Seen</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.ui" line="208"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="30"/>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="562"/>
         <source>%n movies</source>
-        <translation>
-            <numerusform>%n filme</numerusform>
-            <numerusform>%n filmes</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="58"/>
         <source>Media Status Columns</source>
-        <translation>Colunas de estado do média</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="69"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="80"/>
         <source>Load Information</source>
-        <translation>Carregar informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="81"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="82"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="83"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="84"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="85"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="86"/>
         <source>Open Movie Folder</source>
-        <translation>Abrir pasta do Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="87"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="88"/>
         <source>Play movie</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieFilesWidget.cpp" line="564"/>
         <source>%1 of %n movies</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -4282,85 +4253,85 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="17"/>
         <source>Choose a movie</source>
-        <translation>Escolher o filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="26"/>
         <source>Filter</source>
-        <translation>Filtro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="58"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="68"/>
         <source>Add selected movies</source>
-        <translation>Adicionar filmes selecionados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/MovieListDialog.ui" line="88"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="326"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <source>Extra Arts</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <source>Extra Fanarts</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="329"/>
-        <source>Extra Arts</source>
-        <translation>Arts extras</translation>
+        <source>Fanart</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="330"/>
-        <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <source>Poster</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="331"/>
-        <source>Fanart</source>
-        <translation>Fanart</translation>
+        <source>Stream Details</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="332"/>
-        <source>Poster</source>
-        <translation>Cartaz</translation>
+        <source>Trailer</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="333"/>
-        <source>Stream Details</source>
-        <translation>Detalhes da pista</translation>
+        <source>Local Trailer</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="334"/>
-        <source>Trailer</source>
-        <translation>Trailer</translation>
+        <source>Subtitles</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="335"/>
-        <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <source>Tags</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/MovieModel.cpp" line="336"/>
-        <source>Subtitles</source>
-        <translation>Legendas</translation>
-    </message>
-    <message>
-        <location filename="../../src/model/MovieModel.cpp" line="337"/>
-        <source>Tags</source>
-        <translation>Etiquetas</translation>
-    </message>
-    <message>
-        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4368,185 +4339,182 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="23"/>
         <source>Movie Multi Scrape</source>
-        <translation>Extração múltipla de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="36"/>
         <source>Please select the scraper and the infos you want to be loaded. MediaElch will use the best result for each movie you selected.</source>
-        <translation>Por favor, escolha o extrator e as informações que pretende carregar. O MediaElch usará o melhor resultado para cada filme que selecionou.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="48"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="84"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="143"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="233"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="163"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="303"/>
         <source>Logo</source>
-        <translation>Logotipos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="223"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="133"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="113"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="93"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="103"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="173"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="213"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="203"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="153"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="123"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="183"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="243"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="253"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="193"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="293"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="283"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="273"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="263"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="313"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="332"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="358"/>
         <source>Automatically save each movie after scraping</source>
-        <translation>Guardar automaticamente cada filme após a extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="365"/>
         <source>Update only movies with IMDb ID/TMDb Id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="380"/>
         <source>1/20</source>
-        <translation>1/20</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="387"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="412"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="435"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.ui" line="448"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieMultiScrapeDialog.cpp" line="201"/>
         <source>Scraping of %n movies has finished.</source>
-        <translation>
-            <numerusform>A extração de %n filmes terminou.</numerusform>
-            <numerusform>A extração de %n filmes terminou.</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -4554,12 +4522,12 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4567,166 +4535,163 @@ Main menu entry (tooltip)</extracomment>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="31"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="41"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="70"/>
         <source>When using IMDb you can also use the IMDb id as search query.
 If you want to search by an TMDb id please prefix it with &quot;id&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="128"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="163"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="170"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="177"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="184"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="191"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="198"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="205"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="212"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="219"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="226"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="233"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="240"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="264"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="271"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="278"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="285"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="292"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="299"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="306"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="313"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="320"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="327"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="334"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.ui" line="365"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="77"/>
         <source>Cannot scrape a movie without an active scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="153"/>
         <source>Internal inconsistency: Cannot set language dropdown in movie search widget!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="175"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieSearchWidget.cpp" line="314"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4734,112 +4699,112 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your movies. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Em baixo, pode ver os nomes de ficheiros usados para carregar e guardar os seus filmes. Pode editá-los à sua vontade, se quiser usar vários ficheiros separe-os com uma vírgula.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o de nome de ficheiro sem extensão.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="42"/>
         <source>Nfo</source>
-        <translation>Nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="49"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="56"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="63"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="70"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="77"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="216"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="223"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="281"/>
         <source>Movie outline</source>
-        <translation>Resumo do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="288"/>
         <source>Use plot when outline is not available</source>
-        <translation>Usar enredo quando não existir resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="295"/>
         <source>Movie Set Artwork</source>
-        <translation>Artwork de coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="21"/>
         <source>Artwork next to movies</source>
-        <translation>Artwork próxima dos filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="23"/>
         <source>Separate artwork directory</source>
-        <translation>Pasta separada de artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="305"/>
         <source>Movie Set Poster Filename</source>
-        <translation>Nome do ficheiro do cartaz da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="342"/>
         <source>Movie Set Fanart Filname</source>
-        <translation>Nome de ficheiro da fanart da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="379"/>
         <source>Artwork directory</source>
-        <translation>Pasta de artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="391"/>
         <source>Choose directory</source>
-        <translation>Escolher pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="400"/>
         <source>Movie Original Title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.ui" line="407"/>
         <source>Don&apos;t store the original title if it is the same as the normal title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MovieSettingsWidget.cpp" line="163"/>
         <source>Choose a directory where your movie set artwork is stored</source>
-        <translation>Escolher uma pasta onde a artwork da coleção de filmes está guardada</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -4847,283 +4812,283 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="50"/>
         <source>Movie has changed. Click to revert changes.</source>
-        <translation>O filme foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="75"/>
         <source>Movie Name</source>
-        <translation>Nome do filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="121"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="141"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1050"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="155"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="165"/>
         <source>Original Name</source>
-        <translation>Nome original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="175"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="185"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="211"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="228"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="235"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="245"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="255"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="275"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="282"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="317"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="347"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="350"/>
         <source>Watched</source>
-        <translation>Visto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="353"/>
         <source>Not watched</source>
-        <translation>Por ver</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="362"/>
         <source>Plot</source>
-        <translation>Enredo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="386"/>
         <source>Insert YouTube Dummy Link</source>
-        <translation>Inserir link falso do YouTube</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="405"/>
         <source>Download Trailer</source>
-        <translation>Descarregar trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="421"/>
         <source>Play local trailer</source>
-        <translation>Reproduzir trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="431"/>
         <source>Local trailer is available</source>
-        <translation>Está disponível um trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="434"/>
         <source>Local Trailer</source>
-        <translation>Trailer local</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="447"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="480"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="548"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="558"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="570"/>
         <source>Outline</source>
-        <translation>Resumo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="592"/>
         <source>Open movie on IMDb.com</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="595"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="631"/>
         <source>Go</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="618"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="628"/>
         <source>Open movie on TheMovieDB.org</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="663"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="695"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="786"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="705"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="717"/>
         <source>Support for extra fanarts is only available when your movies are stored in separate folders. Check the settings if you&apos;ve stored your movies in separate folders already.</source>
-        <translation>O recurso a fanarts extra só está disponível quando os seus filmes estão guardados em pastas separadas. Verifique as definições, caso já tenha guardado os seus filmes em pastas separadas.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="735"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="758"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="768"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="806"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="796"/>
         <source>Scantype</source>
-        <translation>Varrimento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="942"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="788"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="791"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="847"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="862"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="888"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="881"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="221"/>
         <source>Ratings</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="653"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="952"/>
         <source>Stereo Mode</source>
-        <translation>Modo de Estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="973"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1030"/>
         <source>External Subtitles</source>
-        <translation>Legendas externas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1060"/>
         <source>Forced</source>
-        <translation>Forçadas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1216"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1256"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1238"/>
@@ -5134,103 +5099,103 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1502"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1549"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1263"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1303"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1310"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1350"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1386"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1426"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1433"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1473"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1480"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1520"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1527"/>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1567"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="88"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="89"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="93"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="94"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="98"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="99"/>
         <source>Add Country</source>
-        <translation>Adicionar país</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="103"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="104"/>
         <source>Add Studio</source>
-        <translation>Adicionar estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="485"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="492"/>
         <source>Scraping...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="780"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="816"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.ui" line="1055"/>
@@ -5239,49 +5204,49 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="821"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="822"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="789"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="792"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="807"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="850"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="921"/>
         <source>Saving movie...</source>
-        <translation>A guardar o filme...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="926"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="902"/>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="950"/>
         <source>Saving movies...</source>
-        <translation>A guardar os filmes...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="919"/>
         <source>Movies Saved</source>
-        <translation>Filmes guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movies/MovieWidget.cpp" line="971"/>
         <source>All Movies Saved</source>
-        <translation>Todos os filmes foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5289,12 +5254,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/file_search/MusicFileSearcher.cpp" line="44"/>
         <source>Searching for Music...</source>
-        <translation>A procurar por músia...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/MusicFileSearcher.cpp" line="129"/>
         <source>Loading Music...</source>
-        <translation>A carregar a música...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5302,38 +5267,29 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="31"/>
         <source>Open Folder</source>
-        <translation>Abrir pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="32"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="25"/>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="155"/>
         <source>%n artists</source>
-        <translation>
-            <numerusform>%n artista</numerusform>
-            <numerusform>%n artistas</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="25"/>
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="155"/>
         <source>%n albums</source>
-        <translation>
-            <numerusform>%n álbum</numerusform>
-            <numerusform>%n álbuns</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicFilesWidget.cpp" line="158"/>
         <source>%1 of %n artists</source>
-        <translation>
-            <numerusform>%1 de %n artista</numerusform>
-            <numerusform>%1 de %n artistas</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5341,170 +5297,167 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="17"/>
         <source>Music Multi Scrape</source>
-        <translation>Extração múltipla de músicas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="39"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="48"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="61"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="74"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="87"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="100"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="113"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="126"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="139"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="152"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="165"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="178"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="191"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="204"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="217"/>
         <source>Moods</source>
-        <translation>Disposição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="230"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="243"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="256"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="269"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="282"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="295"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="308"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="321"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="334"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="347"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="369"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="395"/>
         <source>Scrape all albums of selected artists (and not only selected albums)</source>
-        <translation>Extrair todos os álbuns de artistas selecionados (e não apenas dos álbuns selecionados)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="402"/>
         <source>Automatically save each artist and album after scraping</source>
-        <translation>Guardar automaticamente cada artista e álbum após a extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="449"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="472"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.ui" line="485"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/music/MusicMultiScrapeDialog.cpp" line="205"/>
         <source>Scraping of %n items has finished.</source>
-        <translation>
-            <numerusform>Terminou a extração de %n itens.</numerusform>
-            <numerusform>Terminou a extração de %n itens.</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5512,12 +5465,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5525,142 +5478,142 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="34"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="89"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="117"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="140"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="150"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="160"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="170"/>
         <source>Years Active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="180"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="190"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="200"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="210"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="220"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="230"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="240"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="250"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="260"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="270"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="280"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="290"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="300"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="310"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="320"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="330"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="340"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="350"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="360"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="370"/>
         <source>CD Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicSearchWidget.ui" line="387"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar tudo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5668,39 +5621,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your artists and albums. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation>Abaixo pode ver os nomes de ficheiros que são usados ​​para carregar e guardar os Artistas e Álbuns. Pode editá-los como quiser.
-Se quiser guardar o mesmo ficheiro com vários nomes, deve separar os nomes com uma vírgula.
-Por exemplo:  folder.jpg,cover.jpg</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="32"/>
         <source>Artist Thumbnail</source>
-        <translation>Miniatura de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="49"/>
         <source>Artist Fanart</source>
-        <translation>Fanart de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="66"/>
         <source>Artist Logo</source>
-        <translation>Logótipo de artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="83"/>
         <source>Album Thumbnail</source>
-        <translation>Miniatura de álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="100"/>
         <source>Album Disc Art</source>
-        <translation>Capa do álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/MusicSettingsWidget.ui" line="117"/>
         <source>Download Extra Fanarts for Artists</source>
-        <translation>Descarregar Fanarts extras para artistas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5708,10 +5659,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message numerus="yes">
         <location filename="../../src/ui/small_widgets/MusicTreeView.cpp" line="105"/>
         <source>%n albums</source>
-        <translation>
-            <numerusform>%n album</numerusform>
-            <numerusform>%n álbuns</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -5720,13 +5668,13 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="122"/>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="162"/>
         <source>Saving changed Artists and Albums</source>
-        <translation>A guardar alterações em artistas e álbuns</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="140"/>
         <location filename="../../src/ui/music/MusicWidget.cpp" line="187"/>
         <source>All Artists and Albums Saved</source>
-        <translation>Todos os artistas e álbuns foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5734,150 +5682,150 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="53"/>
         <source>Album has changed. Click to revert changes.</source>
-        <translation>O álbum foi alterando. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="79"/>
         <source>Album Name</source>
-        <translation>Nome do álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="137"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="158"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="179"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="186"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="193"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="200"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="207"/>
         <source>Release Date</source>
-        <translation>Data de lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="214"/>
         <source>Review</source>
-        <translation>Avaliação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="254"/>
         <source>MusicBrainz Album ID</source>
-        <translation>Identificador do álbum MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="268"/>
         <source>MusicBrainz Release Group ID</source>
-        <translation>Identificador do grupo de lançamento MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="285"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="326"/>
         <source>Booklet</source>
-        <translation>Brochura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="345"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="368"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="420"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="460"/>
         <source>Cover</source>
-        <translation>Capa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="442"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="505"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="483"/>
         <location filename="../../src/ui/music/MusicWidgetAlbum.ui" line="523"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="41"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="42"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="46"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="47"/>
         <source>Add Mood</source>
-        <translation>Adicionar estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="51"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="52"/>
         <source>Add Style</source>
-        <translation>Adicionar estilo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="186"/>
         <source>Saving Album...</source>
-        <translation>A guardar o álbum...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="192"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetAlbum.cpp" line="524"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -5885,182 +5833,182 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="53"/>
         <source>Artist has changed. Click to revert changes.</source>
-        <translation>O artista foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="79"/>
         <source>Artist Name</source>
-        <translation>Nome do artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="117"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="137"/>
         <source>Path</source>
-        <translation>Localização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="158"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="186"/>
         <source>Born</source>
-        <translation>Nascido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="193"/>
         <source>Formed</source>
-        <translation>Formou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="200"/>
         <source>Years active</source>
-        <translation>Anos ativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="207"/>
         <source>Disbanded</source>
-        <translation>Separou-se</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="214"/>
         <source>Died</source>
-        <translation>Faleceu</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="235"/>
         <source>Biography</source>
-        <translation>Biografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="245"/>
         <source>MusicBrainz ID</source>
-        <translation>Identificador MusicBrainz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="262"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="303"/>
         <source>Discography</source>
-        <translation>Discografia</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="325"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="330"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="340"/>
         <source>Add Album</source>
-        <translation>Adicionar álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="347"/>
         <source>Remove Album</source>
-        <translation>Remover álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="370"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="392"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="415"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="467"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="507"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="633"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="489"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="552"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="615"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="530"/>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="570"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.ui" line="593"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="49"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="50"/>
         <source>Add Genre</source>
-        <translation>Adicionar Género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="54"/>
         <source>Moods</source>
-        <translation>Estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="55"/>
         <source>Add Mood</source>
-        <translation>Adicionar estado de espírito</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="59"/>
         <source>Styles</source>
-        <translation>Estilos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="60"/>
         <source>Add Style</source>
-        <translation>Adicionar estilo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="196"/>
         <source>Saving Artist...</source>
-        <translation>A guardar o artista...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="202"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="501"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/music/MusicWidgetArtist.cpp" line="586"/>
         <source>Unknown Album</source>
-        <translation>Álbum Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6068,87 +6016,87 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="38"/>
         <source>Scrape</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="58"/>
         <source>Save</source>
-        <translation>Guardar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="78"/>
         <source>Save All</source>
-        <translation>Guardar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="98"/>
         <source>Rename selected files</source>
-        <translation>Renomear ficheiros selecionados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="118"/>
         <source>Synchronize to Kodi</source>
-        <translation>Sincronizar com o Kodl</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="138"/>
         <source>Export Database</source>
-        <translation>Exportar base de Dados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="161"/>
         <source>Reload</source>
-        <translation>Recarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="181"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="201"/>
         <source>About</source>
-        <translation>Sobre</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.ui" line="247"/>
         <source>Donate</source>
-        <translation>Fazer um donativo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="17"/>
         <source>Scrape (%1)</source>
-        <translation>Extrair (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="20"/>
         <source>Save (%1)</source>
-        <translation>Guardar (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="24"/>
         <source>Save All (%1)</source>
-        <translation>Guardar todos (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="28"/>
         <source>Reload all files (%1)</source>
-        <translation>Recarregar todos os ficheiros (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="32"/>
         <source>Export HTML</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="36"/>
         <source>Export CSV</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Navbar.cpp" line="43"/>
         <source>Export Database (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6156,7 +6104,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/scrapers/ScraperInterface.cpp" line="17"/>
         <source>Network Error</source>
-        <translation>Erro na rede</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6164,43 +6112,43 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="71"/>
         <source>Host</source>
-        <translation>Anfitrião</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="78"/>
         <source>Port</source>
-        <translation>Porta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="98"/>
         <source>Username</source>
-        <translation>Nome de utilizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="108"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="19"/>
         <source>Enable Proxy</source>
-        <translation>Ativar proxy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="64"/>
         <source>Type</source>
         <comment>Proxy Type</comment>
-        <translation>Tipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="51"/>
         <source>HTTP</source>
-        <translation>HTTP</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/NetworkSettingsWidget.ui" line="36"/>
         <source>Use Proxy for Kodi</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6208,7 +6156,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/PlaceholderLineEdit.cpp" line="26"/>
         <source>Insert placeholder</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6216,183 +6164,183 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/main.cpp" line="36"/>
         <source>Logfile could not be openened</source>
-        <translation>Não foi possível abrir o ficheiro de registo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="37"/>
         <source>The logfile %1 could not be openend for writing.</source>
-        <translation>Não foi possível modificar o ficheiro de registo %1.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="76"/>
         <source>Stylesheet could not be opened!</source>
-        <translation>Não foi possível abrir a folha de estilo.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="78"/>
         <source>The default stylesheet could not be openend for reading.</source>
-        <translation>Não foi possível abrir a folha de estilos padrão para leitura.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/main.cpp" line="79"/>
         <source>The custom stylesheet could not be openend for reading. Using: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <source>No Label</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <source>Red</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <source>Orange</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <source>Yellow</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="392"/>
-        <source>No Label</source>
-        <translation>Sem etiqueta</translation>
+        <source>Green</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="393"/>
-        <source>Red</source>
-        <translation>Vermelho</translation>
+        <source>Blue</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="394"/>
-        <source>Orange</source>
-        <translation>Laranja</translation>
+        <source>Purple</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/globals/Helper.cpp" line="395"/>
-        <source>Yellow</source>
-        <translation>Amarelo</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="396"/>
-        <source>Green</source>
-        <translation>Verde</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="397"/>
-        <source>Blue</source>
-        <translation>Azul</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="398"/>
-        <source>Purple</source>
-        <translation>Roxo</translation>
-    </message>
-    <message>
-        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
-        <translation>Cinzento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="12"/>
         <source>File not found:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="13"/>
         <source>Cannot open advancedsettings.xml in read-only mode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="14"/>
         <source>Couldn&apos;t find an &lt;advancedsettings&gt; tag!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="15"/>
         <source>Found unsupported xml tag:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/settings/AdvancedSettingsXmlReader.cpp" line="16"/>
         <source>Invalid value for xml tag:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
-        <translation>&lt;b&gt;Mover Ficheiro&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowCommonWidgets.cpp" line="59"/>
         <source>Aired order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowCommonWidgets.cpp" line="62"/>
         <source>DVD order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="8"/>
         <source>Timeout by MediaElch</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="9"/>
         <source>Content not found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="10"/>
         <source>Remote connection timed out</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="11"/>
         <source>SSL handshake failed</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="12"/>
         <source>Too many redirects</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="13"/>
         <source>Connection refused by host</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="14"/>
         <source>Host not found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="15"/>
         <source>Unknown network error</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/network/HttpStatusCodes.cpp" line="16"/>
         <source>Could not load the requested resource</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="18"/>
         <location filename="../../src/scrapers/ScraperError.cpp" line="25"/>
         <source>Network Error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="32"/>
         <source>The scraper&apos;s rate limit reached. Please wait ~10 seconds and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="37"/>
         <source>An unknown network error occurred. Are you connected to the internet?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="51"/>
         <source>The scraper did not respond with any data.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperError.cpp" line="55"/>
         <source>The scraper response could not be parsed.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media_center/kodi/ConcertXmlReader.cpp" line="29"/>
         <source>No valid musicvideo root entry found</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6400,22 +6348,22 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="60"/>
         <source>QIODevice::Append is not supported for GZIP</source>
-        <translation>QIODevice::Append não é suportado pelo GZIP</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="66"/>
         <source>Opening gzip for both reading and writing is not supported</source>
-        <translation>A abertura do gzip para leitura e escrita não é suportada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="74"/>
         <source>You can open a gzip either for reading or for writing. Which is it?</source>
-        <translation>Pode abrir um gzip para ler ou gravar. Qual deles?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quagzipfile.cpp" line="80"/>
         <source>Could not gzopen() file</source>
-        <translation>Não foi possível abrir o ficheiro gzopen()</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6423,12 +6371,12 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quaziodevice.cpp" line="188"/>
         <source>QIODevice::Append is not supported for QuaZIODevice</source>
-        <translation>QIODevice::Append não é suportado pelo QuaZIODevice</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../third_party/quazip/quazip/quaziodevice.cpp" line="193"/>
         <source>QIODevice::ReadWrite is not supported for QuaZIODevice</source>
-        <translation>QIODevice::ReadWrite não é suportado pelo QuaZIODevice</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6436,7 +6384,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../third_party/quazip/quazip/quazipfile.cpp" line="251"/>
         <source>ZIP/UNZIP API error %1</source>
-        <translation>Erro da API ZIP/UNZIP %1</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6444,27 +6392,27 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="100"/>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="101"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="102"/>
         <source>Vote Count</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="103"/>
         <source>Min. Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/RatingModel.cpp" line="104"/>
         <source>Max. Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6472,17 +6420,17 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="14"/>
         <source>Form</source>
-        <translation>Formulário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="80"/>
         <source>Add rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/small_widgets/RatingsWidget.ui" line="94"/>
         <source>Remove selected rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6490,145 +6438,133 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="17"/>
         <source>Renamer</source>
-        <translation>Alteração de nomes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="34"/>
         <source>Pattern</source>
-        <translation>Padrão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="75"/>
         <source>Use Season Directories</source>
-        <translation>Usar pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="85"/>
         <source>Multi-File Naming</source>
-        <translation>Alterar nome de vários ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="117"/>
         <source>Rename Directories</source>
-        <translation>Alterar nome de pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="127"/>
         <source>Rename Files</source>
-        <translation>Alterar nome de ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="162"/>
         <source>Directory Naming</source>
-        <translation>Alterar nome de pastas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="194"/>
         <source>File Naming</source>
-        <translation>Nomes dos ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="201"/>
         <source>Season Directory Naming</source>
-        <translation>Nomes das pastas de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="208"/>
         <source>Season &lt;season&gt;</source>
-        <translation>Temporada &lt;season&gt;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="249"/>
         <source>Results</source>
-        <translation>Resultados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="342"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="365"/>
         <source>Dry Run</source>
-        <translation>Operação &quot;a seco&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
         <source>Rename</source>
-        <translation>Alterar nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="38"/>
         <source>Please see %1 for help and examples on how to use the renamer.</source>
-        <translation>Veja a ajuda em %1. Temos exemplos de como usar o alterador de nomes.</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="58"/>
         <source>%n concerts will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="60"/>
         <source>%n movies will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="62"/>
         <source>%n TV shows and %1</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="63"/>
         <source>%n episodes will be renamed</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
         <source>Finished</source>
-        <translation>Concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
         <source>Create dir</source>
-        <translation>Criar pasta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
         <source>Move</source>
-        <translation>Mover</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6636,152 +6572,147 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="35"/>
         <source>Placeholders</source>
-        <translation>Marcadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
         <source>Placeholder</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
         <source>Artist</source>
-        <translation>Artista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
         <source>File extension</source>
-        <translation>Extensão de ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
         <source>Season Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
         <source>Part number of the current file</source>
-        <translation>Número da parte do ficheiro atual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
-        <source>TMDb ID</source>
-        <translation type="unfinished">Identificador do TMDb</translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
         <source>Album</source>
-        <translation>Álbum</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
         <source>Season Number</source>
-        <translation>Número da temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
         <source>Title of the show</source>
-        <translation>Título da série</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
         <source>Year</source>
-        <translation>Ano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
         <source>Studio(s) (separated by a comma)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
         <source>Director(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
         <source>Audio Language(s) (separated by a minus)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
         <source>Episode Number</source>
-        <translation>Número do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
         <source>Resolution (1080p, 720p, ...)</source>
-        <translation>Resolução (1080p, 720p...)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
         <source>File/directory is BluRay</source>
-        <translation>Ficheiro ou pasta é BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
         <source>File/directory is DVD</source>
-        <translation>Ficheiro ou pasta é DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
         <source>File is 3D</source>
-        <translation>Ficheiro é 3D</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
         <source>Movie set name</source>
-        <translation>Nome da coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
         <source>Video Codec</source>
-        <translation>Codec de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
         <source>Episode has a season name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
         <source>Audio Codec</source>
-        <translation>Codec de áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
         <source>Number of audio channels</source>
-        <translation>Número de canais de áudio</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6790,141 +6721,141 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="121"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="151"/>
         <source>Invalid</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="122"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="152"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="123"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="124"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="153"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="125"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="126"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="155"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="127"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="128"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="156"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="129"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="157"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="130"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="131"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="158"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="132"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="133"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="161"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="134"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="159"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="135"/>
         <source>Extra Art</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="136"/>
         <source>Season Backdrop</source>
-        <translation>Fundo de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="137"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="138"/>
         <source>Extra Fanart</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="139"/>
         <source>Show Thumbnail</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="140"/>
         <source>Season Thumbnail</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="141"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="142"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="145"/>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="165"/>
         <source>Unknown</source>
-        <translation>Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="160"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="154"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/ScraperInfos.cpp" line="162"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -6933,162 +6864,162 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="21"/>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="138"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="57"/>
         <source>Enable adult movie scrapers</source>
-        <translation>Ativar extratores de filmes para adultos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="95"/>
         <source>Custom Movie Scraper</source>
-        <translation>Extrator de filmes personalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="101"/>
         <source>Combine multiple scrapers to your custom scraper. If you select other scrapers than IMDB, The Movie DB and Fanart.tv multiple searches may be necessary as only these three share an id.</source>
-        <translation>Combine vários extratores num único extrator personalizado. Se selecionar outros extratores além do IMDB, The Movie DB e Fanart.tv, poderão ser necessárias várias procuras, já que apenas estes três usam identificadores comuns.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="133"/>
         <source>Item</source>
-        <translation>Item</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="147"/>
         <source>TV Scraper</source>
-        <translation>Extrator de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.ui" line="157"/>
         <source>Custom TV Scraper</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="172"/>
         <source>Don&apos;t use</source>
-        <translation>Não usar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="218"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="219"/>
         <source>Tagline</source>
-        <translation>Slogan</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="220"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="221"/>
         <source>Released</source>
-        <translation>Lançamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="222"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="223"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="224"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="225"/>
         <source>Plot</source>
-        <translation>Enredo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="226"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="227"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="228"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="229"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="230"/>
         <source>Studios</source>
-        <translation>Estúdios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="231"/>
         <source>Countries</source>
-        <translation>Países</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="232"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="233"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="234"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="235"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="236"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="237"/>
         <source>Disc Art</source>
-        <translation>CD Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="238"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="239"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="240"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/ScraperSettingsWidget.cpp" line="241"/>
         <source>Unsupported</source>
-        <translation>Incompatível</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7096,12 +7027,12 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/model/tv_show/SeasonModelItem.cpp" line="135"/>
         <source>Season %1 - %2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/tv_show/SeasonModelItem.cpp" line="137"/>
         <source>Season %1</source>
-        <translation>Temporada %1</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7109,59 +7040,59 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="61"/>
         <source>Set</source>
-        <translation>Coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="88"/>
         <source>Set Name</source>
-        <translation>Nome da coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="122"/>
         <source>Movie</source>
-        <translation>Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="127"/>
         <source>Sorttitle</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="150"/>
         <source>Add movie to set</source>
-        <translation>Adicionar filme à coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="153"/>
         <source>Add Movie</source>
-        <translation>Adicionar filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="160"/>
         <source>Remove selected movie from set</source>
-        <translation>Remover filme selecionado da coleção</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="163"/>
         <source>Remove Movie</source>
-        <translation>Remover Filme</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="182"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="204"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="276"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="225"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="300"/>
         <source>Full preview</source>
-        <translation>Pré-visualização inteira</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="239"/>
@@ -7169,32 +7100,32 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="314"/>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="317"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.ui" line="254"/>
         <source>Backdrop</source>
-        <translation>Fundo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="56"/>
         <source>Add Movie Set</source>
-        <translation>Adicionar coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="57"/>
         <source>Delete Movie Set</source>
-        <translation>Eliminar coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="459"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/movie_sets/SetsWidget.cpp" line="491"/>
         <source>New Movie Set</source>
-        <translation>Nova coleção de filmes</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7202,79 +7133,79 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="20"/>
         <source>Settings</source>
-        <translation>Definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="184"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="162"/>
         <source>Kodi</source>
-        <translation>Kodi</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="206"/>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="209"/>
         <source>Import</source>
-        <translation>Importar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="220"/>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="223"/>
         <source>Music</source>
-        <translation>Música</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="62"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="69"/>
         <source>Save Settings</source>
-        <translation>Guardar definições</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="79"/>
         <source>toolBar</source>
-        <translation>barraFerramentas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="118"/>
         <source>Movies</source>
-        <translation>Filmes</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="129"/>
         <source>TV Shows</source>
-        <translation>Séries TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="140"/>
         <source>Concerts</source>
-        <translation>Concertos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="151"/>
         <source>Global</source>
-        <translation>Global</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="173"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.ui" line="195"/>
         <source>Export</source>
-        <translation>Exportar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/SettingsWindow.cpp" line="192"/>
         <source>Settings saved</source>
-        <translation>As definições foram guardadas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7282,32 +7213,32 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="17"/>
         <source>Support MediaElch</source>
-        <translation>Doações para o MediaElch</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="30"/>
         <source>If you like MediaElch and wish to support it you have the chance to do so! You can donate as much as you like via PayPal.</source>
-        <translation>Se gosta do MediaElch e gostaria de apoiá-lo, tem a oportunidade de o fazer! Pode fazer uma doação da quantia que quiser através do PayPal.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="74"/>
         <source>MediaElch makes use of various movie and TV show databases. These databases also need your help to keep their services up and running for free. If you don&apos;t want to donate you can also contribute information and missing artwork if possible.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="127"/>
         <source>Thanks for your help and support!</source>
-        <translation>Obrigado pela sua ajuda e apoio!</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="149"/>
         <source>Hide donate button</source>
-        <translation>Ocultar botão para donativos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/support/SupportDialog.ui" line="172"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7315,7 +7246,7 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/small_widgets/TagCloud.ui" line="31"/>
         <source>Tag</source>
-        <translation>Etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7323,115 +7254,115 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="17"/>
         <source>Trailer</source>
-        <translation>Trailer</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="47"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="87"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="110"/>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="206"/>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="369"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="166"/>
         <source>Preview</source>
-        <translation>Pré-visualização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="171"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="176"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="186"/>
         <source>Back to Search Results</source>
-        <translation>Regressar aos resultados da busca</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="277"/>
         <source>URL</source>
-        <translation>Endereço</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="308"/>
         <source>Progress</source>
-        <translation>Progresso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="331"/>
         <source>Download</source>
-        <translation>Descarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="338"/>
         <source>Cancel Download</source>
-        <translation>Cancelar descarregamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.ui" line="349"/>
         <source>Back to Trailers</source>
-        <translation>Regressar aos trailers</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="345"/>
         <source>Download Finished</source>
-        <translation>Descarregamento concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="356"/>
         <source>The file %1 already exists.</source>
-        <translation>O ficheiro %1 já existe.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="358"/>
         <source>Do you want to overwrite it?</source>
         <extracomment>&quot;it&quot; refers to the file</extracomment>
-        <translation>Quer substituí-lo?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="371"/>
         <source>Download Canceled</source>
-        <translation>Descarregamento cancelado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="375"/>
         <source>Download Not Found (404)</source>
-        <translation>Descarregamento não encontrado (404)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="379"/>
         <source>Download Error (%1)</source>
-        <translation>Erro no descarregamento (%1)</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="433"/>
         <source>Network Error</source>
-        <translation>Erro na rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="434"/>
         <source>Resource could not be played</source>
-        <translation>Não foi possível reproduzir o ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/trailer/TrailerDialog.cpp" line="435"/>
         <source>Video format error</source>
-        <translation>Erro de formato de vídeo</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7439,92 +7370,92 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="36"/>
         <source>TV Scraper</source>
-        <translation>Extrator de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="88"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="107"/>
         <source>ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="114"/>
         <source>Internal TV scraper ID. Used as key in MediaElch&apos;s settings.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="124"/>
         <source>Description</source>
-        <translation>Descrição</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="169"/>
         <source>Website</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="179"/>
         <source>The scraper&apos;s main website.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="192"/>
         <source>Terms of Service</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="199"/>
         <source>Terms of service of the TV scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="212"/>
         <source>Privacy Policy</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="219"/>
         <source>Privacy Policy of the scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="232"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="239"/>
         <source>Where to get help for the TV scraper.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="252"/>
         <source>Is the scraper initialized?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="255"/>
         <source>Is initialized?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.ui" line="262"/>
         <source>Default Language</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.cpp" line="112"/>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvScraperSettingsWidget.cpp" line="112"/>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7532,22 +7463,22 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="52"/>
         <source>Searching for TV Shows...</source>
-        <translation>A procurar séries de TV...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="58"/>
         <source>Loading TV Shows...</source>
-        <translation>A carregar séries de TV...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="87"/>
         <source>Searching for Episodes...</source>
-        <translation>A procurar episódios...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/TvShowFileSearcher.cpp" line="126"/>
         <source>Loading Episodes...</source>
-        <translation>A carregar episódios...</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7556,103 +7487,94 @@ Por exemplo:  folder.jpg,cover.jpg</translation>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="27"/>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="670"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="27"/>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="670"/>
         <source>%n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="466"/>
-        <source>You need to update the show once and load the show&apos;s TMDb ID to list missing episodes.
+        <source>You need to update the show once and load the show's TMDb ID to list missing episodes.
 Afterwards MediaElch will check automatically for new episodes on startup.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="470"/>
         <source>Don&apos;t show this hint again</source>
-        <translation>Não voltar a mostrar esta dica</translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="674"/>
         <source>%1 of %n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="758"/>
         <source>Load Information</source>
-        <translation>Carregar informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="759"/>
         <source>Search for new episodes</source>
-        <translation>A procurar por novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="760"/>
         <source>Mark as watched</source>
-        <translation>Marcar como &quot;visto&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="761"/>
         <source>Mark as unwatched</source>
-        <translation>Marcar como &quot;por ver&quot;</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="762"/>
         <source>Load Stream Details</source>
-        <translation>Carregar detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="763"/>
         <source>Add to Synchronization Queue</source>
-        <translation>Adicionar à fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="764"/>
         <source>Remove from Synchronization Queue</source>
-        <translation>Remover da fila de sincronização</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="765"/>
         <source>Open TV Show Folder</source>
-        <translation>Abrir pasta da série de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="766"/>
         <source>Open NFO File</source>
-        <translation>Abrir ficheiro NFO</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="767"/>
         <source>Play episode</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="784"/>
         <source>Show missing episodes</source>
-        <translation>Mostrar episódios que faltam</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="787"/>
         <source>Hide specials in missing episodes</source>
-        <translation>Ocultar episódios especiais ao listar episódios em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowFilesWidget.cpp" line="465"/>
         <source>Show update needed</source>
-        <translation>É necessário atualizar a série</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7660,42 +7582,42 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="91"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="92"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="93"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="94"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="95"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="96"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="97"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/model/TvShowModel.cpp" line="98"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -7703,303 +7625,297 @@ Afterwards MediaElch will check automatically for new episodes on startup.</sour
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="20"/>
         <source>TV Show Multi Scrape</source>
-        <translation>Extrator múltiplo de episódios de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="30"/>
         <source>Please select the infos you want to be loaded. MediaElch will use the best result for each TV show and episode you selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="61"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="365"/>
         <source>Infos to load</source>
-        <translation>Infos a carregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="70"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="400"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="83"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="278"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="304"/>
         <source>Season Fanart</source>
-        <translation>Fanart de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="96"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="265"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="226"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="109"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="252"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="213"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="501"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="122"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="374"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="239"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="291"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="475"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="200"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="449"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="135"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="387"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="436"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="426"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="46"/>
         <source>Show Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="148"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="161"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="413"/>
         <source>First aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="174"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="488"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="187"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="317"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="339"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="526"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="350"/>
         <source>Episode Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="462"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="559"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="569"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="579"/>
         <source>Order for seasons</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="607"/>
         <source>Update only TV shows/episodes
 which have an ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="621"/>
         <source>Automatically save each TV show/
 episode after scraping</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="660"/>
         <source>1/20</source>
-        <translation>1/20</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="706"/>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="729"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.ui" line="742"/>
         <source>Start Scraping</source>
-        <translation>Iniciar extrações</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="306"/>
         <source>Start scraping using &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="352"/>
         <source>Skipping show &quot;%1&quot; because it does not have a valid ID.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="371"/>
         <source>Search for TV show &quot;%1&quot; because no valid ID was found.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="378"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="475"/>
         <source>Scraping next TV show with ID &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="408"/>
         <source>Search for TV show &quot;%1&quot; because no valid show ID was found for the episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="417"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="493"/>
         <source>S%1E%2: Scraping next episode with show ID &quot;%3&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="463"/>
         <source>Error while searching for TV show: &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="468"/>
         <source>Did not find any results for search term &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="511"/>
         <source>Done.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="531"/>
         <source>%n TV shows</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="532"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="534"/>
         <source>Scraping of %1 and %2 has finished.</source>
-        <translation>Terminou a extração de %1 e %2.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="536"/>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="538"/>
         <source>Scraping of %1 has finished.</source>
-        <translation>A extração de  %1 terminou.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="561"/>
         <source>Finished scraping details of TV show &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="570"/>
         <source>Start loading extra fanart from TheTvDb for TV show with ID &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="753"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="832"/>
         <source>Internal inconsistency: Cannot set language dropdown in TV show search widget!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowMultiScrapeDialog.cpp" line="848"/>
         <source>S%2E%3: Finished scraping episode details. Title is: &quot;%1&quot;.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8007,12 +7923,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/search_dialog/TvShowScrapePreview.ui" line="43"/>
         <source>&lt;b&gt;Preview&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/search_dialog/TvShowScrapePreview.ui" line="83"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Description&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8020,17 +7936,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="17"/>
         <source>Search Result</source>
-        <translation>Resultado da procura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="48"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearch.ui" line="58"/>
         <source>Scrape</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8038,219 +7954,216 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="19"/>
         <source>Scraper</source>
-        <translation>Extrator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="29"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="134"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="179"/>
         <source>Show Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="210"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="519"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="220"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="230"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="539"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="240"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="549"/>
         <source>First aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="250"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="260"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="559"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="270"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="529"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="280"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="290"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="626"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="300"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="606"/>
         <source>Network</source>
-        <translation>Rede</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="327"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="616"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="337"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="347"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="357"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="367"/>
         <source>Season Fanart</source>
-        <translation>Fanart de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="377"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="387"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="397"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="407"/>
         <source>Artwork</source>
-        <translation>Artwork</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="417"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="451"/>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="670"/>
         <source>(Un)Check all</source>
-        <translation>(Des)marcar todos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="464"/>
         <source>No show details will be loaded because only episodes were selected.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="488"/>
         <source>Episode Details</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="586"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="596"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="636"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="682"/>
         <source>Season order</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="697"/>
         <source>No episodes will be loaded. If you want to load episodes, change the update mode below.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="147"/>
         <source>Update TV Show only</source>
-        <translation>Atualizar apenas Séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="152"/>
         <source>Update TV Show and new Episodes</source>
-        <translation>Atualizar séries de TV e novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="157"/>
         <source>Update TV Show and all Episodes</source>
-        <translation>Atualizar séries de TV e todos os episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="162"/>
         <source>Update new Episodes</source>
-        <translation>Atualizar novos episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.ui" line="167"/>
         <source>Update all episodes</source>
-        <translation>Atualizar todos os episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="170"/>
         <source>The %1 scraper could not be initialized!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="148"/>
         <source>Please insert a search string!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message numerus="yes">
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="188"/>
         <source>Found %n results</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowSearchWidget.cpp" line="364"/>
         <source>Internal inconsistency: Selected an invalid scraper!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8258,82 +8171,82 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="17"/>
         <source>Below you see the filenames which are used for loading and saving your TV shows. You can edit them as you like, if you want to use multiple files separate them by comma.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="27"/>
         <source>You can use the placeholder &lt;baseFileName&gt; which is the filename without extension and for season posters &lt;seasonNumber&gt; which is the season number.</source>
-        <translation>Pode usar o marcador &lt;baseFileName&gt; que é o nome do ficheiro, sem extensão, e para cartazes de temporada &lt;seasonNumber&gt;, que é o número da temporada.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="42"/>
         <source>Show nfo</source>
-        <translation>Mostrar nfo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="49"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="56"/>
         <source>Backdrop</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="63"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="70"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="77"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="84"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="91"/>
         <source>Season Poster</source>
-        <translation>Cartaz de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="98"/>
         <source>Season Backdrop</source>
-        <translation>Fundo de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="105"/>
         <source>Episode nfo</source>
-        <translation>Nfo do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="112"/>
         <source>Episode thumbnail</source>
-        <translation>Miniatura de episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="119"/>
         <source>Season Banner</source>
-        <translation>Faixa de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="390"/>
         <source>Season Thumb</source>
-        <translation>Miniatura de temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/settings/TvShowSettingsWidget.ui" line="397"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8341,10 +8254,7 @@ episode after scraping</source>
     <message numerus="yes">
         <location filename="../../src/ui/small_widgets/TvShowTreeView.cpp" line="146"/>
         <source>%n episodes</source>
-        <translation>
-            <numerusform>%n episódio</numerusform>
-            <numerusform>%n episódios</numerusform>
-        </translation>
+        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
 </context>
 <context>
@@ -8352,7 +8262,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/TvShowUpdater.cpp" line="42"/>
         <source>Updating TV Shows</source>
-        <translation>A atualizar séries de TV</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8361,22 +8271,22 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="161"/>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="218"/>
         <source>Saving changed TV Shows and Episodes</source>
-        <translation>A guardar alterações em séries de TV e episódios</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="180"/>
         <source>Could not save episode S%1E%2 of show &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="193"/>
         <source>TV Shows and Episodes Saved</source>
-        <translation>Séries de TV e episódios guardados</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="239"/>
         <source>All TV Shows and Episodes Saved</source>
-        <translation>Todas as séries TV e episódios foram guardados</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8384,292 +8294,292 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="63"/>
         <source>Episode has changed. Click to revert changes.</source>
-        <translation>O episódio foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="82"/>
         <source>Episode Title</source>
-        <translation>Título do episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="137"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="154"/>
         <source>Files</source>
-        <translation>Ficheiros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="460"/>
         <source>TheTVDB ID</source>
-        <translation>Identificador TheTVDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="514"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="168"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="178"/>
         <source>Show Title</source>
-        <translation>Mostrar título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="188"/>
         <source>Season</source>
-        <translation>Temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="223"/>
         <source>Episode</source>
-        <translation>Episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="242"/>
         <source>Display Season</source>
-        <translation>Mostrar temporada</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="302"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="350"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="367"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="377"/>
         <source>dd.MM.yyyy</source>
-        <translation>dd.MM.yyyy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="384"/>
         <source>Play Count</source>
-        <translation>Nº de reproduções</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="400"/>
         <source>Last Played</source>
-        <translation>Última reprodução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="410"/>
         <source>dd.MM.yyyy HH:mm</source>
-        <translation>dd.MM.yyyy HH:mm</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="436"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="446"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="280"/>
         <source>Display Episode</source>
-        <translation>Mostrar episódio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="419"/>
         <source>Bookmark</source>
-        <translation>Marcador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="313"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="477"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="548"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="558"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="595"/>
         <source>Writer</source>
-        <translation>Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="663"/>
         <source>Directors</source>
-        <translation>Realizadores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="691"/>
         <source>Director</source>
-        <translation>Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="701"/>
         <source>Add Director</source>
-        <translation>Adicionar Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="715"/>
         <source>Remove Director</source>
-        <translation>Remover Realizador</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="567"/>
         <source>Writers</source>
-        <translation>Argumentistas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="605"/>
         <source>Add Writer</source>
-        <translation>Adicionar argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="619"/>
         <source>Remove Writer</source>
-        <translation>Remover Argumentista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="759"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="784"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="789"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="831"/>
         <source>Add Actor</source>
-        <translation>Adicionar Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="804"/>
         <source>Remove Actor</source>
-        <translation>Remover Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="878"/>
         <source>Click to change</source>
-        <translation>Clique para Alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="932"/>
         <source>Streamdetails</source>
-        <translation>Detalhes da pista</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="991"/>
         <source>Aspect Ratio</source>
-        <translation>Rácio de aspeto</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="940"/>
         <source>Scantype</source>
-        <translation>TipoAnálise</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="894"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1081"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1106"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="525"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="528"/>
         <source>Codec</source>
-        <translation>Codec</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="981"/>
         <source>Audio</source>
-        <translation>Áudio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1096"/>
         <source>Video</source>
-        <translation>Vídeo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1045"/>
         <source>Duration</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="429"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="959"/>
         <source>HH:mm:ss</source>
-        <translation>HH:mm:ss</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="924"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1116"/>
         <source>Stereo Mode</source>
-        <translation>Modo de Estéreo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1137"/>
         <source>Reload from File</source>
-        <translation>Recarregar do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1211"/>
         <source>Thumbnail</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="1233"/>
         <source>Click to Change</source>
-        <translation>Clique para Alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.ui" line="115"/>
         <source>Episode missing</source>
-        <translation>Episódio em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="92"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="518"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="552"/>
         <source>Track %1</source>
-        <translation>Faixa %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="524"/>
@@ -8677,68 +8587,68 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="556"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="557"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="526"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="529"/>
         <source>Channels</source>
-        <translation>Canais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="544"/>
         <source>Subtitles</source>
-        <translation>Legendas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="585"/>
         <source>Stream details could not be loaded!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="618"/>
         <source>Episode Saved</source>
-        <translation>O episódio foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="620"/>
         <source>Could not save episode S%1E%2 of show &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="666"/>
         <source>Scraping episode...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="800"/>
         <source>Unknown Director</source>
-        <translation>Realizador Desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="850"/>
         <source>Unknown Writer</source>
-        <translation>Argumentista desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1107"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1108"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1171"/>
         <source>Choose Image</source>
-        <translation>Escolher imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="1171"/>
         <source>Images (*.jpg *.jpeg)</source>
-        <translation>Imagens (*.jpg *.jpeg)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8746,69 +8656,69 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="63"/>
         <source>Episode has changed. Click to revert changes.</source>
-        <translation>O episódio foi alterado. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="83"/>
         <source>Title</source>
-        <translation>Título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="138"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="149"/>
         <source>Season Name</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="171"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="232"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="193"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="254"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="298"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="276"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="320"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="342"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.ui" line="119"/>
         <source>Season missing</source>
-        <translation>Temporada em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.cpp" line="111"/>
         <source>Season %1</source>
-        <translation>Temporada %1</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetSeason.cpp" line="188"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; saved</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -8816,208 +8726,208 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="50"/>
         <source>TV Show has changed. Click to revert changes.</source>
-        <translation>A série de TV foi alterada. Clique para reverter as alterações.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="70"/>
         <source>Show Title</source>
-        <translation>Mostrar título</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="98"/>
         <source>Information</source>
-        <translation>Informação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="112"/>
         <source>Dir</source>
-        <translation>Dir</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="126"/>
         <source>IDs</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="208"/>
         <source>TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="242"/>
         <source>Name</source>
-        <translation>Nome</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="252"/>
         <source>Rating</source>
-        <translation>Classificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="315"/>
         <source>Top 250</source>
-        <translation>Top 250</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="352"/>
         <source>Certification</source>
-        <translation>Certificação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="369"/>
         <source>First Aired</source>
-        <translation>Estreou a</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="379"/>
         <source>dd.MM.yyyy</source>
-        <translation>dd.MM.yyyy</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="406"/>
         <source>Studio</source>
-        <translation>Estúdio</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="460"/>
         <source>Overview</source>
-        <translation>Sinopse</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="416"/>
         <source>TV Tune</source>
-        <translation>Tema musical</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="425"/>
         <source>Existing</source>
-        <translation>Presente</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="432"/>
         <source>Missing</source>
-        <translation>Em falta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="448"/>
         <source>Download Theme</source>
-        <translation>Descarregar tema musical</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="386"/>
         <source>Runtime</source>
-        <translation>Duração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="396"/>
         <source> Minutes</source>
-        <translation> minutos</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="505"/>
         <source>Sort Title</source>
-        <translation>Título de ordenação</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="201"/>
         <source>IMDb ID</source>
-        <translation>Identificador do IMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="522"/>
         <source>Extended</source>
-        <translation>Adicional</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="533"/>
         <source>Actors</source>
-        <translation>Atores</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="558"/>
         <source>Actor</source>
-        <translation>Ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="563"/>
         <source>Role</source>
-        <translation>Papel</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="605"/>
         <source>Add Actor</source>
-        <translation>Adicionar ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="578"/>
         <source>Remove Actor</source>
-        <translation>Remover ator</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="263"/>
         <source>User Rating</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="137"/>
         <source>TheTVDB ID</source>
-        <translation>Identificador TheTVDB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="482"/>
         <source>Continuing</source>
-        <translation>Continuando</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="487"/>
         <source>Ended</source>
-        <translation>Finalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="495"/>
         <source>Status</source>
-        <translation>Estado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="154"/>
         <source>TMDb ID</source>
-        <translation>Identificador do TMDb</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="512"/>
         <source>Original Title</source>
-        <translation>Título original</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="652"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1221"/>
         <source>Click to change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="668"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="717"/>
         <source>Extra Fanarts</source>
-        <translation>Fanarts extra</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="739"/>
         <source>Hint: Closed images will be deleted on save.</source>
-        <translation>Dica: as imagens eliminadas aqui só serão eliminadas ao guardar.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="762"/>
         <source>Add Images</source>
-        <translation>Adicionar imagens</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="906"/>
         <source>Poster</source>
-        <translation>Cartaz</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="928"/>
@@ -9027,92 +8937,92 @@ episode after scraping</source>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1133"/>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1177"/>
         <source>Click to Change</source>
-        <translation>Clique para alterar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="950"/>
         <source>Fanart</source>
-        <translation>Fanart</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="994"/>
         <source>Thumb</source>
-        <translation>Miniatura</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1199"/>
         <source>Banner</source>
-        <translation>Faixa</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1067"/>
         <source>Logo</source>
-        <translation>Logotipo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1111"/>
         <source>Clear Art</source>
-        <translation>Clear Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.ui" line="1155"/>
         <source>Character Art</source>
-        <translation>Character Art</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="78"/>
         <source>Genres</source>
-        <translation>Géneros</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="79"/>
         <source>Add Genre</source>
-        <translation>Adicionar género</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="83"/>
         <source>Tags</source>
-        <translation>Etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="84"/>
         <source>Add Tag</source>
-        <translation>Adicionar etiqueta</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="456"/>
         <source>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; Saved</source>
-        <translation>&lt;b&gt;&quot;%1&quot;&lt;/b&gt; foi guardado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="497"/>
         <source>Please wait while your TV show is scraped</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="724"/>
         <source>Downloading images...</source>
-        <translation>A descarregar as imagens...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="878"/>
         <source>Unknown Actor</source>
-        <translation>Ator desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="879"/>
         <source>Unknown Role</source>
-        <translation>Papel desconhecido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="960"/>
         <source>Choose Image</source>
-        <translation>Escolher Imagem</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetTvShow.cpp" line="960"/>
         <source>Images (*.jpg *.jpeg)</source>
-        <translation>Imagens (*.jpg *.jpeg)</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9120,53 +9030,53 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="17"/>
         <source>TV Tunes</source>
-        <translation>Temas musicais</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="54"/>
         <source>Result</source>
-        <translation>Resultado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="118"/>
         <source>Progress</source>
-        <translation>Progresso</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="141"/>
         <source>Download</source>
-        <translation>Descarregar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="148"/>
         <source>Cancel Download</source>
-        <translation>Cancelar descarregamento</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.ui" line="172"/>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="251"/>
         <source>Download Finished</source>
-        <translation>Descarregamento concluído</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="256"/>
         <source>The file %1 already exists.</source>
-        <translation>O ficheiro %1 já existe.</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="258"/>
         <source>Do you want to overwrite it?</source>
         <extracomment>&quot;it&quot; refers to the file</extracomment>
-        <translation>Quer substituí-lo?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvTunesDialog.cpp" line="272"/>
         <source>Download Canceled</source>
-        <translation>Descarregamento cancelado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9174,47 +9084,47 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="45"/>
         <source>Cancel extraction</source>
-        <translation>Cancelar extração</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="65"/>
         <source>Extract without password</source>
-        <translation>Extrair sem palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="68"/>
         <source>Extract</source>
-        <translation>Extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="75"/>
         <source>Extract with password</source>
-        <translation>Extrair com palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.ui" line="95"/>
         <source>Delete this archive</source>
-        <translation>Eliminar este ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="50"/>
         <source>Extraction password</source>
-        <translation>Palavra-passe para extrair</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="50"/>
         <source>Password</source>
-        <translation>Palavra-passe</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="65"/>
         <source>Delete archive?</source>
-        <translation>Eliminar ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/import/UnpackButtons.cpp" line="66"/>
         <source>Do you really want to delete this archive?</source>
-        <translation>Quer mesmo eliminar este ficheiro?</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9222,17 +9132,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="63"/>
         <source>Updates available</source>
-        <translation>Atualizações disponíveis</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="64"/>
         <source>%1 is now available.&lt;br&gt;Get it now on %2</source>
-        <translation>%1 já está disponível.&lt;br&gt;Obtenha-o agora em %2</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/ui/main/Update.cpp" line="68"/>
         <source>Don&apos;t check for updates</source>
-        <translation>Não verificar atualizações</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9240,7 +9150,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/small_widgets/WebImageLabel.ui" line="47"/>
         <source>Resolution</source>
-        <translation>Resolução</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9248,33 +9158,33 @@ episode after scraping</source>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="28"/>
         <source>Could not get duration of file</source>
-        <translation>Não foi possível obter a duração do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="47"/>
         <source>Could not detect runtime of file</source>
-        <translation>Não foi possível detetar o tempo de reprodução do ficheiro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="56"/>
         <location filename="../../src/media/ImageCapture.cpp" line="84"/>
         <source>Temporary output file could not be opened</source>
-        <translation>Não foi possível abrir o ficheiro de saída temporário</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="71"/>
         <source>Could not start ffmpeg</source>
-        <translation>Não foi possível iniciar o ffmpeg</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="74"/>
         <source>Could not start ffmpeg. Please install it and make it available in your $PATH</source>
-        <translation>Não foi possível iniciar o ffmpeg. Por favor instale-o e torne-o disponível no seu $PATH</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/media/ImageCapture.cpp" line="80"/>
         <source>ffmpeg did not finish</source>
-        <translation>ffmpeg não finalizou</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9282,7 +9192,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/file_search/movie/MovieDirectorySearcher.cpp" line="391"/>
         <source>Storing movies in database...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9290,35 +9200,35 @@ episode after scraping</source>
     <message>
         <location filename="../../src/file_search/movie/MovieFileSearcher.cpp" line="58"/>
         <source>Searching for Movies...</source>
-        <translation>A procurar por filmes...</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/file_search/movie/MovieFileSearcher.cpp" line="148"/>
         <source>Searching for movies...</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
         <source>Straight</source>
-        <translation>Heterossexual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Gay</source>
-        <translation>Homossexual</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
         <source>Genre</source>
-        <translation>Género</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9326,12 +9236,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/custom/CustomMovieScraper.cpp" line="20"/>
         <source>Custom Movie Scraper</source>
-        <translation>Extrator de filmes personalizado</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/custom/CustomMovieScraper.cpp" line="178"/>
         <source>TMDb ID is invalid. Cannot scrape movie.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9339,12 +9249,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/custom/CustomTvScraper.cpp" line="28"/>
         <source>Custom TV scraper</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/custom/CustomTvScraper.cpp" line="33"/>
         <source>The custom TV scraper combines multiple scrapers so that details can be loaded from different sites in one step. It depends on TMDb for loading other scraper IDs.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9352,162 +9262,162 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="26"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="84"/>
         <source>Bulgarian</source>
-        <translation>Búlgaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="85"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="86"/>
         <source>Croatian</source>
-        <translation>Croata</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="87"/>
         <source>Czech</source>
-        <translation>Checo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="88"/>
         <source>Danish</source>
-        <translation>Dinamarquês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="89"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="90"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="91"/>
         <source>Finnish</source>
-        <translation>Finlandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="92"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="93"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="94"/>
         <source>Greek</source>
-        <translation>Grego</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="95"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="96"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="97"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="98"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="99"/>
         <source>Korean</source>
-        <translation>Coreano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="100"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="101"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="102"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="103"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="104"/>
         <source>Slovene</source>
-        <translation>Eslovaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="105"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="106"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="107"/>
         <source>Turkish</source>
-        <translation>Turco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="111"/>
         <source>Blu-ray</source>
-        <translation>BluRay</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="112"/>
         <source>DVD</source>
-        <translation>DVD</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="115"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="117"/>
         <source>Preferred Disc Type</source>
-        <translation>Tipo de disco preferido</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="119"/>
         <source>Personal API key</source>
-        <translation>Chave pessoal da API</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="356"/>
         <source>Movie not found on Fanart.tv</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/image/FanartTv.cpp" line="568"/>
         <source>TV show not found on Fanart.tv</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9515,7 +9425,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTvMusic.cpp" line="25"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9523,7 +9433,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/FanartTvMusicArtists.cpp" line="22"/>
         <source>FanartTV is a community-driven image provider.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9531,12 +9441,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/imdb/ImdbMovie.cpp" line="20"/>
         <source>IMDb is the world&apos;s most popular and authoritative source for movie, TV and celebrity content, designed to help fans explore the world of movies and shows and decide what to watch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/imdb/ImdbMovie.cpp" line="47"/>
         <source>Load all tags</source>
-        <translation>Carregar todas as etiquetas</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9544,7 +9454,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTv.cpp" line="20"/>
         <source>IMDb is the world&apos;s most popular and authoritative source for movie, TV and celebrity content, designed to help fans explore the world of movies and shows and decide what to watch.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9552,22 +9462,22 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="37"/>
         <source>Neither IMDb show ID nor episode ID are valid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="61"/>
         <source>IMDb ID could not be loaded from season page! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="76"/>
         <source>IMDb ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvEpisodeScrapeJob.cpp" line="90"/>
         <source>Loaded IMDb content is empty. Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9575,7 +9485,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing an IMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9583,17 +9493,17 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="92"/>
         <source>Could not extract JSON details from IMDb page!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="102"/>
         <source>Could not parse JSON from IMDb page!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowParser.cpp" line="108"/>
         <source>Expected parsed IMDb JSON to be an object!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9601,7 +9511,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowScrapeJob.cpp" line="34"/>
         <source>Show is missing an IMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9609,12 +9519,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowSearchJob.cpp" line="20"/>
         <source>Loaded IMDb web page content is empty. Cannot scrape requested TV show.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/imdb/ImdbTvShowSearchJob.cpp" line="24"/>
         <source>Could not find result table in the scraped HTML. Please contact MediaElch&apos;s developers.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9622,7 +9532,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/TMDbImages.cpp" line="15"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9630,7 +9540,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDb.cpp" line="19"/>
         <source>TheTvDb is one of the most accurate sources for TV and film. Their information comes from fans like you, so create a free account on their website and help your favorite shows and movies. Everything added is shared not only with MediaElch but many other sites, mobile apps, and devices as well.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9638,7 +9548,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbEpisodeScrapeJob.cpp" line="65"/>
         <source>TheTvDb ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9646,7 +9556,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/image/TheTvDbImages.cpp" line="19"/>
         <source>TheTvDb is one of the most accurate sources for TV and film. Their information comes from fans like you, so create a free account on their website and help your favorite shows and movies. Everything added is shared not only with MediaElch but many other sites, mobile apps, and devices as well.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9654,7 +9564,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbSeasonScrapeJob.cpp" line="26"/>
         <source>Show is missing a TheTvDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9662,7 +9572,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/thetvdb/TheTvDbShowScrapeJob.cpp" line="46"/>
         <source>Show is missing a TheTvDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9670,12 +9580,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/concert/tmdb/TmdbConcert.cpp" line="28"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/concert/tmdb/TmdbConcert.cpp" line="132"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9683,12 +9593,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/tmdb/TmdbMovie.cpp" line="45"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/movie/tmdb/TmdbMovie.cpp" line="158"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9696,7 +9606,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTv.cpp" line="20"/>
         <source>The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb&apos;s strong international focus and breadth of data is largely unmatched and something we&apos;re incredibly proud of. Put simply, we live and breathe community and that&apos;s precisely what makes us different.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9704,7 +9614,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvEpisodeScrapeJob.cpp" line="26"/>
         <source>TMDb show ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9712,7 +9622,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9720,12 +9630,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp" line="41"/>
         <source>Continuing</source>
-        <translation>Continuando</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp" line="41"/>
         <source>Ended</source>
-        <translation>Finalizado</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9733,7 +9643,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tmdb/TmdbTvShowScrapeJob.cpp" line="23"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9741,7 +9651,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMaze.cpp" line="19"/>
         <source>TVmaze is a collaborative site, which can be edited by any registered user. Find episode information for any show on any device. anytime, anywhere!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9749,12 +9659,12 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.cpp" line="39"/>
         <source>TVmaze show ID are valid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.cpp" line="66"/>
         <source>TVmaze ID is invalid! Cannot load requested episode.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9762,7 +9672,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeSeasonScrapeJob.cpp" line="25"/>
         <source>Show is missing a TMDb id</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9770,7 +9680,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/tv_show/tvmaze/TvMazeShowScrapeJob.cpp" line="29"/>
         <source>TV show is missing a TVmaze ID</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9778,107 +9688,107 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="31"/>
         <source>Chinese</source>
-        <translation>Chinês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="32"/>
         <source>Dutch</source>
-        <translation>Holandês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="33"/>
         <source>English</source>
-        <translation>Inglês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="34"/>
         <source>French</source>
-        <translation>Francês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="35"/>
         <source>German</source>
-        <translation>Alemão</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="36"/>
         <source>Hebrew</source>
-        <translation>Hebraico</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="37"/>
         <source>Hungarian</source>
-        <translation>Húngaro</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="38"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="39"/>
         <source>Japanese</source>
-        <translation>Japonês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="40"/>
         <source>Norwegian</source>
-        <translation>Norueguês</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="41"/>
         <source>Polish</source>
-        <translation>Polaco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="42"/>
         <source>Portuguese</source>
-        <translation>Português</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="43"/>
         <source>Russian</source>
-        <translation>Russo</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="44"/>
         <source>Spanish</source>
-        <translation>Espanhol</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="45"/>
         <source>Swedish</source>
-        <translation>Sueco</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="47"/>
         <source>The Audio DB</source>
-        <translation>The Audio DB</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="48"/>
         <source>MusicBrainz</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="49"/>
         <source>AllMusic</source>
-        <translation>AllMusic</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="50"/>
         <source>Discogs</source>
-        <translation>Discogs</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="52"/>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/scrapers/music/UniversalMusicScraper.cpp" line="54"/>
         <source>Prefer</source>
-        <translation>Preferir</translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -9886,7 +9796,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/scrapers/movie/videobuster/VideoBuster.cpp" line="18"/>
         <source>VideoBuster is a German movie database.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"/>
     </message>
 </context>
 </TS>

--- a/data/i18n/MediaElch_zh_CN.ts
+++ b/data/i18n/MediaElch_zh_CN.ts
@@ -36,7 +36,7 @@
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="146"/>
         <source>About Qt</source>
-        <translation type="unfinished"></translation>
+        <translation>关于 Qt</translation>
     </message>
     <message>
         <location filename="../../src/ui/main/AboutDialog.ui" line="165"/>
@@ -2668,7 +2668,7 @@
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="21"/>
         <source>Directories</source>
-        <translation type="unfinished"></translation>
+        <translation>目录</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="57"/>
@@ -2778,12 +2778,12 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="300"/>
         <source>Appearance</source>
-        <translation type="unfinished"></translation>
+        <translation>外观</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.ui" line="311"/>
         <source>Main Window Theme (changing it requires restart of MediaElch)</source>
-        <translation type="unfinished"></translation>
+        <translation>主窗口主题（更改它需要重新启动 MediaElch）</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="42"/>
@@ -2817,17 +2817,17 @@ The directories containing your music must contain subdirectories for each artis
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="48"/>
         <source>Auto</source>
-        <translation type="unfinished"></translation>
+        <translation>自动</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="49"/>
         <source>Light</source>
-        <translation type="unfinished"></translation>
+        <translation>浅色</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="50"/>
         <source>Dark</source>
-        <translation type="unfinished"></translation>
+        <translation>深色</translation>
     </message>
     <message>
         <location filename="../../src/ui/settings/GlobalSettingsWidget.cpp" line="66"/>
@@ -4302,57 +4302,57 @@ Main menu entry (tooltip)</extracomment>
 <context>
     <name>MovieModel</name>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="326"/>
+        <location filename="../../src/model/MovieModel.cpp" line="328"/>
         <source>Actors</source>
         <translation>演员</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="327"/>
+        <location filename="../../src/model/MovieModel.cpp" line="329"/>
         <source>Extra Arts</source>
         <translation>额外的艺术图</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="328"/>
+        <location filename="../../src/model/MovieModel.cpp" line="330"/>
         <source>Extra Fanarts</source>
         <translation>其他剧照</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="329"/>
+        <location filename="../../src/model/MovieModel.cpp" line="331"/>
         <source>Fanart</source>
         <translation>剧照</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="330"/>
+        <location filename="../../src/model/MovieModel.cpp" line="332"/>
         <source>Poster</source>
         <translation>海报</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="331"/>
+        <location filename="../../src/model/MovieModel.cpp" line="333"/>
         <source>Stream Details</source>
         <translation>视频压制编码信息</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="332"/>
+        <location filename="../../src/model/MovieModel.cpp" line="334"/>
         <source>Trailer</source>
         <translation>预告片</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="333"/>
+        <location filename="../../src/model/MovieModel.cpp" line="335"/>
         <source>Local Trailer</source>
         <translation>本地预告片</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="334"/>
+        <location filename="../../src/model/MovieModel.cpp" line="336"/>
         <source>Subtitles</source>
         <translation>字幕</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="335"/>
+        <location filename="../../src/model/MovieModel.cpp" line="337"/>
         <source>Tags</source>
         <translation>标签</translation>
     </message>
     <message>
-        <location filename="../../src/model/MovieModel.cpp" line="336"/>
+        <location filename="../../src/model/MovieModel.cpp" line="338"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
@@ -6232,42 +6232,42 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation>无法打开自定义样式表进行读取。使用: %1</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="388"/>
+        <location filename="../../src/globals/Helper.cpp" line="392"/>
         <source>No Label</source>
         <translation>无标签</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="389"/>
+        <location filename="../../src/globals/Helper.cpp" line="393"/>
         <source>Red</source>
         <translation>红</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="390"/>
+        <location filename="../../src/globals/Helper.cpp" line="394"/>
         <source>Orange</source>
         <translation>橘色</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="391"/>
+        <location filename="../../src/globals/Helper.cpp" line="395"/>
         <source>Yellow</source>
         <translation>黄</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="392"/>
+        <location filename="../../src/globals/Helper.cpp" line="396"/>
         <source>Green</source>
         <translation>绿</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="393"/>
+        <location filename="../../src/globals/Helper.cpp" line="397"/>
         <source>Blue</source>
         <translation>蓝</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="394"/>
+        <location filename="../../src/globals/Helper.cpp" line="398"/>
         <source>Purple</source>
         <translation>紫</translation>
     </message>
     <message>
-        <location filename="../../src/globals/Helper.cpp" line="395"/>
+        <location filename="../../src/globals/Helper.cpp" line="399"/>
         <source>Grey</source>
         <translation>灰</translation>
     </message>
@@ -6297,7 +6297,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation>xml标记的值无效：</translation>
     </message>
     <message>
-        <location filename="../../src/renamer/MovieRenamer.cpp" line="344"/>
+        <location filename="../../src/renamer/MovieRenamer.cpp" line="346"/>
         <source>&lt;b&gt;Move File&lt;/b&gt; &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>&lt;b&gt;移动文件&lt;/b&gt; &quot;%1&quot; 改为 &quot;%2&quot;</translation>
     </message>
@@ -6547,7 +6547,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
     </message>
     <message>
         <location filename="../../src/ui/renamer/RenamerDialog.ui" line="375"/>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="401"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="412"/>
         <source>Rename</source>
         <translation>更名</translation>
     </message>
@@ -6585,37 +6585,37 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         </translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="256"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="267"/>
         <source>Finished</source>
         <translation>完成</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="273"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="284"/>
         <source>&lt;b&gt;Movie&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;电影&lt;/b&gt; &quot;%1&quot; 未重命名：已编辑，但未保存</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="302"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="313"/>
         <source>&lt;b&gt;Episode&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;剧集&lt;/b&gt; &quot;%1&quot; 未重命名：已编辑，但未保存</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="327"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="338"/>
         <source>&lt;b&gt;TV Show&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;电视节目&lt;/b&gt; &quot;%1&quot; 未重命名：已编辑，但未保存</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="380"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="391"/>
         <source>&lt;b&gt;Concert&lt;/b&gt; &quot;%1&quot; not renamed: It has been edited but is not saved</source>
         <translation>&lt;b&gt;音乐会&lt;/b&gt; &quot;%1&quot; 未重命名：已编辑，但未保存</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="399"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="410"/>
         <source>Create dir</source>
         <translation>创建目录</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="400"/>
+        <location filename="../../src/ui/renamer/RenamerDialog.cpp" line="411"/>
         <source>Move</source>
         <translation>移动</translation>
     </message>
@@ -6628,142 +6628,147 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</sourc
         <translation>占位符</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="325"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="281"/>
         <source>Placeholder</source>
         <translation>占位符</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="696"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="644"/>
         <source>Artist</source>
         <translation>艺术家</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="542"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="93"/>
         <source>File extension</source>
         <translation>扩展名</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="227"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="463"/>
         <source>Original Title</source>
         <translation>原始片名</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="752"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="489"/>
         <source>Season Name</source>
         <translation>季名称</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="764"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="697"/>
         <source>Part number of the current file</source>
         <translation>多文件视频重命名序号</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="435"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="828"/>
+        <source>TMDb ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="192"/>
         <source>Album</source>
         <translation>专辑</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="113"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="107"/>
         <source>Title</source>
         <translation>片名</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="585"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="773"/>
         <source>Season Number</source>
         <translation>季序号</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="464"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="81"/>
         <source>Title of the show</source>
         <translation>节目名称</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="421"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="799"/>
         <source>Year</source>
         <translation>年份</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="609"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="138"/>
         <source>Description</source>
         <translation>说明</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="556"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="673"/>
         <source>Studio(s) (separated by a comma)</source>
         <translation>制片公司（用逗号分隔）</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="350"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="595"/>
         <source>Sort Title</source>
         <translation>排序片名</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="239"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="501"/>
         <source>Director(s)</source>
         <translation>导演</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="535"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="637"/>
         <source>Audio Language(s) (separated by a minus)</source>
         <translation>音频语言（以减号分隔）</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="87"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="530"/>
         <source>Episode Number</source>
         <translation>剧集序号</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="491"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="163"/>
         <source>Resolution (1080p, 720p, ...)</source>
         <translation>分辨率(1080p, 720p, ...)</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="184"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="231"/>
         <source>File/directory is BluRay</source>
         <translation>文件/目录是BluRay</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="597"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="426"/>
         <source>Subtitle Language(s) (separated by a minus)</source>
         <translation>字幕语言（以减号分隔）</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="74"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="68"/>
         <source>File/directory is DVD</source>
         <translation>文件/目录是DVD</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="60"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="475"/>
         <source>File is 3D</source>
         <translation>文件是3D</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="142"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="121"/>
         <source>Movie set name</source>
         <translation>系列电影名称</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="263"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="414"/>
         <source>IMDb ID</source>
         <translation>IMDb ID</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="521"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="385"/>
         <source>Video Codec</source>
         <translation>视频编码</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="793"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="204"/>
         <source>Episode has a season name</source>
         <translation>剧集有一个季名称</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="99"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="342"/>
         <source>Audio Codec</source>
         <translation>音频编码</translation>
     </message>
     <message>
-        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="392"/>
+        <location filename="../../src/ui/renamer/RenamerPlaceholders.ui" line="566"/>
         <source>Number of audio channels</source>
         <translation>音频声道数</translation>
     </message>
@@ -8346,7 +8351,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="180"/>
         <source>Could not save episode S%1E%2 of show &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>无法保存节目“%3”的第 S%1E%2 集</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidget.cpp" line="193"/>
@@ -8683,7 +8688,7 @@ episode after scraping</source>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="620"/>
         <source>Could not save episode S%1E%2 of show &quot;%3&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>无法保存节目“%3”的第 S%1E%2 集</translation>
     </message>
     <message>
         <location filename="../../src/ui/tv_show/TvShowWidgetEpisode.cpp" line="666"/>
@@ -9281,22 +9286,22 @@ episode after scraping</source>
 <context>
     <name>mediaelch::scraper::AEBN</name>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="72"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
         <source>Straight</source>
         <translation>正常</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="73"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="74"/>
         <source>Gay</source>
         <translation>同性</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="76"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="77"/>
         <source>Language</source>
         <translation>语言</translation>
     </message>
     <message>
-        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="78"/>
+        <location filename="../../src/scrapers/movie/aebn/AEBN.cpp" line="79"/>
         <source>Genre</source>
         <translation>类型</translation>
     </message>

--- a/src/globals/Helper.cpp
+++ b/src/globals/Helper.cpp
@@ -9,6 +9,10 @@
 #include <QPainter>
 #include <QRegularExpression>
 
+#ifdef Q_OS_MAC
+#    include "ui/MacUiUtilities.h"
+#endif
+
 namespace helper {
 
 /// \brief Encodes a string to latin1 percent encoding needed for some scrapers
@@ -396,24 +400,48 @@ QMap<ColorLabel, QString> labels()
     return labels;
 }
 
-QColor colorForLabel(ColorLabel label)
+
+QColor colorForLabel(ColorLabel label, QString theme)
 {
-    switch (label) {
-    case ColorLabel::Red: return {252, 124, 126};
-    case ColorLabel::Orange: return {253, 189, 65};
-    case ColorLabel::Yellow: return {245, 228, 68};
-    case ColorLabel::Green: return {182, 223, 55};
-    case ColorLabel::Blue: return {132, 201, 253};
-    case ColorLabel::Purple: return {226, 167, 253};
-    case ColorLabel::Grey: return {200, 200, 200};
-    case ColorLabel::NoLabel: return {0, 0, 0, 0};
+    // TODO: Introduce enum for main window theme; move macOS detection to settings (?)
+
+#ifdef Q_OS_MAC
+    if (theme == "auto") {
+        theme = mediaelch::ui::macIsInDarkTheme() ? "dark" : "light";
+    }
+#endif
+    theme = theme.startsWith("dark") ? "dark" : "light";
+
+    if (theme == "dark") {
+        switch (label) {
+        case ColorLabel::Red: return {163, 49, 51};
+        case ColorLabel::Orange: return {191, 131, 13};
+        case ColorLabel::Yellow: return {191, 176, 29};
+        case ColorLabel::Green: return {125, 161, 16};
+        case ColorLabel::Blue: return {67, 125, 168};
+        case ColorLabel::Purple: return {124, 77, 145};
+        case ColorLabel::Grey: return {133, 133, 133};
+        case ColorLabel::NoLabel: return {0, 0, 0, 0};
+        }
+    } else {
+        switch (label) {
+        case ColorLabel::Red: return {252, 124, 126};
+        case ColorLabel::Orange: return {253, 189, 65};
+        case ColorLabel::Yellow: return {245, 228, 68};
+        case ColorLabel::Green: return {182, 223, 55};
+        case ColorLabel::Blue: return {132, 201, 253};
+        case ColorLabel::Purple: return {226, 167, 253};
+        case ColorLabel::Grey: return {200, 200, 200};
+        case ColorLabel::NoLabel: return {0, 0, 0, 0};
+        }
     }
     return {0, 0, 0, 0};
 }
 
 QIcon iconForLabel(ColorLabel label)
 {
-    QColor color = colorForLabel(label);
+    // TODO: Get rid of Settings::instance() here.
+    QColor color = colorForLabel(label, Settings::instance()->theme());
     QPainter p;
     QPixmap pixmap(32, 32);
     pixmap.fill(Qt::transparent);

--- a/src/globals/Helper.h
+++ b/src/globals/Helper.h
@@ -45,7 +45,7 @@ QString formatFileSize(int64_t size, const QLocale& locale);
 
 qreal similarity(const QString& s1, const QString& s2);
 QMap<ColorLabel, QString> labels();
-QColor colorForLabel(ColorLabel label);
+QColor colorForLabel(ColorLabel label, QString theme);
 QIcon iconForLabel(ColorLabel label);
 QMap<QString, QString> stereoModes();
 QString matchResolution(int width, int height, const QString& scanType);

--- a/src/model/MovieModel.cpp
+++ b/src/model/MovieModel.cpp
@@ -3,6 +3,7 @@
 #include "globals/Globals.h"
 #include "globals/Helper.h"
 #include "model/MediaStatusColumn.h"
+#include "settings/Settings.h"
 #include "ui/main/MyIconFont.h"
 
 #include <QPainter>
@@ -160,7 +161,8 @@ QVariant MovieModel::data(const QModelIndex& index, int role) const
                 return m_syncIcon;
             }
         } else if (role == Qt::BackgroundRole) {
-            return helper::colorForLabel(movie->label());
+            // TODO: Get rid of Settings::instance() here
+            return helper::colorForLabel(movie->label(), Settings::instance()->theme());
         }
     } else if (role == Qt::DecorationRole) {
         QString icon;


### PR DESCRIPTION
Fix #1545

------



Color labels were for light theme only.  That made it nearly unreadable
in dark theme.

@ironhussar What do you think?


![dark](https://user-images.githubusercontent.com/1667306/219947781-dc6032d3-c1df-4705-b3a9-5b5792ca82d1.png)
