### PR TITLE
fix(Music): Don't require Discogs to load if there is no link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - UI:
   - Dark Theme: The music file list (artist/album) is now readable (better colors)
   - Dark Theme: The search/filter result list has explicit colors: they are now readable (#1629)
+- UniversalMusicScraper: If an artist has no Discogs link on MusicBrainz, MediaElch was stuck.
 
 ### Changed
 

--- a/src/scrapers/music/UniversalMusicScraper.cpp
+++ b/src/scrapers/music/UniversalMusicScraper.cpp
@@ -179,6 +179,8 @@ void UniversalArtistScrapeJob::doStart()
                 checkIfFinished();
             });
             discogsJob->start();
+        } else {
+            m_discogsFinished = true;
         }
 
         for (const DownloadElement& elem : asConst(m_artistDownloads)) {
@@ -351,6 +353,8 @@ void UniversalAlbumScrapeJob::doStart()
                 checkIfFinished();
             });
             discogsJob->start();
+        } else {
+            m_discogsFinished = true;
         }
 
         for (const DownloadElement& elem : asConst(m_albumDownloads)) {

--- a/test/resources/scrapers/universalmusicscraper/bad-habit.ref.txt
+++ b/test/resources/scrapers/universalmusicscraper/bad-habit.ref.txt
@@ -1,0 +1,17 @@
+Artist Reference File
+----------------------
+
+mbId: fe2897f1-a391-41d6-b0e2-f15261be0c69
+allMusicId: 
+name: 
+biography: 
+discography: (N=0)
+genres: (N=0)
+styles: (N=0)
+moods: (N=0)
+yearsActive: 
+formed: 
+born: 
+died: 
+disbanded: 
+extraFanarts: (N=0)

--- a/test/resources/scrapers/universalmusicscraper/metallica.ref.txt
+++ b/test/resources/scrapers/universalmusicscraper/metallica.ref.txt
@@ -107,8 +107,6 @@ discography: (N>100)
     year: 1990
   - title: Stone Cold Crazy
     year: 1990
-  - title: Creeping Death
-    year: 1990
   - title: Enter Sandman / Calling Elvis
     year: 1991
   - title: Shining Star / The Unforgiven
@@ -128,8 +126,6 @@ discography: (N>100)
   - title: Virgin Megastore Box Set
     year: 1992
   - title: Nothing Else Matters / Remedy
-    year: 1992
-  - title: Live At Wembley Stadium London April 20th 1992
     year: 1992
   - title: A Year And A Half In The Life Of ... Continued (Part 2)
     year: 1992
@@ -172,8 +168,6 @@ discography: (N>100)
   - title: Interview Picture Disc And Fully Illustrated Book
     year: 1996
   - title: Pro-1
-    year: 1996
-  - title: Until It Sleeps
     year: 1996
   - title: Fan Can 1
     year: 1996
@@ -250,6 +244,12 @@ discography: (N>100)
   - title: Did Die My Darling / I Finally Found My Way
     year: 1999
   - title: "S & M" Concert Special
+    year: 1999
+  - title: S & M Documentary
+    year: 1999
+  - title:  "S & M"  - Interview
+    year: 1999
+  - title: In The Studio "Load / Reload"
     year: 1999
 genres: (N=1)
   - Pop/Rock

--- a/test/scrapers/universalmusicscraper/testUniversalMusicScraper.cpp
+++ b/test/scrapers/universalmusicscraper/testUniversalMusicScraper.cpp
@@ -112,4 +112,17 @@ TEST_CASE("UniversalMusicScraper loads correct details", "[music][UniversalMusic
         REQUIRE(album.title() == "Master of Puppets");
         test::scraper::compareAgainstReference(album, "scrapers/universalmusicscraper/master-of-puppets");
     }
+
+    SECTION("Load Artist for which there are not MusicBrainz links")
+    {
+        QEventLoop loop;
+        Artist artist;
+        UniversalMusicScraper scraper;
+        QEventLoop::connect(artist.controller(), &ArtistController::sigLoadDone, &loop, &QEventLoop::quit);
+        MusicBrainzId badHabit("fe2897f1-a391-41d6-b0e2-f15261be0c69");
+        artist.controller()->loadData(badHabit, &scraper, noImages);
+        loop.exec();
+
+        test::scraper::compareAgainstReference(artist, "scrapers/universalmusicscraper/bad-habit");
+    }
 }


### PR DESCRIPTION
If MusicBrainz has no Discogs link, don't wait for it to load - it will never happen.