### PR TITLE
fix(UI): Move settings window to top after selecting directory (macOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
    - The language dropdown menu is now sorted according to the translated language names (#1560)
    - Fix the ordering of custom movie scraper details; previously it was sorted randomly (#1562)
  - If a movie directory contains an invalid `*.nfo` file, it was not listed properly when reloading movies (#1564)
+ - macOS: When a new directory is added in the settings window, the main window was moved on top (#1577)
 
 ### Changed
 

--- a/src/ui/settings/GlobalSettingsWidget.cpp
+++ b/src/ui/settings/GlobalSettingsWidget.cpp
@@ -62,8 +62,16 @@ void GlobalSettingsWidget::setSettings(Settings& settings)
 
 void GlobalSettingsWidget::chooseDirToAdd()
 {
-    QString dir = QFileDialog::getExistingDirectory(
-        this, tr("Choose a directory containing your movies, TV show or concerts"), QDir::homePath());
+    QString dir = QFileDialog::getExistingDirectory(this,
+        tr("Choose a directory containing your movies, TV show or concerts"),
+        QDir::homePath(),
+        QFileDialog::ReadOnly | QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+
+    // Issue #1577: On macOS, for some reason, the main window goes on top of the settings window,
+    // hiding it.  Explicitly raise it as a workaround.
+    window()->raise();
+    window()->activateWindow();
+
     if (dir.isEmpty()) {
         // User aborted file dialog.
         return;


### PR DESCRIPTION
For some reason, on the latest macOS versions (with Qt 5.15.2), the settings window disappears when a directory was selected.  The main window is put in front of the settings window.  That is bad, because we currently do not have a "Windows" bar item where users can easily switch between windows.


------

Fix #1577

TODO:

- [x] actually test on macOS