### PR TITLE
fix(Movie): Images were not shown (regression)

### DIFF
--- a/src/media_center/KodiXml.cpp
+++ b/src/media_center/KodiXml.cpp
@@ -332,8 +332,10 @@ bool KodiXml::loadMovie(Movie* movie, QString initialNfoContent)
 
     loadStreamDetails(movie->streamDetails(), domDoc);
 
-    // Existence of images
-    if (nfoContent.isEmpty()) {
+    // Existence of images: If no NFO was given, the movie posters were set via
+    // Database::moviesInDirectory, so no need to do file searches.
+    // TODO: Refactor this condition: This implicit knowledge is hard to keep track of
+    if (initialNfoContent.isEmpty()) {
         for (const auto imageType : Movie::imageTypes()) {
             movie->images().setHasImage(imageType, !imageFileName(movie, imageType).isEmpty());
         }


### PR DESCRIPTION
Follow up to 0491a3cd2f0bc426c0d55dee6372558fdd4cbc35 / #1567: Due to implicit expectations that we look for certain files in the movie's file list only if the initial NFO is empty, which is only the case if we are reloading all movies or there is no NFO in the database. Otherwise the database takes care to set proper "has image" flags.

That needs to be cleaned up.

----

Fix #1572