### PR TITLE
feat: Load images asynchronously in the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
     For example, the country's release date will be used.
   - If a movie has more than one certification in a given language, we sometimes accidentally
     ignored the selected language if TMDB has an empty certification for it (#1641)
+- UI: Images are now loaded asynchronously, which should improve the performance when switching items (#1640)
 
 ### Removed
 

--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -189,6 +189,7 @@ SOURCES += src/main.cpp \
     src/import/MakeMkvCon.cpp \
     src/import/MyFile.cpp \
     src/log/Log.cpp \
+    src/media/AsyncImage.cpp \
     src/media/FileFilter.cpp \
     src/media/FilenameUtils.cpp \
     src/media/ImageCache.cpp \
@@ -551,6 +552,7 @@ HEADERS  += Version.h \
     src/import/MakeMkvCon.h \
     src/import/MyFile.h \
     src/log/Log.h \
+    src/media/AsyncImage.h \
     src/media/FileFilter.h \
     src/media/FilenameUtils.h \
     src/media/ImageCache.h \

--- a/src/data/Image.cpp
+++ b/src/data/Image.cpp
@@ -8,17 +8,17 @@ Image::Image(QObject* parent) : QObject(parent), m_deletion{false}, m_imageId(++
 {
 }
 
-QString Image::fileName() const
+mediaelch::FilePath Image::filePath() const
 {
-    return m_fileName;
+    return m_filePath;
 }
 
-void Image::setFileName(const QString& fileName)
+void Image::setFilePath(const mediaelch::FilePath& filePath)
 {
-    if (fileName == m_fileName) {
+    if (filePath == m_filePath) {
         return;
     }
-    m_fileName = fileName;
+    m_filePath = filePath;
     emit fileNameChanged();
 }
 
@@ -61,7 +61,7 @@ void Image::load()
         return;
     }
 
-    QFile f(fileName());
+    QFile f(filePath().toString());
     if (!f.open(QIODevice::ReadOnly)) {
         return;
     }

--- a/src/data/Image.h
+++ b/src/data/Image.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#include "media/Path.h"
+
 #include <QObject>
 
 class Image : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(QString fileName READ fileName WRITE setFileName NOTIFY fileNameChanged)
     Q_PROPERTY(bool deletion READ deletion WRITE setDeletion NOTIFY deletionChanged)
     Q_PROPERTY(QByteArray rawData READ rawData WRITE setRawData NOTIFY rawDataChanged)
     Q_PROPERTY(int imageId READ imageId CONSTANT)
@@ -13,8 +14,8 @@ class Image : public QObject
 public:
     explicit Image(QObject* parent = nullptr);
 
-    QString fileName() const;
-    void setFileName(const QString& fileName);
+    mediaelch::FilePath filePath() const;
+    void setFilePath(const mediaelch::FilePath& filePath);
 
     bool deletion() const;
     void setDeletion(bool deletion);
@@ -34,7 +35,7 @@ signals:
     void rawDataChanged();
 
 private:
-    QString m_fileName;
+    mediaelch::FilePath m_filePath;
     bool m_deletion;
     QByteArray m_rawData;
     int m_imageId;

--- a/src/data/concert/Concert.cpp
+++ b/src/data/concert/Concert.cpp
@@ -833,7 +833,7 @@ QVector<ExtraFanart> Concert::extraFanarts(MediaCenterInterface* mediaCenterInte
     QVector<ExtraFanart> fanarts;
     for (const QString& file : asConst(m_concert.extraFanarts)) {
         ExtraFanart f;
-        f.path = file;
+        f.path = mediaelch::FilePath(file);
         fanarts.append(f);
     }
     for (const QByteArray& img : asConst(m_extraFanartImagesToAdd)) {

--- a/src/data/movie/Movie.cpp
+++ b/src/data/movie/Movie.cpp
@@ -1,15 +1,16 @@
 #include "Movie.h"
 
-#include <QApplication>
-#include <QDir>
-#include <QFileInfo>
-#include <utility>
-
 #include "globals/Helper.h"
 #include "log/Log.h"
 #include "media/ImageCache.h"
 #include "media_center/MediaCenterInterface.h"
 #include "settings/Settings.h"
+
+#include <QApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <atomic>
+#include <utility>
 
 using namespace std::chrono_literals;
 
@@ -26,8 +27,8 @@ Movie::Movie(QStringList files, QObject* parent) :
     m_discType{DiscType::Single},
     m_label{ColorLabel::NoLabel}
 {
-    static int m_idCounter = 0;
-    m_movieId = ++m_idCounter;
+    static std::atomic_int32_t m_idCounter{0};
+    m_movieId = m_idCounter.fetch_add(1, std::memory_order_relaxed);
     if (!files.isEmpty()) {
         setFiles(files);
     }

--- a/src/data/movie/MovieController.cpp
+++ b/src/data/movie/MovieController.cpp
@@ -21,6 +21,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QRegularExpression>
+#include <QSignalBlocker>
 #include <QtCore/qmath.h>
 #include <chrono>
 
@@ -84,7 +85,8 @@ bool MovieController::loadData(MediaCenterInterface* mediaCenterInterface, bool 
     }
 
     NameFormatter::setExcludeWords(Settings::instance()->excludeWords());
-    m_movie->blockSignals(true);
+
+    const QSignalBlocker blocker(m_movie);
 
     bool infoLoaded = false;
     if (reloadFromNfo) {
@@ -146,7 +148,6 @@ bool MovieController::loadData(MediaCenterInterface* mediaCenterInterface, bool 
     m_infoLoaded = infoLoaded;
     m_infoFromNfoLoaded = infoLoaded && reloadFromNfo;
     m_movie->setChanged(false);
-    m_movie->blockSignals(false);
     return infoLoaded;
 }
 

--- a/src/data/movie/MovieImages.cpp
+++ b/src/data/movie/MovieImages.cpp
@@ -196,7 +196,7 @@ QVector<ExtraFanart> MovieImages::extraFanarts(MediaCenterInterface* mediaCenter
     QVector<ExtraFanart> fanarts;
     for (const QString& file : asConst(m_extraFanarts)) {
         ExtraFanart f;
-        f.path = file;
+        f.path = mediaelch::FilePath(file);
         fanarts.append(f);
     }
     for (const QByteArray& img : asConst(m_extraFanartToAdd)) {

--- a/src/data/music/Artist.cpp
+++ b/src/data/music/Artist.cpp
@@ -469,7 +469,7 @@ QVector<ExtraFanart> Artist::extraFanarts(MediaCenterInterface* mediaCenterInter
     QVector<ExtraFanart> fanarts;
     for (const QString& file : m_extraFanarts) {
         ExtraFanart f;
-        f.path = file;
+        f.path = mediaelch::FilePath(file);
         fanarts.append(f);
     }
     for (const QByteArray& img : m_extraFanartImagesToAdd) {

--- a/src/data/tv_show/TvShow.cpp
+++ b/src/data/tv_show/TvShow.cpp
@@ -1196,7 +1196,7 @@ QVector<ExtraFanart> TvShow::extraFanarts(MediaCenterInterface* mediaCenterInter
     QVector<ExtraFanart> fanarts;
     for (const auto& file : m_extraFanarts) {
         ExtraFanart f;
-        f.path = file;
+        f.path = mediaelch::FilePath(file);
         fanarts.append(f);
     }
     for (const auto& img : m_extraFanartImagesToAdd) {

--- a/src/globals/Globals.h
+++ b/src/globals/Globals.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "media/Path.h"
 #include "utils/Meta.h"
 
 #include <QDate>
@@ -273,7 +274,7 @@ enum class ScraperData : int
 struct ExtraFanart
 {
     QByteArray image;
-    QString path;
+    mediaelch::FilePath path;
 };
 
 enum class ColorLabel : int

--- a/src/media/AsyncImage.cpp
+++ b/src/media/AsyncImage.cpp
@@ -1,0 +1,162 @@
+#include "media/AsyncImage.h"
+
+#include "log/Log.h"
+#include "media/ImageUtils.h"
+
+#include <QFuture>
+#include <QtConcurrent>
+#include <chrono>
+
+namespace {
+
+std::chrono::seconds getLastModified(const mediaelch::FilePath& fileName)
+{
+    using namespace std::chrono_literals;
+#if QT_VERSION < QT_VERSION_CHECK(5, 8, 0)
+    return std::chrono::seconds{QFileInfo(fileName.toString()).lastModified().toMSecsSinceEpoch() / 1000ll};
+#else
+    return std::chrono::seconds{QFileInfo(fileName.toString()).lastModified().toSecsSinceEpoch()};
+#endif
+}
+
+bool isLastModifiedTheSame(const mediaelch::FilePath& fileName, std::chrono::seconds cachedSecSinceEpoch)
+{
+    // +/- 10s difference allowed
+    using namespace std::chrono_literals;
+    const auto actualLastModified = getLastModified(fileName);
+    return cachedSecSinceEpoch <= actualLastModified + 10s && //
+           cachedSecSinceEpoch >= actualLastModified - 10s;
+}
+
+mediaelch::impl::ResizedImage readImageSync(mediaelch::FilePath path)
+{
+    mediaelch::impl::ResizedImage img;
+    QFile file(path.toString());
+    if (file.open(QIODevice::ReadOnly)) {
+        img.image = QImage::fromData(file.readAll());
+        file.close();
+        img.originalSize = img.image.size();
+        img.resizedSize = img.originalSize;
+    } else {
+        qCWarning(generic) << "[AsyncImage] Could not load image from:" << path.toNativePathString();
+    }
+    return img;
+}
+
+mediaelch::impl::ResizedImage readAndResizeImageSync(mediaelch::FilePath path, QSize targetSize)
+{
+    mediaelch::impl::ResizedImage img = readImageSync(std::move(path));
+    img.resizedSize = targetSize;
+    if (!img.image.isNull()) {
+        img.image = mediaelch::scaledImage(img.image, targetSize);
+    }
+    return img;
+}
+
+mediaelch::impl::ResizedImage
+readAndResizeAndCacheImageSync(mediaelch::DirectoryPath cacheDir, mediaelch::FilePath imgPath, QSize targetSize)
+{
+    if (!cacheDir.isValid()) {
+        return readAndResizeImageSync(imgPath, targetSize);
+    }
+
+    QString hash = mediaelch::pathHash(imgPath);
+    QString nameFilter = QStringLiteral("%1_%2_%3_*") //
+                             .arg(hash)
+                             .arg(targetSize.width())
+                             .arg(targetSize.height());
+
+    QDir dir = cacheDir.dir();
+    QStringList files = dir.entryList({nameFilter});
+
+    // Check the cache directory: If the first matched file is usable, i.e. has a proper
+    // modification date and filename format, use it.
+    QSize cachedOriginalSize;
+    bool cacheNeedsUpdate = true;
+    if (!files.isEmpty()) {
+        const QString fileName = files.first();
+        const QStringList parts = fileName.split("_");
+        if (parts.count() > 5) {
+            cachedOriginalSize.setWidth(parts.at(3).toInt());
+            cachedOriginalSize.setHeight(parts.at(4).toInt());
+        }
+        bool ok = false;
+        auto lastModified = std::chrono::seconds{parts.at(5).toLongLong(&ok, 10)};
+        cacheNeedsUpdate = !(ok && lastModified.count() > 0 && isLastModifiedTheSame(imgPath, lastModified));
+    }
+
+    if (cacheNeedsUpdate) {
+        // It could happen that the to-be-cached image appears lexicographically after the other files,
+        // e.g. due to a different/changed size/date.  In that case, the first, outdated cache would
+        // always be loaded and result in `cacheNeedsUpdate` always being true.
+        for (const QString& file : files) {
+            QFile::remove(cacheDir.filePath(file));
+        }
+
+        auto origImg = readAndResizeImageSync(imgPath, targetSize);
+        QString cacheFileName = QStringLiteral("%1_%2_%3_%4_%5_%6_.png")
+                                    .arg(hash)
+                                    .arg(targetSize.width())
+                                    .arg(targetSize.height())
+                                    .arg(origImg.originalSize.width())
+                                    .arg(origImg.originalSize.height())
+                                    .arg(getLastModified(imgPath).count());
+        origImg.image.save(cacheDir.filePath(cacheFileName), "png", -1);
+        return origImg;
+
+    } else {
+        mediaelch::impl::ResizedImage img;
+        QString cachedImagePath = cacheDir.filePath(files.first());
+
+        QFile file(cachedImagePath);
+        if (file.open(QIODevice::ReadOnly)) {
+            img.image = QImage::fromData(file.readAll());
+            file.close();
+            img.originalSize = cachedOriginalSize;
+            img.resizedSize = targetSize;
+
+            img.image = mediaelch::scaledImage(img.image, targetSize);
+        } else {
+            qCWarning(generic) << "[Image] Couldn't load cached image of" << imgPath.toNativePathString() << "at"
+                               << QDir::toNativeSeparators(cachedImagePath);
+        }
+        return img;
+    }
+}
+
+} // namespace
+
+namespace mediaelch {
+
+std::unique_ptr<AsyncImage> AsyncImage::fromPath(mediaelch::FilePath path)
+{
+    // std::make_unique() can't access private constructor; and we are neither exception safe
+    // to begin with nor do we try to reduce allocations, so no big deal.
+    auto img = std::unique_ptr<AsyncImage>(new AsyncImage());
+    img->m_path = path;
+    connect(&img->m_watcher, &QFutureWatcher<QImage>::finished, img.get(), &AsyncImage::onLoaded);
+    img->m_watcher.setFuture(QtConcurrent::run(readImageSync, std::move(path)));
+    return img;
+}
+
+std::unique_ptr<AsyncImage>
+AsyncImage::fromPathCached(mediaelch::DirectoryPath cacheDir, mediaelch::FilePath path, QSize targetSize)
+{
+    // std::make_unique() can't access private constructor; and we are neither exception safe
+    // to begin with nor do we try to reduce allocations, so no big deal.
+    auto img = std::unique_ptr<AsyncImage>(new AsyncImage());
+    img->m_path = path;
+    connect(&img->m_watcher, &QFutureWatcher<QImage>::finished, img.get(), &AsyncImage::onLoaded);
+    img->m_watcher.setFuture(
+        QtConcurrent::run(readAndResizeAndCacheImageSync, std::move(cacheDir), std::move(path), std::move(targetSize)));
+    return img;
+}
+
+void AsyncImage::onLoaded()
+{
+    m_img = m_watcher.result();
+    // m_watcher.setFuture({}); // TODO
+    emit sigLoaded();
+}
+
+} // namespace mediaelch

--- a/src/media/AsyncImage.h
+++ b/src/media/AsyncImage.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "media/Path.h"
+
+#include <QFutureWatcher>
+#include <QImage>
+#include <QObject>
+#include <QSize>
+
+namespace mediaelch {
+
+namespace impl {
+
+struct ResizedImage
+{
+    QImage image;
+    QSize originalSize;
+    QSize resizedSize;
+};
+
+} // namespace impl
+
+/// \brief Asynchronously load a QImage, resize it to a preferred size, and cache it on disk.
+/// \details
+///   You can use AsyncCachedImage to load an image asynchronously and get notified
+///   when to image is loaded.  This class must only be used from a single thread,
+///   i.e. its accessor-functions are not thread safe.
+///
+///   Caches the image if it is requested in a certain size, as the resize operation
+///   can heavily decrease the file size and subsequent loads can be faster (due to
+///   loading the cached image instead of the original).
+class AsyncImage : public QObject
+{
+    Q_OBJECT
+
+public:
+    static std::unique_ptr<AsyncImage> fromPath(mediaelch::FilePath path);
+    static std::unique_ptr<AsyncImage>
+    fromPathCached(mediaelch::DirectoryPath cacheDir, mediaelch::FilePath path, QSize targetSize);
+
+    /// \brief Returns a reference to the image, possibly 0.
+    ELCH_NODISCARD QImage& image() { return m_img.image; }
+    ELCH_NODISCARD QSize originalSize() const { return m_img.originalSize; }
+    ELCH_NODISCARD bool isNull() const { return m_img.image.isNull(); }
+    ELCH_NODISCARD bool isLoaded() const { return m_ready; }
+    ELCH_NODISCARD const mediaelch::FilePath& path() const { return m_path; }
+
+signals:
+    void sigLoaded();
+
+private:
+    explicit AsyncImage(QObject* parent = nullptr) : QObject(parent) {}
+
+private slots:
+    /// Fills the image variable.  Must always be called on the same thread
+    /// as the owner of this AsyncCachedImage.
+    void onLoaded();
+
+private:
+    QFutureWatcher<impl::ResizedImage> m_watcher;
+    impl::ResizedImage m_img;
+    mediaelch::FilePath m_path;
+    bool m_ready{false};
+};
+
+} // namespace mediaelch

--- a/src/media/CMakeLists.txt
+++ b/src/media/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(
   mediaelch_media OBJECT
+  AsyncImage.cpp
   FileFilter.cpp
   FilenameUtils.cpp
   ImageCache.cpp
@@ -14,8 +15,11 @@ add_library(
 target_link_libraries(
   mediaelch_media
   PRIVATE
-    Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Widgets
     # TODO: Remove GUI once Globals.h does not depend on it anymore
-    Qt${QT_VERSION_MAJOR}::Gui Qt${QT_VERSION_MAJOR}::Network
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Network
+    Qt${QT_VERSION_MAJOR}::Concurrent
 )
 mediaelch_post_target_defaults(mediaelch_media)

--- a/src/media/ImageCache.cpp
+++ b/src/media/ImageCache.cpp
@@ -4,15 +4,14 @@
 #include "media/ImageUtils.h"
 #include "settings/Settings.h"
 
-#include <QCryptographicHash>
-#include <QDateTime>
 #include <QDir>
 #include <QFileInfo>
+#include <QtConcurrent>
 
 ImageCache::ImageCache(QObject* parent) : QObject(parent)
 {
     mediaelch::DirectoryPath location = Settings::instance()->imageCacheDir();
-    QDir dir(location.dir());
+    QDir dir = location.dir();
     if (!dir.exists()) {
         dir.mkdir(location.toString());
     }
@@ -28,112 +27,24 @@ ImageCache::ImageCache(QObject* parent) : QObject(parent)
     qCDebug(generic) << "[ImageCache] Using cache directory:" << m_cacheDir;
 }
 
-ImageCache* ImageCache::instance(QObject* parent)
+ImageCache* ImageCache::instance()
 {
-    static auto* s_instance = new ImageCache(parent);
-    return s_instance;
+    static ImageCache s_instance;
+    return &s_instance;
 }
 
-QImage ImageCache::image(mediaelch::FilePath path, int width, int height, int& origWidth, int& origHeight)
-{
-    if (!m_cacheDir.isValid()) {
-        return scaledImage(mediaelch::getImage(path), width, height);
-    }
-
-    QString md5 = QCryptographicHash::hash(path.toString().toUtf8(), QCryptographicHash::Md5).toHex();
-    QString baseName = QString("%1_%2_%3_").arg(md5).arg(width).arg(height);
-
-    bool update = true;
-    QDir dir = m_cacheDir.dir();
-    QStringList files = dir.entryList(QStringList() << baseName + "*");
-    if (!files.isEmpty()) {
-        QString fileName = files.first();
-        QStringList parts = fileName.split("_");
-        if (parts.count() > 6) {
-            origWidth = parts.at(3).toInt();
-            origHeight = parts.at(4).toInt();
-        }
-    }
-
-    if (update) {
-        QImage origImg = mediaelch::getImage(path);
-        origWidth = origImg.width();
-        origHeight = origImg.height();
-        QImage img = scaledImage(origImg, width, height);
-        QString fileName = QString("%1_%2_%3_%4_%5_%6_.png")
-                               .arg(md5)
-                               .arg(width)
-                               .arg(height)
-                               .arg(origWidth)
-                               .arg(origHeight)
-                               .arg(getLastModified(path));
-        img.save(m_cacheDir.filePath(fileName), "png", -1);
-        return img;
-    }
-
-    return mediaelch::getImage(mediaelch::FilePath(m_cacheDir.filePath(files.first())));
-}
-
-QImage ImageCache::scaledImage(QImage img, int width, int height)
-{
-    if (width != 0 && height != 0) {
-        return img.scaled(width, height, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    }
-    if (width != 0) {
-        return img.scaledToWidth(width, Qt::SmoothTransformation);
-    }
-    if (height != 0) {
-        return img.scaledToHeight(height, Qt::SmoothTransformation);
-    }
-    return img;
-}
-
-void ImageCache::invalidateImages(mediaelch::FilePath path)
+void ImageCache::invalidateImages(const mediaelch::FilePath& path)
 {
     if (!m_cacheDir.isValid()) {
         return;
     }
 
-    QString md5 = QCryptographicHash::hash(path.toString().toUtf8(), QCryptographicHash::Md5).toHex();
     QDir dir = m_cacheDir.dir();
-    const QStringList entries = dir.entryList(QStringList() << md5 + "*");
+    const QStringList entries = dir.entryList({mediaelch::pathHash(path) + "*"});
     for (const QString& file : entries) {
         QFile f(dir.absolutePath() + "/" + file);
         f.remove();
     }
-}
-
-QSize ImageCache::imageSize(mediaelch::FilePath path)
-{
-    if (!m_cacheDir.isValid()) {
-        return mediaelch::getImage(path).size();
-    }
-
-    QString md5 = QCryptographicHash::hash(path.toString().toUtf8(), QCryptographicHash::Md5).toHex();
-    QString baseName = QString("%1_").arg(md5);
-    QDir dir = m_cacheDir.dir();
-    QStringList files = dir.entryList(QStringList() << baseName + "*");
-    if (files.isEmpty() || files.first().split("_").count() < 7) {
-        return mediaelch::getImage(path).size();
-    }
-
-    QStringList parts = files.first().split("_");
-    if (parts.at(5).toInt() > 0 && getLastModified(path) != parts.at(5).toUInt()) {
-        return mediaelch::getImage(path).size();
-    }
-
-    return {parts.at(3).toInt(), parts.at(4).toInt()};
-}
-
-qint64 ImageCache::getLastModified(const mediaelch::FilePath& fileName)
-{
-    // TODO: Use toSecsSinceEpoch() when Qt 5.8 is required.
-    qint64 now = QDateTime::currentDateTime().toMSecsSinceEpoch() / 1000;
-    if (!m_lastModifiedTimes.contains(fileName) || m_lastModifiedTimes.value(fileName).first() < now - 10) {
-        qint64 lastMod = QFileInfo(fileName.toString()).lastModified().toMSecsSinceEpoch() / 1000;
-        m_lastModifiedTimes.insert(fileName, {now, lastMod});
-    }
-    return m_lastModifiedTimes.value(fileName).last();
 }
 
 void ImageCache::clearCache()
@@ -145,4 +56,9 @@ void ImageCache::clearCache()
     for (const QFileInfo& file : entries) {
         QFile(file.absoluteFilePath()).remove();
     }
+}
+
+std::unique_ptr<mediaelch::AsyncImage> ImageCache::loadImageAsync(const mediaelch::FilePath& path, QSize targetSize)
+{
+    return mediaelch::AsyncImage::fromPathCached(m_cacheDir, path, targetSize);
 }

--- a/src/media/ImageCache.h
+++ b/src/media/ImageCache.h
@@ -1,27 +1,29 @@
 #pragma once
 
+#include "media/AsyncImage.h"
 #include "media/Path.h"
 
-#include <QHash>
-#include <QImage>
 #include <QSize>
 #include <QString>
-#include <QVector>
 
 class ImageCache : public QObject
 {
     Q_OBJECT
 public:
     explicit ImageCache(QObject* parent = nullptr);
-    static ImageCache* instance(QObject* parent = nullptr);
-    QImage image(mediaelch::FilePath path, int width, int height, int& origWidth, int& origHeight);
-    QSize imageSize(mediaelch::FilePath path);
-    void invalidateImages(mediaelch::FilePath path);
+    static ImageCache* instance();
+
+    void invalidateImages(const mediaelch::FilePath& path);
     void clearCache();
+
+    /// \brief Asynchronously load the given image and resize it. Caches the resized result on disk.
+    /// \details
+    ///   If either width or height of the targetSize is 0, the aspect ratio is respected and the
+    ///   not-null value used. See mediaelch::scaledImage() for details.  The resized result
+    ///   is cached on disk and loaded instead of the original on subsequent requests.
+    ///   No in-memory caching is performed.
+    std::unique_ptr<mediaelch::AsyncImage> loadImageAsync(const mediaelch::FilePath& path, QSize targetSize);
 
 private:
     mediaelch::DirectoryPath m_cacheDir;
-    QHash<mediaelch::FilePath, QVector<qint64>> m_lastModifiedTimes;
-    QImage scaledImage(QImage img, int width, int height);
-    qint64 getLastModified(const mediaelch::FilePath& fileName);
 };

--- a/src/media/ImageUtils.cpp
+++ b/src/media/ImageUtils.cpp
@@ -45,4 +45,24 @@ QImage getImage(mediaelch::FilePath path)
     return img;
 }
 
+
+QImage scaledImage(const QImage& img, int width, int height)
+{
+    if (width != 0 && height != 0) {
+        return img.scaled(width, height, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    }
+    if (width != 0) {
+        return img.scaledToWidth(width, Qt::SmoothTransformation);
+    }
+    if (height != 0) {
+        return img.scaledToHeight(height, Qt::SmoothTransformation);
+    }
+    return img;
+}
+
+QImage scaledImage(const QImage& img, QSize size)
+{
+    return scaledImage(img, size.width(), size.height());
+}
+
 } // namespace mediaelch

--- a/src/media/ImageUtils.h
+++ b/src/media/ImageUtils.h
@@ -12,4 +12,7 @@ void resizeBackdrop(QByteArray& image);
 
 QImage getImage(mediaelch::FilePath path);
 
+QImage scaledImage(const QImage& img, int width, int height);
+QImage scaledImage(const QImage& img, QSize size);
+
 } // namespace mediaelch

--- a/src/media/Path.cpp
+++ b/src/media/Path.cpp
@@ -1,5 +1,7 @@
 #include "media/Path.h"
 
+#include <QCryptographicHash>
+
 namespace mediaelch {
 
 QString DirectoryPath::toNativePathString() const
@@ -84,5 +86,9 @@ void operator<<(FileList& list, const FilePath& file)
     list.push_back(file);
 }
 
+QString pathHash(const mediaelch::FilePath& path)
+{
+    return QCryptographicHash::hash(path.toString().toUtf8(), QCryptographicHash::Md5).toHex();
+}
 
 } // namespace mediaelch

--- a/src/media/Path.h
+++ b/src/media/Path.h
@@ -172,4 +172,6 @@ bool operator!=(const FileList& lhs, const FileList& rhs);
 void operator<<(FileList& list, const FilePath& file);
 
 
+QString pathHash(const mediaelch::FilePath& path);
+
 } // namespace mediaelch

--- a/src/media_center/KodiXml.cpp
+++ b/src/media_center/KodiXml.cpp
@@ -294,7 +294,7 @@ QString KodiXml::nfoFilePath(Concert* concert)
 }
 
 /**
- * \brief Loads movie infos (except images)
+ * \brief Loads movie infos (except images). Does not block signals of the movie.
  * \param movie Movie to load
  * \return Loading success
  */
@@ -1710,8 +1710,8 @@ bool KodiXml::saveAlbum(Album* album)
             if (!image->deletion()) {
                 image->load(); // load to get binary
             }
-            if (!image->fileName().isEmpty()) { // TODO: `image->deletion() &&`
-                QFile::remove(image->fileName());
+            if (image->filePath().isValid()) { // TODO: `image->deletion() &&`
+                QFile::remove(image->filePath().toString());
             }
         }
         int bookletNum = 1;
@@ -1768,7 +1768,7 @@ void KodiXml::loadBooklets(Album* album)
     QStringList filters{"*.jpg", "*.jpeg", "*.JPEG", "*.Jpeg", "*.JPeg"};
     for (const QString& file : dir.entryList(filters, QDir::Files | QDir::NoDotAndDotDot, QDir::Name)) {
         auto* img = new Image;
-        img->setFileName(QDir::toNativeSeparators(dir.path() + "/" + file));
+        img->setFilePath(mediaelch::FilePath(dir.path() + "/" + file));
         album->bookletModel()->addImage(img);
     }
     album->bookletModel()->setHasChanged(false);

--- a/src/model/ImageModel.cpp
+++ b/src/model/ImageModel.cpp
@@ -46,7 +46,7 @@ QVariant ImageModel::data(const QModelIndex& index, int role) const
     }
 
     switch (role) {
-    case ImageRoles::FilenameRole: return img->fileName();
+    case ImageRoles::FilenameRole: return img->filePath().toNativePathString();
     case ImageRoles::RawDataRole: return img->rawData();
     case ImageRoles::DeletionRole: return img->deletion();
     case ImageRoles::ImageDataRole: {
@@ -87,10 +87,10 @@ void ImageModel::markForRemoval(QByteArray& image)
     }
 }
 
-void ImageModel::markForRemoval(QString& filename)
+void ImageModel::markForRemoval(const mediaelch::FilePath& filename)
 {
     const auto index = std::find_if(m_images.begin(), m_images.end(), [&filename](Image* img) { //
-        return img->fileName() == filename;
+        return img->filePath() == filename;
     });
     if (index != m_images.end()) {
         (*index)->setDeletion(true);
@@ -176,10 +176,10 @@ bool ImageModel::setData(int row, const QVariant& value, int role)
 
     switch (role) {
     case FilenameRole: {
-        if (value.toString() == img->fileName()) {
+        if (value.toString() == img->filePath().toString()) {
             return false;
         }
-        img->setFileName(value.toString());
+        img->setFilePath(mediaelch::FilePath(value.toString()));
         break;
     }
     case RawDataRole: {

--- a/src/model/ImageModel.h
+++ b/src/model/ImageModel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "data/Image.h"
+#include "media/Path.h"
 
 #include <QAbstractListModel>
 #include <QList>
@@ -32,7 +33,7 @@ public:
 
     void removeImage(Image* image);
     void markForRemoval(QByteArray& image);
-    void markForRemoval(QString& filename);
+    void markForRemoval(const mediaelch::FilePath& filename);
 
 
     Q_INVOKABLE void move(int from, int to);

--- a/src/scrapers/image/TmdbImages.cpp
+++ b/src/scrapers/image/TmdbImages.cpp
@@ -105,7 +105,7 @@ TmdbImages::TmdbImages(QObject* parent) : ImageProvider(parent)
     m_tmdb = new mediaelch::scraper::TmdbMovie(this);
 }
 
-TmdbImages::~TmdbImages() {};
+TmdbImages::~TmdbImages(){};
 
 const ImageProvider::ScraperMeta& TmdbImages::meta() const
 {

--- a/src/ui/concerts/ConcertWidget.cpp
+++ b/src/ui/concerts/ConcertWidget.cpp
@@ -423,7 +423,7 @@ void ConcertWidget::updateImage(ImageType imageType, ClosableImage* image)
     } else if (!m_concert->imagesToRemove().contains(imageType) && m_concert->hasImage(imageType)) {
         QString imgFileName = Manager::instance()->mediaCenterInterface()->imageFileName(m_concert, imageType);
         if (!imgFileName.isEmpty()) {
-            image->setImage(imgFileName);
+            image->setImageFromPath(mediaelch::FilePath(imgFileName));
         }
     }
 }

--- a/src/ui/image/ImagePreviewDialog.h
+++ b/src/ui/image/ImagePreviewDialog.h
@@ -1,9 +1,17 @@
 #pragma once
 
+#include "media/Path.h"
+
 #include <QDialog>
+#include <QMovie>
+#include <memory>
 
 namespace Ui {
 class ImagePreviewDialog;
+}
+
+namespace mediaelch {
+class AsyncImage;
 }
 
 /// \brief This dialog shows a full size preview of images, e.g. a movie's poster.
@@ -18,6 +26,9 @@ public:
     /// \brief Sets the image to be displayed
     /// \param img Image in high definition to be shown to the user.
     void setImage(QPixmap img);
+    /// \brief Sets the image to be displayed. Loaded from disk.
+    /// \param path Image to show in high resolution.
+    void setImageFromPath(const mediaelch::FilePath& path);
 
 public slots:
     /// \brief Executes the dialog and adjusts its size.
@@ -25,5 +36,11 @@ public slots:
     int exec() override;
 
 private:
+    void setLoading(bool loading);
+
+private:
     Ui::ImagePreviewDialog* ui;
+    std::unique_ptr<mediaelch::AsyncImage> m_asyncImage;
+    QMovie* m_loadingMovie{nullptr};
+    bool m_isLoading{false};
 };

--- a/src/ui/image/ImagePreviewDialog.ui
+++ b/src/ui/image/ImagePreviewDialog.ui
@@ -50,10 +50,10 @@
        <item>
         <widget class="QLabel" name="image">
          <property name="text">
-          <string/>
+          <string notr="true"/>
          </property>
          <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          <set>Qt::AlignCenter</set>
          </property>
         </widget>
        </item>

--- a/src/ui/main/AboutDialog.cpp
+++ b/src/ui/main/AboutDialog.cpp
@@ -70,11 +70,12 @@ void AboutDialog::setDeveloperDetails()
                << "<br><br>";
 
     // Directories
-    infoStream << "Application dir: " << QDir::toNativeSeparators(Settings::applicationDir()) << "<br>"
+    infoStream << "Application directory: " << QDir::toNativeSeparators(Settings::applicationDir()) << "<br>"
                << "Settings file: " << Settings::instance()->settings()->fileName() << "<br>"
                << "Data dir: "
                << QDir::toNativeSeparators(QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation))
                << "<br>"
+               << "Image cache directory: " << Settings::instance()->imageCacheDir().toNativePathString() << "<br>"
                << "Qt Translation Path: "
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)

--- a/src/ui/movies/MovieWidget.cpp
+++ b/src/ui/movies/MovieWidget.cpp
@@ -714,8 +714,8 @@ void MovieWidget::updateMovieInfo()
 
 void MovieWidget::updateImages(QSet<ImageType> images)
 {
-    for (const auto imageType : images) {
-        for (auto* cImage : ui->artStackedWidget->findChildren<ClosableImage*>()) {
+    for (auto* cImage : ui->artStackedWidget->findChildren<ClosableImage*>()) {
+        for (const ImageType imageType : images) {
             if (cImage->imageType() == imageType) {
                 updateImage(imageType, cImage);
                 break;
@@ -727,11 +727,12 @@ void MovieWidget::updateImages(QSet<ImageType> images)
 void MovieWidget::updateImage(ImageType imageType, ClosableImage* image)
 {
     if (!m_movie->images().image(imageType).isNull()) {
+        // cache
         image->setImage(m_movie->images().image(imageType));
     } else if (!m_movie->images().imagesToRemove().contains(imageType) && m_movie->hasImage(imageType)) {
         QString imgFileName = Manager::instance()->mediaCenterInterface()->imageFileName(m_movie, imageType);
         if (!imgFileName.isEmpty()) {
-            image->setImage(imgFileName);
+            image->setImageFromPath(mediaelch::FilePath(imgFileName));
         }
     }
 }

--- a/src/ui/music/MusicWidgetAlbum.cpp
+++ b/src/ui/music/MusicWidgetAlbum.cpp
@@ -299,7 +299,7 @@ void MusicWidgetAlbum::updateImage(ImageType imageType, ClosableImage* image)
     } else if (!m_album->imagesToRemove().contains(imageType)) {
         QString imgFileName = Manager::instance()->mediaCenterInterface()->imageFileName(m_album, imageType);
         if (!imgFileName.isEmpty()) {
-            image->setImage(imgFileName);
+            image->setImageFromPath(mediaelch::FilePath(imgFileName));
         }
     }
 }
@@ -558,7 +558,7 @@ void MusicWidgetAlbum::onBookletAdded(Image* img)
     if (m_album == nullptr) {
         return;
     }
-    ui->booklets->addImage(img->rawData(), img->fileName());
+    ui->booklets->addImage(img->rawData(), img->filePath().toString());
 
     if (m_album->bookletModel()->hasChanged()) {
         ui->buttonRevert->setVisible(true);
@@ -581,7 +581,7 @@ void MusicWidgetAlbum::onBookletRemoved(QString file)
         return;
     }
 
-    m_album->bookletModel()->markForRemoval(file);
+    m_album->bookletModel()->markForRemoval(mediaelch::FilePath(file));
     ui->buttonRevert->setVisible(true);
 }
 

--- a/src/ui/music/MusicWidgetArtist.cpp
+++ b/src/ui/music/MusicWidgetArtist.cpp
@@ -294,7 +294,7 @@ void MusicWidgetArtist::updateImage(ImageType imageType, ClosableImage* image)
     } else if (!m_artist->imagesToRemove().contains(imageType)) {
         QString imgFileName = Manager::instance()->mediaCenterInterface()->imageFileName(m_artist, imageType);
         if (!imgFileName.isEmpty()) {
-            image->setImage(imgFileName);
+            image->setImageFromPath(mediaelch::FilePath(imgFileName));
         }
     }
 }

--- a/src/ui/small_widgets/ClosableImage.h
+++ b/src/ui/small_widgets/ClosableImage.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "globals/Globals.h"
+#include "media/ImageCache.h"
+#include "media/Path.h"
 
 #include <QLabel>
 #include <QMouseEvent>
@@ -9,37 +11,33 @@
 #include <QPropertyAnimation>
 #include <QWidget>
 
-class ClosableImage : public QLabel
+class ClosableImage final : public QLabel
 {
     Q_OBJECT
     Q_PROPERTY(int mySize READ mySize WRITE setMySize USER true)
     Q_PROPERTY(bool clickable READ clickable WRITE setClickable DESIGNABLE true)
     Q_PROPERTY(int myFixedHeight READ myFixedHeight WRITE setMyFixedHeight DESIGNABLE true)
-    Q_PROPERTY(QString title READ title WRITE setTitle DESIGNABLE true)
 
 public:
     explicit ClosableImage(QWidget* parent = nullptr);
     void setMyData(const QVariant& myData);
-    QVariant myData() const;
+    ELCH_NODISCARD QVariant myData() const;
     void setImage(const QByteArray& image);
-    void setImage(const QString& image);
-    void setImageByPath(const QString& image);
-    QByteArray image();
+    void setImageFromPath(const mediaelch::FilePath& image);
+    ELCH_NODISCARD QByteArray image();
     int mySize() const;
     void setMySize(const int& size);
-    void setShowZoomAndResolution(const bool& show);
+    void setShowZoomAndResolution(bool show);
     void setFixedSize(Qt::Orientation scaleTo, int size);
     void setMyFixedHeight(const int& height);
     int myFixedHeight() const;
     void setDefaultPixmap(QPixmap pixmap, bool useDefaultBorder = true);
     void clear();
-    void setClickable(const bool& clickable);
+    void setClickable(bool clickable);
     bool clickable() const;
-    void setLoading(const bool& loading);
-    void setTitle(const QString& text);
-    QString title() const;
+    void setLoading(bool loading);
     void setImageType(ImageType type);
-    ImageType imageType() const;
+    ELCH_NODISCARD ImageType imageType() const;
 
     bool showCapture() const;
     void setShowCapture(bool showCapture);
@@ -60,35 +58,40 @@ protected:
 
 private slots:
     void closed();
+    void onAsyncImageLoaded();
+    void onCloseImageRequest();
+
+private:
+    void updateSize(int imageWidth, int imageHeight);
+    ELCH_NODISCARD int imageWith() const;
+    ELCH_NODISCARD QRect imgRect();
+    ELCH_NODISCARD QRect closeRect();
+    ELCH_NODISCARD QRect zoomRect();
+    ELCH_NODISCARD QRect captureRect();
+    ELCH_NODISCARD bool confirmDeleteImage();
+    ELCH_NODISCARD bool hasImage() const
+    {
+        return !m_image.isNull() || (m_imageFromPath != nullptr && !m_imageFromPath->isNull());
+    }
 
 private:
     QVariant m_myData;
     QByteArray m_image;
-    QString m_imagePath;
-    QPixmap m_pixmap;
+    std::unique_ptr<mediaelch::AsyncImage> m_imageFromPath{nullptr};
+    QPixmap m_pixmapForCloseAnimation;
     QPixmap m_defaultPixmap;
-    int m_mySize = 0;
-    QString m_title;
     QFont m_font;
     QPixmap m_zoomIn;
     QPixmap m_capture;
-    bool m_showZoomAndResolution = false;
-    bool m_showCapture = false;
-    int m_fixedSize = 0;
-    int m_scaleTo = 0;
-    bool m_clickable = false;
-    bool m_loading = false;
-    int m_fixedHeight = 0;
-    QMovie* m_loadingMovie = nullptr;
+    QMovie* m_loadingMovie{nullptr};
     QPointer<QPropertyAnimation> m_anim;
     ImageType m_imageType = ImageType::None;
-    QPixmap m_emptyPixmap;
-
-    void updateSize(int imageWidth, int imageHeight);
-    QRect imgRect();
-    QRect closeRect();
-    QRect zoomRect();
-    QRect captureRect();
-    bool confirmDeleteImage();
-    void drawTitle(QPainter& p);
+    int m_mySize{0};
+    int m_fixedSize{180};
+    int m_fixedHeight{0};
+    int m_scaleTo{Qt::Horizontal};
+    bool m_clickable{false};
+    bool m_isLoading{false};
+    bool m_showZoomAndResolution{true};
+    bool m_showCapture{false};
 };

--- a/src/ui/small_widgets/ImageGallery.cpp
+++ b/src/ui/small_widgets/ImageGallery.cpp
@@ -122,12 +122,12 @@ void ImageGallery::setImages(QVector<ExtraFanart> images)
         } else {
             label->setFixedSize(Qt::Vertical, m_imageHeight);
         }
-        label->setMyData(fanart.path);
+        label->setMyData(fanart.path.toString());
 
         if (!fanart.image.isNull()) {
             label->setImage(fanart.image);
         } else {
-            label->setImage(fanart.path);
+            label->setImageFromPath(fanart.path);
         }
         connect(label, &ClosableImage::sigClose, this, &ImageGallery::onCloseImage);
         m_imageLabels.append(label);
@@ -147,12 +147,12 @@ void ImageGallery::setImages(QList<Image*> images)
         } else {
             label->setFixedSize(Qt::Vertical, m_imageHeight);
         }
-        label->setMyData(image->fileName());
+        label->setMyData(image->filePath().toString());
 
         if (!image->rawData().isNull()) {
             label->setImage(image->rawData());
         } else {
-            label->setImage(image->fileName());
+            label->setImageFromPath(image->filePath());
         }
         connect(label, &ClosableImage::sigClose, this, &ImageGallery::onCloseImage);
         m_imageLabels.append(label);

--- a/src/ui/tv_show/TvShowWidgetEpisode.cpp
+++ b/src/ui/tv_show/TvShowWidgetEpisode.cpp
@@ -472,8 +472,8 @@ void TvShowWidgetEpisode::updateEpisodeInfo()
                     ->mediaCenterInterface()
                     ->imageFileName(m_episode, ImageType::TvShowEpisodeThumb)
                     .isEmpty()) {
-        ui->thumbnail->setImage(
-            Manager::instance()->mediaCenterInterface()->imageFileName(m_episode, ImageType::TvShowEpisodeThumb));
+        ui->thumbnail->setImageFromPath(mediaelch::FilePath{
+            Manager::instance()->mediaCenterInterface()->imageFileName(m_episode, ImageType::TvShowEpisodeThumb)});
     }
 
     ui->season->blockSignals(false);
@@ -1063,8 +1063,8 @@ void TvShowWidgetEpisode::onDeleteThumbnail()
                 ->mediaCenterInterface()
                 ->imageFileName(m_episode, ImageType::TvShowEpisodeThumb)
                 .isEmpty()) {
-        ui->thumbnail->setImage(
-            Manager::instance()->mediaCenterInterface()->imageFileName(m_episode, ImageType::TvShowEpisodeThumb));
+        ui->thumbnail->setImageFromPath(mediaelch::FilePath{
+            Manager::instance()->mediaCenterInterface()->imageFileName(m_episode, ImageType::TvShowEpisodeThumb)});
     }
     ui->buttonRevert->setVisible(true);
 }

--- a/src/ui/tv_show/TvShowWidgetSeason.cpp
+++ b/src/ui/tv_show/TvShowWidgetSeason.cpp
@@ -159,8 +159,8 @@ void TvShowWidgetSeason::updateImages(QSet<ImageType> images)
                         .isEmpty()
                    && (!m_show->imagesToRemove().contains(imageType)
                        || !m_show->imagesToRemove().value(imageType).contains(m_season))) {
-            image->setImage(
-                Manager::instance()->mediaCenterInterfaceTvShow()->imageFileName(m_show, imageType, m_season));
+            image->setImageFromPath(mediaelch::FilePath{
+                Manager::instance()->mediaCenterInterfaceTvShow()->imageFileName(m_show, imageType, m_season)});
         }
     }
 }

--- a/src/ui/tv_show/TvShowWidgetTvShow.cpp
+++ b/src/ui/tv_show/TvShowWidgetTvShow.cpp
@@ -450,7 +450,8 @@ void TvShowWidgetTvShow::updateImages(QSet<ImageType> images)
             image->setImage(m_show->image(imageType));
         } else if (!m_show->imagesToRemove().contains(imageType)
                    && !Manager::instance()->mediaCenterInterface()->imageFileName(m_show, imageType).isEmpty()) {
-            image->setImage(Manager::instance()->mediaCenterInterface()->imageFileName(m_show, imageType));
+            image->setImageFromPath(
+                mediaelch::FilePath{Manager::instance()->mediaCenterInterface()->imageFileName(m_show, imageType)});
         }
     }
 }

--- a/src/utils/Meta.h
+++ b/src/utils/Meta.h
@@ -1,5 +1,8 @@
 #pragma once
 
+// Meta programming stuff.
+// This file must not depend on Globals.h or any other MediaElch header.
+
 #include <QtGlobal>
 #include <limits>
 #include <stdexcept>


### PR DESCRIPTION
For #1640

------

Load images in `ClosableImage` asynchronously if a file from disk is requested.

--------

@fungos  You can try out this PR to see whether performance improves on your side as well. In my case, performance has been drastically increased for movies that have huge posters/banners.

Note, however, that I didn't implement it _properly_ yet. This is for testing only as of now. :)
There may be race conditions if movies are switched too fast and I've practically disabled the image cache. That will come later. It's a proof-of-concept for now.
