### PR TITLE
fix(UI): Correctly scale icons in left navigation bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - The music file list (artist/album) is now readable (better colors)
   - The search/filter result list has explicit colors: they are now readable (#1629)
   - TV Status field and the Movie Streamdetails->Stereo fields are now properly colored (#1657)
+  - The numbers and icons in the left navigation bar were not properly scaled (#1662)
 - UniversalMusicScraper: If an artist has no Discogs link on MusicBrainz, MediaElch was stuck.
 - ADE: Overview and posters are properly scraped again (#1650)
 - IMDb: Fix scraping of episode IDs from season pages

--- a/src/ui/base.css
+++ b/src/ui/base.css
@@ -218,19 +218,19 @@
 #centralWidget #buttonMusic,
 #centralWidget #buttonDownloads {
     border: none;
-    margin-left: 10px;
-    margin-right: 10px;
+    margin-left: 6px;
+    margin-right: 6px;
 }
-#centralWidget #labelMovies,
 #centralWidget #labelShows,
 #centralWidget #labelConcerts,
 #centralWidget #labelMusic,
 #centralWidget #labelDownloads,
 #centralWidget #labelPlugins {
     color: rgba(255, 255, 255, 200);
-    margin-top: 15px;
+    margin-top: 8px;
 }
 #centralWidget #labelMovies {
+    color: rgba(255, 255, 255, 200);
     margin-top: 0px;
 }
 

--- a/src/ui/dark.css
+++ b/src/ui/dark.css
@@ -218,19 +218,19 @@
 #centralWidget #buttonMusic,
 #centralWidget #buttonDownloads {
     border: none;
-    margin-left: 10px;
-    margin-right: 10px;
+    margin-left: 6px;
+    margin-right: 6px;
 }
-#centralWidget #labelMovies,
 #centralWidget #labelShows,
 #centralWidget #labelConcerts,
 #centralWidget #labelMusic,
 #centralWidget #labelDownloads,
 #centralWidget #labelPlugins {
     color: rgba(255, 255, 255, 200);
-    margin-top: 15px;
+    margin-top: 8px;
 }
 #centralWidget #labelMovies {
+    color: rgba(255, 255, 255, 200);
     margin-top: 0px;
 }
 

--- a/src/ui/light.css
+++ b/src/ui/light.css
@@ -218,19 +218,19 @@
 #centralWidget #buttonMusic,
 #centralWidget #buttonDownloads {
     border: none;
-    margin-left: 10px;
-    margin-right: 10px;
+    margin-left: 6px;
+    margin-right: 6px;
 }
-#centralWidget #labelMovies,
 #centralWidget #labelShows,
 #centralWidget #labelConcerts,
 #centralWidget #labelMusic,
 #centralWidget #labelDownloads,
 #centralWidget #labelPlugins {
     color: rgba(255, 255, 255, 200);
-    margin-top: 15px;
+    margin-top: 8px;
 }
 #centralWidget #labelMovies {
+    color: rgba(255, 255, 255, 200);
     margin-top: 0px;
 }
 

--- a/src/ui/main/MainWindow.cpp
+++ b/src/ui/main/MainWindow.cpp
@@ -222,24 +222,6 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
     connect(ui->movieDuplicatesWidget, &MovieDuplicates::sigJumpToMovie,     this, &MainWindow::onJumpToMovie);
     // clang-format on
 
-#ifdef Q_OS_WIN
-    setStyleSheet(styleSheet() + " #centralWidget { border-bottom: 1px solid rgba(0, 0, 0, 100); } ");
-
-    QFont font = ui->labelMovies->font();
-    font.setPointSize(font.pointSize() - 3);
-    font.setBold(true);
-    ui->labelMovies->setFont(font);
-    ui->labelConcerts->setFont(font);
-    ui->labelShows->setFont(font);
-    ui->labelMusic->setFont(font);
-    ui->labelDownloads->setFont(font);
-
-    for (QToolButton* btn : ui->menuWidget->findChildren<QToolButton*>()) {
-        btn->setIconSize(QSize(32, 32));
-    }
-    ui->navbar->setFixedHeight(56);
-#endif
-
     if (Settings::instance()->startupSection() == "tvshows") {
         onMenu(ui->buttonTvshows);
     } else if (Settings::instance()->startupSection() == "concerts") {

--- a/src/ui/main/MainWindow.ui
+++ b/src/ui/main/MainWindow.ui
@@ -98,8 +98,8 @@
          </property>
          <property name="iconSize">
           <size>
-           <width>28</width>
-           <height>28</height>
+           <width>32</width>
+           <height>32</height>
           </size>
          </property>
          <property name="page" stdset="0">
@@ -129,8 +129,8 @@
          </property>
          <property name="iconSize">
           <size>
-           <width>28</width>
-           <height>28</height>
+           <width>32</width>
+           <height>32</height>
           </size>
          </property>
          <property name="page" stdset="0">
@@ -160,8 +160,8 @@
          </property>
          <property name="iconSize">
           <size>
-           <width>28</width>
-           <height>28</height>
+           <width>32</width>
+           <height>32</height>
           </size>
          </property>
          <property name="page" stdset="0">
@@ -191,8 +191,8 @@
          </property>
          <property name="iconSize">
           <size>
-           <width>28</width>
-           <height>28</height>
+           <width>32</width>
+           <height>32</height>
           </size>
          </property>
          <property name="page" stdset="0">
@@ -222,8 +222,8 @@
          </property>
          <property name="iconSize">
           <size>
-           <width>28</width>
-           <height>28</height>
+           <width>32</width>
+           <height>32</height>
           </size>
          </property>
          <property name="page" stdset="0">
@@ -271,8 +271,8 @@
          </property>
          <property name="iconSize">
           <size>
-           <width>28</width>
-           <height>28</height>
+           <width>32</width>
+           <height>32</height>
           </size>
          </property>
          <property name="page" stdset="0">
@@ -320,8 +320,8 @@
          </property>
          <property name="iconSize">
           <size>
-           <width>28</width>
-           <height>28</height>
+           <width>32</width>
+           <height>32</height>
           </size>
          </property>
          <property name="page" stdset="0">
@@ -369,8 +369,8 @@
          </property>
          <property name="iconSize">
           <size>
-           <width>28</width>
-           <height>28</height>
+           <width>32</width>
+           <height>32</height>
           </size>
          </property>
          <property name="page" stdset="0">
@@ -418,8 +418,8 @@
          </property>
          <property name="iconSize">
           <size>
-           <width>28</width>
-           <height>28</height>
+           <width>32</width>
+           <height>32</height>
           </size>
          </property>
          <property name="page" stdset="0">
@@ -434,14 +434,14 @@
         <layout class="QVBoxLayout" name="layoutImport"/>
        </item>
        <item>
-        <spacer name="verticalSpacer">
+        <spacer name="menuSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>20</height>
           </size>
          </property>
         </spacer>
@@ -529,7 +529,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>72</width>
+                <width>83</width>
                 <height>736</height>
                </rect>
               </property>
@@ -607,7 +607,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>100</width>
+                <width>49</width>
                 <height>30</height>
                </rect>
               </property>
@@ -704,7 +704,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>100</width>
+                <width>49</width>
                 <height>30</height>
                </rect>
               </property>
@@ -826,7 +826,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>100</width>
+                <width>83</width>
                 <height>30</height>
                </rect>
               </property>

--- a/src/ui/main/MyIconFont.h
+++ b/src/ui/main/MyIconFont.h
@@ -91,13 +91,13 @@ public:
         const QColor& color,
         const QString& painterName = QString(),
         int markerNum = -1,
-        float scaleFactor = 0.9f);
+        float scaleFactor = 0.98f);
     QIcon icon(const QString& name,
         const QColor& color,
         const QColor& selectionColor,
         const QString& painterName = QString(),
         int markerNum = -1,
-        float scaleFactor = 0.9f);
+        float scaleFactor = 0.98f);
     QIcon icon(MyIconFontIconPainter* painter, const QVariantMap& optionMap = QVariantMap());
 
     void give(const QString& name, MyIconFontIconPainter* painter);


### PR DESCRIPTION
The numbers in bubbles were not device-pixel-ratio independent.  They were wrongly sized on some systems.  Furthermore, increase the icon size for Linux and macOS of the left navigation bar.

For #1662