### PR TITLE
fix(CustomMovieScraper): Load images from fanart.tv if requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 
 ### Fixed
 
-- Movie scraper: Original title was missing and the setting "ignore duplicate original title"
+- Movie scrapers: Original title was missing and the setting "ignore duplicate original title"
   was ignored (#1601).
+- Custom Movie Scraper: Images from fanart.tv were not loaded, even though it was selected in MediaElch's settings (#1598)
 - Universal Music Scraper: The MusicBrainz part of the universal music scraper now works again (#1597).
 
 ### Changed


### PR DESCRIPTION
This was forgotten in the movie scraper rewrite.  The coding may be verbose, but it will fix a feature that is commonly used by our users.


---

Fix #1598