### PR TITLE
fix(UI): Add "missing" label to "first aired" field if it is the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@
     For example, the country's release date will be used.
   - If a movie has more than one certification in a given language, we sometimes accidentally
     ignored the selected language if TMDB has an empty certification for it (#1641)
-- UI: Images are now loaded asynchronously, which should improve the performance when switching items (#1640)
+- UI:
+  - Images are now loaded asynchronously, which should improve the performance when switching items (#1640)
+  - TV shows: If the "first aired" date is invalid/missing, MediaElch shows the current date, but adds a "missing" marker (#1663)
 - TV shows: The TMDB id, if available, is now marked as "default" in NFO files.
 - Settings: Changing the main window theme no longer requires a restart.
 

--- a/src/ui/tv_show/TvShowWidgetEpisode.cpp
+++ b/src/ui/tv_show/TvShowWidgetEpisode.cpp
@@ -253,6 +253,7 @@ void TvShowWidgetEpisode::onClear()
 
     blocked = ui->firstAired->blockSignals(true);
     ui->firstAired->setDate(QDate::currentDate());
+    ui->lblMissingFirstAired->setVisible(true);
     ui->firstAired->blockSignals(blocked);
 
     blocked = ui->playCount->blockSignals(true);
@@ -402,6 +403,7 @@ void TvShowWidgetEpisode::updateEpisodeInfo()
 
     ui->top250->setValue(m_episode->top250());
     ui->firstAired->setDate(m_episode->firstAired());
+    ui->lblMissingFirstAired->setVisible(!m_episode->firstAired().isValid());
     ui->playCount->setValue(m_episode->playCount());
     ui->lastPlayed->setDateTime(m_episode->lastPlayed());
     ui->studio->setText(m_episode->network());
@@ -1007,6 +1009,7 @@ void TvShowWidgetEpisode::onCertificationChange(QString text)
 void TvShowWidgetEpisode::onFirstAiredChange(QDate date)
 {
     m_episode->setFirstAired(date);
+    ui->lblMissingFirstAired->setVisible(!date.isValid());
     ui->buttonRevert->setVisible(true);
 }
 

--- a/src/ui/tv_show/TvShowWidgetEpisode.ui
+++ b/src/ui/tv_show/TvShowWidgetEpisode.ui
@@ -515,6 +515,12 @@
             </item>
             <item row="7" column="1">
              <widget class="QComboBox" name="certification">
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="editable">
                <bool>true</bool>
               </property>
@@ -527,16 +533,6 @@
              <widget class="QLabel" name="lblFirstAired">
               <property name="text">
                <string>First Aired</string>
-              </property>
-             </widget>
-            </item>
-            <item row="8" column="1">
-             <widget class="QDateEdit" name="firstAired">
-              <property name="buttonSymbols">
-               <enum>QAbstractSpinBox::NoButtons</enum>
-              </property>
-              <property name="displayFormat">
-               <string>dd.MM.yyyy</string>
               </property>
              </widget>
             </item>
@@ -611,6 +607,52 @@
             </item>
             <item row="12" column="1">
              <widget class="QTextEdit" name="overview"/>
+            </item>
+            <item row="8" column="1">
+             <layout class="QHBoxLayout" name="layoutFirstAired" stretch="0,0,1">
+              <item>
+               <widget class="QDateEdit" name="firstAired">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>140</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="buttonSymbols">
+                 <enum>QAbstractSpinBox::NoButtons</enum>
+                </property>
+                <property name="displayFormat">
+                 <string>dd.MM.yyyy</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="lblMissingFirstAired">
+                <property name="text">
+                 <string>missing</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_15">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
             </item>
            </layout>
           </item>

--- a/src/ui/tv_show/TvShowWidgetTvShow.cpp
+++ b/src/ui/tv_show/TvShowWidgetTvShow.cpp
@@ -243,6 +243,7 @@ void TvShowWidgetTvShow::onClear()
 
     blocked = ui->firstAired->blockSignals(true);
     ui->firstAired->setDate(QDate::currentDate());
+    ui->lblMissingFirstAired->setVisible(true);
     ui->firstAired->blockSignals(blocked);
 
     blocked = ui->overview->blockSignals(true);
@@ -351,6 +352,7 @@ void TvShowWidgetTvShow::updateTvShowInfo()
     ui->userRating->setValue(m_show->userRating());
     ui->top250->setValue(m_show->top250());
     ui->firstAired->setDate(m_show->firstAired());
+    ui->lblMissingFirstAired->setVisible(!m_show->firstAired().isValid());
     ui->studio->setText(m_show->network());
     ui->overview->setPlainText(m_show->overview());
     ui->runtime->setValue(static_cast<int>(m_show->runtime().count()));
@@ -1108,6 +1110,7 @@ void TvShowWidgetTvShow::onRuntimeChange(int runtime)
 void TvShowWidgetTvShow::onFirstAiredChange(QDate date)
 {
     m_show->setFirstAired(date);
+    ui->lblMissingFirstAired->setVisible(!date.isValid());
     ui->buttonRevert->setVisible(true);
 }
 

--- a/src/ui/tv_show/TvShowWidgetTvShow.ui
+++ b/src/ui/tv_show/TvShowWidgetTvShow.ui
@@ -467,6 +467,12 @@
             </item>
             <item row="7" column="1">
              <widget class="QComboBox" name="certification">
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="editable">
                <bool>true</bool>
               </property>
@@ -479,16 +485,6 @@
              <widget class="QLabel" name="lblFirstAired">
               <property name="text">
                <string>First Aired</string>
-              </property>
-             </widget>
-            </item>
-            <item row="8" column="1">
-             <widget class="QDateEdit" name="firstAired">
-              <property name="buttonSymbols">
-               <enum>QAbstractSpinBox::NoButtons</enum>
-              </property>
-              <property name="displayFormat">
-               <string>dd.MM.yyyy</string>
               </property>
              </widget>
             </item>
@@ -575,6 +571,55 @@
             </item>
             <item row="12" column="1">
              <widget class="QTextEdit" name="overview"/>
+            </item>
+            <item row="8" column="1">
+             <layout class="QHBoxLayout" name="firstAiredLayout" stretch="0,0,1">
+              <item>
+               <widget class="QDateEdit" name="firstAired">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>140</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="buttonSymbols">
+                 <enum>QAbstractSpinBox::NoButtons</enum>
+                </property>
+                <property name="displayFormat">
+                 <string>dd.MM.yyyy</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="lblMissingFirstAired">
+                <property name="text">
+                 <string>&lt;i&gt;missing&lt;/i&gt;</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_12">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
             </item>
            </layout>
           </item>


### PR DESCRIPTION
For TV shows and episodes, add a marker "missing" to indicate that the "first aired" date is missing.  Qt does not have a good way to mark the QDateWidget "invalid".  It requires a date that it can show.

And the defaults are awful: 2000-01-01 is the default. We simply show the _current_ date with a label "missing" in case the date is invalid.

----

Fix  #1663