### PR TITLE
fix(TMDB): Ignore empty certifications for a given language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 ### Changed
 
 - Image Dialog: Images downloaded from fanart.tv are now sorted by preferred language, if set (#1619)
+- TMDB: API queries now set a "region" based on the selected language.
+  For example, the country's release date will be used.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@
 ### Changed
 
 - Image Dialog: Images downloaded from fanart.tv are now sorted by preferred language, if set (#1619)
-- TMDB: API queries now set a "region" based on the selected language.
-  For example, the country's release date will be used.
+- TMDB:
+  - API queries now set a "region" based on the selected language.
+    For example, the country's release date will be used.
+  - If a movie has more than one certification in a given language, we sometimes accidentally
+    ignored the selected language if TMDB has an empty certification for it (#1641)
 
 ### Removed
 

--- a/src/model/music/MusicModel.cpp
+++ b/src/model/music/MusicModel.cpp
@@ -4,8 +4,7 @@
 #include "globals/Helper.h"
 #include "model/music/MusicModelRoles.h"
 
-MusicModel::MusicModel(QObject* parent) :
-    QAbstractItemModel(parent), m_rootItem{new MusicModelItem(nullptr)}
+MusicModel::MusicModel(QObject* parent) : QAbstractItemModel(parent), m_rootItem{new MusicModelItem(nullptr)}
 {
 }
 

--- a/src/scrapers/movie/tmdb/TmdbMovieScrapeJob.cpp
+++ b/src/scrapers/movie/tmdb/TmdbMovieScrapeJob.cpp
@@ -347,16 +347,18 @@ void TmdbMovieScrapeJob::parseAndAssignInfos(const QJsonDocument& json)
         const auto countries = parsedJson.value("countries").toArray();
         for (const auto& it : countries) {
             const auto countryObj = it.toObject();
-            const QString iso3166 = countryObj.value("iso_3166_1").toString();
             const Certification certification = Certification(countryObj.value("certification").toString());
-            if (iso3166 == "US") {
-                us = certification;
-            }
-            if (iso3166 == "GB") {
-                gb = certification;
-            }
-            if (iso3166.toUpper() == config().locale.country()) {
-                locale = certification;
+            if (certification.isValid()) {
+                const QString iso3166 = countryObj.value("iso_3166_1").toString();
+                if (iso3166 == "US") {
+                    us = certification;
+                }
+                if (iso3166 == "GB") {
+                    gb = certification;
+                }
+                if (iso3166.toUpper() == config().locale.country()) {
+                    locale = certification;
+                }
             }
         }
 

--- a/src/scrapers/tmdb/TmdbApi.cpp
+++ b/src/scrapers/tmdb/TmdbApi.cpp
@@ -266,6 +266,7 @@ QUrl TmdbApi::getMovieUrl(QString movieId,
         case ApiMovieDetails::IMAGES: return QStringLiteral("/images");
         case ApiMovieDetails::CASTS: return QStringLiteral("/casts");
         case ApiMovieDetails::TRAILERS: return QStringLiteral("/trailers");
+        // Old version of /release_dates
         case ApiMovieDetails::RELEASES: return QStringLiteral("/releases");
         }
         return QString{};

--- a/src/scrapers/tmdb/TmdbApi.cpp
+++ b/src/scrapers/tmdb/TmdbApi.cpp
@@ -142,6 +142,10 @@ QUrl TmdbApi::makeApiUrl(const QString& suffix, const Locale& locale, QUrlQuery 
 {
     query.addQueryItem("api_key", TmdbApi::apiKey());
     query.addQueryItem("language", locale.toString('-'));
+    if (locale.hasCountry()) {
+        // See https://developer.themoviedb.org/docs/region-support
+        query.addQueryItem("region", locale.country());
+    }
 
     return QStringLiteral("https://api.themoviedb.org/3%1?%2").arg(suffix, query.toString());
 }

--- a/test/resources/scrapers/tmdb/Finding_Dory_tmdb127380.ref.txt
+++ b/test/resources/scrapers/tmdb/Finding_Dory_tmdb127380.ref.txt
@@ -66,7 +66,7 @@ actors: (N>30)
  - id: 
    name: Ty Burrell
    role: Bailey (voice)
-   thumb: http://image.tmdb.org/t/p/original/1bO1J5d1WbwTXWmGeRthfZVDfjN.jpg
+   thumb: http://image.tmdb.org/t/p/original/zXrrbvW2ZKHYHbhujDj8aBlO4yx.jpg
    order: 6
    imageHasChanged: false
  - id: 
@@ -138,7 +138,7 @@ actors: (N>30)
  - id: 
    name: John Ratzenberger
    role: Husband Crab (Bill) (voice)
-   thumb: http://image.tmdb.org/t/p/original/oRtDEOuIO1yDhTz5dORBdxXuLMO.jpg
+   thumb: http://image.tmdb.org/t/p/original/e5aNU09v1q6WYTx9pNzC7yjSpve.jpg
    order: 18
    imageHasChanged: false
  - id: 
@@ -160,7 +160,7 @@ countries: (N=1)
 studios: (N<6)
   - Pixar
   - Walt Disney Pictures
-trailer: https://www.youtube.com/watch?v=iG0P6bjyUNI
+trailer: https://www.youtube.com/watch?v=JhvrQeY3doI
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>
@@ -172,7 +172,7 @@ subtitles: (N=0)
 fileLastModified: <not set or invalid>
 files: (N=0)
 folderName: 
-posters: (N>20)
+posters: (N>30)
   - id: 
     originalUrl: http://image.tmdb.org/t/p/original/3UVe8NL1E2ZdUZ9EDlKGJY5UzE.jpg
     thumbUrl: http://image.tmdb.org/t/p/w342/3UVe8NL1E2ZdUZ9EDlKGJY5UzE.jpg
@@ -214,10 +214,18 @@ posters: (N>20)
     aspect: 
     season: SeasonNumber=xx
   - ... and >20 more
-backdrops: (N>10)
+backdrops: (N>20)
   - id: 
     originalUrl: http://image.tmdb.org/t/p/original/8yYuFjRsozwOckhAaTHRLTiDwml.jpg
     thumbUrl: http://image.tmdb.org/t/p/w780/8yYuFjRsozwOckhAaTHRLTiDwml.jpg
+    originalSize: h=2160 w=3840
+    language: 
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
+  - id: 
+    originalUrl: http://image.tmdb.org/t/p/original/o11rDwFa7nZMVI57Mm3C44YwmmF.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w780/o11rDwFa7nZMVI57Mm3C44YwmmF.jpg
     originalSize: h=2160 w=3840
     language: 
     hint: 
@@ -243,14 +251,6 @@ backdrops: (N>10)
     originalUrl: http://image.tmdb.org/t/p/original/2iU2IcwBJbuZo2umfU2amO3FqCi.jpg
     thumbUrl: http://image.tmdb.org/t/p/w780/2iU2IcwBJbuZo2umfU2amO3FqCi.jpg
     originalSize: h=2160 w=3840
-    language: 
-    hint: 
-    aspect: 
-    season: SeasonNumber=xx
-  - id: 
-    originalUrl: http://image.tmdb.org/t/p/original/fYHWIo5OPVBjpqDcHf9EcbtZO0G.jpg
-    thumbUrl: http://image.tmdb.org/t/p/w780/fYHWIo5OPVBjpqDcHf9EcbtZO0G.jpg
-    originalSize: h=1080 w=1920
     language: 
     hint: 
     aspect: 

--- a/test/resources/scrapers/tmdb/Finding_Dory_tt2277860.ref.txt
+++ b/test/resources/scrapers/tmdb/Finding_Dory_tt2277860.ref.txt
@@ -66,7 +66,7 @@ actors: (N>30)
  - id: 
    name: Ty Burrell
    role: Bailey (voice)
-   thumb: http://image.tmdb.org/t/p/original/1bO1J5d1WbwTXWmGeRthfZVDfjN.jpg
+   thumb: http://image.tmdb.org/t/p/original/zXrrbvW2ZKHYHbhujDj8aBlO4yx.jpg
    order: 6
    imageHasChanged: false
  - id: 
@@ -138,7 +138,7 @@ actors: (N>30)
  - id: 
    name: John Ratzenberger
    role: Husband Crab (Bill) (voice)
-   thumb: http://image.tmdb.org/t/p/original/oRtDEOuIO1yDhTz5dORBdxXuLMO.jpg
+   thumb: http://image.tmdb.org/t/p/original/e5aNU09v1q6WYTx9pNzC7yjSpve.jpg
    order: 18
    imageHasChanged: false
  - id: 
@@ -160,7 +160,7 @@ countries: (N=1)
 studios: (N<6)
   - Pixar
   - Walt Disney Pictures
-trailer: https://www.youtube.com/watch?v=iG0P6bjyUNI
+trailer: https://www.youtube.com/watch?v=JhvrQeY3doI
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>
@@ -172,7 +172,7 @@ subtitles: (N=0)
 fileLastModified: <not set or invalid>
 files: (N=0)
 folderName: 
-posters: (N>20)
+posters: (N>30)
   - id: 
     originalUrl: http://image.tmdb.org/t/p/original/3UVe8NL1E2ZdUZ9EDlKGJY5UzE.jpg
     thumbUrl: http://image.tmdb.org/t/p/w342/3UVe8NL1E2ZdUZ9EDlKGJY5UzE.jpg
@@ -214,10 +214,18 @@ posters: (N>20)
     aspect: 
     season: SeasonNumber=xx
   - ... and >20 more
-backdrops: (N>10)
+backdrops: (N>20)
   - id: 
     originalUrl: http://image.tmdb.org/t/p/original/8yYuFjRsozwOckhAaTHRLTiDwml.jpg
     thumbUrl: http://image.tmdb.org/t/p/w780/8yYuFjRsozwOckhAaTHRLTiDwml.jpg
+    originalSize: h=2160 w=3840
+    language: 
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
+  - id: 
+    originalUrl: http://image.tmdb.org/t/p/original/o11rDwFa7nZMVI57Mm3C44YwmmF.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w780/o11rDwFa7nZMVI57Mm3C44YwmmF.jpg
     originalSize: h=2160 w=3840
     language: 
     hint: 
@@ -243,14 +251,6 @@ backdrops: (N>10)
     originalUrl: http://image.tmdb.org/t/p/original/2iU2IcwBJbuZo2umfU2amO3FqCi.jpg
     thumbUrl: http://image.tmdb.org/t/p/w780/2iU2IcwBJbuZo2umfU2amO3FqCi.jpg
     originalSize: h=2160 w=3840
-    language: 
-    hint: 
-    aspect: 
-    season: SeasonNumber=xx
-  - id: 
-    originalUrl: http://image.tmdb.org/t/p/original/fYHWIo5OPVBjpqDcHf9EcbtZO0G.jpg
-    thumbUrl: http://image.tmdb.org/t/p/w780/fYHWIo5OPVBjpqDcHf9EcbtZO0G.jpg
-    originalSize: h=1080 w=1920
     language: 
     hint: 
     aspect: 

--- a/test/resources/scrapers/tmdb/The_Rescuers_de-DE_tmdb11319.ref.txt
+++ b/test/resources/scrapers/tmdb/The_Rescuers_de-DE_tmdb11319.ref.txt
@@ -1,0 +1,258 @@
+Movie Reference File
+----------------------
+
+imdbId: tt0076618
+tmdbId: 11319
+wikidataId: 
+mediaCenterId: -1
+title: Bernard & Bianca - Die Mäusepolizei
+sortTitle: 
+originalTitle: The Rescuers
+overview:
+    Die Vollwaise Penny wird von der bösen Madame Medusa entführt. Mit Hilfe des Mäd
+    chens plant die gierige Alte, in den Besitz des größten Diamanten der Welt zu ge
+    langen. Penny schafft es jedoch, eine Flaschenpost abzuschicken. Als die abenteu
+    erlustige Artgenossin Bianca von dem Hilferuf erfährt, entschließt sie sich, das
+     Kind zu retten. Zusammen mit dem verschmitzten Mäuse-Hausmeister Bernard und de
+    m unbeholfenen Albatros Orville sucht sie Medusas Versteck auf.
+outline: 
+movie set: tmdbid=57971 | name=Bernard & Bianca Filmreihe
+movie set overview: Disney Filmreihe mit Bernard &amp; Bianca
+tagline:
+    Zwei kleine Agenten gegen die böseste Frau der Welt in einem umwerfenden Animati
+    onsabenteuer!
+ratings (N=1)
+  source=themoviedb | rating=6.6 | votes=2000 | min=0 | max=10
+userRating: 0
+imdbTop250: 0
+released: 1977-06-22
+runtime: 78min
+writer:
+    Larry Clemmons, Ken Anderson, Vance Gerry, Burny Mattinson, David Michener, Fran
+    k Thomas, Ted Berman, Margery Sharp, Fred Lucky, Dick Sebast
+director: John Lounsbery
+actors: (N>10)
+ - id: 
+   name: Bob Newhart
+   role: Bernard (voice)
+   thumb: http://image.tmdb.org/t/p/original/kOyxzZMzbCcXMddD17F8S33I3ZU.jpg
+   order: 0
+   imageHasChanged: false
+ - id: 
+   name: Eva Gabor
+   role: Miss Bianca (voice)
+   thumb: http://image.tmdb.org/t/p/original/eCmr6otRLtOPDA6VwEN2KYaALjg.jpg
+   order: 1
+   imageHasChanged: false
+ - id: 
+   name: Geraldine Page
+   role: Madame Medusa (voice)
+   thumb: http://image.tmdb.org/t/p/original/j4MIWqbktbtFIGEz3DvB47gDnWB.jpg
+   order: 2
+   imageHasChanged: false
+ - id: 
+   name: Joe Flynn
+   role: Mr. Snoops (voice)
+   thumb: http://image.tmdb.org/t/p/original/km1TY2ieAp51uKLDBNUEANvUmaq.jpg
+   order: 3
+   imageHasChanged: false
+ - id: 
+   name: Jeanette Nolan
+   role: Ellie Mae (voice)
+   thumb: http://image.tmdb.org/t/p/original/wb9G3heeItXTpXqPy4HlNDMJWrE.jpg
+   order: 4
+   imageHasChanged: false
+ - id: 
+   name: Pat Buttram
+   role: Luke (voice)
+   thumb: http://image.tmdb.org/t/p/original/jRVB0shCimyljcDYlIUpdcAVe8E.jpg
+   order: 5
+   imageHasChanged: false
+ - id: 
+   name: Jim Jordan
+   role: Orville (voice)
+   thumb: http://image.tmdb.org/t/p/original/gNupv2JEfBWfZVISoWP6q3cw4TT.jpg
+   order: 6
+   imageHasChanged: false
+ - id: 
+   name: John McIntire
+   role: Rufus (voice)
+   thumb: http://image.tmdb.org/t/p/original/knjm7tflaLTysmynYUnvJgv5wIq.jpg
+   order: 7
+   imageHasChanged: false
+ - id: 
+   name: Michelle Stacy
+   role: Penny (voice)
+   thumb: http://image.tmdb.org/t/p/original/9C46LewFGCokeMpl0dJhMNaaIsm.jpg
+   order: 8
+   imageHasChanged: false
+ - id: 
+   name: Bernard Fox
+   role: The Chairman (voice)
+   thumb: http://image.tmdb.org/t/p/original/7eSBf5vDFSAJJv8VxR0VfyXajkR.jpg
+   order: 9
+   imageHasChanged: false
+ - id: 
+   name: Larry Clemmons
+   role: Gramps (voice)
+   thumb: 
+   order: 10
+   imageHasChanged: false
+ - id: 
+   name: James MacDonald
+   role: Evinrude / Brutus / Nero (voice)
+   thumb: http://image.tmdb.org/t/p/original/qf3IMvOrc39jKz6Bddtv4Ur2ski.jpg
+   order: 11
+   imageHasChanged: false
+ - id: 
+   name: George Lindsey
+   role: Rabbit (voice)
+   thumb: http://image.tmdb.org/t/p/original/nWUSieNbrvClvbB8b03OU4dBfTY.jpg
+   order: 12
+   imageHasChanged: false
+ - id: 
+   name: Bill McMillian
+   role: TV Announcer (voice)
+   thumb: 
+   order: 13
+   imageHasChanged: false
+ - id: 
+   name: Dub Taylor
+   role: Digger (voice)
+   thumb: http://image.tmdb.org/t/p/original/ip23tIc5UhSfWdKpsNKay1wUJie.jpg
+   order: 14
+   imageHasChanged: false
+ - id: 
+   name: John Fiedler
+   role: Owl (voice)
+   thumb: http://image.tmdb.org/t/p/original/6vfLLGeGuO6Ko0VRnyhgE2v6RUu.jpg
+   order: 15
+   imageHasChanged: false
+ - id: 
+   name: Robie Lester
+   role: Miss Bianca (singing voice, uncredited)
+   thumb: http://image.tmdb.org/t/p/original/9vufbx16YYXgRXATeGJIS97a9GB.jpg
+   order: 16
+   imageHasChanged: false
+ - id: 
+   name: Mel Blanc
+   role: Bats (voice) (uncredited)
+   thumb: http://image.tmdb.org/t/p/original/8fevv4K06TmHsYom2XfmxgKrTcd.jpg
+   order: 17
+   imageHasChanged: false
+ - id: 
+   name: Peter Renaday
+   role: American Deligate (voice) (uncredited)
+   thumb: http://image.tmdb.org/t/p/original/dzigC811W3TRz6RJDKH4fXXrQs.jpg
+   order: 18
+   imageHasChanged: false
+certification: 0
+genres: (N<6)
+  - Fantasy
+  - Familie
+  - Animation
+  - Abenteuer
+tags: (N=0)
+countries: (N=1)
+  - United States of America
+studios: (N=1)
+  - Walt Disney Productions
+trailer: https://www.youtube.com/watch?v=9d3At0Zng3k
+playcount: 0
+lastPlayed: <not set or invalid>
+dateAdded: <not set or invalid>
+discType: Single
+color label: 0
+resumeTime: position=0 / total=0
+streamDetails: <nullptr>
+subtitles: (N=0)
+fileLastModified: <not set or invalid>
+files: (N=0)
+folderName: 
+posters: (N>30)
+  - id: 
+    originalUrl: http://image.tmdb.org/t/p/original/5CsR8E8rwNDfzzzaoamjbzoWnNI.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w342/5CsR8E8rwNDfzzzaoamjbzoWnNI.jpg
+    originalSize: h=3000 w=2000
+    language: de
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
+  - id: 
+    originalUrl: http://image.tmdb.org/t/p/original/pm501ckgnaNRl3itHGEVjZlOtvL.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w342/pm501ckgnaNRl3itHGEVjZlOtvL.jpg
+    originalSize: h=2100 w=1400
+    language: de
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
+  - id: 
+    originalUrl: http://image.tmdb.org/t/p/original/hv3csvozTNy1sNHXh77OsjKjITe.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w342/hv3csvozTNy1sNHXh77OsjKjITe.jpg
+    originalSize: h=854 w=569
+    language: de
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
+  - id: 
+    originalUrl: http://image.tmdb.org/t/p/original/yQJCGlhkQuB04ltGiC5ar4jaZeC.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w342/yQJCGlhkQuB04ltGiC5ar4jaZeC.jpg
+    originalSize: h=750 w=500
+    language: de
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
+  - id: 
+    originalUrl: http://image.tmdb.org/t/p/original/gPqjThVKfBHvQq5FQrJFlkbCPaW.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w342/gPqjThVKfBHvQq5FQrJFlkbCPaW.jpg
+    originalSize: h=750 w=500
+    language: de
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
+  - ... and >20 more
+backdrops: (N>10)
+  - id: 
+    originalUrl: http://image.tmdb.org/t/p/original/dSlofjxxcTSLmnH6602WsSSELU5.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w780/dSlofjxxcTSLmnH6602WsSSELU5.jpg
+    originalSize: h=1080 w=1920
+    language: 
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
+  - id: 
+    originalUrl: http://image.tmdb.org/t/p/original/hUnMp2tcrKyfpPEFLDRcnJ0l6au.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w780/hUnMp2tcrKyfpPEFLDRcnJ0l6au.jpg
+    originalSize: h=1330 w=2364
+    language: 
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
+  - id: 
+    originalUrl: http://image.tmdb.org/t/p/original/j50Sr0ULbsf0Rbw0BB91ZbtQoaB.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w780/j50Sr0ULbsf0Rbw0BB91ZbtQoaB.jpg
+    originalSize: h=2160 w=3840
+    language: 
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
+  - id: 
+    originalUrl: http://image.tmdb.org/t/p/original/87F4k8S5Q5U6INzytrERgJJ5Q56.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w780/87F4k8S5Q5U6INzytrERgJJ5Q56.jpg
+    originalSize: h=1080 w=1920
+    language: 
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
+  - id: 
+    originalUrl: http://image.tmdb.org/t/p/original/tIhdMcCs6OOyg27knpzKSGj7CWJ.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w780/tIhdMcCs6OOyg27knpzKSGj7CWJ.jpg
+    originalSize: h=1080 w=1920
+    language: 
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
+  - ... and >5 more
+discArts: (N=0)
+clearArts: (N=0)
+logos: (N=0)


### PR DESCRIPTION
Fix  #1641

----------

If a given language had more than one certification, and the last one
was empty, the language was simply ignored.