### PR TITLE
fix(MovieScraper): Correctly copy original title if required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ### Fixed
 
-- tbd
+- Movie scraper: Original title was missing and the setting "ignore duplicate original title"
+  was ignored (#1601).
 
 ### Changed
 

--- a/src/data/movie/MovieController.cpp
+++ b/src/data/movie/MovieController.cpp
@@ -202,7 +202,11 @@ void MovieController::loadData(QHash<mediaelch::scraper::MovieScraper*, mediaelc
 
     connect(scrapeJob, &MovieScrapeJob::loadFinished, this, [this, scraper](MovieScrapeJob* job) { //
         job->deleteLater();
-        copyDetailsToMovie(*m_movie, job->movie(), job->config().details, Settings::instance()->usePlotForOutline());
+        copyDetailsToMovie(*m_movie,
+            job->movie(),
+            job->config().details,
+            Settings::instance()->usePlotForOutline(),
+            Settings::instance()->ignoreDuplicateOriginalTitle());
         scraperLoadDone(scraper, job);
     });
     scrapeJob->start();

--- a/src/scrapers/movie/MovieMerger.cpp
+++ b/src/scrapers/movie/MovieMerger.cpp
@@ -9,7 +9,11 @@ namespace mediaelch {
 namespace scraper {
 
 // TODO: Option "only replace if source has value"
-static void copyDetailToMovie(Movie& target, const Movie& source, MovieScraperInfo detail, bool usePlotForOutline)
+static void copyDetailToMovie(Movie& target,
+    const Movie& source,
+    MovieScraperInfo detail,
+    bool usePlotForOutline,
+    bool ignoreDuplicateOriginalTitle)
 {
     if (source.tmdbId().isValid()) {
         target.setTmdbId(source.tmdbId());
@@ -25,6 +29,9 @@ static void copyDetailToMovie(Movie& target, const Movie& source, MovieScraperIn
     }
     case MovieScraperInfo::Title: {
         target.setName(source.name());
+        if (!ignoreDuplicateOriginalTitle || source.name() != source.originalName()) {
+            target.setOriginalName(source.originalName());
+        }
         break;
     }
     case MovieScraperInfo::Tagline: {
@@ -53,7 +60,7 @@ static void copyDetailToMovie(Movie& target, const Movie& source, MovieScraperIn
     }
     case MovieScraperInfo::Overview: {
         target.setOverview(source.overview());
-        if (source.outline().isEmpty()) {
+        if (!source.outline().isEmpty()) {
             target.setOutline(source.outline());
         } else if (usePlotForOutline) {
             target.setOutline(source.overview());
@@ -180,10 +187,11 @@ static void copyDetailToMovie(Movie& target, const Movie& source, MovieScraperIn
 void copyDetailsToMovie(Movie& target,
     const Movie& source,
     const QSet<MovieScraperInfo>& details,
-    bool usePlotForOutline)
+    bool usePlotForOutline,
+    bool ignoreDuplicateOriginalTitle)
 {
     for (MovieScraperInfo detail : details) {
-        copyDetailToMovie(target, source, detail, usePlotForOutline);
+        copyDetailToMovie(target, source, detail, usePlotForOutline, ignoreDuplicateOriginalTitle);
     }
 }
 

--- a/src/scrapers/movie/MovieMerger.h
+++ b/src/scrapers/movie/MovieMerger.h
@@ -9,10 +9,12 @@ class Movie;
 namespace mediaelch {
 namespace scraper {
 
+// TODO: No multiple boolean arguments
 void copyDetailsToMovie(Movie& target,
     const Movie& source,
     const QSet<MovieScraperInfo>& details,
-    bool usePlotForOutline);
+    bool usePlotForOutline,
+    bool ignoreDuplicateOriginalTitle);
 
 } // namespace scraper
 } // namespace mediaelch

--- a/src/scrapers/movie/custom/CustomMovieScrapeJob.cpp
+++ b/src/scrapers/movie/custom/CustomMovieScrapeJob.cpp
@@ -47,8 +47,11 @@ void CustomMovieScrapeJob::doStart()
 
 void CustomMovieScrapeJob::onScraperFinished(MovieScrapeJob* scrapeJob)
 {
-    copyDetailsToMovie(
-        *m_movie, scrapeJob->movie(), scrapeJob->config().details, Settings::instance()->usePlotForOutline());
+    copyDetailsToMovie(*m_movie,
+        scrapeJob->movie(),
+        scrapeJob->config().details,
+        Settings::instance()->usePlotForOutline(),
+        Settings::instance()->ignoreDuplicateOriginalTitle());
     scrapeJob->deleteLater();
 
     const bool isRemoved = m_jobs.removeOne(scrapeJob);

--- a/test/helpers/CMakeLists.txt
+++ b/test/helpers/CMakeLists.txt
@@ -1,8 +1,14 @@
 add_library(libmediaelch_testhelpers STATIC)
 target_sources(
   libmediaelch_testhelpers
-  PRIVATE matchers.cpp diff.cpp resource_dir.cpp reference_file.cpp
-          normalize.cpp scraper_helpers.cpp
+  PRIVATE
+    matchers.cpp
+    diff.cpp
+    resource_dir.cpp
+    reference_file.cpp
+    normalize.cpp
+    scraper_helpers.cpp
+    fake_data.cpp
 )
 target_link_libraries(
   libmediaelch_testhelpers

--- a/test/helpers/fake_data.cpp
+++ b/test/helpers/fake_data.cpp
@@ -1,0 +1,106 @@
+#include "test/helpers/fake_data.h"
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace test {
+
+std::unique_ptr<Movie> movieWithAllDetails()
+{
+    auto movie = std::make_unique<Movie>();
+    movie->setName("Allegiant");
+    movie->setOriginalName("AllegiantOriginal");
+    movie->setSortTitle("TmovieFc10");
+
+    {
+        Rating rating;
+        rating.rating = 5.8;
+        rating.voteCount = 1641;
+        rating.source = "imdb";
+        rating.maxRating = 10;
+        movie->ratings().setOrAddRating(rating);
+    }
+    {
+        Rating rating;
+        rating.rating = 1.2;
+        rating.voteCount = 3400;
+        rating.source = "themoviedb";
+        rating.maxRating = 10;
+        movie->ratings().setOrAddRating(rating);
+    }
+    {
+        Rating rating;
+        rating.rating = 4.2;
+        rating.voteCount = 784;
+        rating.source = "someOther";
+        movie->ratings().setOrAddRating(rating);
+    }
+
+    movie->setTop250(240);
+    movie->setOutline("TmovieFc02");
+    movie->setOverview("Beatrice Prior and Tobias Eaton venture into the world outside of the fence and are taken "
+                       "into protective custody by a mysterious agency known as the Bureau of Genetic Welfare.");
+    movie->setTagline("Break the boundaries of your world");
+    movie->setRuntime(88min);
+    Poster poster;
+    poster.originalUrl = "http://image.tmdb.org/t/p/original/tSFBh9Ayn5uiwbUK9HvD2lrRgaQ.jpg";
+    poster.thumbUrl = "http://image.tmdb.org/t/p/w500/tSFBh9Ayn5uiwbUK9HvD2lrRgaQ.jpg";
+    movie->images().addPoster(poster);
+    movie->setCertification(Certification("Rated M"));
+    movie->setPlayCount(1);
+    movie->setLastPlayed(QDateTime::fromString("2017-09-06 12:44:12", Qt::ISODate));
+    movie->setFiles(mediaelch::FileList({R"(F:\Movies- Test - Scraped\Allegiant (2016)\BDMV\index.bdmv)"}));
+    // TODO: basepath
+    movie->setImdbId(ImdbId("tt3410834"));
+    movie->addGenre("Adventure");
+    movie->addGenre("Science Fiction");
+    movie->addCountry("United States of America");
+
+    MovieSet set;
+    set.tmdbId = TmdbId(283579);
+    set.name = "Divergent Collection";
+    set.overview =
+        "A series of dystopian science fiction action films based on the Divergent novels by the American author "
+        "Veronica Roth. Set in a dystopian and post-apocalyptic Chicago where people are divided into distinct "
+        "factions based on human virtues. Beatrice Prior (Tris) is warned that she is Divergent and thus will "
+        "never fit into any one of the factions. She along with Tobias Eaton (Four) soon learn that a sinister "
+        "plot is brewing in the seemingly perfect society.";
+    movie->setSet(set);
+
+    movie->addTag("Best Tag");
+    movie->setDirector("Robert Schwentke");
+    movie->setWriter("Adam Cooper, Bill Collage, Stephen Chbosky");
+    movie->setReleased(QDate::fromString("2016-03-09", Qt::ISODate));
+    movie->addStudio("Summit Entertainment");
+    movie->setTrailer(QUrl("TmovieFc19"));
+    // requires that setFiles() was called
+    movie->streamDetails()->setVideoDetail(StreamDetails::VideoDetails::Codec, "h264");
+    movie->streamDetails()->setVideoDetail(StreamDetails::VideoDetails::Aspect, "1.777778");
+    movie->streamDetails()->setVideoDetail(StreamDetails::VideoDetails::Width, "1920");
+    movie->streamDetails()->setVideoDetail(StreamDetails::VideoDetails::Height, "1080");
+    movie->streamDetails()->setVideoDetail(StreamDetails::VideoDetails::DurationInSeconds, "5311");
+    movie->streamDetails()->setVideoDetail(StreamDetails::VideoDetails::StereoMode, "");
+    movie->streamDetails()->setAudioDetail(1, StreamDetails::AudioDetails::Codec, "ac3");
+    movie->streamDetails()->setAudioDetail(1, StreamDetails::AudioDetails::Language, "eng");
+    movie->streamDetails()->setAudioDetail(1, StreamDetails::AudioDetails::Channels, "2");
+    movie->streamDetails()->setAudioDetail(2, StreamDetails::AudioDetails::Codec, "ac3");
+    movie->streamDetails()->setAudioDetail(2, StreamDetails::AudioDetails::Language, "");
+    movie->streamDetails()->setAudioDetail(2, StreamDetails::AudioDetails::Channels, "2");
+    movie->streamDetails()->setSubtitleDetail(1, StreamDetails::SubtitleDetails::Language, "eng");
+    movie->streamDetails()->setSubtitleDetail(2, StreamDetails::SubtitleDetails::Language, "");
+    Actor actor;
+    actor.name = "Shailene Woodley";
+    actor.role = R"(Beatrice "Tris" Prior)";
+    actor.thumb = "http://image.tmdb.org/t/p/original/kkLbiTlBGNwJL9qHuVHeqCMNrEx.jpg";
+    // TODO: order
+    movie->addActor(actor);
+    // 2nd actor
+    actor.name = "Theo James";
+    actor.role = R"(Tobias "Four" Eaton)";
+    actor.thumb = "http://image.tmdb.org/t/p/original/hLNSoQ3gc52X5VVb172yO3CuUEq.jpg";
+    // TODO: order
+    movie->addActor(actor);
+    return movie;
+}
+} // namespace test

--- a/test/helpers/fake_data.h
+++ b/test/helpers/fake_data.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "data/movie/Movie.h"
+
+#include <memory>
+
+namespace test {
+
+std::unique_ptr<Movie> movieWithAllDetails();
+
+} // namespace test

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(
     scrapers/testImdbTvSeasonParser.cpp
     scrapers/custom_movie_scraper/StubMovieScraper.cpp
     scrapers/custom_movie_scraper/testCustomMovieScraper.cpp
+    scrapers/testMovieMerger.cpp
     settings/testAdvancedSettings.cpp
     tv_shows/testEpisodeNumberExtraction.cpp
     tv_shows/testSeasonNumberExtraction.cpp

--- a/test/unit/scrapers/custom_movie_scraper/StubMovieScraper.cpp
+++ b/test/unit/scrapers/custom_movie_scraper/StubMovieScraper.cpp
@@ -30,7 +30,8 @@ mediaelch::scraper::MovieScrapeJob* StubMovieScraper::loadMovie(mediaelch::scrap
 StubMovieScrapeJob::StubMovieScrapeJob(Config config, Movie& stubMovie, QObject* parent) :
     mediaelch::scraper::MovieScrapeJob(std::move(config), parent)
 {
-    mediaelch::scraper::copyDetailsToMovie(movie(), stubMovie, mediaelch::scraper::allMovieScraperInfos(), false);
+    mediaelch::scraper::copyDetailsToMovie(
+        movie(), stubMovie, mediaelch::scraper::allMovieScraperInfos(), false, false);
     setAutoDelete(false);
 }
 

--- a/test/unit/scrapers/testMovieMerger.cpp
+++ b/test/unit/scrapers/testMovieMerger.cpp
@@ -1,0 +1,60 @@
+#include "test/test_helpers.h"
+
+#include "media_center/kodi/MovieXmlReader.h"
+#include "src/scrapers/movie/MovieMerger.h"
+#include "test/helpers/fake_data.h"
+#include "test/helpers/resource_dir.h"
+
+TEST_CASE("movies are correctly merged", "[movie][merger]")
+{
+    using namespace mediaelch::scraper;
+
+    std::unique_ptr<Movie> original = test::movieWithAllDetails();
+
+    SECTION("All details are copied")
+    {
+        Movie copy;
+        copyDetailsToMovie(copy, *original, allMovieScraperInfos(), true, false);
+
+        CHECK(copy.name() == original->name());
+        CHECK(copy.originalName() == original->originalName());
+        CHECK(copy.overview() == original->overview());
+        CHECK(copy.outline() == original->outline());
+    }
+
+    SECTION("Uses plot for outline if original has not outline")
+    {
+        Movie copy;
+        original->setOutline("");
+        copyDetailsToMovie(copy, *original, allMovieScraperInfos(), true, true);
+
+        CHECK(copy.name() == original->name());
+        CHECK(copy.originalName() == original->originalName());
+        CHECK(copy.overview() == original->overview());
+        CHECK(copy.outline() == original->overview()); // !
+    }
+
+    SECTION("Does not use plot for outline if not requested")
+    {
+        Movie copy;
+        original->setOutline("");
+        copyDetailsToMovie(copy, *original, allMovieScraperInfos(), false, true);
+
+        CHECK(copy.name() == original->name());
+        CHECK(copy.originalName() == original->originalName());
+        CHECK(copy.overview() == original->overview());
+        CHECK(copy.outline().isEmpty()); // !
+    }
+
+    SECTION("Does not copy original title if it's the same")
+    {
+        Movie copy;
+        original->setOriginalName(original->name());
+        copyDetailsToMovie(copy, *original, allMovieScraperInfos(), true, true);
+
+        CHECK(copy.name() == original->name());
+        CHECK(copy.originalName().isEmpty());
+        CHECK(copy.overview() == original->overview());
+        CHECK(copy.outline() == original->outline());
+    }
+}


### PR DESCRIPTION
After the movie scraper refactoring, it was forgotten to copy the _original_ title if needed.  The setting "ignore duplicate original title" needs to be respected as well.

----

Fix #1601