### PR TITLE
refactor(network): Move website cache to NetworkManager

### DIFF
--- a/src/network/NetworkManager.cpp
+++ b/src/network/NetworkManager.cpp
@@ -50,5 +50,10 @@ QNetworkReply* NetworkManager::postWithWatcher(const QNetworkRequest& request, c
     return reply;
 }
 
+WebsiteCache& NetworkManager::cache()
+{
+    return m_cache;
+}
+
 } // namespace network
 } // namespace mediaelch

--- a/src/network/NetworkManager.h
+++ b/src/network/NetworkManager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "network/WebsiteCache.h"
+
 #include <QAuthenticator>
 #include <QByteArray>
 #include <QNetworkAccessManager>
@@ -33,12 +35,18 @@ public:
     QNetworkReply* post(const QNetworkRequest& request, const QByteArray& data);
     QNetworkReply* postWithWatcher(const QNetworkRequest& request, const QByteArray& data);
 
+    // TODO: If possible, integrate cache with functions above.  Needs refactoring, because
+    //       we can't simply return a QNetworkReply on our own.
+
+    WebsiteCache& cache();
+
 signals:
     void authenticationRequired(QNetworkReply* reply, QAuthenticator* authenticator);
     void finished(QNetworkReply* reply);
 
 private:
     QNetworkAccessManager m_qnam;
+    WebsiteCache m_cache;
 };
 
 } // namespace network

--- a/src/network/WebsiteCache.cpp
+++ b/src/network/WebsiteCache.cpp
@@ -5,7 +5,7 @@
 #include <QUrl>
 
 namespace mediaelch {
-namespace scraper {
+namespace network {
 
 WebsiteCache::WebsiteCache()
 {
@@ -61,5 +61,5 @@ void WebsiteCache::clearOldCacheEntries()
     }
 }
 
-} // namespace scraper
+} // namespace network
 } // namespace mediaelch

--- a/src/network/WebsiteCache.h
+++ b/src/network/WebsiteCache.h
@@ -9,7 +9,7 @@
 #include <QUrl>
 
 namespace mediaelch {
-namespace scraper {
+namespace network {
 
 /// \brief TheTvDb API cache stores the result for a API request as a string.
 ///
@@ -45,5 +45,5 @@ private:
     QTimer m_timer;
 };
 
-} // namespace scraper
+} // namespace network
 } // namespace mediaelch

--- a/src/network/WebsiteCache.h
+++ b/src/network/WebsiteCache.h
@@ -4,6 +4,7 @@
 
 #include <QDateTime>
 #include <QMap>
+#include <QNetworkRequest>
 #include <QString>
 #include <QTimer>
 #include <QUrl>
@@ -18,13 +19,15 @@ namespace network {
 class WebsiteCache
 {
 public:
-    constexpr static int timeoutSeconds = 240;
+    constexpr static int timeoutSeconds = 240; // 4min
 
     WebsiteCache();
 
-    void addElement(const QUrl& url, const Locale& locale, QString data);
-    QString getElement(const QUrl& url, const Locale& locale);
-    bool hasValidElement(const QUrl& url, const Locale& locale);
+    void addElement(const QNetworkRequest& request, QString data);
+    QString getElement(const QNetworkRequest& request);
+    bool hasValidElement(const QNetworkRequest& request);
+
+    void clear();
 
 private:
     struct CacheElement
@@ -32,8 +35,6 @@ private:
         QDateTime date;
         QString data;
     };
-
-    QString hash(const QUrl& url, const Locale& locale);
 
     /// \brief Clears old cache entries that are older than timeoutSeconds.
     ///

--- a/src/scrapers/imdb/ImdbApi.h
+++ b/src/scrapers/imdb/ImdbApi.h
@@ -77,7 +77,7 @@ private:
 private:
     const QString m_language;
     mediaelch::network::NetworkManager m_network;
-    WebsiteCache m_cache;
+    network::WebsiteCache m_cache;
 };
 
 } // namespace scraper

--- a/src/scrapers/imdb/ImdbApi.h
+++ b/src/scrapers/imdb/ImdbApi.h
@@ -6,7 +6,6 @@
 #include "data/tv_show/SeasonNumber.h"
 #include "data/tv_show/SeasonOrder.h"
 #include "network/NetworkManager.h"
-#include "network/WebsiteCache.h"
 #include "scrapers/ScraperError.h"
 #include "scrapers/ScraperInfos.h"
 
@@ -77,7 +76,6 @@ private:
 private:
     const QString m_language;
     mediaelch::network::NetworkManager m_network;
-    network::WebsiteCache m_cache;
 };
 
 } // namespace scraper

--- a/src/scrapers/movie/adultdvdempire/AdultDvdEmpireApi.h
+++ b/src/scrapers/movie/adultdvdempire/AdultDvdEmpireApi.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "network/NetworkManager.h"
-#include "network/WebsiteCache.h"
 #include "scrapers/ScraperError.h"
 
 #include <QObject>
@@ -40,7 +39,6 @@ private:
 
 private:
     mediaelch::network::NetworkManager m_network;
-    network::WebsiteCache m_cache;
 };
 
 } // namespace scraper

--- a/src/scrapers/movie/adultdvdempire/AdultDvdEmpireApi.h
+++ b/src/scrapers/movie/adultdvdempire/AdultDvdEmpireApi.h
@@ -40,7 +40,7 @@ private:
 
 private:
     mediaelch::network::NetworkManager m_network;
-    WebsiteCache m_cache;
+    network::WebsiteCache m_cache;
 };
 
 } // namespace scraper

--- a/src/scrapers/movie/aebn/AebnApi.h
+++ b/src/scrapers/movie/aebn/AebnApi.h
@@ -42,7 +42,7 @@ private:
 
 private:
     mediaelch::network::NetworkManager m_network;
-    WebsiteCache m_cache;
+    network::WebsiteCache m_cache;
 };
 
 } // namespace scraper

--- a/src/scrapers/movie/aebn/AebnApi.h
+++ b/src/scrapers/movie/aebn/AebnApi.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "network/NetworkManager.h"
-#include "network/WebsiteCache.h"
 #include "scrapers/ScraperError.h"
 
 #include <QObject>
@@ -42,7 +41,6 @@ private:
 
 private:
     mediaelch::network::NetworkManager m_network;
-    network::WebsiteCache m_cache;
 };
 
 } // namespace scraper

--- a/src/scrapers/movie/hotmovies/HotMoviesApi.cpp
+++ b/src/scrapers/movie/hotmovies/HotMoviesApi.cpp
@@ -13,20 +13,20 @@ HotMoviesApi::HotMoviesApi(QObject* parent) : QObject(parent)
 
 void HotMoviesApi::sendGetRequest(const QUrl& url, HotMoviesApi::ApiCallback callback)
 {
-    if (m_cache.hasValidElement(url, Locale::English)) {
+    QNetworkRequest request = mediaelch::network::requestWithDefaults(url);
+
+    if (m_network.cache().hasValidElement(request)) {
         // Do not immediately run the callback because classes higher up may
         // set up a Qt connection while the network request is running.
-        QTimer::singleShot(
-            0, this, [cb = std::move(callback), element = m_cache.getElement(url, Locale::English)]() { //
-                cb(element, {});
-            });
+        QTimer::singleShot(0, this, [cb = std::move(callback), element = m_network.cache().getElement(request)]() { //
+            cb(element, {});
+        });
         return;
     }
 
-    QNetworkRequest request = mediaelch::network::requestWithDefaults(url);
     QNetworkReply* reply = m_network.getWithWatcher(request);
 
-    connect(reply, &QNetworkReply::finished, this, [reply, cb = std::move(callback), this]() {
+    connect(reply, &QNetworkReply::finished, this, [reply, cb = std::move(callback), request, this]() {
         auto dls = makeDeleteLaterScope(reply);
 
         QString data;
@@ -38,7 +38,7 @@ void HotMoviesApi::sendGetRequest(const QUrl& url, HotMoviesApi::ApiCallback cal
         }
 
         if (!data.isEmpty()) {
-            m_cache.addElement(reply->url(), Locale::English, data);
+            m_network.cache().addElement(request, data);
         }
 
         ScraperError error = makeScraperError(data, *reply, {});

--- a/src/scrapers/movie/hotmovies/HotMoviesApi.h
+++ b/src/scrapers/movie/hotmovies/HotMoviesApi.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "network/NetworkManager.h"
-#include "network/WebsiteCache.h"
 #include "scrapers/ScraperError.h"
 
 #include <QObject>
@@ -40,7 +39,6 @@ private:
 
 private:
     mediaelch::network::NetworkManager m_network;
-    network::WebsiteCache m_cache;
 };
 
 } // namespace scraper

--- a/src/scrapers/movie/hotmovies/HotMoviesApi.h
+++ b/src/scrapers/movie/hotmovies/HotMoviesApi.h
@@ -40,7 +40,7 @@ private:
 
 private:
     mediaelch::network::NetworkManager m_network;
-    WebsiteCache m_cache;
+    network::WebsiteCache m_cache;
 };
 
 } // namespace scraper

--- a/src/scrapers/movie/videobuster/VideoBusterApi.h
+++ b/src/scrapers/movie/videobuster/VideoBusterApi.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "network/NetworkManager.h"
-#include "network/WebsiteCache.h"
 #include "scrapers/ScraperError.h"
 
 #include <QObject>
@@ -43,7 +42,6 @@ private:
 
 private:
     mediaelch::network::NetworkManager m_network;
-    network::WebsiteCache m_cache;
 };
 
 } // namespace scraper

--- a/src/scrapers/movie/videobuster/VideoBusterApi.h
+++ b/src/scrapers/movie/videobuster/VideoBusterApi.h
@@ -43,7 +43,7 @@ private:
 
 private:
     mediaelch::network::NetworkManager m_network;
-    WebsiteCache m_cache;
+    network::WebsiteCache m_cache;
 };
 
 } // namespace scraper

--- a/src/scrapers/music/AllMusic.h
+++ b/src/scrapers/music/AllMusic.h
@@ -32,7 +32,7 @@ public:
 
 private:
     network::NetworkManager m_network;
-    WebsiteCache m_cache;
+    network::WebsiteCache m_cache;
 };
 
 class AllMusic : public QObject

--- a/src/scrapers/music/AllMusic.h
+++ b/src/scrapers/music/AllMusic.h
@@ -2,7 +2,6 @@
 
 #include "data/AllMusicId.h"
 #include "network/NetworkManager.h"
-#include "network/WebsiteCache.h"
 #include "scrapers/ScraperError.h"
 #include "scrapers/ScraperInfos.h"
 
@@ -32,7 +31,6 @@ public:
 
 private:
     network::NetworkManager m_network;
-    network::WebsiteCache m_cache;
 };
 
 class AllMusic : public QObject

--- a/src/scrapers/music/MusicBrainz.h
+++ b/src/scrapers/music/MusicBrainz.h
@@ -50,7 +50,7 @@ public:
 
 private:
     network::NetworkManager m_network;
-    WebsiteCache m_cache;
+    network::WebsiteCache m_cache;
 };
 
 class MusicBrainz : public QObject

--- a/src/scrapers/music/MusicBrainz.h
+++ b/src/scrapers/music/MusicBrainz.h
@@ -3,7 +3,6 @@
 #include "data/AllMusicId.h"
 #include "data/MusicBrainzId.h"
 #include "network/NetworkManager.h"
-#include "network/WebsiteCache.h"
 #include "scrapers/ScraperError.h"
 #include "scrapers/ScraperInfos.h"
 #include "scrapers/ScraperResult.h"
@@ -50,7 +49,6 @@ public:
 
 private:
     network::NetworkManager m_network;
-    network::WebsiteCache m_cache;
 };
 
 class MusicBrainz : public QObject

--- a/src/scrapers/music/TheAudioDb.cpp
+++ b/src/scrapers/music/TheAudioDb.cpp
@@ -18,20 +18,21 @@ TheAudioDbApi::TheAudioDbApi(QObject* parent) : QObject(parent), m_tadbApiKey{"7
 
 void TheAudioDbApi::sendGetRequest(const Locale& locale, const QUrl& url, TheAudioDbApi::ApiCallback callback)
 {
-    if (m_cache.hasValidElement(url, locale)) {
+    QNetworkRequest request = mediaelch::network::requestWithDefaults(url);
+
+    if (m_network.cache().hasValidElement(request)) {
         // Do not immediately run the callback because classes higher up may
         // set up a Qt connection while the network request is running.
-        QTimer::singleShot(0, this, [cb = std::move(callback), element = m_cache.getElement(url, locale)]() { //
+        QTimer::singleShot(0, this, [cb = std::move(callback), element = m_network.cache().getElement(request)]() { //
             cb(element, {});
         });
         return;
     }
 
-    QNetworkRequest request = mediaelch::network::requestWithDefaults(url);
 
     QNetworkReply* reply = m_network.getWithWatcher(request);
 
-    connect(reply, &QNetworkReply::finished, this, [reply, cb = std::move(callback), locale, this]() {
+    connect(reply, &QNetworkReply::finished, this, [reply, cb = std::move(callback), locale, request, this]() {
         auto dls = makeDeleteLaterScope(reply);
 
         QString data;
@@ -43,7 +44,7 @@ void TheAudioDbApi::sendGetRequest(const Locale& locale, const QUrl& url, TheAud
         }
 
         if (!data.isEmpty()) {
-            m_cache.addElement(reply->url(), locale, data);
+            m_network.cache().addElement(request, data);
         }
 
         ScraperError error = makeScraperError(data, *reply, {});

--- a/src/scrapers/music/TheAudioDb.h
+++ b/src/scrapers/music/TheAudioDb.h
@@ -42,7 +42,7 @@ public:
 
 private:
     network::NetworkManager m_network;
-    WebsiteCache m_cache;
+    network::WebsiteCache m_cache;
     QString m_tadbApiKey;
 };
 

--- a/src/scrapers/music/TheAudioDb.h
+++ b/src/scrapers/music/TheAudioDb.h
@@ -4,7 +4,6 @@
 #include "data/MusicBrainzId.h"
 #include "data/TheAudioDbId.h"
 #include "network/NetworkManager.h"
-#include "network/WebsiteCache.h"
 #include "scrapers/ScraperError.h"
 #include "scrapers/ScraperInfos.h"
 
@@ -42,7 +41,6 @@ public:
 
 private:
     network::NetworkManager m_network;
-    network::WebsiteCache m_cache;
     QString m_tadbApiKey;
 };
 

--- a/src/scrapers/tmdb/TmdbApi.cpp
+++ b/src/scrapers/tmdb/TmdbApi.cpp
@@ -57,21 +57,21 @@ const TmdbApiConfiguration& TmdbApi::config() const
 
 void TmdbApi::sendGetRequest(const Locale& locale, const QUrl& url, TmdbApi::ApiCallback callback)
 {
-    if (m_cache.hasValidElement(url, locale)) {
+    QNetworkRequest request = mediaelch::network::jsonRequestWithDefaults(url);
+
+    if (m_network.cache().hasValidElement(request)) {
         // Do not immediately run the callback because classes higher up may
         // set up a Qt connection while the network request is running.
-        QTimer::singleShot(0, this, [cb = std::move(callback), element = m_cache.getElement(url, locale)]() {
+        QTimer::singleShot(0, this, [cb = std::move(callback), element = m_network.cache().getElement(request)]() {
             // should not result in a parse error because the cache element is
-            // only stored if no error occured at all.
+            // only stored if no error occurred at all.
             cb(QJsonDocument::fromJson(element.toUtf8()), {});
         });
         return;
     }
 
-    QNetworkRequest request = mediaelch::network::jsonRequestWithDefaults(url);
     QNetworkReply* reply = m_network.getWithWatcher(request);
-
-    connect(reply, &QNetworkReply::finished, this, [reply, cb = std::move(callback), locale, this]() {
+    connect(reply, &QNetworkReply::finished, this, [reply, cb = std::move(callback), locale, request, this]() {
         auto dls = makeDeleteLaterScope(reply);
 
         QString data;
@@ -87,7 +87,7 @@ void TmdbApi::sendGetRequest(const Locale& locale, const QUrl& url, TmdbApi::Api
         if (!data.isEmpty()) {
             json = QJsonDocument::fromJson(data.toUtf8(), &parseError);
             if (parseError.error == QJsonParseError::NoError) {
-                m_cache.addElement(reply->url(), locale, data);
+                m_network.cache().addElement(request, data);
             }
         }
 

--- a/src/scrapers/tmdb/TmdbApi.h
+++ b/src/scrapers/tmdb/TmdbApi.h
@@ -7,7 +7,6 @@
 #include "data/tv_show/SeasonOrder.h"
 #include "network/NetworkManager.h"
 #include "network/NetworkRequest.h"
-#include "network/WebsiteCache.h"
 #include "scrapers/ScraperError.h"
 #include "scrapers/ScraperInfos.h"
 
@@ -127,7 +126,6 @@ public:
 private:
     const QString m_language;
     network::NetworkManager m_network;
-    network::WebsiteCache m_cache;
     TmdbApiConfiguration m_config;
     bool m_isInitialized = false;
 };

--- a/src/scrapers/tmdb/TmdbApi.h
+++ b/src/scrapers/tmdb/TmdbApi.h
@@ -127,7 +127,7 @@ public:
 private:
     const QString m_language;
     network::NetworkManager m_network;
-    WebsiteCache m_cache;
+    network::WebsiteCache m_cache;
     TmdbApiConfiguration m_config;
     bool m_isInitialized = false;
 };

--- a/src/scrapers/tv_show/thetvdb/TheTvDbApi.cpp
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbApi.cpp
@@ -65,10 +65,13 @@ bool TheTvDbApi::isInitialized() const
 
 void TheTvDbApi::sendGetRequest(const Locale& locale, const QUrl& url, TheTvDbApi::ApiCallback callback)
 {
-    if (m_cache.hasValidElement(url, locale)) {
+    QNetworkRequest request = mediaelch::network::jsonRequestWithDefaults(url);
+    addHeadersToRequest(locale, request);
+
+    if (m_network.cache().hasValidElement(request)) {
         // Do not immediately run the callback because classes higher up may
         // set up a Qt connection while the network request is running.
-        QTimer::singleShot(0, this, [cb = std::move(callback), element = m_cache.getElement(url, locale)]() {
+        QTimer::singleShot(0, this, [cb = std::move(callback), element = m_network.cache().getElement(request)]() {
             // should not result in a parse error because the cache element is
             // only stored if no error occured at all.
             cb(QJsonDocument::fromJson(element.toUtf8()), {});
@@ -76,12 +79,9 @@ void TheTvDbApi::sendGetRequest(const Locale& locale, const QUrl& url, TheTvDbAp
         return;
     }
 
-    QNetworkRequest request = mediaelch::network::jsonRequestWithDefaults(url);
-    addHeadersToRequest(locale, request);
-
     QNetworkReply* reply = m_network.getWithWatcher(request);
 
-    connect(reply, &QNetworkReply::finished, this, [reply, cb = std::move(callback), locale, this]() {
+    connect(reply, &QNetworkReply::finished, this, [reply, cb = std::move(callback), locale, request, this]() {
         auto dls = makeDeleteLaterScope(reply);
 
         QString data;
@@ -97,7 +97,7 @@ void TheTvDbApi::sendGetRequest(const Locale& locale, const QUrl& url, TheTvDbAp
         if (!data.isEmpty()) {
             json = QJsonDocument::fromJson(data.toUtf8(), &parseError);
             if (parseError.error == QJsonParseError::NoError) {
-                m_cache.addElement(reply->url(), locale, data);
+                m_network.cache().addElement(request, data);
             }
         }
 

--- a/src/scrapers/tv_show/thetvdb/TheTvDbApi.h
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbApi.h
@@ -5,7 +5,6 @@
 #include "data/tv_show/SeasonNumber.h"
 #include "data/tv_show/SeasonOrder.h"
 #include "network/NetworkManager.h"
-#include "network/WebsiteCache.h"
 #include "scrapers/ScraperError.h"
 #include "scrapers/ScraperInfos.h"
 
@@ -117,7 +116,6 @@ private:
     const QString m_language;
     mediaelch::network::NetworkManager m_network;
     ApiToken m_token;
-    network::WebsiteCache m_cache;
 };
 
 } // namespace scraper

--- a/src/scrapers/tv_show/thetvdb/TheTvDbApi.h
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbApi.h
@@ -117,7 +117,7 @@ private:
     const QString m_language;
     mediaelch::network::NetworkManager m_network;
     ApiToken m_token;
-    WebsiteCache m_cache;
+    network::WebsiteCache m_cache;
 };
 
 } // namespace scraper

--- a/src/scrapers/tv_show/tvmaze/TvMazeApi.h
+++ b/src/scrapers/tv_show/tvmaze/TvMazeApi.h
@@ -51,7 +51,7 @@ private:
 
 private:
     mediaelch::network::NetworkManager m_network;
-    WebsiteCache m_cache;
+    network::WebsiteCache m_cache;
 };
 
 } // namespace scraper

--- a/src/scrapers/tv_show/tvmaze/TvMazeApi.h
+++ b/src/scrapers/tv_show/tvmaze/TvMazeApi.h
@@ -4,7 +4,6 @@
 #include "data/tv_show/SeasonNumber.h"
 #include "network/HttpStatusCodes.h"
 #include "network/NetworkManager.h"
-#include "network/WebsiteCache.h"
 #include "scrapers/ScraperError.h"
 
 #include <QJsonDocument>
@@ -51,7 +50,6 @@ private:
 
 private:
     mediaelch::network::NetworkManager m_network;
-    network::WebsiteCache m_cache;
 };
 
 } // namespace scraper


### PR DESCRIPTION
The network manager now has a website cache.  Most users of
NetworkManager has a WebsiteCache themselves.  In the future, they
should probably be combined somehow.

-----

In preparation for #1578