### PR TITLE
fix(AdvancedSettings): Don't clear sort tokens when reading `<exclude>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 
 ### Fixed
 
+- The movie renamer did not replace `<director>` in movie folder names (#1611)
+- Advanced Settings: If `<exclude>` exists in `advancedsettings.xml`, we accidentally cleared
+  the sort tokens, meaning sorting without articles was not possible (#1613)
 - Movie scrapers: Original title was missing and the setting "ignore duplicate original title"
   was ignored (#1601).
 - Custom Movie Scraper: Images from fanart.tv were not loaded, even though it was selected in MediaElch's settings (#1598)
-- The movie renamer did not replace `<director>` in movie folder names (#1611)
 - IMDb TV: If a season has an episode No. 0 (e.g. a pilot), it could not be scraped and all other episodes were offset by 1 (#1614)
 - Universal Music Scraper: 
   - The MusicBrainz part of the universal music scraper now works again (#1597).

--- a/docs/advancedsettings.xml
+++ b/docs/advancedsettings.xml
@@ -17,7 +17,7 @@
         When <portableMode> is set to true MediaElch will store its settings,
         temporary files and caches in the application directory and not in
         standard locations based on your OS.
-        This settings is only available on Windows.
+        This setting is only available on Windows.
     -->
     <portableMode>false</portableMode>
 
@@ -164,7 +164,7 @@
 
     <!--
         <audioCodecs> defines a mapping which is applied when
-        streamdetails are loaded. The example below will replace
+        stream-details are loaded. The example below will replace
         the audio codec "MPA1L3" with "MP3".
     -->
     <audioCodecs>
@@ -175,7 +175,7 @@
 
     <!--
         <videoCodecs> defines a mapping which is applied when
-        streamdetails are loaded. The example below will replace
+        stream-details are loaded. The example below will replace
         the video codec "v_mpeg4/iso/avc" and "avc" with "h264".
     -->
     <videoCodecs>
@@ -229,10 +229,10 @@
         <!-- You have to specify what part of the path should be checked.
              The "applyTo" attribute can be used for this. Possible values are:
               - "filename" -> only the last segment is checked, e.g. "movie.mov"
-              - "folders" -> each foldername is checked (note the "s", not "folder")
+              - "folders" -> each folder name is checked (note the "s", not "folder")
 
              The examples below make use of that. We can ignore files that begin with
-             an underscore or foldernames by an exact match (e.g. ".git" folders).
+             an underscore or folder names by an exact match (e.g. ".git" folders).
         -->
         <!-- <pattern applyTo="filename">^_</pattern> -->
         <!-- <pattern applyTo="folders">^[.]git$</pattern> -->

--- a/test/unit/scrapers/testImdbTvEpisodeParser.cpp
+++ b/test/unit/scrapers/testImdbTvEpisodeParser.cpp
@@ -14,7 +14,14 @@ title="So It's Come to This: A Simpsons Clip Show" itemprop="url"> <div data-con
 <img width="224" height="126" class="zero-z-index" alt="So It's Come to This: A Simpsons Clip Show" src="https://m.media-amazon.com/images/M/MV5BMmVlZjM1N2QtNjZhZC00OTcwLWFiOWMtOTdhZTg0Njk5YmZmXkEyXkFqcGdeQXVyNjcwMzEzMTU@._V1_UX224_CR0,0,224,126_AL_.jpg">
 <div>S4, Ep18</div>
 </div>
-</a>
+</a>  </div>
+  <div class="info" itemprop="episodes" itemscope itemtype="http://schema.org/TVEpisode">
+    <meta itemprop="episodeNumber" content="18"/>
+    <div class="airdate">
+            11 Sep. 1994
+    </div>
+    <strong><a href="/title/tt0773651/?ref_=ttep_ep18"
+title="So It's Come to This: A Simpsons Clip Show" itemprop="name">So It's Come to This: A Simpsons Clip Show</a></strong>
     )";
 
     ImdbId expectedEpisodeId("tt0773651");

--- a/test/unit/settings/testAdvancedSettings.cpp
+++ b/test/unit/settings/testAdvancedSettings.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Advanced Settings XML", "[settings]")
 
     SECTION("xml with content")
     {
-        QString emptyXml = addBaseXml(R"xml(
+        QString xml = addBaseXml(R"xml(
             <log>
                 <debug>true</debug>
                 <file>./MediaElchTest.log</file>
@@ -42,14 +42,28 @@ TEST_CASE("Advanced Settings XML", "[settings]")
             <genres>
                 <map from="SciFi" to="Science Fiction" />
             </genres>
+            <sorttokens>
+                <!-- English -->
+                <token>The</token>
+                <!-- German -->
+                <token>Der</token>
+            </sorttokens>
+            <exclude>
+              <pattern applyTo="filename">^_</pattern>
+              <pattern applyTo="folders">^[.]git$</pattern>
+            </exclude>
         )xml");
 
-        AdvancedSettings settings = AdvancedSettingsXmlReader::loadFromXml(emptyXml).first;
+        auto result = AdvancedSettingsXmlReader::loadFromXml(xml);
+        AdvancedSettings settings = result.first;
 
         CHECK(settings.debugLog());
         CHECK(settings.logFile() == "./MediaElchTest.log");
         REQUIRE(settings.genreMappings().size() == 1);
         CHECK(settings.genreMappings()["SciFi"] == "Science Fiction");
+        REQUIRE(settings.sortTokens().size() == 2);
+        CHECK(settings.sortTokens()[0] == "The");
+        CHECK(settings.sortTokens()[1] == "Der");
     }
 
     const auto checkEpisodeThumbValues = [](const auto& pair) {


### PR DESCRIPTION
Fix #1613

---

Due to Copy&Paste, we used `m_settings.m_sortTokens.clear();` when
reading `exclude`.