### PR TITLE
feat(ImageDialog): Sort images (e.g. fanart.tv) by preferred locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Changed
 
-- tbd
+- Image Dialog: Images downloaded from fanart.tv are now sorted by preferred language, if set (#1619)
 
 ### Removed
 

--- a/src/ui/image/ImageDialog.h
+++ b/src/ui/image/ImageDialog.h
@@ -130,7 +130,7 @@ private:
     Album* m_album{nullptr};
 
 private:
-    void setAndStartDownloads(QVector<Poster> downloads);
+    void setAndStartDownloads(const QVector<Poster>& downloads);
 
     mediaelch::network::NetworkManager* network();
     void setupProviderCombo();


### PR DESCRIPTION
The image dialog, when downloading images, now sorts the list of images by preferred language before downloading if available.

---

Fix #1619