### PR TITLE
ci(AppImage): Always include SVG image plugin

### DIFF
--- a/.ci/linux/package_linux_appimage.sh
+++ b/.ci/linux/package_linux_appimage.sh
@@ -101,7 +101,7 @@ unset QT_PLUGIN_PATH
 unset LD_LIBRARY_PATH
 # linuxdeployqt uses $VERSION this for naming the file
 VERSION="${ME_VERSION}"
-EXTRA_QT_PLUGINS="qt5dxcb-plugin"
+EXTRA_QT_PLUGINS="qt5dxcb-plugin;svg"
 
 export VERSION
 export EXTRA_QT_PLUGINS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - UniversalMusicScraper: If an artist has no Discogs link on MusicBrainz, MediaElch was stuck.
 - ADE: Overview and posters are properly scraped again (#1650)
 - IMDb: Fix scraping of episode IDs from season pages
+- AppImage: the SVG plugin is now shipped explicitly, fixing the icons in the navigation bar (#1662)
 
 ### Changed
 


### PR DESCRIPTION
For whatever reason, the SVG plugin was not deployed by linuxdeploy (via https://github.com/linuxdeploy/linuxdeploy-plugin-qt ).

Adding it explicitly helped. As a side-effect, the icons in the navigation bar are finally displayed correctly.

---

Fix #1662