### PR TITLE
fix(UI): Fix background of filter dropdown menu in dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Fixed
 
 - Movies: Opening and immediately closing the trailer search could crash MediaElch
+- UI:
+  - Dark Theme: The music file list (artist/album) is now readable (better colors)
+  - Dark Theme: The search/filter result list has explicit colors: they are now readable (#1629)
 
 ### Changed
 

--- a/docs/advancedsettings.xml
+++ b/docs/advancedsettings.xml
@@ -37,13 +37,6 @@
     <gui>
         <forceCache>false</forceCache>
         <!--
-            Either "light" (default) or "dark".  The dark theme only affects the
-            main window and is an early beta.  This entry will be replaced by a proper
-            option in MediaElch's settings window without notice, so only use this
-            for testing!
-        -->
-        <!--<theme>light</theme>-->
-        <!--
             If set, MediaElch will load this stylesheet instead of the bundled `light.css`.
             Only use this tag if you want to develop a custom MediaElch theme for the main window.
             Overrides <theme> above.

--- a/src/data/Filter.cpp
+++ b/src/data/Filter.cpp
@@ -79,20 +79,27 @@ Filter::Filter(QString text, QString shortText, QStringList filterText, bool has
  */
 bool Filter::accepts(QString text) const
 {
-    if (isInfo(MovieFilters::Title) || isInfo(MovieFilters::OriginalTitle)
-        || (isInfo(MovieFilters::ImdbId) && m_hasInfo) || (isInfo(MovieFilters::TmdbId) && m_hasInfo)
-        || isInfo(MovieFilters::Path) || isInfo(TvShowFilters::Title) || isInfo(ConcertFilters::Title)) {
+    if (isInfo(MovieFilters::Title) || isInfo(MovieFilters::OriginalTitle) || isInfo(MovieFilters::Path)
+        || isInfo(TvShowFilters::Title) || isInfo(ConcertFilters::Title)) {
         return true;
-    }
-    if (isInfo(MovieFilters::WikidataId) && text.startsWith("Q")) {
+
+    } else if (isInfo(MovieFilters::WikidataId) && text.startsWith("Q")) {
         return true;
-    }
-    for (const auto& filterText : m_filterText) {
-        if (filterText.startsWith(text, Qt::CaseInsensitive)) {
-            return true;
+
+    } else if (m_hasInfo && isInfo(MovieFilters::ImdbId) && ImdbId::isValidFormat(text)) {
+        return true;
+
+    } else if (m_hasInfo && isInfo(MovieFilters::TmdbId) && TmdbId::isValidFormat(text)) {
+        return true;
+
+    } else {
+        for (const auto& filterText : m_filterText) {
+            if (filterText.startsWith(text, Qt::CaseInsensitive)) {
+                return true;
+            }
         }
+        return false;
     }
-    return false;
 }
 
 /**

--- a/src/data/TmdbId.cpp
+++ b/src/data/TmdbId.cpp
@@ -36,8 +36,7 @@ QString TmdbId::withPrefix() const
 
 bool TmdbId::isValid() const
 {
-    static QRegularExpression rx("^\\d+$");
-    return rx.match(m_tmdbId).hasMatch();
+    return TmdbId::isValidFormat(m_tmdbId);
 }
 
 bool TmdbId::isValidPrefixedFormat(const QString& tmdbId)
@@ -45,7 +44,15 @@ bool TmdbId::isValidPrefixedFormat(const QString& tmdbId)
     static QRegularExpression rx("^tmdb\\d+$");
     QRegularExpressionMatch match = rx.match(tmdbId);
     // id is greater 0
-    return match.hasMatch() && tmdbId != "id0";
+    return match.hasMatch() && tmdbId != "tmdb0";
+}
+
+bool TmdbId::isValidFormat(const QString& tmdbId)
+{
+    static QRegularExpression rx("^(?:tmdb)?\\d+$");
+    QRegularExpressionMatch match = rx.match(tmdbId);
+    // id is greater 0
+    return match.hasMatch() && tmdbId != "0" && tmdbId != "tmdb0";
 }
 
 QString TmdbId::removePrefix(const QString& tmdbId)

--- a/src/data/TmdbId.h
+++ b/src/data/TmdbId.h
@@ -17,9 +17,14 @@ public:
     QString toString() const;
     QString withPrefix() const;
     bool isValid() const;
-    /// \brief Returns true if the given id has the common TheTvDb ID format.
-    /// \details A TheTvDb ID is valid if it starts with "id".
+
+    /// \brief   Returns true if the given id has the common TheTvDb ID format.
+    /// \details A TmdbId ID is valid if it starts with "tmdb".
     static bool isValidPrefixedFormat(const QString& tmdbId);
+    /// \brief   Returns true if the given id has a common TheTvDb ID format.
+    /// \details A TmdbId ID is valid if it starts with "tmdb", but this function
+    ///          accepts a number without the prefix as well..
+    static bool isValidFormat(const QString& tmdbId);
     static QString removePrefix(const QString& tmdbId);
 
     static const TmdbId NoId;

--- a/src/model/music/MusicModel.cpp
+++ b/src/model/music/MusicModel.cpp
@@ -49,26 +49,6 @@ QVariant MusicModel::data(const QModelIndex& index, int role) const
     if (role == MusicRoles::IsNew) {
         return item->data(role);
     }
-    if (role == Qt::ForegroundRole) {
-        if (item->data(MusicRoles::HasChanged).toBool()) {
-            return QColor(255, 0, 0);
-        }
-        return QColor(17, 51, 80);
-    }
-    if (role == Qt::FontRole) {
-        QFont font;
-        if (item->data(MusicRoles::HasChanged).toBool()) {
-            font.setItalic(true);
-        }
-        if (MusicType(item->data(MusicRoles::Type).toInt()) == MusicType::Artist) {
-            font.setBold(true);
-        } else {
-#ifdef Q_OS_MAC
-            font.setPointSize(font.pointSize() - 2);
-#endif
-        }
-        return font;
-    }
     if (role == Qt::SizeHintRole) {
 #ifdef Q_OS_WIN
         return QSize(0, 22);

--- a/src/ui/base.css
+++ b/src/ui/base.css
@@ -111,7 +111,8 @@
  */
 #centralWidget QTableWidget,
 #centralWidget QTableView,
-#centralWidget QTreeView {
+#centralWidget QTreeView,
+#centralWidget QListWidget {
     selection-background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 $table_selection_gradient_top, stop:1 $table_selection_gradient_bottom);
     alternate-background-color: $background_secondary_color;
     background-color: $background_primary_color;
@@ -121,12 +122,14 @@
 }
 #centralWidget QTableWidget::item,
 #centralWidget QTableView::item,
-#centralWidget QTreeView::item {
+#centralWidget QTreeView::item,
+#centralWidget QListWidget::item {
     color: $font_primary_color;
 }
 #centralWidget QTableWidget::item:selected,
 #centralWidget QTableView::item:selected,
-#centralWidget QTreeView::item:selected {
+#centralWidget QTreeView::item:selected,
+#centralWidget QListWidget::item:selected {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 $table_selection_gradient_top, stop:1 $table_selection_gradient_bottom);
     color: $table_selection_font_color;
 }
@@ -546,6 +549,10 @@ FilterWidget #lineEdit {
     border: none;
     background-color: transparent;
     border-bottom: 1px dotted $stroke_color;
+}
+
+#filterList {
+    border: 1px solid $stroke_contrast_color;
 }
 
 /*********************************************************

--- a/src/ui/dark.css
+++ b/src/ui/dark.css
@@ -111,7 +111,8 @@
  */
 #centralWidget QTableWidget,
 #centralWidget QTableView,
-#centralWidget QTreeView {
+#centralWidget QTreeView,
+#centralWidget QListWidget {
     selection-background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #4185b6, stop:1 #1b6aa5);
     alternate-background-color: #272c2f;
     background-color: #2c3135;
@@ -121,12 +122,14 @@
 }
 #centralWidget QTableWidget::item,
 #centralWidget QTableView::item,
-#centralWidget QTreeView::item {
+#centralWidget QTreeView::item,
+#centralWidget QListWidget::item {
     color: #EBEBEB;
 }
 #centralWidget QTableWidget::item:selected,
 #centralWidget QTableView::item:selected,
-#centralWidget QTreeView::item:selected {
+#centralWidget QTreeView::item:selected,
+#centralWidget QListWidget::item:selected {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #4185b6, stop:1 #1b6aa5);
     color: #EBEBEB;
 }
@@ -546,6 +549,10 @@ FilterWidget #lineEdit {
     border: none;
     background-color: transparent;
     border-bottom: 1px dotted #1E1E1E;
+}
+
+#filterList {
+    border: 1px solid #d8d8d8;
 }
 
 /*********************************************************

--- a/src/ui/light.css
+++ b/src/ui/light.css
@@ -111,7 +111,8 @@
  */
 #centralWidget QTableWidget,
 #centralWidget QTableView,
-#centralWidget QTreeView {
+#centralWidget QTreeView,
+#centralWidget QListWidget {
     selection-background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #4185b6, stop:1 #1b6aa5);
     alternate-background-color: #f9f9f9;
     background-color: #ffffff;
@@ -121,12 +122,14 @@
 }
 #centralWidget QTableWidget::item,
 #centralWidget QTableView::item,
-#centralWidget QTreeView::item {
+#centralWidget QTreeView::item,
+#centralWidget QListWidget::item {
     color: #27272f;
 }
 #centralWidget QTableWidget::item:selected,
 #centralWidget QTableView::item:selected,
-#centralWidget QTreeView::item:selected {
+#centralWidget QTreeView::item:selected,
+#centralWidget QListWidget::item:selected {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #4185b6, stop:1 #1b6aa5);
     color: #ffffff;
 }
@@ -546,6 +549,10 @@ FilterWidget #lineEdit {
     border: none;
     background-color: transparent;
     border-bottom: 1px dotted #ebebeb;
+}
+
+#filterList {
+    border: 1px solid #27272f;
 }
 
 /*********************************************************

--- a/src/ui/palette_dark.json
+++ b/src/ui/palette_dark.json
@@ -16,6 +16,7 @@
   "accent_color": "#f89b35",
   "accent_secondary_color": "#2093FE",
   "stroke_color": "#1E1E1E",
+  "stroke_contrast_color": "#d8d8d8",
   "button_font_color": "#595959",
   "radio_button_background_color": "#595959",
   "radio_button_background_checked_color": "#2093FE",

--- a/src/ui/palette_light.json
+++ b/src/ui/palette_light.json
@@ -16,6 +16,7 @@
   "accent_color": "#f89b35",
   "accent_secondary_color": "#43a9e4",
   "stroke_color": "#ebebeb",
+  "stroke_contrast_color": "#27272f",
   "button_font_color": "#ffffff",
   "radio_button_background_color": "#595959",
   "radio_button_background_checked_color": "#428BCA",

--- a/src/ui/small_widgets/FilterWidget.h
+++ b/src/ui/small_widgets/FilterWidget.h
@@ -3,7 +3,6 @@
 #include "data/Filter.h"
 #include "globals/Globals.h"
 
-#include <QKeyEvent>
 #include <QListWidget>
 #include <QWidget>
 
@@ -11,10 +10,8 @@ namespace Ui {
 class FilterWidget;
 }
 
-/**
- * \brief The FilterWidget class
- * This is the small input in the upper right
- */
+/// \brief   A widget for filtering files.
+/// \details This is the small input in the upper right corner of MediaElch.
 class FilterWidget : public QWidget
 {
     Q_OBJECT
@@ -25,8 +22,8 @@ public:
     void setActiveMainWidget(MainWidgets widget);
 
 signals:
-    void sigFilterTextChanged(QString);
-    void sigFilterChanged(QVector<Filter*>, QString);
+    void sigFilterTextChanged(QString filterText);
+    void sigFilterChanged(QVector<Filter*> filters, QString filterText);
 
 private slots:
     void onFilterTextChanged(QString text);
@@ -61,10 +58,10 @@ private:
 private:
     void clearTempFilterStore();
     void initAvailableFilters();
-    QVector<Filter*> setupMovieFilters();
-    QVector<Filter*> setupTvShowFilters();
-    QVector<Filter*> setupConcertFilters();
-    QVector<Filter*> setupMusicFilters();
+    ELCH_NODISCARD QVector<Filter*> setupMovieFilters();
+    ELCH_NODISCARD QVector<Filter*> setupTvShowFilters();
+    ELCH_NODISCARD QVector<Filter*> setupConcertFilters();
+    ELCH_NODISCARD QVector<Filter*> setupMusicFilters();
     void storeFilters(MainWidgets widget);
     void loadFilters(MainWidgets widget);
     void setupFilterListUi();

--- a/src/ui/small_widgets/MusicTreeView.h
+++ b/src/ui/small_widgets/MusicTreeView.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "model/music/MusicModelRoles.h"
+#include "utils/Meta.h"
 
 #include <QPainter>
+#include <QPixmap>
 #include <QTreeView>
 #include <QWidget>
 
@@ -18,26 +19,31 @@ protected:
     void drawRow(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
 
 private:
-    const int m_albumIndent{40};
-    const int m_branchIndent{30};
+    void drawBranches(QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QRect& rect,
+        const QModelIndex& index) const;
 
     void drawArtistRow(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const;
     void drawAlbumRow(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const;
+    void drawRowBackground(QPainter* painter, QStyleOptionViewItem opt, const QModelIndex& index) const;
 
-    int drawNewIcon(QPainter* painter,
+    /// \brief   Draw the "is new" icon.
+    /// \details On Windows image files are drawn whereas on mac and linux FontAwesome
+    ///          icons are used.
+    /// \return  Item indent, based on whether there is a "is new" icon or not.
+    ELCH_NODISCARD int drawNewIcon(QPainter* painter,
         const QStyleOptionViewItem& option,
         const QModelIndex& index,
+        bool isSelected,
         int branchIndent) const;
-    void setAlternateRowColors(QStyleOptionViewItem& option, const QModelIndex& index) const;
 
-    inline bool isAlbumRow(const QModelIndex& index) const
-    {
-        using namespace mediaelch;
-        return MusicType(index.data(MusicRoles::Type).toInt()) == MusicType::Album;
-    }
-    inline bool isArtistRow(const QModelIndex& index) const
-    {
-        using namespace mediaelch;
-        return MusicType(index.data(MusicRoles::Type).toInt()) == MusicType::Artist;
-    }
+    ELCH_NODISCARD bool isAlbumRow(const QModelIndex& index) const;
+    ELCH_NODISCARD bool isArtistRow(const QModelIndex& index) const;
+
+private:
+    const QPixmap m_newIcon;
+
+    const int m_albumIndent{40};
+    const int m_branchIndent{30};
 };

--- a/src/ui/small_widgets/TvShowTreeView.cpp
+++ b/src/ui/small_widgets/TvShowTreeView.cpp
@@ -62,7 +62,6 @@ void TvShowTreeView::drawRow(QPainter* painter, const QStyleOptionViewItem& opti
         opt.state |= QStyle::State_Selected;
     }
 
-
     // Draw Background
     drawRowBackground(painter, opt, index);
 
@@ -98,32 +97,16 @@ void TvShowTreeView::drawTvShowRow(QPainter* painter,
     drawBranches(painter, opt, branches, index);
 
     const int rowPadding = 4;
-    int textRowHeight = (option.rect.height() - 2 * rowPadding) / 2;
+    const int itemIndent = m_branchIndent + drawNewIcon(painter, option, index, isSelected, m_branchIndent);
 
-    int itemIndent = 0;
-    if (index.data(TvShowRoles::IsNew).toBool()) {
-        itemIndent = 20;
-        // On Windows image files are drawn whereas on mac and linux FontAwesome icons are used.
-#ifdef Q_OS_WIN
-        QRect iconRect(option.rect.x() + m_branchIndent, option.rect.y(), itemIndent - 6, option.rect.height());
-        painter->drawPixmap(iconRect.x() + (iconRect.width() - m_newIcon.width()) / 2,
-            iconRect.y() + (iconRect.height() - m_newIcon.height()) / 2,
-            m_newIcon);
-#else
-        QRect iconRect(option.rect.x() + m_branchIndent, option.rect.y(), itemIndent - 6, option.rect.height());
-        int drawSize = qRound(iconRect.width() * 1.0);
-        painter->setPen(isSelected ? QColor(255, 255, 255) : QColor(58, 135, 173));
-        painter->setFont(Manager::instance()->iconFont()->font(drawSize));
-        painter->drawText(iconRect, QString(QChar(icon_star)), QTextOption(Qt::AlignCenter | Qt::AlignVCenter));
-#endif
-    }
+    const int textRowHeight = (option.rect.height() - 2 * rowPadding) / 2;
+    const int textRowWidth = option.rect.width() - itemIndent;
+    const int posX = option.rect.x() + itemIndent;
+    const int posY = option.rect.y() + rowPadding;
 
-    QRect showRect(option.rect.x() + m_branchIndent + itemIndent,
-        option.rect.y() + rowPadding + 1,
-        option.rect.width() - m_branchIndent - itemIndent,
-        textRowHeight);
-    QRect episodesRect(option.rect.x() + m_branchIndent + itemIndent,
-        option.rect.y() + textRowHeight + rowPadding,
+    QRect showRect(posX, posY + 1, textRowWidth, textRowHeight);
+    QRect episodesRect(posX, //
+        posY + textRowHeight,
         header()->sectionSize(0) - m_branchIndent - itemIndent,
         textRowHeight);
 
@@ -198,23 +181,7 @@ void TvShowTreeView::drawEpisodeRow(QPainter* painter,
         itemIndent += 20;
     }
 
-    // On Windows image files are drawn whereas on mac and linux FontAwesome icons are used.
-
-    if (index.data(TvShowRoles::IsNew).toBool()) {
-#ifdef Q_OS_WIN
-        QRect iconRect(option.rect.x() + itemIndent, option.rect.y(), 18, option.rect.height());
-        painter->drawPixmap(iconRect.x() + (iconRect.width() - m_newIcon.width()) / 2,
-            iconRect.y() + (iconRect.height() - m_newIcon.height()) / 2,
-            m_newIcon);
-#else
-        QRect iconRect(option.rect.x() + itemIndent, option.rect.y(), 14, option.rect.height());
-        int drawSize = qRound(iconRect.width() * 1.0);
-        painter->setPen(isSelected ? QColor(255, 255, 255) : QColor(58, 135, 173));
-        painter->setFont(Manager::instance()->iconFont()->font(drawSize));
-        painter->drawText(iconRect, QString(QChar(icon_star)), QTextOption(Qt::AlignCenter | Qt::AlignVCenter));
-#endif
-        itemIndent += 20;
-    }
+    itemIndent += drawNewIcon(painter, option, index, isSelected, itemIndent);
 
     if (index.data(TvShowRoles::SyncNeeded).toBool()) {
 #ifdef Q_OS_WIN
@@ -277,6 +244,32 @@ void TvShowTreeView::drawRowBackground(QPainter* painter, QStyleOptionViewItem o
     // On Linux/Windows, PE_PanelItemViewRow does not draw selection backgrounds.
     style()->drawPrimitive(QStyle::PE_PanelItemViewItem, &opt, painter, this);
 #endif
+}
+
+int TvShowTreeView::drawNewIcon(QPainter* painter,
+    const QStyleOptionViewItem& option,
+    const QModelIndex& index,
+    bool isSelected,
+    int branchIndent) const
+{
+    if (index.data(TvShowRoles::IsNew).toBool()) {
+#ifdef Q_OS_WIN
+        QRect iconRect(option.rect.x() + branchIndent, option.rect.y(), 18, option.rect.height());
+        painter->drawPixmap(iconRect.x() + (iconRect.width() - m_newIcon.width()) / 2,
+            iconRect.y() + (iconRect.height() - m_newIcon.height()) / 2,
+            m_newIcon);
+#else
+        QRect iconRect(option.rect.x() + branchIndent, option.rect.y(), 14, option.rect.height());
+        int drawSize = qRound(iconRect.width() * 1.0);
+        painter->setPen(isSelected ? QColor(255, 255, 255) : QColor(58, 135, 173));
+        painter->setFont(Manager::instance()->iconFont()->font(drawSize));
+        painter->drawText(iconRect, QString(QChar(icon_star)), QTextOption(Qt::AlignCenter | Qt::AlignVCenter));
+#endif
+        return 20;
+
+    } else {
+        return 0;
+    }
 }
 
 bool TvShowTreeView::isShowRow(const QModelIndex& index) const

--- a/src/ui/small_widgets/TvShowTreeView.h
+++ b/src/ui/small_widgets/TvShowTreeView.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "utils/Meta.h"
+
 #include <QPainter>
 #include <QPixmap>
 #include <QTreeView>
@@ -27,15 +29,26 @@ private:
     void drawEpisodeRow(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const;
     void drawRowBackground(QPainter* painter, QStyleOptionViewItem opt, const QModelIndex& index) const;
 
-    bool isShowRow(const QModelIndex& index) const;
-    bool isSeasonRow(const QModelIndex& index) const;
-    bool isEpisodeRow(const QModelIndex& index) const;
+    /// \brief   Draw the "is new" icon.
+    /// \details On Windows image files are drawn whereas on mac and linux FontAwesome
+    ///          icons are used.
+    /// \return  Item indent, based on whether there is a "is new" icon or not.
+    ELCH_NODISCARD int drawNewIcon(QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index,
+        bool isSelected,
+        int branchIndent) const;
 
+    ELCH_NODISCARD bool isShowRow(const QModelIndex& index) const;
+    ELCH_NODISCARD bool isSeasonRow(const QModelIndex& index) const;
+    ELCH_NODISCARD bool isEpisodeRow(const QModelIndex& index) const;
+
+private:
     const QPixmap m_newIcon;
     const QPixmap m_syncIcon;
     const QPixmap m_missingIcon;
 
-    const int m_seasonIndent = 30;
-    const int m_episodeIndent = 50;
-    const int m_branchIndent = 30;
+    const int m_seasonIndent{30};
+    const int m_episodeIndent{50};
+    const int m_branchIndent{30};
 };

--- a/test/unit/data/testTmdbId.cpp
+++ b/test/unit/data/testTmdbId.cpp
@@ -4,7 +4,7 @@
 
 #include <sstream>
 
-TEST_CASE("TmdbId data type", "[data]")
+TEST_CASE("TmdbId data type", "[data][tmdb]")
 {
     SECTION("Default Case")
     {
@@ -18,7 +18,11 @@ TEST_CASE("TmdbId data type", "[data]")
     {
         CHECK_FALSE(TmdbId().isValid());
         CHECK_FALSE(TmdbId("").isValid());
+        CHECK_FALSE(TmdbId("0").isValid());
+        CHECK_FALSE(TmdbId("tmdb0").isValid());
+        CHECK_FALSE(TmdbId("id123").isValid());
 
+        CHECK(TmdbId("tmdb262504").isValid());
         CHECK(TmdbId("262504").isValid());
     }
 


### PR DESCRIPTION
Fix #1629

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

![Screenshot_20230806_124343](https://github.com/Komet/MediaElch/assets/1667306/792df6f8-9f7a-4a57-9a10-4beab3f69ee0)


</td>
<td>

![Screenshot_20230806_124240](https://github.com/Komet/MediaElch/assets/1667306/596ef074-50fd-4579-95a6-20c771332de6)

</td>
</tr>

<tr>
<td>

![Screenshot_20230806_133633](https://github.com/Komet/MediaElch/assets/1667306/8abdf179-efb7-48a2-964c-9d10c8ec657b)

</td>
<td>

![Screenshot_20230806_133255](https://github.com/Komet/MediaElch/assets/1667306/1a2ad008-72b4-49d3-be00-2750ced7eab5)

</td>
</tr>

<tr>
<td>

![Screenshot_20230806_133534](https://github.com/Komet/MediaElch/assets/1667306/d7eaac47-46c6-4a81-afd2-d713837bf1a3)

</td>
<td>

![Screenshot_20230806_133417](https://github.com/Komet/MediaElch/assets/1667306/c31e3c4a-e734-43c2-8e27-7d50f32a9964)

</td>
</tr>
</table>