### PR TITLE
fix(MusicBrainz): Don't set Content-Type header in GET request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Movie scraper: Original title was missing and the setting "ignore duplicate original title"
   was ignored (#1601).
+- Universal Music Scraper: The MusicBrainz part of the universal music scraper now works again (#1597).
 
 ### Changed
 

--- a/src/scrapers/music/MusicBrainz.cpp
+++ b/src/scrapers/music/MusicBrainz.cpp
@@ -20,7 +20,6 @@ MusicBrainzApi::MusicBrainzApi(QObject* parent) : QObject(parent)
 void MusicBrainzApi::sendGetRequest(const Locale& locale, const QUrl& url, MusicBrainzApi::ApiCallback callback)
 {
     QNetworkRequest request = mediaelch::network::requestWithDefaults(url);
-    request.setRawHeader("Content-Type", "application/xml");
     request.setRawHeader("Accept", "application/xml");
 
     if (m_network.cache().hasValidElement(request)) {
@@ -42,6 +41,7 @@ void MusicBrainzApi::sendGetRequest(const Locale& locale, const QUrl& url, Music
 
         } else {
             qCWarning(generic) << "[MusicBrainz] Network Error:" << reply->errorString() << "for URL" << reply->url();
+            // For debugging: << reply->readAll();
         }
 
         if (!data.isEmpty()) {


### PR DESCRIPTION
It appears as if MusicBrainz can't handle search requests with a Content-Type header anymore, at least not XML.

Without the header, requests work as expected.

Fix #1597