### PR TITLE
fix(TV show multi scraper): Missing error message replacement

### DIFF
--- a/src/ui/tv_show/TvShowMultiScrapeDialog.cpp
+++ b/src/ui/tv_show/TvShowMultiScrapeDialog.cpp
@@ -349,7 +349,9 @@ void TvShowMultiScrapeDialog::scrapeNext()
         if (show != nullptr) {
             const auto id = getShowIdentifierForScraper(*m_currentScraper, *show);
             if (id.str().isEmpty()) {
-                logToUser(tr("Skipping show \"%1\" because it does not have a valid ID."));
+                logToUser(tr("Skipping show \"%1\" because it does not have a valid ID and you requested only shows "
+                             "with an ID to be scraped.")
+                              .arg(show->title()));
                 scrapeNext();
                 return;
             }


### PR DESCRIPTION
If `Update only TV shows/episodes which have an ID` is selected and a show does not have an ID, we displayed `Skipping show "%1" because it does not have a valid ID.`, i.e. without the text replacement.

-----

Reported in Kodi forum.