### PR TITLE
fix(UI): Fix image column count in image dialogs on first appearance

### DIFF
--- a/src/scrapers/imdb/ImdbApi.h
+++ b/src/scrapers/imdb/ImdbApi.h
@@ -64,7 +64,7 @@ public:
     ELCH_NODISCARD static QUrl makeFullAssetUrl(const QString& suffix);
 
 private:
-    /// \brief Add neccassaray headers for IMDb to the request object.
+    /// \brief Add necessary headers for IMDb to the request object.
     void addHeadersToRequest(const Locale& locale, QNetworkRequest& request);
 
     ELCH_NODISCARD QUrl makeTitleUrl(const ImdbId& id, PageKind page) const;

--- a/src/scrapers/tv_show/thetvdb/TheTvDbApi.h
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbApi.h
@@ -98,7 +98,7 @@ public:
     static QUrl makeFullAssetUrl(const QString& suffix);
 
 private:
-    /// \brief Add neccassaray headers for TheTvDb to the request object.
+    /// \brief Add necessary headers for TheTvDb to the request object.
     /// Token must exist.
     /// \see TheTvDbApi::obtainJsonWebToken
     void addHeadersToRequest(const Locale& locale, QNetworkRequest& request);

--- a/src/ui/concerts/ConcertWidget.cpp
+++ b/src/ui/concerts/ConcertWidget.cpp
@@ -590,7 +590,6 @@ void ConcertWidget::onAddExtraFanart()
     // TODO: Don't use "this", because we don't want to inherit the stylesheet,
     // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
-    imageDialog->setImageType(ImageType::ConcertExtraFanart);
     imageDialog->setMultiSelection(true);
     imageDialog->setConcert(m_concert);
     imageDialog->setDefaultDownloads(m_concert->backdrops());
@@ -633,7 +632,6 @@ void ConcertWidget::onChooseImage()
     // TODO: Don't use "this", because we don't want to inherit the stylesheet,
     // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
-    imageDialog->setImageType(image->imageType());
     imageDialog->setConcert(m_concert);
     if (image->imageType() == ImageType::ConcertPoster) {
         imageDialog->setDefaultDownloads(m_concert->posters());

--- a/src/ui/concerts/ConcertWidget.cpp
+++ b/src/ui/concerts/ConcertWidget.cpp
@@ -267,8 +267,8 @@ void ConcertWidget::onStartScraperSearch()
     emit setActionSearchEnabled(false, MainWidgets::Concerts);
     emit setActionSaveEnabled(false, MainWidgets::Concerts);
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* searchWidget = new ConcertSearch(MainWindow::instance());
     searchWidget->execWithSearch(m_concert->title());
 
@@ -587,8 +587,8 @@ void ConcertWidget::onAddExtraFanart()
         return;
     }
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
     imageDialog->setImageType(ImageType::ConcertExtraFanart);
     imageDialog->setMultiSelection(true);
@@ -630,8 +630,8 @@ void ConcertWidget::onChooseImage()
         return;
     }
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
     imageDialog->setImageType(image->imageType());
     imageDialog->setConcert(m_concert);

--- a/src/ui/image/ImageDialog.h
+++ b/src/ui/image/ImageDialog.h
@@ -43,7 +43,6 @@ public:
     QUrl imageUrl();
     /// \brief Return the URLs of the selected images
     QVector<QUrl> imageUrls();
-    void setImageType(ImageType type);
     void setItemType(ItemType type);
     void setMultiSelection(const bool& enable);
     void setMovie(Movie* movie);
@@ -111,25 +110,24 @@ private:
 
     mediaelch::network::NetworkManager m_network;
     int m_currentDownloadIndex = 0;
-    QNetworkReply* m_currentDownloadReply = nullptr;
-    ImageType m_imageType = ImageType::None;
+    QNetworkReply* m_currentDownloadReply{nullptr};
     QVector<DownloadElement> m_elements;
     QUrl m_imageUrl;
     QVector<QUrl> m_imageUrls;
-    ImageType m_type = ImageType::None;
+    ImageType m_type{ImageType::None};
     QVector<mediaelch::scraper::ImageProvider*> m_providers;
-    Concert* m_concert = nullptr;
-    Movie* m_movie = nullptr;
-    TvShow* m_tvShow = nullptr;
-    TvShowEpisode* m_tvShowEpisode = nullptr;
+    Concert* m_concert{nullptr};
+    Movie* m_movie{nullptr};
+    TvShow* m_tvShow{nullptr};
+    TvShowEpisode* m_tvShowEpisode{nullptr};
     ItemType m_itemType = ItemType::Movie;
     QVector<Poster> m_defaultElements;
-    mediaelch::scraper::ImageProvider* m_currentProvider = nullptr;
+    mediaelch::scraper::ImageProvider* m_currentProvider{nullptr};
     SeasonNumber m_season;
     EpisodeNumber m_episode;
-    bool m_multiSelection = false;
-    Artist* m_artist = nullptr;
-    Album* m_album = nullptr;
+    bool m_multiSelection{false};
+    Artist* m_artist{nullptr};
+    Album* m_album{nullptr};
 
 private:
     void setAndStartDownloads(QVector<Poster> downloads);

--- a/src/ui/image/ImageDialog.ui
+++ b/src/ui/image/ImageDialog.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>667</width>
+    <width>702</width>
     <height>600</height>
    </rect>
   </property>
@@ -73,6 +73,12 @@
    </item>
    <item>
     <widget class="QStackedWidget" name="stackedWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="autoFillBackground">
       <bool>true</bool>
      </property>

--- a/src/ui/import/DownloadsWidget.cpp
+++ b/src/ui/import/DownloadsWidget.cpp
@@ -45,8 +45,8 @@ DownloadsWidget::DownloadsWidget(QWidget* parent) : QWidget(parent), ui(new Ui::
 #endif
 
     m_extractor = new Extractor(this);
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     m_makeMkvDialog = new MakeMkvDialog(MainWindow::instance());
 
     connect(m_extractor, &Extractor::sigError, this, &DownloadsWidget::onExtractorError);

--- a/src/ui/movie_sets/SetsWidget.cpp
+++ b/src/ui/movie_sets/SetsWidget.cpp
@@ -369,7 +369,6 @@ void SetsWidget::chooseSetPoster()
     // TODO: Don't use "this", because we don't want to inherit the stylesheet,
     // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
-    imageDialog->setImageType(ImageType::MovieSetPoster);
     imageDialog->setMovie(movie);
     imageDialog->execWithType(ImageType::MoviePoster);
     const int exitCode = imageDialog->result();
@@ -405,7 +404,6 @@ void SetsWidget::chooseSetBackdrop()
     // TODO: Don't use "this", because we don't want to inherit the stylesheet,
     // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
-    imageDialog->setImageType(ImageType::MovieSetBackdrop);
     imageDialog->setMovie(movie);
     imageDialog->execWithType(ImageType::MovieBackdrop);
     const int exitCode = imageDialog->result();

--- a/src/ui/movie_sets/SetsWidget.cpp
+++ b/src/ui/movie_sets/SetsWidget.cpp
@@ -296,8 +296,8 @@ void SetsWidget::onAddMovie()
         return;
     }
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* listDialog = new MovieListDialog(MainWindow::instance());
     const int exitCode = listDialog->exec();
     QVector<Movie*> movies = listDialog->selectedMovies();
@@ -366,8 +366,8 @@ void SetsWidget::chooseSetPoster()
     auto* movie = new Movie(QStringList());
     movie->setName(setName);
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
     imageDialog->setImageType(ImageType::MovieSetPoster);
     imageDialog->setMovie(movie);
@@ -402,8 +402,8 @@ void SetsWidget::chooseSetBackdrop()
     auto* movie = new Movie(QStringList());
     movie->setName(setName);
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
     imageDialog->setImageType(ImageType::MovieSetBackdrop);
     imageDialog->setMovie(movie);
@@ -477,8 +477,8 @@ void SetsWidget::onPreviewBackdrop()
  */
 void SetsWidget::onPreviewPoster()
 {
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* dialog = new ImagePreviewDialog(MainWindow::instance());
     dialog->setImage(QPixmap::fromImage(m_currentPoster));
     dialog->exec();

--- a/src/ui/movies/CertificationWidget.cpp
+++ b/src/ui/movies/CertificationWidget.cpp
@@ -254,8 +254,8 @@ void CertificationWidget::addMovie()
 
     const auto cert = Certification(ui->certifications->item(ui->certifications->currentRow(), 0)->text());
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* listDialog = new MovieListDialog(MainWindow::instance());
     const int exitCode = listDialog->execWithoutCertification(cert);
     QVector<Movie*> movies = listDialog->selectedMovies();

--- a/src/ui/movies/GenreWidget.cpp
+++ b/src/ui/movies/GenreWidget.cpp
@@ -250,8 +250,8 @@ void GenreWidget::addMovie()
         return;
     }
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* listDialog = new MovieListDialog(MainWindow::instance());
     const int exitCode = listDialog->execWithoutGenre(ui->genres->item(ui->genres->currentRow(), 0)->text());
     QVector<Movie*> movies = listDialog->selectedMovies();

--- a/src/ui/movies/MovieFilesWidget.cpp
+++ b/src/ui/movies/MovieFilesWidget.cpp
@@ -183,8 +183,8 @@ void MovieFilesWidget::multiScrape()
         return;
     }
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* searchWidget = new MovieMultiScrapeDialog(MainWindow::instance());
     searchWidget->setMovies(movies);
     const int result = searchWidget->exec();

--- a/src/ui/movies/MovieWidget.cpp
+++ b/src/ui/movies/MovieWidget.cpp
@@ -425,8 +425,8 @@ void MovieWidget::startScraperSearch()
     emit setActionSearchEnabled(false, MainWidgets::Movies);
     emit setActionSaveEnabled(false, MainWidgets::Movies);
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* searchWidget = new MovieSearch(MainWindow::instance());
     searchWidget->execWithSearch(m_movie->name(), m_movie->imdbId(), m_movie->tmdbId());
 
@@ -868,8 +868,8 @@ void MovieWidget::onDownloadTrailer()
     if (m_movie == nullptr) {
         return;
     }
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* dialog = new TrailerDialog(MainWindow::instance());
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->exec(m_movie);
@@ -1463,8 +1463,8 @@ void MovieWidget::onChooseImage()
         return;
     }
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
     imageDialog->setImageType(image->imageType());
     imageDialog->setMovie(m_movie);

--- a/src/ui/movies/MovieWidget.cpp
+++ b/src/ui/movies/MovieWidget.cpp
@@ -1413,7 +1413,6 @@ void MovieWidget::onAddExtraFanart()
     // TODO: Don't use "this", because we don't want to inherit the stylesheet,
     //       but we can't pass "nullptr", because otherwise, there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
-    imageDialog->setImageType(ImageType::MovieExtraFanart);
     imageDialog->setMultiSelection(true);
     imageDialog->setMovie(m_movie);
     imageDialog->setDefaultDownloads(m_movie->images().backdrops());
@@ -1466,7 +1465,6 @@ void MovieWidget::onChooseImage()
     // TODO: Don't use "this", because we don't want to inherit the stylesheet,
     // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
-    imageDialog->setImageType(image->imageType());
     imageDialog->setMovie(m_movie);
     if (image->imageType() == ImageType::MoviePoster) {
         imageDialog->setDefaultDownloads(m_movie->images().posters());

--- a/src/ui/music/MusicFilesWidget.cpp
+++ b/src/ui/music/MusicFilesWidget.cpp
@@ -186,8 +186,8 @@ QVector<Album*> MusicFilesWidget::selectedAlbums()
 
 void MusicFilesWidget::multiScrape()
 {
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* scrapeWidget = new MusicMultiScrapeDialog(MainWindow::instance());
     scrapeWidget->setItems(selectedArtists(), selectedAlbums());
     scrapeWidget->exec();

--- a/src/ui/music/MusicWidgetAlbum.cpp
+++ b/src/ui/music/MusicWidgetAlbum.cpp
@@ -422,7 +422,6 @@ void MusicWidgetAlbum::onChooseImage()
     // TODO: Don't use "this", because we don't want to inherit the stylesheet,
     // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
-    imageDialog->setImageType(image->imageType());
     imageDialog->setAlbum(m_album);
 
     if (!m_album->images(image->imageType()).isEmpty()) {
@@ -595,7 +594,6 @@ void MusicWidgetAlbum::onAddBooklet()
     // TODO: Don't use "this", because we don't want to inherit the stylesheet,
     //       but we can't pass "nullptr", because otherwise, there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
-    imageDialog->setImageType(ImageType::AlbumBooklet);
     imageDialog->setMultiSelection(true);
     imageDialog->setAlbum(m_album);
 

--- a/src/ui/music/MusicWidgetAlbum.cpp
+++ b/src/ui/music/MusicWidgetAlbum.cpp
@@ -205,8 +205,8 @@ void MusicWidgetAlbum::onStartScraperSearch()
     emit sigSetActionSearchEnabled(false, MainWidgets::Music);
     emit sigSetActionSaveEnabled(false, MainWidgets::Music);
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* searchWidget = new MusicSearch(MainWindow::instance());
     searchWidget->execWithSearch("album",
         m_album->title(),
@@ -419,8 +419,8 @@ void MusicWidgetAlbum::onChooseImage()
         return;
     }
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
     imageDialog->setImageType(image->imageType());
     imageDialog->setAlbum(m_album);

--- a/src/ui/music/MusicWidgetArtist.cpp
+++ b/src/ui/music/MusicWidgetArtist.cpp
@@ -212,8 +212,8 @@ void MusicWidgetArtist::onStartScraperSearch()
     emit sigSetActionSearchEnabled(false, MainWidgets::Music);
     emit sigSetActionSaveEnabled(false, MainWidgets::Music);
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* searchWidget = new MusicSearch(MainWindow::instance());
     searchWidget->execWithSearch("artist", m_artist->name());
 
@@ -397,8 +397,8 @@ void MusicWidgetArtist::onChooseImage()
         return;
     }
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
     imageDialog->setImageType(image->imageType());
     imageDialog->setArtist(m_artist);
@@ -544,8 +544,8 @@ void MusicWidgetArtist::onAddExtraFanart()
         return;
     }
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
     imageDialog->setImageType(ImageType::ArtistExtraFanart);
     imageDialog->setMultiSelection(true);

--- a/src/ui/music/MusicWidgetArtist.cpp
+++ b/src/ui/music/MusicWidgetArtist.cpp
@@ -400,7 +400,6 @@ void MusicWidgetArtist::onChooseImage()
     // TODO: Don't use "this", because we don't want to inherit the stylesheet,
     // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
-    imageDialog->setImageType(image->imageType());
     imageDialog->setArtist(m_artist);
 
     if (!m_artist->images(image->imageType()).isEmpty()) {
@@ -547,7 +546,6 @@ void MusicWidgetArtist::onAddExtraFanart()
     // TODO: Don't use "this", because we don't want to inherit the stylesheet,
     // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
-    imageDialog->setImageType(ImageType::ArtistExtraFanart);
     imageDialog->setMultiSelection(true);
     imageDialog->setArtist(m_artist);
     imageDialog->setDefaultDownloads(m_artist->images(ImageType::ArtistFanart));

--- a/src/ui/tv_show/TvShowFilesWidget.cpp
+++ b/src/ui/tv_show/TvShowFilesWidget.cpp
@@ -716,8 +716,8 @@ void TvShowFilesWidget::multiScrape()
         return;
     }
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* scrapeWidget = new TvShowMultiScrapeDialog(shows, episodes, MainWindow::instance());
     const int result = scrapeWidget->exec();
     scrapeWidget->deleteLater();

--- a/src/ui/tv_show/TvShowWidgetEpisode.cpp
+++ b/src/ui/tv_show/TvShowWidgetEpisode.cpp
@@ -651,8 +651,8 @@ void TvShowWidgetEpisode::onStartScraperSearch()
     emit sigSetActionSearchEnabled(false, MainWidgets::TvShows);
     emit sigSetActionSaveEnabled(false, MainWidgets::TvShows);
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* searchWidget = new TvShowSearch(MainWindow::instance());
     searchWidget->setSearchType(TvShowType::Episode);
     searchWidget->execWithSearch(m_episode->showTitle());
@@ -719,8 +719,8 @@ void TvShowWidgetEpisode::onChooseThumbnail()
         return;
     }
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
     imageDialog->setImageType(ImageType::TvShowEpisodeThumb);
     imageDialog->setTvShowEpisode(m_episode);

--- a/src/ui/tv_show/TvShowWidgetEpisode.cpp
+++ b/src/ui/tv_show/TvShowWidgetEpisode.cpp
@@ -722,7 +722,6 @@ void TvShowWidgetEpisode::onChooseThumbnail()
     // TODO: Don't use "this", because we don't want to inherit the stylesheet,
     // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
-    imageDialog->setImageType(ImageType::TvShowEpisodeThumb);
     imageDialog->setTvShowEpisode(m_episode);
     QVector<Poster> posters;
     if (!m_episode->thumbnail().isEmpty()) {

--- a/src/ui/tv_show/TvShowWidgetSeason.cpp
+++ b/src/ui/tv_show/TvShowWidgetSeason.cpp
@@ -246,8 +246,8 @@ void TvShowWidgetSeason::onChooseImage()
         return;
     }
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
     imageDialog->setImageType(image->imageType());
     imageDialog->setTvShow(m_show);

--- a/src/ui/tv_show/TvShowWidgetSeason.cpp
+++ b/src/ui/tv_show/TvShowWidgetSeason.cpp
@@ -249,7 +249,6 @@ void TvShowWidgetSeason::onChooseImage()
     // TODO: Don't use "this", because we don't want to inherit the stylesheet,
     // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
-    imageDialog->setImageType(image->imageType());
     imageDialog->setTvShow(m_show);
     imageDialog->setSeason(m_season);
 

--- a/src/ui/tv_show/TvShowWidgetTvShow.cpp
+++ b/src/ui/tv_show/TvShowWidgetTvShow.cpp
@@ -477,8 +477,8 @@ void TvShowWidgetTvShow::onStartScraperSearch()
     emit sigSetActionSaveEnabled(false, MainWidgets::TvShows);
     emit sigSetActionSearchEnabled(false, MainWidgets::TvShows);
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* searchWidget = new TvShowSearch(MainWindow::instance());
     searchWidget->setSearchType(TvShowType::TvShow);
     searchWidget->execWithSearch(m_show->title());
@@ -1117,8 +1117,8 @@ void TvShowWidgetTvShow::onAddExtraFanart()
         return;
     }
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
     imageDialog->setImageType(ImageType::TvShowExtraFanart);
     imageDialog->setMultiSelection(true);
@@ -1165,8 +1165,8 @@ void TvShowWidgetTvShow::onDownloadTune()
         return;
     }
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* tvTunesDialog = new TvTunesDialog(*m_show, MainWindow::instance());
     tvTunesDialog->setAttribute(Qt::WA_DeleteOnClose);
     const int result = tvTunesDialog->exec();
@@ -1187,8 +1187,8 @@ void TvShowWidgetTvShow::onChooseImage()
         return;
     }
 
-    // TODO: Don't use "this", because we don't want to inherit the stylsheet,
-    // but we can't pass "nullptr", because otheriwse there won't be a modal.
+    // TODO: Don't use "this", because we don't want to inherit the stylesheet,
+    // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
     imageDialog->setImageType(image->imageType());
     imageDialog->setTvShow(m_show);

--- a/src/ui/tv_show/TvShowWidgetTvShow.cpp
+++ b/src/ui/tv_show/TvShowWidgetTvShow.cpp
@@ -1120,7 +1120,6 @@ void TvShowWidgetTvShow::onAddExtraFanart()
     // TODO: Don't use "this", because we don't want to inherit the stylesheet,
     // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
-    imageDialog->setImageType(ImageType::TvShowExtraFanart);
     imageDialog->setMultiSelection(true);
     imageDialog->setTvShow(m_show);
     imageDialog->setDefaultDownloads(m_show->backdrops());
@@ -1190,7 +1189,6 @@ void TvShowWidgetTvShow::onChooseImage()
     // TODO: Don't use "this", because we don't want to inherit the stylesheet,
     // but we can't pass "nullptr", because otherwise there won't be a modal.
     auto* imageDialog = new ImageDialog(MainWindow::instance());
-    imageDialog->setImageType(image->imageType());
     imageDialog->setTvShow(m_show);
     switch (image->imageType()) {
     case ImageType::TvShowPoster: imageDialog->setDefaultDownloads(m_show->posters()); break;


### PR DESCRIPTION
[](https://github.com/Komet/MediaElch/commit/cecaf56b723e806eec41ea1b2ccd53a9ef679f33)

The image dialog window is resized during `exec()`.  That, however,
does not immediately resize the image table.  That happens later, as
children's size is based on the parents size.  This has the effect,
that the column-calculation is based on a lower size than is being shown
to the user.  By postponing the calculation to the next event loop
iteration, we get a proper number of columns.

_Before_
![Screenshot_20230730_165048](https://github.com/Komet/MediaElch/assets/1667306/8e90076a-1f37-4eb3-ad16-dae18b4b9d05)


_After_
![Screenshot_20230730_164949](https://github.com/Komet/MediaElch/assets/1667306/94507440-9211-47e2-94ac-9d2d2e9b7085)

Fixes #1620

