### PR TITLE
Fix #1635 Duplicate movie Genres, Countries and Studio labels when scrapping

### DIFF
--- a/src/data/movie/Movie.cpp
+++ b/src/data/movie/Movie.cpp
@@ -852,7 +852,7 @@ void Movie::addActor(Actor actor)
  */
 void Movie::addCountry(QString country) // NOLINT // we require pass-by-value
 {
-    if (country.isEmpty()) {
+    if (country.isEmpty() || m_countries.contains(country)) {
         return;
     }
     m_countries.append(country);
@@ -866,7 +866,7 @@ void Movie::addCountry(QString country) // NOLINT // we require pass-by-value
  */
 void Movie::addGenre(QString genre) // NOLINT // we require pass-by-value
 {
-    if (genre.isEmpty()) {
+    if (genre.isEmpty() || m_genres.contains(genre)) {
         return;
     }
     m_genres.append(genre);
@@ -880,7 +880,7 @@ void Movie::addGenre(QString genre) // NOLINT // we require pass-by-value
  */
 void Movie::addStudio(QString studio) // NOLINT // we require pass-by-value
 {
-    if (studio.isEmpty()) {
+    if (studio.isEmpty() || m_studios.contains(studio)) {
         return;
     }
     m_studios.append(studio);
@@ -889,7 +889,7 @@ void Movie::addStudio(QString studio) // NOLINT // we require pass-by-value
 
 void Movie::addTag(QString tag) // NOLINT // we require pass-by-value
 {
-    if (m_tags.contains(tag)) {
+    if (tag.isEmpty() || m_tags.contains(tag)) {
         return;
     }
     m_tags.append(tag);


### PR DESCRIPTION
Tags are set the same way as genres, countries and studios, but didn't have duplication problem because there was a check if the tag is already set for the movie. I added the same check to genre, country and studio. Probably not necessary, but I also added test for empty argument into `Movie::addTag`, since it was done in the other functions.

It probably makes more sense to use `QMap` instead of `QStringList` for tags, genres, countries, and studios. It would make checking for existing items faster, and when iterating `QMap`, the items will be sorted by keys. But I'm not sure how much it would affect the performance, and it would probably require a lot of changes.