### PR TITLE
feat(Movie Search): Add preview of poster/overview to search dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### Added
 
-- tbd
+ - The movie search dialog has gained a preview (#1607)
 
 
 ## 2.10.2 - 2023-07-01

--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -396,6 +396,7 @@ SOURCES += src/main.cpp \
     src/ui/movies/MovieSearch.cpp \
     src/ui/movies/MovieSearchWidget.cpp \
     src/ui/movies/MovieWidget.cpp \
+    src/ui/movies/MoviePreviewAdapter.cpp \
     src/ui/music/MusicFilesWidget.cpp \
     src/ui/music/MusicMultiScrapeDialog.cpp \
     src/ui/music/MusicSearch.cpp \
@@ -757,6 +758,7 @@ HEADERS  += Version.h \
     src/ui/movies/MovieSearch.h \
     src/ui/movies/MovieSearchWidget.h \
     src/ui/movies/MovieWidget.h \
+    src/ui/movies/MoviePreviewAdapter.h \
     src/ui/music/MusicFilesWidget.h \
     src/ui/music/MusicMultiScrapeDialog.h \
     src/ui/music/MusicSearch.h \

--- a/src/ui/movies/CMakeLists.txt
+++ b/src/ui/movies/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(
   MovieDuplicateItem.cpp
   MovieDuplicates.cpp
   MovieFilesWidget.cpp
+  MoviePreviewAdapter.cpp
   MovieSearch.cpp
 )
 

--- a/src/ui/movies/MoviePreviewAdapter.cpp
+++ b/src/ui/movies/MoviePreviewAdapter.cpp
@@ -1,0 +1,19 @@
+#include "ui/movies/MoviePreviewAdapter.h"
+
+namespace mediaelch {
+
+MoviePreviewAdapter::~MoviePreviewAdapter() = default;
+
+std::unique_ptr<ScrapePreview::JobAdapter>
+MoviePreviewAdapter::createFor(scraper::MovieScraper* scraper, scraper::MovieIdentifier id, Locale locale)
+{
+    scraper::MovieScrapeJob::Config config;
+    config.identifier = std::move(id);
+    config.locale = std::move(locale);
+    config.details = {MovieScraperInfo::Title, MovieScraperInfo::Overview, MovieScraperInfo::Poster};
+
+    scraper::MovieScrapeJob* job = scraper->loadMovie(config);
+    return std::make_unique<MoviePreviewAdapter>(job);
+}
+
+} // namespace mediaelch

--- a/src/ui/movies/MoviePreviewAdapter.h
+++ b/src/ui/movies/MoviePreviewAdapter.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "data/movie/Movie.h"
+#include "scrapers/movie/MovieScrapeJob.h"
+#include "scrapers/movie/MovieScraper.h"
+#include "ui/small_widgets/ScrapePreview.h"
+#include "utils/Meta.h"
+
+#include <QPointer>
+#include <memory>
+
+namespace mediaelch {
+
+class MoviePreviewAdapter : public ScrapePreview::JobAdapter
+{
+public:
+    static std::unique_ptr<ScrapePreview::JobAdapter>
+    createFor(scraper::MovieScraper* scraper, scraper::MovieIdentifier id, Locale locale);
+
+public:
+    explicit MoviePreviewAdapter(scraper::MovieScrapeJob* scrapeJob) : m_scrapeJob{scrapeJob} {}
+    ~MoviePreviewAdapter() override;
+
+    ELCH_NODISCARD worker::Job* scrapeJob() override { return m_scrapeJob.data(); }
+
+    ELCH_NODISCARD QString title() override
+    {
+        MediaElch_Expects(m_scrapeJob != nullptr);
+        return m_scrapeJob->movie().name();
+    }
+
+    ELCH_NODISCARD QString description() override
+    {
+        MediaElch_Expects(m_scrapeJob != nullptr);
+        return m_scrapeJob->movie().overview();
+    }
+
+    ELCH_NODISCARD Poster poster() override
+    {
+        MediaElch_Expects(m_scrapeJob != nullptr);
+        if (!m_scrapeJob->movie().images().posters().isEmpty()) {
+            return m_scrapeJob->movie().images().posters().first();
+        } else {
+            return {};
+        }
+    }
+
+private:
+    QPointer<scraper::MovieScrapeJob> m_scrapeJob{nullptr};
+};
+
+} // namespace mediaelch

--- a/src/ui/movies/MovieSearchWidget.h
+++ b/src/ui/movies/MovieSearchWidget.h
@@ -5,8 +5,10 @@
 #include "globals/Globals.h"
 #include "scrapers/ScraperInfos.h"
 #include "scrapers/movie/MovieScraper.h"
+#include "scrapers/movie/MovieSearchJob.h"
 
 #include <QMap>
+#include <QPointer>
 #include <QString>
 #include <QTableWidgetItem>
 #include <QVector>
@@ -16,11 +18,6 @@ namespace Ui {
 class MovieSearchWidget;
 }
 
-namespace mediaelch {
-namespace scraper {
-class MovieScraper;
-}
-} // namespace mediaelch
 
 class MovieSearchWidget : public QWidget
 {
@@ -48,8 +45,16 @@ signals:
 
 private slots:
     void startSearch();
-    void showResults(mediaelch::scraper::MovieSearchJob* searchJob);
-    void resultClicked(QTableWidgetItem* item);
+    void onShowResults(mediaelch::scraper::MovieSearchJob* searchJob);
+
+    /// \brief When the selected item changes, e.g. via click or keys.
+    /// \param current Currently selected result.
+    /// \param previous Previously selected result. Unused, only due to Qt API.
+    void onSelectedResultChanged(QTableWidgetItem* current, QTableWidgetItem* previous);
+    /// \brief Stores the double-clicked id and accepts the dialog.
+    /// \param item Item which was clicked
+    void onResultDoubleClicked(QTableWidgetItem* item);
+
     void updateInfoToLoad();
     void toggleAllInfo(bool checked);
     void onScraperChanged(int index);
@@ -59,7 +64,8 @@ private slots:
 private:
     bool isCustomScrapingInProgress() { return !m_customScrapersLeft.isEmpty(); }
 
-    void clearResults();
+    void abortAndClearResults();
+    void abortCurrentJobs();
     void setCheckBoxesForCurrentScraper();
     void setupComboBoxes();
     void setSearchText();
@@ -80,6 +86,7 @@ private:
 
     // Selected scraper or the currently used scraper for the custom movie scraper.
     mediaelch::scraper::MovieScraper* m_currentScraper{nullptr};
+    QPointer<mediaelch::scraper::MovieSearchJob> m_currentSearchJob{nullptr};
 
     QString m_scraperMovieId;
     QSet<MovieScraperInfo> m_infosToLoad;

--- a/src/ui/movies/MovieSearchWidget.ui
+++ b/src/ui/movies/MovieSearchWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>720</width>
-    <height>660</height>
+    <height>661</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,1">
@@ -94,7 +94,7 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</strin
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0">
      <item>
       <layout class="QVBoxLayout" name="vboxResults">
        <item>
@@ -105,36 +105,60 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</strin
         </widget>
        </item>
        <item>
-        <widget class="QTableWidget" name="results">
-         <property name="editTriggers">
-          <set>QAbstractItemView::NoEditTriggers</set>
+        <widget class="QSplitter" name="splitter">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>1</verstretch>
+          </sizepolicy>
          </property>
-         <property name="alternatingRowColors">
-          <bool>true</bool>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-         <property name="selectionMode">
-          <enum>QAbstractItemView::SingleSelection</enum>
-         </property>
-         <property name="selectionBehavior">
-          <enum>QAbstractItemView::SelectRows</enum>
-         </property>
-         <property name="showGrid">
+         <property name="opaqueResize">
           <bool>false</bool>
          </property>
-         <attribute name="horizontalHeaderVisible">
+         <property name="childrenCollapsible">
           <bool>false</bool>
-         </attribute>
-         <attribute name="horizontalHeaderStretchLastSection">
-          <bool>true</bool>
-         </attribute>
-         <attribute name="verticalHeaderVisible">
-          <bool>false</bool>
-         </attribute>
-         <column>
-          <property name="text">
-           <string>Result</string>
+         </property>
+         <widget class="QTableWidget" name="results">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>1</verstretch>
+           </sizepolicy>
           </property>
-         </column>
+          <property name="editTriggers">
+           <set>QAbstractItemView::NoEditTriggers</set>
+          </property>
+          <property name="alternatingRowColors">
+           <bool>true</bool>
+          </property>
+          <property name="selectionMode">
+           <enum>QAbstractItemView::SingleSelection</enum>
+          </property>
+          <property name="selectionBehavior">
+           <enum>QAbstractItemView::SelectRows</enum>
+          </property>
+          <property name="showGrid">
+           <bool>false</bool>
+          </property>
+          <attribute name="horizontalHeaderVisible">
+           <bool>false</bool>
+          </attribute>
+          <attribute name="horizontalHeaderStretchLastSection">
+           <bool>true</bool>
+          </attribute>
+          <attribute name="verticalHeaderVisible">
+           <bool>false</bool>
+          </attribute>
+          <column>
+           <property name="text">
+            <string>Result</string>
+           </property>
+          </column>
+         </widget>
+         <widget class="ScrapePreview" name="preview" native="true"/>
         </widget>
        </item>
       </layout>
@@ -410,6 +434,12 @@ If you want to search by an TMDb id please prefix it with &quot;id&quot;.</strin
    <class>MyLineEdit</class>
    <extends>QLineEdit</extends>
    <header>ui/small_widgets/MyLineEdit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ScrapePreview</class>
+   <extends>QWidget</extends>
+   <header>ui/small_widgets/ScrapePreview.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/ui/small_widgets/ScrapePreview.h
+++ b/src/ui/small_widgets/ScrapePreview.h
@@ -39,6 +39,6 @@ private slots:
 
 private:
     Ui::ScrapePreview* ui = nullptr;
-    std::unique_ptr<JobAdapter> m_currentJob = nullptr;
+    std::unique_ptr<JobAdapter> m_currentAdapter = nullptr;
     QPixmap m_placeholderPoster;
 };


### PR DESCRIPTION
This commit adds a preview widget to the Movie search widget. This makes it easier to select the correct movie, especially if there are multiple results that are quite similar.

![Screenshot_20230709_153647](https://github.com/Komet/MediaElch/assets/1667306/6d03f904-86f5-49fa-991a-ac972852030b)
