### PR TITLE
fix(IMDb TV): Fix scraping of episodes if there is an episode 00

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Movie scrapers: Original title was missing and the setting "ignore duplicate original title"
   was ignored (#1601).
 - Custom Movie Scraper: Images from fanart.tv were not loaded, even though it was selected in MediaElch's settings (#1598)
+- The movie renamer did not replace `<director>` in movie folder names (#1611)
+- IMDb TV: If a season has an episode No. 0 (e.g. a pilot), it could not be scraped and all other episodes were offset by 1 (#1614)
 - Universal Music Scraper: 
   - The MusicBrainz part of the universal music scraper now works again (#1597).
   - Discogs correctly loads an artists biography again (#1606)

--- a/scripts/library/tvshows_en/Buffy/Season_01.txt
+++ b/scripts/library/tvshows_en/Buffy/Season_01.txt
@@ -1,0 +1,3 @@
+S01E00 Unaired Pilot
+S01E01 Welcome to the Hellmouth
+S01E02 The Harvest

--- a/src/scrapers/tv_show/imdb/ImdbTvEpisodeParser.cpp
+++ b/src/scrapers/tv_show/imdb/ImdbTvEpisodeParser.cpp
@@ -276,9 +276,16 @@ void ImdbTvEpisodeParser::parseInfos(TvShowEpisode& episode, const QString& html
 
 void ImdbTvEpisodeParser::parseIdFromSeason(TvShowEpisode& episode, const QString& html)
 {
-    QString rawRegex =
-        QStringLiteral(R"re(<a href="/title/(tt\d+)/\?ref_=ttep_ep%1")re").arg(episode.episodeNumber().toString());
-    QRegularExpression regex(rawRegex);
+    // Example HTML:
+    //   ```html
+    //   <meta itemprop="episodeNumber" content="1"/>
+    //     …
+    //   <a href="/title/tt0452716/?ref_=ttep_ep2"…
+    //   ```
+    QRegularExpression regex(
+        QStringLiteral(R"re(<meta itemprop="episodeNumber" content="%1".*<a href="/title/(tt\d+)/\?ref_=ttep_ep)re")
+            .arg(episode.episodeNumber().toString()),
+        QRegularExpression::InvertedGreedinessOption | QRegularExpression::DotMatchesEverythingOption);
 
     QRegularExpressionMatch match = regex.match(html);
     if (!match.hasMatch()) {

--- a/test/resources/scrapers/imdbtv/Buffy-S01E00-minimal-details.ref.txt
+++ b/test/resources/scrapers/imdbtv/Buffy-S01E00-minimal-details.ref.txt
@@ -1,0 +1,31 @@
+TvShowEpisode Reference File
+------------------
+
+tmdbId: 
+imdbId: tt0533518
+tvdbId: 
+tvmazeId: 
+title: Unaired Pilot
+showTitle: 
+ratings (N=1)
+  source=imdb | rating=6.6 | votes=1000 | min=0 | max=10
+userRating: 0
+imdbTop250: 0
+season: SeasonNumber=01
+episode: EpisodeNumber=00
+displaySeason: SeasonNumber=xx
+displayEpisode: EpisodeNumber=xx
+overview: 
+writers: (N=0)
+directors: (N=0)
+playCount: 0
+lastPlayed: <not set or invalid>
+firstAired: 2011-09-30
+tags: (N=0)
+epBookmark: <not set or invalid>
+certification: 
+network: 
+thumbnail: https://m.media-amazon.com/images/M/MV5BYzY5ZGE1MGQtM2YzNi00NTc0LTliNTQtM2M0NzViODRlNGJjXkEyXkFqcGdeQXVyMjg2MTMyNTM@._V1_UX400_CR0,0,400,225_AL_.jpg
+actors: (N=0)
+streamDetails: <not loaded>
+files: (N=0)

--- a/test/resources/scrapers/imdbtv/Buffy-S01E01-minimal-details.ref.txt
+++ b/test/resources/scrapers/imdbtv/Buffy-S01E01-minimal-details.ref.txt
@@ -1,0 +1,31 @@
+TvShowEpisode Reference File
+------------------
+
+tmdbId: 
+imdbId: tt0452716
+tvdbId: 
+tvmazeId: 
+title: Welcome to the Hellmouth
+showTitle: 
+ratings (N=1)
+  source=imdb | rating=7.8 | votes=5000 | min=0 | max=10
+userRating: 0
+imdbTop250: 0
+season: SeasonNumber=01
+episode: EpisodeNumber=01
+displaySeason: SeasonNumber=xx
+displayEpisode: EpisodeNumber=xx
+overview: 
+writers: (N=0)
+directors: (N=0)
+playCount: 0
+lastPlayed: <not set or invalid>
+firstAired: 1998-10-09
+tags: (N=0)
+epBookmark: <not set or invalid>
+certification: 
+network: 
+thumbnail: https://m.media-amazon.com/images/M/MV5BMTU2NDQ1NTI2MF5BMl5BanBnXkFtZTgwNDMzMTM1NjM@._V1_UX400_CR0,0,400,225_AL_.jpg
+actors: (N=0)
+streamDetails: <not loaded>
+files: (N=0)

--- a/test/resources/scrapers/imdbtv/The-Simpsons-tt0096697-minimal-details.ref.txt
+++ b/test/resources/scrapers/imdbtv/The-Simpsons-tt0096697-minimal-details.ref.txt
@@ -24,9 +24,9 @@ genres: (N<6)
 tags: (N<6)
   - beer
   - sitcom
-  - dysfunctional family
   - satire
   - cult tv
+  - adult animation
 certification: TV-14
 network: 
 episodeGuideUrl: 

--- a/test/scrapers/imdbtv/testImdbTvEpisodeLoader.cpp
+++ b/test/scrapers/imdbtv/testImdbTvEpisodeLoader.cpp
@@ -15,11 +15,11 @@ TEST_CASE("ImdbTv scrapes episode details for The Simpsons S12E19", "[episode][I
     SeasonNumber season(12);
     EpisodeNumber episodeNumber(19);
     ImdbId showId("tt0096697");
-    ImdbId imdbId("tt0701133");
+    ImdbId episodeId("tt0701133");
 
     SECTION("Loads minimal details with episode ImdbTv ID")
     {
-        EpisodeIdentifier id(imdbId);
+        EpisodeIdentifier id(episodeId);
         EpisodeScrapeJob::Config config{id, Locale::English, {EpisodeScraperInfo::Title}};
 
         auto scrapeJob = std::make_unique<ImdbTvEpisodeScrapeJob>(getImdbApi(), config);
@@ -53,7 +53,7 @@ TEST_CASE("ImdbTv scrapes episode details for The Simpsons S12E19", "[episode][I
     SECTION("Loads all details for The Simpsons S12E19")
     {
         ImdbTv imdbTv;
-        EpisodeIdentifier id(imdbId);
+        EpisodeIdentifier id(episodeId);
         EpisodeScrapeJob::Config config{id, Locale::English, imdbTv.meta().supportedEpisodeDetails};
 
         auto scrapeJob = std::make_unique<ImdbTvEpisodeScrapeJob>(getImdbApi(), config);
@@ -62,5 +62,41 @@ TEST_CASE("ImdbTv scrapes episode details for The Simpsons S12E19", "[episode][I
 
         REQUIRE(episode.imdbId() == ImdbId("tt0701133"));
         test::scraper::compareAgainstReference(episode, "scrapers/imdbtv/The-Simpsons-S12E19-tt0701133-all-details");
+    }
+}
+
+TEST_CASE("ImdbTv scrapes episode details for Buffy", "[buffy][episode][ImdbTv][load_data]")
+{
+    SeasonNumber season(1);
+    ImdbId showId("tt0118276");
+
+    SECTION("Loads minimal details for episode number 00")
+    {
+        EpisodeNumber episodeNumber(0);
+        ImdbId episodeId("tt0533518");
+        EpisodeIdentifier id(showId.toString(), season, episodeNumber, SeasonOrder::Aired);
+        EpisodeScrapeJob::Config config{id, Locale::English, {EpisodeScraperInfo::Title}};
+
+        auto scrapeJob = std::make_unique<ImdbTvEpisodeScrapeJob>(getImdbApi(), config);
+        test::scrapeEpisodeSync(scrapeJob.get());
+        auto& episode = scrapeJob->episode();
+
+        REQUIRE(episode.imdbId() == ImdbId("tt0533518"));
+        test::scraper::compareAgainstReference(episode, "scrapers/imdbtv/Buffy-S01E00-minimal-details");
+    }
+
+    SECTION("Loads minimal details for episode number 01")
+    {
+        EpisodeNumber episodeNumber(1);
+        ImdbId episodeId("tt0452716");
+        EpisodeIdentifier id(showId.toString(), season, episodeNumber, SeasonOrder::Aired);
+        EpisodeScrapeJob::Config config{id, Locale::English, {EpisodeScraperInfo::Title}};
+
+        auto scrapeJob = std::make_unique<ImdbTvEpisodeScrapeJob>(getImdbApi(), config);
+        test::scrapeEpisodeSync(scrapeJob.get());
+        auto& episode = scrapeJob->episode();
+
+        REQUIRE(episode.imdbId() == ImdbId("tt0452716"));
+        test::scraper::compareAgainstReference(episode, "scrapers/imdbtv/Buffy-S01E01-minimal-details");
     }
 }


### PR DESCRIPTION
Episode "00" (e.g. pilot episodes) increased IMDbs episode URL counter. That means, we were always off-by-one and episode 00 could not be scraped.  This is now fixed and we have tests to ensure that this does not happen again.

---

Fix #1610