### PR TITLE
fix(UI): Sort custom movie scraper details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
  - UI: Color labels have better color for the dark theme (#1545)
  - UI: The language dropdown menu is now sorted according to the translated language names (#1560)
+ - UI: Fix the ordering of custom movie scraper details (previously sorted randomly)
 
 ### Changed
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -119,9 +119,9 @@ endif()
 # ------------------------------------------------------------------------------
 # Sources
 if(Qt6_FOUND)
-    target_sources(libmediaelch PUBLIC ../ui_qt6.qrc)
+  target_sources(libmediaelch PUBLIC ../ui_qt6.qrc)
 else()
-    target_sources(libmediaelch PUBLIC ../ui_qt5.qrc)
+  target_sources(libmediaelch PUBLIC ../ui_qt5.qrc)
 endif()
 target_sources(libmediaelch PUBLIC ../data/MediaElch.qrc)
 target_sources(libmediaelch PRIVATE qml/AlbumImageProvider.cpp)

--- a/src/ui/settings/CustomTvScraperSettingsWidget.cpp
+++ b/src/ui/settings/CustomTvScraperSettingsWidget.cpp
@@ -67,6 +67,15 @@ void CustomTvScraperSettingsWidget::loadSettings()
         EpisodeScraperInfo::Title,
         EpisodeScraperInfo::Writer};
 
+#ifdef QT_DEBUG
+    { // TODO: Maybe a simple macro?
+        QSet<ShowScraperInfo> deduplicated{tvInfos.cbegin(), tvInfos.cend()};
+        MediaElch_Assert(deduplicated.size() == tvInfos.size());
+        QSet<EpisodeScraperInfo> deduplicatedEpisodeInfos{episodeInfos.cbegin(), episodeInfos.cend()};
+        MediaElch_Assert(deduplicatedEpisodeInfos.size() == episodeInfos.size());
+    }
+#endif
+
     ui->customTvScraperShowDetails->clearContents();
     ui->customTvScraperShowDetails->setRowCount(0);
 

--- a/src/ui/settings/ScraperSettingsWidget.cpp
+++ b/src/ui/settings/ScraperSettingsWidget.cpp
@@ -94,7 +94,8 @@ void ScraperSettingsWidget::loadSettings()
 {
     ui->chkEnableAdultScrapers->setChecked(m_settings->showAdultScrapers());
 
-    QSet<MovieScraperInfo> infos = {MovieScraperInfo::Title,
+    // QVector instead of QSet to keep order.
+    QVector<MovieScraperInfo> infos = {MovieScraperInfo::Title,
         MovieScraperInfo::Set,
         MovieScraperInfo::Tagline,
         MovieScraperInfo::Rating,
@@ -116,6 +117,13 @@ void ScraperSettingsWidget::loadSettings()
         MovieScraperInfo::CdArt,
         MovieScraperInfo::Banner,
         MovieScraperInfo::Thumb};
+
+#ifdef QT_DEBUG
+    { // TODO: Maybe a simple macro?
+        QSet<MovieScraperInfo> deduplicated{infos.cbegin(), infos.cend()};
+        MediaElch_Assert(deduplicated.size() == infos.size());
+    }
+#endif
 
     ui->customScraperTable->clearContents();
     ui->customScraperTable->setRowCount(0);


### PR DESCRIPTION
The list of custom movie scraper details was not sorted, because we used `QSet` and not an array/vector.  Move to `QVector` but assert that we don't list duplicates via assertions in debug mode.