### PR TITLE
fix(UI): Selection background color of shows/episodes and artists/albums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
  - UI:
+   - Selecting TV shows / episodes or artist / albums now has proper background colors on Windows and macOS (#1569) 
    - Color labels have better color for the dark theme (#1545)
    - The language dropdown menu is now sorted according to the translated language names (#1560)
    - Fix the ordering of custom movie scraper details (previously sorted randomly)

--- a/src/ui/base.css
+++ b/src/ui/base.css
@@ -131,6 +131,10 @@
     color: $table_selection_font_color;
 }
 
+#centralWidget QTreeView {
+     show-decoration-selected: 1;
+}
+
 #centralWidget QTableWidget {
     border: none;
 }

--- a/src/ui/dark.css
+++ b/src/ui/dark.css
@@ -131,6 +131,10 @@
     color: #EBEBEB;
 }
 
+#centralWidget QTreeView {
+     show-decoration-selected: 1;
+}
+
 #centralWidget QTableWidget {
     border: none;
 }

--- a/src/ui/light.css
+++ b/src/ui/light.css
@@ -131,6 +131,10 @@
     color: #ffffff;
 }
 
+#centralWidget QTreeView {
+     show-decoration-selected: 1;
+}
+
 #centralWidget QTableWidget {
     border: none;
 }

--- a/src/ui/small_widgets/MusicTreeView.cpp
+++ b/src/ui/small_widgets/MusicTreeView.cpp
@@ -47,7 +47,14 @@ void MusicTreeView::drawRow(QPainter* painter, const QStyleOptionViewItem& optio
     if (selectionModel()->isSelected(index)) {
         opt.state |= QStyle::State_Selected;
     }
+
+#ifdef Q_OS_MAC
+    // On macOS, PE_PanelItemViewItem works as well for selection background, but not for alternating colors.
     style()->drawPrimitive(QStyle::PE_PanelItemViewRow, &opt, painter, this);
+#else
+    // On Linux/Windows, PE_PanelItemViewRow does not draw selection backgrounds.
+    style()->drawPrimitive(QStyle::PE_PanelItemViewItem, &opt, painter, this);
+#endif
 
     if (isArtistRow(index)) {
         drawArtistRow(painter, option, index);

--- a/src/ui/small_widgets/TvShowTreeView.cpp
+++ b/src/ui/small_widgets/TvShowTreeView.cpp
@@ -62,6 +62,7 @@ void TvShowTreeView::drawRow(QPainter* painter, const QStyleOptionViewItem& opti
         opt.state |= QStyle::State_Selected;
     }
 
+
     // Draw Background
     drawRowBackground(painter, opt, index);
 
@@ -265,7 +266,17 @@ void TvShowTreeView::drawRowBackground(QPainter* painter, QStyleOptionViewItem o
         const int indent = (isSeasonRow(index)) ? m_seasonIndent : m_episodeIndent;
         opt.rect.setX(opt.rect.x() + indent - 4);
     }
+
+    // TODO: Figure out why PE_PanelItemViewRow works on macOS (commit 3d1c37a35c52a593e78335da851f520b9151f81f)
+    //       but doesn't on Linux/Windows.
+    //       It could be https://stackoverflow.com/a/34646515/1603627 , but why?
+#ifdef Q_OS_MAC
+    // On macOS, PE_PanelItemViewItem works as well for selection background, but not for alternating colors.
     style()->drawPrimitive(QStyle::PE_PanelItemViewRow, &opt, painter, this);
+#else
+    // On Linux/Windows, PE_PanelItemViewRow does not draw selection backgrounds.
+    style()->drawPrimitive(QStyle::PE_PanelItemViewItem, &opt, painter, this);
+#endif
 }
 
 bool TvShowTreeView::isShowRow(const QModelIndex& index) const


### PR DESCRIPTION
It seems due to strange behavior of Qt, settings the background color for selections via `selection-background-color` only affects `PE_PanelItemViewRow` on macOS, whereas `PE_PanelItemViewItem` is affected by `background-color` and `::item:selected` on Windows/Linux.

See https://stackoverflow.com/a/34646515/1603627

This is strange. I don't get why this is the case, yet.

Fix #1569