### PR TITLE
feat(TV show): Allow multiple studios/networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
 
 ### Added
 
-- tbd
+- TV shows and episodes: If there is more than one network (separated by `,`),
+  they will be stored as separate `<studio>` tags in the NFO file (#1705)
 
 ## 2.10.6 - 2023-12-03
 

--- a/src/cli/list.cpp
+++ b/src/cli/list.cpp
@@ -155,7 +155,7 @@ void listTvShows()
             table.writeCell(show->tvmazeId().toString());
             table.writeCell(show->tvdbId().isValid() ? show->tvdbId().withPrefix() : "");
             table.writeCell(show->title());
-            table.writeCell(show->network());
+            table.writeCell(show->networks().join(", "));
         }
     }
 }

--- a/src/data/tv_show/TvShow.cpp
+++ b/src/data/tv_show/TvShow.cpp
@@ -74,7 +74,7 @@ void TvShow::clear(QSet<ShowScraperInfo> infos)
         m_genres.clear();
     }
     if (infos.contains(ShowScraperInfo::Network)) {
-        m_network.clear();
+        m_networks.clear();
     }
     if (infos.contains(ShowScraperInfo::Overview)) {
         m_overview.clear();
@@ -212,7 +212,7 @@ void TvShow::exportTo(Exporter& exporter) const
     exporter.exportGenres(m_genres);
     exporter.exportTags(m_tags);
     exporter.exportCertification(m_certification);
-    exporter.exportNetwork(m_network);
+    exporter.exportNetworks(m_networks);
     exporter.exportEpisodeGuideUrl(m_episodeGuideUrl);
     exporter.exportActors(m_actors);
     exporter.exportPosters(m_posters);
@@ -319,10 +319,10 @@ void TvShow::scrapeData(mediaelch::scraper::TvScraper* scraper,
                 // TODO: We need to download images (e.g. actor thumbs somewhere)
 
                 // Map according to advanced settings
-                const QString network = helper::mapStudio(episode->network());
+                const QStringList networks = helper::mapStudio(episode->networks());
                 const Certification certification = helper::mapCertification(episode->certification());
 
-                episode->setNetwork(network);
+                episode->setNetworks(networks);
                 episode->setCertification(certification);
             }
 
@@ -353,11 +353,11 @@ void TvShow::scrapeData(mediaelch::scraper::TvScraper* scraper,
 
         // Map according to advanced settings
         const QStringList genres = helper::mapGenre(job->tvShow().genres());
-        const QString network = helper::mapStudio(job->tvShow().network());
+        const QStringList networks = helper::mapStudio(job->tvShow().networks());
         const Certification certification = helper::mapCertification(job->tvShow().certification());
 
         job->tvShow().setGenres(genres);
-        job->tvShow().setNetwork(network);
+        job->tvShow().setNetworks(networks);
         job->tvShow().setCertification(certification);
 
         scraper::copyDetailsToShow(*this, job->tvShow(), job->config().details);
@@ -513,9 +513,9 @@ Certification TvShow::certification() const
  * \return Network of the show
  * \see TvShow::setNetwork
  */
-QString TvShow::network() const
+QStringList TvShow::networks() const
 {
-    return m_network;
+    return m_networks;
 }
 
 /**
@@ -878,10 +878,6 @@ void TvShow::setGenres(QStringList genres)
     setChanged(true);
 }
 
-/**
- * \brief Adds a genre
- * \see TvShow::genres
- */
 void TvShow::addGenre(QString genre)
 {
     if (genre.isEmpty()) {
@@ -897,25 +893,27 @@ void TvShow::addTag(QString tag)
     setChanged(true);
 }
 
-/**
- * \brief Sets the certification
- * \see TvShow::certification
- */
 void TvShow::setCertification(Certification certification)
 {
     m_certification = certification;
     setChanged(true);
 }
 
-/**
- * \brief Sets the network
- * \see TvShow::network
- */
-void TvShow::setNetwork(QString network)
+void TvShow::setNetworks(QStringList networks)
 {
-    m_network = network;
+    m_networks = networks;
     setChanged(true);
 }
+
+void TvShow::addNetwork(QString network)
+{
+    if (network.isEmpty()) {
+        return;
+    }
+    m_networks.append(network);
+    setChanged(true);
+}
+
 
 /**
  * \brief Sets the plot
@@ -1530,12 +1528,15 @@ QDebug operator<<(QDebug dbg, const TvShow& show)
     }
     out.append(QStringLiteral("  FirstAired:    ").append(show.firstAired().toString("yyyy-MM-dd")).append(nl));
     out.append(QStringLiteral("  Certification: ").append(show.certification().toString()).append(nl));
-    out.append(QStringLiteral("  Network:       ").append(show.network()).append(nl));
+    const auto& networks = show.networks();
+    for (const QString& network : networks) {
+        out.append(QStringLiteral("  Network:       ").append(network)).append(nl);
+    }
     out.append(QStringLiteral("  Overview:      ").append(show.overview())).append(nl);
     out.append(QStringLiteral("  Status:        ").append(show.status())).append(nl);
     const auto& genres = show.genres();
     for (const QString& genre : genres) {
-        out.append(QString("  Genre:         ").append(genre)).append(nl);
+        out.append(QStringLiteral("  Genre:         ").append(genre)).append(nl);
     }
     for (const Actor* actor : show.actors().actors()) {
         out.append(QStringLiteral("  Actor:         ").append(nl));

--- a/src/data/tv_show/TvShow.h
+++ b/src/data/tv_show/TvShow.h
@@ -69,7 +69,7 @@ public:
     QStringList tags() const;
     QVector<QString*> genresPointer();
     Certification certification() const;
-    QString network() const;
+    QStringList networks() const;
     QString overview() const;
     TmdbId tmdbId() const;
     TvDbId tvdbId() const;
@@ -132,7 +132,8 @@ public:
     void addGenre(QString genre);
     void addTag(QString tag);
     void setCertification(Certification certification);
-    void setNetwork(QString network);
+    void setNetworks(QStringList networks);
+    void addNetwork(QString network);
     void setOverview(QString overview);
     void setTmdbId(TmdbId id);
     void setTvdbId(TvDbId id);
@@ -252,7 +253,7 @@ public:
         virtual void exportGenres(const QStringList& genres) = 0;
         virtual void exportTags(const QStringList& tags) = 0;
         virtual void exportCertification(const Certification& certification) = 0;
-        virtual void exportNetwork(const QString& network) = 0;
+        virtual void exportNetworks(const QStringList& networks) = 0;
         virtual void exportEpisodeGuideUrl(const QString& episodeGuideUrl) = 0;
         virtual void exportActors(const Actors& actors) = 0;
         virtual void exportPosters(const QVector<Poster>& posters) = 0;
@@ -292,7 +293,7 @@ private:
     QStringList m_genres;
     QStringList m_tags;
     Certification m_certification;
-    QString m_network;
+    QStringList m_networks;
     QString m_overview;
     TmdbId m_tmdbId;
     TvDbId m_tvdbId;

--- a/src/data/tv_show/TvShowEpisode.h
+++ b/src/data/tv_show/TvShowEpisode.h
@@ -79,7 +79,7 @@ public:
     QStringList tags() const;
     QTime epBookmark() const;
     Certification certification() const;
-    QString network() const;
+    QStringList networks() const;
     QString seasonString() const;
     QString seasonName() const;
     QString episodeString() const;
@@ -121,7 +121,8 @@ public:
     void setFirstAired(QDate firstAired);
     void addTag(QString tag);
     void setCertification(Certification certification);
-    void setNetwork(QString network);
+    void setNetworks(QStringList network);
+    void addNetwork(QString network);
     void setThumbnail(QUrl url);
     void setThumbnailImage(QByteArray thumbnail);
     void setEpBookmark(QTime epBookmark);
@@ -212,7 +213,7 @@ public:
         virtual void exportTags(const QStringList& tags) = 0;
         virtual void exportEpBookmark(const QTime& epBookmark) = 0;
         virtual void exportCertification(const Certification& certification) = 0;
-        virtual void exportNetwork(const QString& network) = 0;
+        virtual void exportNetworks(const QStringList& networks) = 0;
         virtual void exportThumbnail(const QUrl& thumbnail) = 0;
         virtual void exportActors(const Actors& actors) = 0;
         virtual void exportStreamDetails(const StreamDetails* streamDetails) = 0;
@@ -251,7 +252,7 @@ private:
     QStringList m_tags;
     QTime m_epBookmark;
     Certification m_certification;
-    QString m_network;
+    QStringList m_networks;
     QUrl m_thumbnail;
     QByteArray m_thumbnailImage;
     EpisodeModelItem* m_modelItem = nullptr;

--- a/src/export/CsvExport.cpp
+++ b/src/export/CsvExport.cpp
@@ -247,7 +247,7 @@ void CsvTvShowExport::exportTvShows(const QVector<TvShow*>& shows, std::function
             {s(Field::ShowSortTitle), show->sortTitle()},
             {s(Field::ShowOriginalTitle), show->originalTitle()},
             {s(Field::ShowFirstAired), show->firstAired().toString(Qt::ISODate)},
-            {s(Field::ShowNetwork), show->network()},
+            {s(Field::ShowNetwork), show->networks().join(", ")},
             {s(Field::ShowCertification), show->certification().toString()},
             {s(Field::ShowGenres), show->genres().join(", ")},
             {s(Field::ShowTags), show->tags().join(", ")},

--- a/src/export/SimpleEngine.cpp
+++ b/src/export/SimpleEngine.cpp
@@ -361,7 +361,7 @@ void SimpleEngine::replaceVars(QString& m, const TvShow* show, bool subDir)
     m.replace("{{ TVSHOW.CERTIFICATION }}", show->certification().toString().toHtmlEscaped());
     m.replace(
         "{{ TVSHOW.FIRST_AIRED }}", show->firstAired().isValid() ? show->firstAired().toString("yyyy-MM-dd") : "");
-    m.replace("{{ TVSHOW.STUDIO }}", show->network().toHtmlEscaped());
+    m.replace("{{ TVSHOW.STUDIO }}", show->networks().join(", ").toHtmlEscaped());
     m.replace("{{ TVSHOW.PLOT }}", show->overview().toHtmlEscaped().replace("\n", "<br />"));
     m.replace("{{ TVSHOW.TAGS }}", show->tags().join(", ").toHtmlEscaped());
     m.replace("{{ TVSHOW.GENRES }}", show->genres().join(", ").toHtmlEscaped());
@@ -451,7 +451,7 @@ void SimpleEngine::replaceVars(QString& m, const TvShowEpisode* episode, bool su
         episode->firstAired().isValid() ? episode->firstAired().toString("yyyy-MM-dd") : "");
     m.replace("{{ EPISODE.LAST_PLAYED }}",
         episode->lastPlayed().isValid() ? episode->lastPlayed().toString("yyyy-MM-dd hh:mm") : "");
-    m.replace("{{ EPISODE.STUDIO }}", episode->network().toHtmlEscaped());
+    m.replace("{{ EPISODE.STUDIO }}", episode->networks().join(", ").toHtmlEscaped());
     m.replace("{{ EPISODE.PLOT }}", episode->overview().toHtmlEscaped().replace("\n", "<br />"));
     m.replace("{{ EPISODE.WRITERS }}", episode->writers().join(", ").toHtmlEscaped());
     m.replace("{{ EPISODE.DIRECTORS }}", episode->directors().join(", ").toHtmlEscaped());

--- a/src/globals/Helper.cpp
+++ b/src/globals/Helper.cpp
@@ -302,6 +302,20 @@ QString mapStudio(const QString& text)
     return text;
 }
 
+QStringList mapStudio(const QStringList& studios)
+{
+    if (Settings::instance()->advanced()->studioMappings().isEmpty()) {
+        return studios;
+    }
+
+    QStringList mappedStudios;
+    for (const QString& studio : studios) {
+        mappedStudios << mapStudio(studio);
+    }
+    return mappedStudios;
+}
+
+
 QString mapCountry(const QString& text)
 {
     if (Settings::instance()->advanced()->countryMappings().isEmpty()) {
@@ -314,10 +328,24 @@ QString mapCountry(const QString& text)
     return text;
 }
 
+QStringList mapCountry(const QStringList& countries)
+{
+    if (Settings::instance()->advanced()->countryMappings().isEmpty()) {
+        return countries;
+    }
+
+    QStringList mappedCountries;
+    for (const QString& country : countries) {
+        mappedCountries << mapCountry(country);
+    }
+    return mappedCountries;
+}
+
+
 QString formatFileSizeBinary(double size, const QLocale& locale)
 {
     // We use the decimal system, i.e. 1000 and not the binary system with 1000.
-    // Otherwise the units would be GiB, Mib and kiB.
+    // Otherwise, the units would be GiB, Mib and kiB.
     if (size > 1024. * 1024. * 1024.) {
         return QString("%1 GiB").arg(locale.toString(size / 1024.0 / 1024.0 / 1024.0, 'f', 2));
     }

--- a/src/globals/Helper.h
+++ b/src/globals/Helper.h
@@ -37,7 +37,9 @@ QString mapGenre(const QString& text);
 QStringList mapGenre(const QStringList& genres);
 Certification mapCertification(const Certification& certification);
 QString mapStudio(const QString& text);
+QStringList mapStudio(const QStringList& studio);
 QString mapCountry(const QString& text);
+QStringList mapCountry(const QStringList& countries);
 
 QString formatFileSizeBinary(double size, const QLocale& locale);
 QString formatFileSize(double size, const QLocale& locale);

--- a/src/media_center/kodi/EpisodeXmlReader.cpp
+++ b/src/media_center/kodi/EpisodeXmlReader.cpp
@@ -181,8 +181,9 @@ bool EpisodeXmlReader::parseNfoDom(QDomElement episodeDetails)
             }
         }
     }
-    if (!episodeDetails.elementsByTagName("studio").isEmpty()) {
-        m_episode.setNetwork(episodeDetails.elementsByTagName("studio").at(0).toElement().text());
+
+    for (int i = 0, n = episodeDetails.elementsByTagName("studio").size(); i < n; i++) {
+        m_episode.addNetwork(episodeDetails.elementsByTagName("studio").at(i).toElement().text());
     }
 
     // tags are officially not yet supported, even by Kodi 19 but scraper providers start

--- a/src/media_center/kodi/EpisodeXmlWriter.cpp
+++ b/src/media_center/kodi/EpisodeXmlWriter.cpp
@@ -114,31 +114,21 @@ void EpisodeXmlWriterGeneric::writeSingleEpisodeDetails(QXmlStreamWriter& xml, T
     xml.writeTextElement("playcount", QString("%1").arg(episode->playCount()));
     xml.writeTextElement("lastplayed", episode->lastPlayed().toString("yyyy-MM-dd HH:mm:ss"));
     xml.writeTextElement("aired", episode->firstAired().toString("yyyy-MM-dd"));
-    xml.writeTextElement("studio", episode->network());
+    KodiXml::writeStringsAsOneTagEach(xml, "studio", episode->networks());
     if (!episode->epBookmark().isNull() && QTime(0, 0, 0).secsTo(episode->epBookmark()) > 0) {
         xml.writeTextElement("epbookmark", QString("%1").arg(QTime(0, 0, 0).secsTo(episode->epBookmark())));
     }
 
-    const auto& writers = episode->writers();
-    for (const QString& writer : writers) {
-        xml.writeTextElement("credits", writer);
-    }
+    KodiXml::writeStringsAsOneTagEach(xml, "credits", episode->writers());
+    KodiXml::writeStringsAsOneTagEach(xml, "director", episode->directors());
 
-    const auto& directors = episode->directors();
-    for (const QString& director : directors) {
-        xml.writeTextElement("director", director);
-    }
     if (writeThumbUrlsToNfo() && !episode->thumbnail().isEmpty()) {
         xml.writeTextElement("thumb", episode->thumbnail().toString());
     }
 
     writeActors(xml, episode->actors());
 
-    // officially not supported but scraper providers start to support it
-    const auto& tags = episode->tags();
-    for (const QString& tag : tags) {
-        xml.writeTextElement("tag", tag);
-    }
+    KodiXml::writeStringsAsOneTagEach(xml, "tag", episode->tags());
 
     KodiXml::writeStreamDetails(xml, episode->streamDetails(), {});
 

--- a/src/media_center/kodi/TvShowXmlReader.cpp
+++ b/src/media_center/kodi/TvShowXmlReader.cpp
@@ -164,8 +164,8 @@ bool TvShowXmlReader::parseNfoDom(QDomDocument domDoc)
         m_show.setDateAdded(QDateTime::fromString(
             domDoc.elementsByTagName("dateadded").at(0).toElement().text(), "yyyy-MM-dd HH:mm:ss"));
     }
-    if (!domDoc.elementsByTagName("studio").isEmpty()) {
-        m_show.setNetwork(domDoc.elementsByTagName("studio").at(0).toElement().text());
+    for (int i = 0, n = domDoc.elementsByTagName("studio").size(); i < n; i++) {
+        m_show.addNetwork(domDoc.elementsByTagName("studio").at(i).toElement().text());
     }
     if (!domDoc.elementsByTagName("episodeguide").isEmpty()
         && !domDoc.elementsByTagName("episodeguide").at(0).toElement().elementsByTagName("url").isEmpty()) {

--- a/src/media_center/kodi/TvShowXmlWriter.cpp
+++ b/src/media_center/kodi/TvShowXmlWriter.cpp
@@ -134,7 +134,8 @@ QByteArray TvShowXmlWriterGeneric::getTvShowXml(bool testMode)
     }
     xml.writeTextElement("dateadded", m_show.dateAdded().toString("yyyy-MM-dd HH:mm:ss"));
     xml.writeTextElement("status", m_show.status());
-    xml.writeTextElement("studio", m_show.network());
+
+    KodiXml::writeStringsAsOneTagEach(xml, "studio", m_show.networks());
 
     if (m_show.runtime() > 0min) {
         xml.writeTextElement("runtime", QString::number(m_show.runtime().count()));
@@ -209,11 +210,7 @@ QByteArray TvShowXmlWriterGeneric::getTvShowXml(bool testMode)
         xml.writeEndElement();
     }
 
-    const auto& genres = m_show.genres();
-    for (const QString& genre : genres) {
-        xml.writeTextElement("genre", genre);
-    }
-
+    KodiXml::writeStringsAsOneTagEach(xml, "genre", m_show.genres());
     KodiXml::writeStringsAsOneTagEach(xml, "tag", m_show.tags());
 
     if (writeThumbUrlsToNfo()) {

--- a/src/scrapers/TvShowUpdater.cpp
+++ b/src/scrapers/TvShowUpdater.cpp
@@ -56,10 +56,10 @@ void TvShowUpdater::updateShow(TvShow* show, bool force)
 
         for (TvShowEpisode* episode : scrapedEpisodes) {
             // Map according to advanced settings
-            const QString network = helper::mapStudio(episode->network());
+            const QStringList networks = helper::mapStudio(episode->networks());
             const Certification certification = helper::mapCertification(episode->certification());
 
-            episode->setNetwork(network);
+            episode->setNetworks(networks);
             episode->setCertification(certification);
         }
 

--- a/src/scrapers/tv_show/ShowMerger.cpp
+++ b/src/scrapers/tv_show/ShowMerger.cpp
@@ -69,7 +69,10 @@ static void copyDetailToShow(TvShow& target, TvShow& source, ShowScraperInfo det
         break;
     }
     case ShowScraperInfo::Network: {
-        target.setNetwork(source.network());
+        const auto networks = source.networks();
+        for (const QString& network : networks) {
+            target.addNetwork(network);
+        }
         break;
     }
     case ShowScraperInfo::Overview: {
@@ -197,7 +200,10 @@ static void copyDetailToEpisode(TvShowEpisode& target, const TvShowEpisode& sour
         break;
     }
     case EpisodeScraperInfo::Network: {
-        target.setNetwork(source.network());
+        const auto& networks = source.networks();
+        for (const QString& network : networks) {
+            target.addNetwork(network);
+        }
         break;
     }
     case EpisodeScraperInfo::Overview: {

--- a/src/scrapers/tv_show/thetvdb/TheTvDbShowParser.cpp
+++ b/src/scrapers/tv_show/thetvdb/TheTvDbShowParser.cpp
@@ -25,7 +25,7 @@ void TheTvDbShowParser::parseInfos(const QJsonObject& json)
 
     // TheTVDb month and day don't have a leading zero
     m_show.setFirstAired(QDate::fromString(showData.value("firstAired").toString(), "yyyy-M-d"));
-    m_show.setNetwork(showData.value("network").toString());
+    m_show.addNetwork(showData.value("network").toString());
     m_show.setOverview(showData.value("overview").toString());
 
     {

--- a/src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp
+++ b/src/scrapers/tv_show/tmdb/TmdbTvShowParser.cpp
@@ -205,13 +205,11 @@ void TmdbTvShowParser::parseInfos(const QJsonDocument& json, const Locale& local
     // -------------------------------------
     {
         QJsonArray networks = data["networks"].toArray();
-        QStringList gatheredNetworks;
         for (QJsonValueRef val : networks) {
             QString name = val.toObject()["name"].toString();
-            gatheredNetworks.append(name);
-        }
-        if (!gatheredNetworks.isEmpty()) {
-            m_show.setNetwork(gatheredNetworks.join(", "));
+            if (!name.isEmpty()) {
+                m_show.addNetwork(name);
+            }
         }
     }
 

--- a/src/scrapers/tv_show/tvmaze/TvMazeShowParser.cpp
+++ b/src/scrapers/tv_show/tvmaze/TvMazeShowParser.cpp
@@ -177,12 +177,13 @@ void TvMazeShowParser::parseInfos(const QJsonDocument& json)
 
     // -------------------------------------
     {
+        // TVMaze only supports one network.
         QString network = data["network"].toObject()["name"].toString();
         if (network.isEmpty()) {
             network = data["webChannel"].toObject()["name"].toString();
         }
         if (!network.isEmpty()) {
-            m_show.setNetwork(network);
+            m_show.addNetwork(network);
         }
     }
 }

--- a/src/ui/tv_show/TvShowWidgetEpisode.cpp
+++ b/src/ui/tv_show/TvShowWidgetEpisode.cpp
@@ -406,7 +406,7 @@ void TvShowWidgetEpisode::updateEpisodeInfo()
     ui->lblMissingFirstAired->setVisible(!m_episode->firstAired().isValid());
     ui->playCount->setValue(m_episode->playCount());
     ui->lastPlayed->setDateTime(m_episode->lastPlayed());
-    ui->studio->setText(m_episode->network());
+    ui->studio->setText(m_episode->networks().join(", "));
     ui->overview->setPlainText(m_episode->overview());
     ui->epBookmark->setTime(m_episode->epBookmark());
 
@@ -810,8 +810,6 @@ void TvShowWidgetEpisode::onPosterDownloadFinished(DownloadManagerElement elem)
     }
 }
 
-/*** add/remove/edit Actors, Genres, Countries and Studios ***/
-
 /**
  * \brief Adds a director
  */
@@ -1022,21 +1020,19 @@ void TvShowWidgetEpisode::onPlayCountChange(int value)
     ui->buttonRevert->setVisible(true);
 }
 
-/**
- * \brief Marks the episode as changed when the last played date has changed
- */
 void TvShowWidgetEpisode::onLastPlayedChange(QDateTime dateTime)
 {
     m_episode->setLastPlayed(dateTime);
     ui->buttonRevert->setVisible(true);
 }
 
-/**
- * \brief Marks the episode as changed when the studio has changed
- */
 void TvShowWidgetEpisode::onStudioChange(QString text)
 {
-    m_episode->setNetwork(text);
+    QStringList networks = text.split(",", Qt::SkipEmptyParts);
+    for (auto& network : networks) {
+        network = network.trimmed();
+    }
+    m_episode->setNetworks(networks);
     ui->buttonRevert->setVisible(true);
 }
 
@@ -1049,9 +1045,6 @@ void TvShowWidgetEpisode::onEpBookmarkChange(QTime time)
     ui->buttonRevert->setVisible(true);
 }
 
-/**
- * \brief Marks the episode as changed when the overview has changed
- */
 void TvShowWidgetEpisode::onOverviewChange()
 {
     m_episode->setOverview(ui->overview->toPlainText());

--- a/src/ui/tv_show/TvShowWidgetTvShow.cpp
+++ b/src/ui/tv_show/TvShowWidgetTvShow.cpp
@@ -353,7 +353,7 @@ void TvShowWidgetTvShow::updateTvShowInfo()
     ui->top250->setValue(m_show->top250());
     ui->firstAired->setDate(m_show->firstAired());
     ui->lblMissingFirstAired->setVisible(!m_show->firstAired().isValid());
-    ui->studio->setText(m_show->network());
+    ui->studio->setText(m_show->networks().join(", "));
     ui->overview->setPlainText(m_show->overview());
     ui->runtime->setValue(static_cast<int>(m_show->runtime().count()));
     if (m_show->status() == "Continuing") {
@@ -833,8 +833,6 @@ void TvShowWidgetTvShow::onDownloadsLeft(int left, DownloadManagerElement elem)
         Constants::TvShowProgressMessageId + elem.show->showId());
 }
 
-/*** add/remove/edit Actors, Genres, Countries and Studios ***/
-
 /**
  * \brief Adds a genre
  */
@@ -1114,18 +1112,16 @@ void TvShowWidgetTvShow::onFirstAiredChange(QDate date)
     ui->buttonRevert->setVisible(true);
 }
 
-/**
- * \brief Marks the show as changed when the studio has changed
- */
-void TvShowWidgetTvShow::onStudioChange(QString studio)
+void TvShowWidgetTvShow::onStudioChange(QString studios)
 {
-    m_show->setNetwork(std::move(studio));
+    QStringList networks = studios.split(",", Qt::SkipEmptyParts);
+    for (auto& network : networks) {
+        network = network.trimmed();
+    }
+    m_show->setNetworks(networks);
     ui->buttonRevert->setVisible(true);
 }
 
-/**
- * \brief Marks the show as changed when the overview has changed
- */
 void TvShowWidgetTvShow::onOverviewChange()
 {
     m_show->setOverview(ui->overview->toPlainText());

--- a/src/ui/tv_show/TvShowWidgetTvShow.h
+++ b/src/ui/tv_show/TvShowWidgetTvShow.h
@@ -76,7 +76,7 @@ private slots:
     void onUserRatingChange(double value);
     void onTop250Change(int value);
     void onFirstAiredChange(QDate date);
-    void onStudioChange(QString studio);
+    void onStudioChange(QString studios);
     void onOverviewChange();
     void onActorEdited(QTableWidgetItem* item);
     void onRuntimeChange(int runtime);

--- a/test/helpers/reference_file.cpp
+++ b/test/helpers/reference_file.cpp
@@ -535,7 +535,7 @@ public:
     {
         writeToReference(m_out, "certification", certification);
     }
-    void exportNetwork(const QString& network) override { writeToReference(m_out, "network", network); }
+    void exportNetworks(const QStringList& networks) override { writeToReference(m_out, "networks", networks); }
     void exportEpisodeGuideUrl(const QString& episodeGuideUrl) override
     {
         writeToReference(m_out, "episodeGuideUrl", episodeGuideUrl);
@@ -656,7 +656,7 @@ public:
     {
         writeToReference(m_out, "certification", certification);
     }
-    void exportNetwork(const QString& network) override { writeToReference(m_out, "network", network); }
+    void exportNetworks(const QStringList& networks) override { writeToReference(m_out, "networks", networks); }
     void exportThumbnail(const QUrl& thumbnail) override { writeToReference(m_out, "thumbnail", thumbnail); }
     void exportActors(const Actors& actors) override { writeToReference(m_out, "actors", actors); }
     void exportStreamDetails(const StreamDetails* streamDetails) override

--- a/test/integration/media_center/testKodi_v18_show.cpp
+++ b/test/integration/media_center/testKodi_v18_show.cpp
@@ -106,7 +106,8 @@ TEST_CASE("TV show XML writer for Kodi v18", "[data][tvshow][kodi][nfo]")
         show.addGenre("Drama");
         show.addTag("BestTag");
         show.setStatus("Ended");
-        show.setNetwork("The WB");
+        show.addNetwork("The WB");
+        show.addNetwork("The Other WB");
         {
             Poster banner;
             banner.thumbUrl = "http://thetvdb.com/banners/graphical/71035-g7.jpg";

--- a/test/integration/media_center/testKodi_v20_show.cpp
+++ b/test/integration/media_center/testKodi_v20_show.cpp
@@ -106,7 +106,8 @@ TEST_CASE("TV show XML writer for Kodi v20", "[data][tvshow][kodi][nfo]")
         show.addGenre("Drama");
         show.addTag("BestTag");
         show.setStatus("Ended");
-        show.setNetwork("The WB");
+        show.addNetwork("The WB");
+        show.addNetwork("The other WB");
         {
             Poster banner;
             banner.thumbUrl = "http://thetvdb.com/banners/graphical/71035-g7.jpg";

--- a/test/resources/scrapers/aebn/M-Is-For-Mischief-159236.ref.txt
+++ b/test/resources/scrapers/aebn/M-Is-For-Mischief-159236.ref.txt
@@ -58,10 +58,10 @@ actors: (N<6)
    imageHasChanged: false
 certification: 
 genres: (N<6)
-  - Natural Breasts
-  - Teen (18+)
-  - All Sex
   - Schoolgirls
+  - All Sex
+  - Teen (18+)
+  - Natural Breasts
 tags: (N>10)
   - Vaginal Sex
   - Deep Throating

--- a/test/resources/scrapers/discogs/rammstein-details-11771.ref.txt
+++ b/test/resources/scrapers/discogs/rammstein-details-11771.ref.txt
@@ -129,8 +129,6 @@ discography: (N>90)
     year: 2003
   - title: Lichtspielhaus
     year: 2003
-  - title: Music Box
-    year: 2003
   - title: Reise, Reise Videospecial
     year: 2004
   - title: Interview Disc 1
@@ -142,8 +140,6 @@ discography: (N>90)
   - title: Platinum Collection '2003 - "Links" Greatest Hits 
     year: 2004
   - title: Reise,Reise Interview
-    year: 2004
-  - title: Mutter
     year: 2004
   - title: Ohne Dich
     year: 2004
@@ -229,6 +225,10 @@ discography: (N>90)
     year: 2022
   - title: Adieu
     year: 2022
+  - title: MTV / VOX
+    year: 
+  - title: Rammstein Tipo - Duplicamos La Imagen
+    year: 
 genres: (N=0)
 styles: (N=0)
 moods: (N=0)

--- a/test/resources/scrapers/fernsehserien_de/Black-Mirror-S04E05-no-id.ref.txt
+++ b/test/resources/scrapers/fernsehserien_de/Black-Mirror-S04E05-no-id.ref.txt
@@ -30,7 +30,7 @@ firstAired: 2017-12-29
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>

--- a/test/resources/scrapers/fernsehserien_de/Black-Mirror-S05.ref.txt
+++ b/test/resources/scrapers/fernsehserien_de/Black-Mirror-S05.ref.txt
@@ -36,7 +36,7 @@ firstAired: 2019-06-05
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -85,7 +85,7 @@ firstAired: 2019-06-05
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -133,7 +133,7 @@ firstAired: 2019-06-05
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>

--- a/test/resources/scrapers/fernsehserien_de/Black-Mirror-all-seasons.ref.txt
+++ b/test/resources/scrapers/fernsehserien_de/Black-Mirror-all-seasons.ref.txt
@@ -28,7 +28,7 @@ firstAired: 2017-10-21
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -63,7 +63,7 @@ firstAired: 2018-12-28
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -104,7 +104,7 @@ firstAired: 2013-12-11
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N>20)
  - id: 
@@ -282,7 +282,7 @@ firstAired: 2013-12-18
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -326,7 +326,7 @@ firstAired: 2013-12-25
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N>10)
  - id: 
@@ -451,7 +451,7 @@ firstAired: 2014-08-20
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N>10)
  - id: 
@@ -564,7 +564,7 @@ firstAired: 2014-08-13
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N>10)
  - id: 
@@ -712,7 +712,7 @@ firstAired: 2014-08-27
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N>20)
  - id: 
@@ -877,7 +877,7 @@ firstAired: 2016-10-21
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -918,7 +918,7 @@ firstAired: 2016-10-21
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -959,7 +959,7 @@ firstAired: 2016-10-21
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1000,7 +1000,7 @@ firstAired: 2016-10-21
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://bilder.fernsehserien.de/epg/epg-archiv/2023/06/27/8abb4a16afad1c293bc9223bb03dd5fea5b5eb68_b-w-970.jpg.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1040,7 +1040,7 @@ firstAired: 2016-10-21
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1087,7 +1087,7 @@ firstAired: 2016-10-21
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1132,7 +1132,7 @@ firstAired: 2017-12-29
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://bilder.fernsehserien.de/epg/epg-archiv/2023/06/21/cb156451408e9ad77756c7b7361f7b5f80123b4f_b-w-970.jpg.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1174,7 +1174,7 @@ firstAired: 2017-12-29
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1218,7 +1218,7 @@ firstAired: 2017-12-29
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://bilder.fernsehserien.de/epg/epg-archiv/2023/07/12/26d30b7bd6ec47bc9d65b643923986e1_b-w-970.jpg.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1263,7 +1263,7 @@ firstAired: 2017-12-29
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1305,7 +1305,7 @@ firstAired: 2017-12-29
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1346,7 +1346,7 @@ firstAired: 2017-12-29
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1389,7 +1389,7 @@ firstAired: 2019-06-05
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1438,7 +1438,7 @@ firstAired: 2019-06-05
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1486,7 +1486,7 @@ firstAired: 2019-06-05
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1521,7 +1521,7 @@ firstAired: 2023-06-15
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1556,7 +1556,7 @@ firstAired: 2023-06-15
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1591,7 +1591,7 @@ firstAired: 2023-06-15
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1626,7 +1626,7 @@ firstAired: 2023-06-15
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>
@@ -1661,7 +1661,7 @@ firstAired: 2023-06-15
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: 
 actors: (N=0)
 streamDetails: <not loaded>

--- a/test/resources/scrapers/fernsehserien_de/Die-Simpsons.ref.txt
+++ b/test/resources/scrapers/fernsehserien_de/Die-Simpsons.ref.txt
@@ -47,7 +47,7 @@ genres: (N<6)
   - Zeichentrick
 tags: (N=0)
 certification: 
-network: 
+networks: (N=0)
 episodeGuideUrl: 
 actors: (N>5)
  - id: 

--- a/test/resources/scrapers/fernsehserien_de/Game-of-Thrones.ref.txt
+++ b/test/resources/scrapers/fernsehserien_de/Game-of-Thrones.ref.txt
@@ -30,7 +30,7 @@ genres: (N<6)
   - Fantasy
 tags: (N=0)
 certification: 
-network: 
+networks: (N=0)
 episodeGuideUrl: 
 actors: (N>5)
  - id: 
@@ -48,7 +48,9 @@ actors: (N>5)
  - id: 
    name: Emilia Clarke
    role: Daenerys Targaryen
-   thumb: https://bilder.fernsehserien.de/gfx/person_1000/e/emilia-clarke.jpg
+   thumb:
+    https://bilder.fernsehserien.de/gfx/person_1000/e/emilia-clarke-46506-1704360411
+    .jpg
    order: 2
    imageHasChanged: false
  - id: 

--- a/test/resources/scrapers/fernsehserien_de/Scrubs.ref.txt
+++ b/test/resources/scrapers/fernsehserien_de/Scrubs.ref.txt
@@ -34,12 +34,12 @@ genres: (N<6)
   - Comedy
 tags: (N=0)
 certification: 
-network: 
+networks: (N=0)
 episodeGuideUrl: 
 actors: (N>5)
  - id: 
    name: Sarah Chalke
-   role: Elliot Reid (197 Folgen, 2001–2010)
+   role: Elliot Reid (179 Folgen, 2001–2010)
    thumb: https://bilder.fernsehserien.de/gfx/person_1000/s/sarah-chalke.jpg
    order: 0
    imageHasChanged: false
@@ -51,7 +51,7 @@ actors: (N>5)
    imageHasChanged: false
  - id: 
    name: John C. McGinley
-   role: Dr. Perry Cox (186 Folgen, 2001–2010)
+   role: Dr. Perry Cox (182 Folgen, 2001–2010)
    thumb: https://bilder.fernsehserien.de/gfx/person_1000/j/john-c-mcginley.jpg
    order: 2
    imageHasChanged: false

--- a/test/resources/scrapers/fernsehserien_de/The-Simpsons-S05E02.ref.txt
+++ b/test/resources/scrapers/fernsehserien_de/The-Simpsons-S05E02.ref.txt
@@ -31,8 +31,8 @@ firstAired: 1999-10-02
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
-thumbnail: https://bilder.fernsehserien.de/epg/epg-archiv/2023/07/12/36697e2a489c466da77a317662e19791_b-w-970.jpg.jpg
+networks: (N=0)
+thumbnail: https://bilder.fernsehserien.de/epg/epg-archiv/2023/12/29/1cab57f153f64abba59b474141d0c5b5_b-w-970.jpg.jpg
 actors: (N>5)
  - id: 
    name: Dan Castellaneta

--- a/test/resources/scrapers/fernsehserien_de/The-Simpsons-S12E19-no-id.ref.txt
+++ b/test/resources/scrapers/fernsehserien_de/The-Simpsons-S12E19-no-id.ref.txt
@@ -30,7 +30,7 @@ firstAired: 2002-02-04
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://bilder.fernsehserien.de/epg/epg-archiv/2023/07/13/e59b825d2c9947a888dd410bd0701b01_b-w-970.jpg.jpg
 actors: (N<6)
  - id: 

--- a/test/resources/scrapers/fernsehserien_de/The-Simpsons-S12E19-with-id.ref.txt
+++ b/test/resources/scrapers/fernsehserien_de/The-Simpsons-S12E19-with-id.ref.txt
@@ -30,7 +30,7 @@ firstAired: 2002-02-04
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://bilder.fernsehserien.de/epg/epg-archiv/2023/07/13/e59b825d2c9947a888dd410bd0701b01_b-w-970.jpg.jpg
 actors: (N<6)
  - id: 

--- a/test/resources/scrapers/fernsehserien_de/Y_a-pas-d_age.ref.txt
+++ b/test/resources/scrapers/fernsehserien_de/Y_a-pas-d_age.ref.txt
@@ -23,7 +23,7 @@ genres: (N=1)
   - Comedyserien
 tags: (N=0)
 certification: 
-network: 
+networks: (N=0)
 episodeGuideUrl: 
 actors: (N=0)
 posters: (N=0)

--- a/test/resources/scrapers/imdbtv/Black-Mirror-S05.ref.txt
+++ b/test/resources/scrapers/imdbtv/Black-Mirror-S05.ref.txt
@@ -29,7 +29,7 @@ firstAired: 2019-06-05
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://m.media-amazon.com/images/M/MV5BOWRlMWM4MTItMTNhMi00ZjgwLWIzYTEtMDI1MjNmOTlhYjA4XkEyXkFqcGdeQXVyNDg4NjY5OTQ@._V1_UX400_CR0,0,400,225_AL_.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -65,7 +65,7 @@ firstAired: 2019-06-05
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://m.media-amazon.com/images/M/MV5BZmVkYjk1ODQtODk5OC00ZGY1LTg3YzMtYTBiYjg5MGEwYTk1XkEyXkFqcGdeQXVyNDg4NjY5OTQ@._V1_UX400_CR0,0,400,225_AL_.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -101,7 +101,7 @@ firstAired: 2019-06-05
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://m.media-amazon.com/images/M/MV5BOTQ1N2I2OTctNWE4NC00YjBiLWE5ZGItZWRjMjNlOGZmNmU0XkEyXkFqcGdeQXVyNDg4NjY5OTQ@._V1_UX400_CR0,0,400,225_AL_.jpg
 actors: (N=0)
 streamDetails: <not loaded>

--- a/test/resources/scrapers/imdbtv/Buffy-S01E00-minimal-details.ref.txt
+++ b/test/resources/scrapers/imdbtv/Buffy-S01E00-minimal-details.ref.txt
@@ -24,7 +24,7 @@ firstAired: 2011-09-30
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://m.media-amazon.com/images/M/MV5BYzY5ZGE1MGQtM2YzNi00NTc0LTliNTQtM2M0NzViODRlNGJjXkEyXkFqcGdeQXVyMjg2MTMyNTM@._V1_UX400_CR0,0,400,225_AL_.jpg
 actors: (N=0)
 streamDetails: <not loaded>

--- a/test/resources/scrapers/imdbtv/Buffy-S01E01-minimal-details.ref.txt
+++ b/test/resources/scrapers/imdbtv/Buffy-S01E01-minimal-details.ref.txt
@@ -24,7 +24,7 @@ firstAired: 1998-10-09
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://m.media-amazon.com/images/M/MV5BMTU2NDQ1NTI2MF5BMl5BanBnXkFtZTgwNDMzMTM1NjM@._V1_UX400_CR0,0,400,225_AL_.jpg
 actors: (N=0)
 streamDetails: <not loaded>

--- a/test/resources/scrapers/imdbtv/Scrubs-tt0285403.ref.txt
+++ b/test/resources/scrapers/imdbtv/Scrubs-tt0285403.ref.txt
@@ -28,7 +28,7 @@ tags: (N<6)
   - california
   - male bonding
 certification: TV-14
-network: 
+networks: (N=0)
 episodeGuideUrl: 
 actors: (N=0)
 posters: (N=1)

--- a/test/resources/scrapers/imdbtv/Sherlock-tt0285403.ref.txt
+++ b/test/resources/scrapers/imdbtv/Sherlock-tt0285403.ref.txt
@@ -30,7 +30,7 @@ tags: (N<6)
   - murder
   - modernized setting
 certification: TV-14
-network: 
+networks: (N=0)
 episodeGuideUrl: 
 actors: (N=0)
 posters: (N=1)

--- a/test/resources/scrapers/imdbtv/The-Simpsons-S12E19-minimal-details.ref.txt
+++ b/test/resources/scrapers/imdbtv/The-Simpsons-S12E19-minimal-details.ref.txt
@@ -24,7 +24,7 @@ firstAired: 2002-02-04
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://m.media-amazon.com/images/M/MV5BMzkyMzZiNGMtOGFkOC00Mjk3LWJkNDYtZGZiYzc4YjUwNjc5XkEyXkFqcGdeQXVyNjcwMzEzMTU@._V1_UX400_CR0,0,400,225_AL_.jpg
 actors: (N=0)
 streamDetails: <not loaded>

--- a/test/resources/scrapers/imdbtv/The-Simpsons-S12E19-tt0701133-all-details.ref.txt
+++ b/test/resources/scrapers/imdbtv/The-Simpsons-S12E19-tt0701133-all-details.ref.txt
@@ -24,7 +24,7 @@ firstAired: 2002-02-04
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://m.media-amazon.com/images/M/MV5BMzkyMzZiNGMtOGFkOC00Mjk3LWJkNDYtZGZiYzc4YjUwNjc5XkEyXkFqcGdeQXVyNjcwMzEzMTU@._V1_UX400_CR0,0,400,225_AL_.jpg
 actors: (N=0)
 streamDetails: <not loaded>

--- a/test/resources/scrapers/imdbtv/The-Simpsons-S12E19-tt0701133-minimal-details.ref.txt
+++ b/test/resources/scrapers/imdbtv/The-Simpsons-S12E19-tt0701133-minimal-details.ref.txt
@@ -24,7 +24,7 @@ firstAired: 2002-02-04
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://m.media-amazon.com/images/M/MV5BMzkyMzZiNGMtOGFkOC00Mjk3LWJkNDYtZGZiYzc4YjUwNjc5XkEyXkFqcGdeQXVyNjcwMzEzMTU@._V1_UX400_CR0,0,400,225_AL_.jpg
 actors: (N=0)
 streamDetails: <not loaded>

--- a/test/resources/scrapers/imdbtv/The-Simpsons-tt0096697-minimal-details.ref.txt
+++ b/test/resources/scrapers/imdbtv/The-Simpsons-tt0096697-minimal-details.ref.txt
@@ -28,7 +28,7 @@ tags: (N<6)
   - cult tv
   - family as protagonists
 certification: TV-14
-network: 
+networks: (N=0)
 episodeGuideUrl: 
 actors: (N=0)
 posters: (N=1)

--- a/test/resources/scrapers/tmdb/Finding_Dory_tmdb127380.ref.txt
+++ b/test/resources/scrapers/tmdb/Finding_Dory_tmdb127380.ref.txt
@@ -30,7 +30,7 @@ actors: (N>30)
  - id: 
    name: Albert Brooks
    role: Marlin (voice)
-   thumb: http://image.tmdb.org/t/p/original/8iDSGu5l93N7benjf6b3AysBore.jpg
+   thumb: http://image.tmdb.org/t/p/original/zhYhOkN2TRsFrEt7RHOAYGz8ZfF.jpg
    order: 0
    imageHasChanged: false
  - id: 
@@ -54,7 +54,7 @@ actors: (N>30)
  - id: 
    name: Diane Keaton
    role: Jenny (voice)
-   thumb: http://image.tmdb.org/t/p/original/siSWRRFN9uO6iCN7y9OrHU5IaJ.jpg
+   thumb: http://image.tmdb.org/t/p/original/mRq2Rxh2hmG3kFPRp4NEGXRaLPB.jpg
    order: 4
    imageHasChanged: false
  - id: 
@@ -96,7 +96,7 @@ actors: (N>30)
  - id: 
    name: Bill Hader
    role: Husband Fish (Stan) (voice)
-   thumb: http://image.tmdb.org/t/p/original/50FpKsWiyqbZxu0oLBAGbWn7wag.jpg
+   thumb: http://image.tmdb.org/t/p/original/dm5x0mPXyibcNgVH4nPvOuAwxWt.jpg
    order: 11
    imageHasChanged: false
  - id: 
@@ -138,7 +138,7 @@ actors: (N>30)
  - id: 
    name: John Ratzenberger
    role: Husband Crab (Bill) (voice)
-   thumb: http://image.tmdb.org/t/p/original/oRtDEOuIO1yDhTz5dORBdxXuLMO.jpg
+   thumb: http://image.tmdb.org/t/p/original/e5aNU09v1q6WYTx9pNzC7yjSpve.jpg
    order: 18
    imageHasChanged: false
  - id: 
@@ -160,7 +160,7 @@ countries: (N=1)
 studios: (N<6)
   - Pixar
   - Walt Disney Pictures
-trailer: https://www.youtube.com/watch?v=JhvrQeY3doI
+trailer: https://www.youtube.com/watch?v=iG0P6bjyUNI
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>
@@ -190,6 +190,14 @@ posters: (N>30)
     aspect: 
     season: SeasonNumber=xx
   - id: 
+    originalUrl: http://image.tmdb.org/t/p/original/yFjVlsJmEMacU0BNUwdGZlo2ixq.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w342/yFjVlsJmEMacU0BNUwdGZlo2ixq.jpg
+    originalSize: h=3000 w=2000
+    language: en
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
+  - id: 
     originalUrl: http://image.tmdb.org/t/p/original/9NHzsMos9OZFoS66ThX99GFVpQc.jpg
     thumbUrl: http://image.tmdb.org/t/p/w342/9NHzsMos9OZFoS66ThX99GFVpQc.jpg
     originalSize: h=3000 w=2000
@@ -205,27 +213,19 @@ posters: (N>30)
     hint: 
     aspect: 
     season: SeasonNumber=xx
-  - id: 
-    originalUrl: http://image.tmdb.org/t/p/original/ipJx835Tv6rtGht3uT7kA9Nxrnh.jpg
-    thumbUrl: http://image.tmdb.org/t/p/w342/ipJx835Tv6rtGht3uT7kA9Nxrnh.jpg
-    originalSize: h=3000 w=2000
-    language: en
-    hint: 
-    aspect: 
-    season: SeasonNumber=xx
   - ... and >20 more
 backdrops: (N>20)
   - id: 
-    originalUrl: http://image.tmdb.org/t/p/original/8yYuFjRsozwOckhAaTHRLTiDwml.jpg
-    thumbUrl: http://image.tmdb.org/t/p/w780/8yYuFjRsozwOckhAaTHRLTiDwml.jpg
+    originalUrl: http://image.tmdb.org/t/p/original/o11rDwFa7nZMVI57Mm3C44YwmmF.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w780/o11rDwFa7nZMVI57Mm3C44YwmmF.jpg
     originalSize: h=2160 w=3840
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
   - id: 
-    originalUrl: http://image.tmdb.org/t/p/original/o11rDwFa7nZMVI57Mm3C44YwmmF.jpg
-    thumbUrl: http://image.tmdb.org/t/p/w780/o11rDwFa7nZMVI57Mm3C44YwmmF.jpg
+    originalUrl: http://image.tmdb.org/t/p/original/8yYuFjRsozwOckhAaTHRLTiDwml.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w780/8yYuFjRsozwOckhAaTHRLTiDwml.jpg
     originalSize: h=2160 w=3840
     language: 
     hint: 

--- a/test/resources/scrapers/tmdb/Finding_Dory_tt2277860.ref.txt
+++ b/test/resources/scrapers/tmdb/Finding_Dory_tt2277860.ref.txt
@@ -30,7 +30,7 @@ actors: (N>30)
  - id: 
    name: Albert Brooks
    role: Marlin (voice)
-   thumb: http://image.tmdb.org/t/p/original/8iDSGu5l93N7benjf6b3AysBore.jpg
+   thumb: http://image.tmdb.org/t/p/original/zhYhOkN2TRsFrEt7RHOAYGz8ZfF.jpg
    order: 0
    imageHasChanged: false
  - id: 
@@ -54,7 +54,7 @@ actors: (N>30)
  - id: 
    name: Diane Keaton
    role: Jenny (voice)
-   thumb: http://image.tmdb.org/t/p/original/siSWRRFN9uO6iCN7y9OrHU5IaJ.jpg
+   thumb: http://image.tmdb.org/t/p/original/mRq2Rxh2hmG3kFPRp4NEGXRaLPB.jpg
    order: 4
    imageHasChanged: false
  - id: 
@@ -96,7 +96,7 @@ actors: (N>30)
  - id: 
    name: Bill Hader
    role: Husband Fish (Stan) (voice)
-   thumb: http://image.tmdb.org/t/p/original/50FpKsWiyqbZxu0oLBAGbWn7wag.jpg
+   thumb: http://image.tmdb.org/t/p/original/dm5x0mPXyibcNgVH4nPvOuAwxWt.jpg
    order: 11
    imageHasChanged: false
  - id: 
@@ -138,7 +138,7 @@ actors: (N>30)
  - id: 
    name: John Ratzenberger
    role: Husband Crab (Bill) (voice)
-   thumb: http://image.tmdb.org/t/p/original/oRtDEOuIO1yDhTz5dORBdxXuLMO.jpg
+   thumb: http://image.tmdb.org/t/p/original/e5aNU09v1q6WYTx9pNzC7yjSpve.jpg
    order: 18
    imageHasChanged: false
  - id: 
@@ -160,7 +160,7 @@ countries: (N=1)
 studios: (N<6)
   - Pixar
   - Walt Disney Pictures
-trailer: https://www.youtube.com/watch?v=JhvrQeY3doI
+trailer: https://www.youtube.com/watch?v=iG0P6bjyUNI
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>
@@ -190,6 +190,14 @@ posters: (N>30)
     aspect: 
     season: SeasonNumber=xx
   - id: 
+    originalUrl: http://image.tmdb.org/t/p/original/yFjVlsJmEMacU0BNUwdGZlo2ixq.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w342/yFjVlsJmEMacU0BNUwdGZlo2ixq.jpg
+    originalSize: h=3000 w=2000
+    language: en
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
+  - id: 
     originalUrl: http://image.tmdb.org/t/p/original/9NHzsMos9OZFoS66ThX99GFVpQc.jpg
     thumbUrl: http://image.tmdb.org/t/p/w342/9NHzsMos9OZFoS66ThX99GFVpQc.jpg
     originalSize: h=3000 w=2000
@@ -205,27 +213,19 @@ posters: (N>30)
     hint: 
     aspect: 
     season: SeasonNumber=xx
-  - id: 
-    originalUrl: http://image.tmdb.org/t/p/original/ipJx835Tv6rtGht3uT7kA9Nxrnh.jpg
-    thumbUrl: http://image.tmdb.org/t/p/w342/ipJx835Tv6rtGht3uT7kA9Nxrnh.jpg
-    originalSize: h=3000 w=2000
-    language: en
-    hint: 
-    aspect: 
-    season: SeasonNumber=xx
   - ... and >20 more
 backdrops: (N>20)
   - id: 
-    originalUrl: http://image.tmdb.org/t/p/original/8yYuFjRsozwOckhAaTHRLTiDwml.jpg
-    thumbUrl: http://image.tmdb.org/t/p/w780/8yYuFjRsozwOckhAaTHRLTiDwml.jpg
+    originalUrl: http://image.tmdb.org/t/p/original/o11rDwFa7nZMVI57Mm3C44YwmmF.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w780/o11rDwFa7nZMVI57Mm3C44YwmmF.jpg
     originalSize: h=2160 w=3840
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
   - id: 
-    originalUrl: http://image.tmdb.org/t/p/original/o11rDwFa7nZMVI57Mm3C44YwmmF.jpg
-    thumbUrl: http://image.tmdb.org/t/p/w780/o11rDwFa7nZMVI57Mm3C44YwmmF.jpg
+    originalUrl: http://image.tmdb.org/t/p/original/8yYuFjRsozwOckhAaTHRLTiDwml.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w780/8yYuFjRsozwOckhAaTHRLTiDwml.jpg
     originalSize: h=2160 w=3840
     language: 
     hint: 

--- a/test/resources/scrapers/tmdb/The_Rescuers_de-DE_tmdb11319.ref.txt
+++ b/test/resources/scrapers/tmdb/The_Rescuers_de-DE_tmdb11319.ref.txt
@@ -47,7 +47,7 @@ actors: (N>10)
  - id: 
    name: Geraldine Page
    role: Madame Medusa (voice)
-   thumb: http://image.tmdb.org/t/p/original/5G8uNYzNtEMBSnOUUs6ms1JcOJj.jpg
+   thumb: http://image.tmdb.org/t/p/original/oBQTdTuGwc88tV32V0bbzAiLwhi.jpg
    order: 2
    imageHasChanged: false
  - id: 
@@ -119,7 +119,7 @@ actors: (N>10)
  - id: 
    name: Dub Taylor
    role: Digger (voice)
-   thumb: http://image.tmdb.org/t/p/original/ip23tIc5UhSfWdKpsNKay1wUJie.jpg
+   thumb: http://image.tmdb.org/t/p/original/gDgTAXPq5vOW5CWxF2MaeQ9Kjkn.jpg
    order: 14
    imageHasChanged: false
  - id: 
@@ -221,9 +221,17 @@ backdrops: (N>10)
     aspect: 
     season: SeasonNumber=xx
   - id: 
-    originalUrl: http://image.tmdb.org/t/p/original/hUnMp2tcrKyfpPEFLDRcnJ0l6au.jpg
-    thumbUrl: http://image.tmdb.org/t/p/w780/hUnMp2tcrKyfpPEFLDRcnJ0l6au.jpg
-    originalSize: h=1330 w=2364
+    originalUrl: http://image.tmdb.org/t/p/original/kRbXMT2ysEJ84Tr2Nk9c88w3mv.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w780/kRbXMT2ysEJ84Tr2Nk9c88w3mv.jpg
+    originalSize: h=2160 w=3840
+    language: 
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
+  - id: 
+    originalUrl: http://image.tmdb.org/t/p/original/2rJ1LDxVS2EofZmRT7YiCgIFSq3.jpg
+    thumbUrl: http://image.tmdb.org/t/p/w780/2rJ1LDxVS2EofZmRT7YiCgIFSq3.jpg
+    originalSize: h=1440 w=2560
     language: 
     hint: 
     aspect: 
@@ -240,14 +248,6 @@ backdrops: (N>10)
     originalUrl: http://image.tmdb.org/t/p/original/j50Sr0ULbsf0Rbw0BB91ZbtQoaB.jpg
     thumbUrl: http://image.tmdb.org/t/p/w780/j50Sr0ULbsf0Rbw0BB91ZbtQoaB.jpg
     originalSize: h=2160 w=3840
-    language: 
-    hint: 
-    aspect: 
-    season: SeasonNumber=xx
-  - id: 
-    originalUrl: http://image.tmdb.org/t/p/original/tIhdMcCs6OOyg27knpzKSGj7CWJ.jpg
-    thumbUrl: http://image.tmdb.org/t/p/w780/tIhdMcCs6OOyg27knpzKSGj7CWJ.jpg
-    originalSize: h=1080 w=1920
     language: 
     hint: 
     aspect: 

--- a/test/resources/scrapers/tmdb_concert/Rammstein_in_Amerika_tmdb361631.ref.txt
+++ b/test/resources/scrapers/tmdb_concert/Rammstein_in_Amerika_tmdb361631.ref.txt
@@ -16,7 +16,7 @@ overview:
      various periods in the band’s history, the band members speak about their exper
     iences across the Atlantic.
 ratings (N=1)
-  source=themoviedb | rating=8.022 | votes=46 | min=0 | max=10
+  source=themoviedb | rating=7.979 | votes=47 | min=0 | max=10
 userRating: 0
 releaseDate: 2015-09-25
 tagline: 

--- a/test/resources/scrapers/tmdbtv/Scrubs-tmdb4556-all-details-DE.ref.txt
+++ b/test/resources/scrapers/tmdbtv/Scrubs-tmdb4556-all-details-DE.ref.txt
@@ -31,12 +31,14 @@ tags: (N>5)
   - mental hospital
   - ... and <6 more
 certification: 16
-network: NBC, ABC
+networks: (N<6)
+  - NBC
+  - ABC
 episodeGuideUrl: 
 actors: (N>800)
  - id: 5367
    name: Zach Braff
-   role: John "J.D." Dorian
+   role: John 'J.D.' Dorian
    thumb: https://image.tmdb.org/t/p/original/wUAj6juL6HErqEJ1GtuI63rbVea.jpg
    order: 0
    imageHasChanged: false
@@ -82,22 +84,22 @@ actors: (N>800)
    thumb: https://image.tmdb.org/t/p/original/dJveBsGlMfmjxXysVUSzDTynde1.jpg
    order: 7
    imageHasChanged: false
+ - id: 212821
+   name: Christa Miller
+   role: Jordan Sullivan
+   thumb: https://image.tmdb.org/t/p/original/gfLL2dM209v3WfVrovwGszjgtB3.jpg
+   order: 8
+   imageHasChanged: false
  - id: 46920
    name: Sam Lloyd
    role: Ted Buckland
    thumb: https://image.tmdb.org/t/p/original/ti0pt6k5eXGbW8j7ktxSXLfutLA.jpg
-   order: 8
+   order: 9
    imageHasChanged: false
  - id: 49551
    name: Aloma Wright
    role: Laverne Roberts, Nurse Shirley
    thumb: https://image.tmdb.org/t/p/original/18zBXoQRTpgLyHHKXSzlxgYlaSB.jpg
-   order: 9
-   imageHasChanged: false
- - id: 212821
-   name: Christa Miller
-   role: Jordan Sullivan
-   thumb: https://image.tmdb.org/t/p/original/gfLL2dM209v3WfVrovwGszjgtB3.jpg
    order: 10
    imageHasChanged: false
  - id: 128155

--- a/test/resources/scrapers/tmdbtv/Scrubs-tmdb4556-all-details.ref.txt
+++ b/test/resources/scrapers/tmdbtv/Scrubs-tmdb4556-all-details.ref.txt
@@ -28,12 +28,14 @@ tags: (N>5)
   - mental hospital
   - ... and <6 more
 certification: TV-14
-network: NBC, ABC
+networks: (N<6)
+  - NBC
+  - ABC
 episodeGuideUrl: 
 actors: (N>800)
  - id: 5367
    name: Zach Braff
-   role: John "J.D." Dorian
+   role: John 'J.D.' Dorian
    thumb: https://image.tmdb.org/t/p/original/wUAj6juL6HErqEJ1GtuI63rbVea.jpg
    order: 0
    imageHasChanged: false
@@ -79,22 +81,22 @@ actors: (N>800)
    thumb: https://image.tmdb.org/t/p/original/dJveBsGlMfmjxXysVUSzDTynde1.jpg
    order: 7
    imageHasChanged: false
+ - id: 212821
+   name: Christa Miller
+   role: Jordan Sullivan
+   thumb: https://image.tmdb.org/t/p/original/gfLL2dM209v3WfVrovwGszjgtB3.jpg
+   order: 8
+   imageHasChanged: false
  - id: 46920
    name: Sam Lloyd
    role: Ted Buckland
    thumb: https://image.tmdb.org/t/p/original/ti0pt6k5eXGbW8j7ktxSXLfutLA.jpg
-   order: 8
+   order: 9
    imageHasChanged: false
  - id: 49551
    name: Aloma Wright
    role: Laverne Roberts, Nurse Shirley
    thumb: https://image.tmdb.org/t/p/original/18zBXoQRTpgLyHHKXSzlxgYlaSB.jpg
-   order: 9
-   imageHasChanged: false
- - id: 212821
-   name: Christa Miller
-   role: Jordan Sullivan
-   thumb: https://image.tmdb.org/t/p/original/gfLL2dM209v3WfVrovwGszjgtB3.jpg
    order: 10
    imageHasChanged: false
  - id: 128155
@@ -135,7 +137,7 @@ actors: (N>800)
    imageHasChanged: false
  - id: 1228157
    name: Mike Schwartz
-   role: Lloyd, Delivery Guy, Patient
+   role: Lloyd, Patient, Delivery Guy
    thumb: https://image.tmdb.org/t/p/original/91JdROqsqiH8tN5ipAdo69ge4xW.jpg
    order: 17
    imageHasChanged: false

--- a/test/resources/scrapers/tmdbtv/Scrubs-tmdb4556-minimal-details-DE.ref.txt
+++ b/test/resources/scrapers/tmdbtv/Scrubs-tmdb4556-minimal-details-DE.ref.txt
@@ -31,12 +31,14 @@ tags: (N>5)
   - mental hospital
   - ... and <6 more
 certification: 16
-network: NBC, ABC
+networks: (N<6)
+  - NBC
+  - ABC
 episodeGuideUrl: 
 actors: (N>800)
  - id: 5367
    name: Zach Braff
-   role: John "J.D." Dorian
+   role: John 'J.D.' Dorian
    thumb: https://image.tmdb.org/t/p/original/wUAj6juL6HErqEJ1GtuI63rbVea.jpg
    order: 0
    imageHasChanged: false
@@ -82,22 +84,22 @@ actors: (N>800)
    thumb: https://image.tmdb.org/t/p/original/dJveBsGlMfmjxXysVUSzDTynde1.jpg
    order: 7
    imageHasChanged: false
+ - id: 212821
+   name: Christa Miller
+   role: Jordan Sullivan
+   thumb: https://image.tmdb.org/t/p/original/gfLL2dM209v3WfVrovwGszjgtB3.jpg
+   order: 8
+   imageHasChanged: false
  - id: 46920
    name: Sam Lloyd
    role: Ted Buckland
    thumb: https://image.tmdb.org/t/p/original/ti0pt6k5eXGbW8j7ktxSXLfutLA.jpg
-   order: 8
+   order: 9
    imageHasChanged: false
  - id: 49551
    name: Aloma Wright
    role: Laverne Roberts, Nurse Shirley
    thumb: https://image.tmdb.org/t/p/original/18zBXoQRTpgLyHHKXSzlxgYlaSB.jpg
-   order: 9
-   imageHasChanged: false
- - id: 212821
-   name: Christa Miller
-   role: Jordan Sullivan
-   thumb: https://image.tmdb.org/t/p/original/gfLL2dM209v3WfVrovwGszjgtB3.jpg
    order: 10
    imageHasChanged: false
  - id: 128155

--- a/test/resources/scrapers/tmdbtv/Stargate-SG-1-tmdb4629.ref.txt
+++ b/test/resources/scrapers/tmdbtv/Stargate-SG-1-tmdb4629.ref.txt
@@ -28,13 +28,15 @@ genres: (N<6)
   - Mystery
 tags: (N>5)
   - space travel
-  - alien
   - space
   - travel
+  - alien
   - alien planet
   - ... and <6 more
 certification: TV-PG
-network: Showtime, Syfy
+networks: (N<6)
+  - Showtime
+  - Syfy
 episodeGuideUrl: 
 actors: (N>800)
  - id: 26085
@@ -61,16 +63,16 @@ actors: (N>800)
    thumb: https://image.tmdb.org/t/p/original/4YkOrSUmfKljqTMwGIo50oviKe1.jpg
    order: 3
    imageHasChanged: false
- - id: 51800
-   name: Teryl Rothery
-   role: Dr. Janet Fraiser
-   thumb: https://image.tmdb.org/t/p/original/16rUSnTH56cKatjd6kjEYEfU4cA.jpg
-   order: 4
-   imageHasChanged: false
  - id: 15863
    name: Don S. Davis
    role: George Hammond
    thumb: https://image.tmdb.org/t/p/original/gxUvCXIFxAMqcWgosErBP5rHKDw.jpg
+   order: 4
+   imageHasChanged: false
+ - id: 51800
+   name: Teryl Rothery
+   role: Janet Fraiser
+   thumb: https://image.tmdb.org/t/p/original/16rUSnTH56cKatjd6kjEYEfU4cA.jpg
    order: 5
    imageHasChanged: false
  - id: 16180
@@ -112,9 +114,9 @@ actors: (N>800)
  - id: 118463
    name: Peter DeLuise
    role:
-    Director / Peter DeLuise, Airman, SF Guard (Uncredited), Man Leaving Cafe, Inter
-    viewer, Free Jaffa (Voice only) (Uncredited), Machine Gun Guard, Young Urgo in U
-    niform, Screaming Villager, Lieutenant, Tok'ra Guard
+    Director / Peter DeLuise, Airman, SF Guard (Uncredited), Young Urgo in Uniform, 
+    Tok'ra Guard, Lieutenant, Man Leaving Cafe, Screaming Villager, Interviewer, Mac
+    hine Gun Guard, Free Jaffa (Voice only) (Uncredited)
    thumb: https://image.tmdb.org/t/p/original/sLkSOm6HBLB4VCfshQLdSEq63tr.jpg
    order: 12
    imageHasChanged: false
@@ -136,32 +138,32 @@ actors: (N>800)
    thumb: https://image.tmdb.org/t/p/original/bD08h8S2wmXmw6MDD2mHuRO4J2B.jpg
    order: 15
    imageHasChanged: false
+ - id: 111378
+   name: Cliff Simon
+   role: Ba'al
+   thumb: https://image.tmdb.org/t/p/original/e8t2fD2kFUMQBJDRm2ehcvdCxBJ.jpg
+   order: 16
+   imageHasChanged: false
  - id: 59245
    name: Laara Sadiq
-   role: Technician #2, Technican, Technician Davis, Technician
+   role: Technician #2, Technician Davis, Technican, Technician
    thumb: https://image.tmdb.org/t/p/original/l7MkydwslaXo1EmYrRpJARnaFKs.jpg
-   order: 16
+   order: 17
    imageHasChanged: false
  - id: 1366510
    name: Fraser Aitcheson
    role:
-    Hathor's Jaffa, Jaffa Warrior, Jaffa, Ares' Jaffa commander (Uncredited), Jaffa 
-    Commander, Anubis' Jaffa, Free Jaffa (Uncredited), Orderly, Dakara Jaffa 3 (Uncr
-    edited), Free Jaffa 2 (Uncredited), Jaffa Guard, Apophis' Red Jaffa, Tagrean Wor
-    ker
+    Hathor's Jaffa, Jaffa Commander, Jaffa Warrior, Dakara Jaffa 3 (Uncredited), Anu
+    bis' Jaffa, Free Jaffa 2 (Uncredited), Jaffa Guard, Apophis' Red Jaffa, Orderly,
+     Tagrean Worker, Jaffa, Ares' Jaffa commander (Uncredited), Free Jaffa (Uncredit
+    ed)
    thumb: https://image.tmdb.org/t/p/original/j0fou5tZvXHe3GcVr24UnYQLg6S.jpg
-   order: 17
+   order: 18
    imageHasChanged: false
  - id: 780
    name: Ronny Cox
    role: Senator Robert Kinsey
    thumb: https://image.tmdb.org/t/p/original/cKkVkqft2RacSDhsKxO8nMFgeAd.jpg
-   order: 18
-   imageHasChanged: false
- - id: 158575
-   name: Tom McBeath
-   role: Harry Maybourne
-   thumb: https://image.tmdb.org/t/p/original/vKeYC2KlMiq4S48ZafMll7jl9CJ.jpg
    order: 19
    imageHasChanged: false
   - ... and >800 more

--- a/test/resources/scrapers/tmdbtv/The-Simpsons-S12.ref.txt
+++ b/test/resources/scrapers/tmdbtv/The-Simpsons-S12.ref.txt
@@ -28,9 +28,9 @@ overview:
     a dolphin in "Night of the Dolphin."
 writers: (N<6)
   - Don Payne
-  - Rob LaZebnik
   - Carolyn Omine
   - John Frink
+  - Rob LaZebnik
 directors: (N=1)
   - Matthew Nastuk
 playCount: 0
@@ -39,7 +39,7 @@ firstAired: 2000-11-01
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/w5WbT0dzggTabsPM9fTqzxvJIQA.jpg
 actors: (N>5)
  - id: 6036
@@ -122,7 +122,7 @@ firstAired: 2000-11-05
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/7KqfXGaCAvTVRne3nMxDdGSQqKS.jpg
 actors: (N>10)
  - id: 75341
@@ -230,13 +230,13 @@ firstAired: 2000-11-12
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/eVB8FoLCUQOJXPl9uIrSwILUH3.jpg
 actors: (N>10)
  - id: 4690
    name: Christopher Walken
    role: 
-   thumb: https://image.tmdb.org/t/p/original/3Ht7zld9UcnHyOa7WY7HrNjlJn6.jpg
+   thumb: https://image.tmdb.org/t/p/original/ApgDL7nudR9T2GpjCG4vESgymO2.jpg
    order: 0
    imageHasChanged: false
  - id: 49819
@@ -266,7 +266,7 @@ actors: (N>10)
  - id: 69597
    name: Drew Barrymore
    role: 
-   thumb: https://image.tmdb.org/t/p/original/mVQdb6w6gXmLZ6nZ3K9Fw3vzawM.jpg
+   thumb: https://image.tmdb.org/t/p/original/w0lfuDg0vwqtmF3FUr9oiQvFS4b.jpg
    order: 5
    imageHasChanged: false
  - id: 3266
@@ -349,7 +349,7 @@ firstAired: 2000-11-19
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/fHmxaDYvXCmsZqs6WulMamdu9Wi.jpg
 actors: (N>5)
  - id: 11866
@@ -432,7 +432,7 @@ firstAired: 2000-11-26
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/lAOtgJtTADRrr5gxNdh4kEuepD5.jpg
 actors: (N>5)
  - id: 44051
@@ -524,7 +524,7 @@ firstAired: 2000-12-03
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/gjBbpzQ3b3E7fHb5gkMCHsOImFQ.jpg
 actors: (N>5)
  - id: 2463
@@ -613,7 +613,7 @@ firstAired: 2000-12-10
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/7BGkc4yGkjdTxo4L3d4JvqotGcQ.jpg
 actors: (N>5)
  - id: 819
@@ -696,7 +696,7 @@ firstAired: 2000-12-17
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/qkYS65fLQl7ViimNkGabSlCVlQu.jpg
 actors: (N>5)
  - id: 6035
@@ -787,7 +787,7 @@ firstAired: 2001-01-07
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/5uTFgcEU2TkH4rTdgWE3tusXZs6.jpg
 actors: (N>5)
  - id: 198
@@ -863,13 +863,13 @@ firstAired: 2001-01-14
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/s5lvq1sIdICOqX0kKzdAWUQNdCT.jpg
 actors: (N>10)
  - id: 2232
    name: Michael Keaton
    role: Jack Crowley (voice)
-   thumb: https://image.tmdb.org/t/p/original/82rxrGxOqQW2NjKsIiNbDYHFfmb.jpg
+   thumb: https://image.tmdb.org/t/p/original/baeHNv3qrVsnApuKbZXiJOhqMnw.jpg
    order: 0
    imageHasChanged: false
  - id: 119713
@@ -971,7 +971,7 @@ firstAired: 2001-02-04
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/u7nlutZgBVe7QbSsNrYbGa30a8x.jpg
 actors: (N>5)
  - id: 11161
@@ -1058,7 +1058,7 @@ firstAired: 2001-02-11
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/zPO8DEthCIGNpWErs3bvRuT4emQ.jpg
 actors: (N>10)
  - id: 1214573
@@ -1173,7 +1173,7 @@ firstAired: 2001-02-18
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/p2zf41UdmgoPBXS0xSrIMldqOFq.jpg
 actors: (N>5)
  - id: 75341
@@ -1261,7 +1261,7 @@ firstAired: 2001-02-25
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/9MTd6DWjQccIztGqN3IXd3wZ4v0.jpg
 actors: (N>10)
  - id: 269848
@@ -1273,7 +1273,7 @@ actors: (N>10)
  - id: 12111
    name: Justin Timberlake
    role: Justin Timberlake (voice)
-   thumb: https://image.tmdb.org/t/p/original/6Yk5t9RwkdkAT8Qv45934Eez2CA.jpg
+   thumb: https://image.tmdb.org/t/p/original/hFfgtpXWlsbuzgwBKdRWdvrcRad.jpg
    order: 1
    imageHasChanged: false
  - id: 77073
@@ -1369,7 +1369,7 @@ firstAired: 2001-03-04
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/qWzLc6ln1aGwtPGu6NcUpQwYkx0.jpg
 actors: (N>5)
  - id: 6035
@@ -1466,7 +1466,7 @@ firstAired: 2001-03-11
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/9jlTs2EYzfgGG86kzO82jLnk9Qu.jpg
 actors: (N>5)
  - id: 129332
@@ -1567,7 +1567,7 @@ firstAired: 2001-04-01
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/2muVedvhUd87ZFWmEfnS9Y8WT1d.jpg
 actors: (N>5)
  - id: 198
@@ -1623,7 +1623,7 @@ tvmazeId:
 title: Trilogy of Error
 showTitle: 
 ratings (N=1)
-  source=tmdb | rating=7.8 | votes=20 | min=0 | max=10
+  source=tmdb | rating=7.6 | votes=20 | min=0 | max=10
 userRating: 0
 imdbTop250: 0
 season: SeasonNumber=12
@@ -1644,7 +1644,7 @@ firstAired: 2001-04-29
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/2rRKXgrKzGJncVQkFtzQpvZ9RkU.jpg
 actors: (N>5)
  - id: 51391
@@ -1744,7 +1744,7 @@ firstAired: 2001-05-06
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/2Bay9dWHz1uW3gE2hwZsjeQQ6bl.jpg
 actors: (N>5)
  - id: 129662
@@ -1839,7 +1839,7 @@ firstAired: 2001-05-13
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/kYNauorldGvl55Vx0x6E7mbP9Gy.jpg
 actors: (N>5)
  - id: 198
@@ -1921,7 +1921,7 @@ firstAired: 2001-05-20
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/lNcBNNaPp3Uk14iIJuQkpIjNfJM.jpg
 actors: (N>5)
  - id: 6036

--- a/test/resources/scrapers/tmdbtv/The-Simpsons-all-seasons-S12-E19.ref.txt
+++ b/test/resources/scrapers/tmdbtv/The-Simpsons-all-seasons-S12-E19.ref.txt
@@ -28,7 +28,7 @@ firstAired: 2001-05-06
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/2Bay9dWHz1uW3gE2hwZsjeQQ6bl.jpg
 actors: (N>5)
  - id: 129662

--- a/test/resources/scrapers/tmdbtv/The-Simpsons-tmdb456-S12E19-all-details-DE.ref.txt
+++ b/test/resources/scrapers/tmdbtv/The-Simpsons-tmdb456-S12E19-all-details-DE.ref.txt
@@ -32,7 +32,7 @@ firstAired: 2001-05-06
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/2Bay9dWHz1uW3gE2hwZsjeQQ6bl.jpg
 actors: (N>5)
  - id: 198

--- a/test/resources/scrapers/tmdbtv/The-Simpsons-tmdb456-S12E19-all-details.ref.txt
+++ b/test/resources/scrapers/tmdbtv/The-Simpsons-tmdb456-S12E19-all-details.ref.txt
@@ -28,7 +28,7 @@ firstAired: 2001-05-06
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/2Bay9dWHz1uW3gE2hwZsjeQQ6bl.jpg
 actors: (N>5)
  - id: 198

--- a/test/resources/scrapers/tmdbtv/The-Simpsons-tmdb456-S12E19-minimal-details-DE.ref.txt
+++ b/test/resources/scrapers/tmdbtv/The-Simpsons-tmdb456-S12E19-minimal-details-DE.ref.txt
@@ -32,7 +32,7 @@ firstAired: 2001-05-06
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/2Bay9dWHz1uW3gE2hwZsjeQQ6bl.jpg
 actors: (N>5)
  - id: 198

--- a/test/resources/scrapers/tmdbtv/The-Simpsons-tmdb456-S12E19-minimal-details.ref.txt
+++ b/test/resources/scrapers/tmdbtv/The-Simpsons-tmdb456-S12E19-minimal-details.ref.txt
@@ -28,7 +28,7 @@ firstAired: 2001-05-06
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://image.tmdb.org/t/p/original/2Bay9dWHz1uW3gE2hwZsjeQQ6bl.jpg
 actors: (N>5)
  - id: 198

--- a/test/resources/scrapers/tmdbtv/The-Simpsons-tmdb456-minimal-details.ref.txt
+++ b/test/resources/scrapers/tmdbtv/The-Simpsons-tmdb456-minimal-details.ref.txt
@@ -17,7 +17,7 @@ overview:
     w has also made name for itself in its fearless satirical take on politics, medi
     a and American life in general.
 ratings (N=1)
-  source=themoviedb | rating=7.8 | votes=9000 | min=0 | max=10
+  source=themoviedb | rating=8 | votes=9000 | min=0 | max=10
 userRating: 0
 imdbTop250: 0
 firstAired: 1989-12-17
@@ -27,14 +27,15 @@ genres: (N<6)
   - Animation
   - Comedy
 tags: (N>10)
+  - nuclear power plant
+  - middle class
   - cartoon
   - satire
-  - nuclear power plant
   - parody
-  - middle class
   - ... and >5 more
 certification: TV-PG
-network: FOX
+networks: (N=1)
+  - FOX
 episodeGuideUrl: 
 actors: (N>800)
  - id: 198
@@ -76,47 +77,48 @@ actors: (N>800)
  - id: 6009
    name: Pamela Hayden
    role:
-    Milhouse (voice), (voice), Milhouse / Jimbo (voice), Milhouse / Rod Flanders (vo
+    Milhouse (voice), Milhouse / Jimbo (voice), (voice), Milhouse / Rod Flanders (vo
     ice), Rod Flanders (voice), Jimbo (voice), Milhouse / Jimbo / Rod Flanders (voic
-    e), Mediocroto (voice), Milhouse / Ethan Foley / Boy (voice), Milhouse Van Houte
-    n / Sarah Wiggum (voice), Milhouse / Svetlana / Woman in Audience #2 (voice), Mi
-    lhouse / Janey / Ex-Wife (voice), Saultery Stevens (voice), Brittany / Merchandi
-    ser #1 (voice), Lard Lad Donuts Employee (voice), Jimbo / Rod Flanders (voice), 
-    Milhouse / Rod Flanders / Jimbo (voice), Milhouse / Jimbo / Janey / Kid / Bad Gi
-    rl #2 (voice), Tortured People (voice), Milhouse / Boy (voice), Son #1 / Son #2 
-    (voice), Janey / Boy with Howie / Howie's Mother (voice), Milhouse / Rod Flander
-    s / Santa Woman (voice), Nurse (voice), Milhouse / Jimbo / Janey (voice), Securi
-    ty Guard #1 (voice), Wendell (voice), People by Death Time (voice), Straight-Edg
-    e Spuckler (voice), Gloria Prince (voice), Milhouse / Janey / Dolph (voice), Mil
-    house / Applicant / Woman in Audience (voice), Milhouse / Announcer (voice), Mil
-    house / Psychiatrist (voice), Sarah Wiggum (voice)
+    e), Straight-Edge Spuckler (voice), Lard Lad Donuts Employee (voice), Saultery S
+    tevens (voice), Brittany / Merchandiser #1 (voice), Janey / Boy with Howie / How
+    ie's Mother (voice), Nurse (voice), Tortured People (voice), Milhouse / Jimbo / 
+    Janey / Kid / Bad Girl #2 (voice), Son #1 / Son #2 (voice), Milhouse / Boy (voic
+    e), Milhouse / Rod Flanders / Jimbo (voice), Milhouse Van Houten / Sarah Wiggum 
+    (voice), Milhouse / Ethan Foley / Boy (voice), Mediocroto (voice), Milhouse / Ja
+    ney / Ex-Wife (voice), Jimbo / Rod Flanders (voice), Milhouse / Svetlana / Woman
+     in Audience #2 (voice), Milhouse / Announcer (voice), Milhouse / Janey / Dolph 
+    (voice), Milhouse / Applicant / Woman in Audience (voice), Sarah Wiggum (voice),
+     Milhouse / Psychiatrist (voice), Milhouse / Jimbo / Janey (voice), Oats Crowd (
+    voice), Milhouse / Rod Flanders / Santa Woman (voice), Gloria Prince (voice), Pe
+    ople by Death Time (voice), Wendell (voice), Security Guard #1 (voice)
    thumb: https://image.tmdb.org/t/p/original/mPMtuVB6AEulRhlfn69y5RvgmNT.jpg
    order: 6
    imageHasChanged: false
  - id: 34983
    name: Tress MacNeille
    role:
-    Ms. Dare / Gwen / Homer's Cousin's Wife (voice), Dolph (voice), Agnes Skinner (v
-    oice), (voice), Brandine Spuckler (voice), Shauna Chalmers (voice), Ms. Muntz (v
-    oice), Dolph / Shauna Chalmers (voice), Doris (voice), Dolph / Agnes Skinner (vo
-    ice), Ms. Muntz / Mrs. Bad Halloween Candy / Shauna Chalmers (voice), Dolph / Cu
-    ddle Kitten NFT Leader (voice), Lady in Audience (voice), Agnes Skinner / Adil H
-    oxha / Airport Announcer (voice), Miss Springfield / Martha / Tracey (voice), Br
-    andine Spuckler / Ms. York (voice), Crazy Cat Lady / Linda / Agnes Skinner (voic
-    e), Shauna Chalmers /Brandine Spuckler / Crazy Cat Lady (voice), Female Doctor (
-    voice), Agnes Skinner / Doris (voice), Shauna Chalmers / Crazy Cat Lady, Mrs. Ch
-    ase (voice), Greta Wolfcastle / Mopey Mary (voice), Ms. Albright / Churchgoer / 
-    Jimbo (voice), Kumiko Nakamura / News Reporter / Dolph / Wendell Borton (voice),
-     Mrs. Vanderbilt (voice), Lindsey Naegle (voice), Crazy Cat Lady / Agnes Skinner
-     (voice), Cora (voice), Moira (voice), Sandra (voice), DMV Worker (voice), Brune
-    lla Pommelhorst (voice), Ms. Mints (voice), Dolph / Madison (voice), Hazel (voic
-    e), Lindsay Naegle / Manjula / Lunchlady Doris / Cookie Kwan (voice), Brandine D
-    el Roy / Plopper / Dubya Spuckler (voice), Agnes Skinner / Shauna Chalmers /Bran
-    dine Spuckler (voice), Mother (voice), Crazy Cat Lady (voice), Mabel (voice), Ma
-    ya / Waitress / Baseball Player (voice), Crazy Cat Lady / Shauna Chalmers (voice
-    ), Bad Girl #1 (voice), Dolph Shapiro / Shauna Chalmers (voice), Gary (voice), K
-    aitlyn (voice), Luigi's Mother (voice), Female Narrator (voice), Shauna Chalmers
-     / Dolph (voice)
+    Ms. Dare / Gwen / Homer's Cousin's Wife (voice), Dolph (voice), (voice), Agnes S
+    kinner (voice), Brandine Spuckler (voice), Shauna Chalmers (voice), Ms. Muntz (v
+    oice), Dolph / Agnes Skinner (voice), Dolph / Shauna Chalmers (voice), Doris (vo
+    ice), Crazy Cat Lady (voice), Female Narrator (voice), Mrs. Chase (voice), Greta
+     Wolfcastle / Mopey Mary (voice), Agnes Skinner / Shauna Chalmers /Brandine Spuc
+    kler (voice), Shauna Chalmers / Crazy Cat Lady, Female Doctor (voice), Agnes Ski
+    nner / Adil Hoxha / Airport Announcer (voice), Miss Springfield / Martha / Trace
+    y (voice), Crazy Cat Lady / Linda / Agnes Skinner (voice), Shauna Chalmers /Bran
+    dine Spuckler / Crazy Cat Lady (voice), Lady in Audience (voice), Brandine Spuck
+    ler / Ms. York (voice), Moira (voice), Agnes Skinner / Doris (voice), Lindsey Na
+    egle (voice), Cora (voice), Mrs. Vanderbilt (voice), Crazy Cat Lady / Agnes Skin
+    ner (voice), Kumiko Nakamura / News Reporter / Dolph / Wendell Borton (voice), M
+    s. Albright / Churchgoer / Jimbo (voice), Sandra (voice), Brunella Pommelhorst /
+     Doris (voice), Brandine Del Roy / Plopper / Dubya Spuckler (voice), Power Plant
+     System (voice), Dolph / Cuddle Kitten NFT Leader (voice), Lindsay Naegle / Manj
+    ula / Lunchlady Doris / Cookie Kwan (voice), Brunella Pommelhorst (voice), Ms. M
+    ints (voice), Dolph / Madison (voice), DMV Worker (voice), Shauna Chalmers / Dol
+    ph (voice), Ms. Muntz / Mrs. Bad Halloween Candy / Shauna Chalmers (voice), Bad 
+    Girl #1 (voice), Gary (voice), Dolph Shapiro / Shauna Chalmers (voice), Luigi's 
+    Mother (voice), Kaitlyn (voice), Mabel (voice), Maya / Waitress / Baseball Playe
+    r (voice), Hazel (voice), Crazy Cat Lady / Shauna Chalmers (voice), Mother (voic
+    e)
    thumb: https://image.tmdb.org/t/p/original/gI2LsgByvSffQY34vabVnPmrHzw.jpg
    order: 7
    imageHasChanged: false
@@ -129,27 +131,28 @@ actors: (N>800)
  - id: 1216346
    name: Chris Edgerly
    role:
-    (voice), Tucker Carlson (voice), Male Doctor (voice), Bowling Alley Manager (voi
-    ce), Uber Hombre / Scarlet Pimpernel (voice), Boat Owner / Neighborhood Meeting 
-    Notification (voice), Scotus Szyslak (voice), Beyond Bullying Professor (voice),
-     Doctor (voice), Weinstein (voice), Stan Laurel (voice), Springfield Retirement 
-    Home Receptionist (voice), Nutz Therapist (voice), Commercial Guy at the Beach /
-     Award Man (voice)
+    (voice), Tucker Carlson (voice), Springfield Retirement Home Receptionist (voice
+    ), Beyond Bullying Professor (voice), Commercial Guy at the Beach / Award Man (v
+    oice), Doctor (voice), Flexulon / Hallucination Otto (voice), Male Doctor (voice
+    ), Boat Owner / Neighborhood Meeting Notification (voice), Weinstein (voice), Sc
+    otus Szyslak (voice), Nutz Therapist (voice), Stan Laurel (voice), Helicopter Ma
+    n #2 (voice), George Harrison / Coal Manager (voice), Uber Hombre / Scarlet Pimp
+    ernel (voice), Bowling Alley Manager (voice)
    thumb: https://image.tmdb.org/t/p/original/bjkN9Ugv6Kd3Z3y9p9DgWAc10Q7.jpg
    order: 9
    imageHasChanged: false
  - id: 6007
    name: Maggie Roswell
    role:
-    Maude Flanders (voice), Helen Lovejoy (voice), Luann Van Houten (voice), Elizabe
-    th Hoover (voice), Helen Lovejoy / Luann Van Houten (voice), Helen Lovejoy / Eli
-    zabeth Hoover (voice), Camper #2 / Reporter (voice), Maude Flanders / Helen Love
-    joy (voice), Elizabeth Hoover / Luann Van Houten (voice), Mother #1 / Daughter /
-     Mother in Monroe ad (voice), Luann Van Houten / Maude Flanders (voice), Helen L
-    ovejoy / Institute Council Member #3 (voice), Helen Lovejoy / Singing Waiters (v
-    oice), Gov. Mary Bailey (voice), Helen Lovejoy / Elizabeth Hoover / Luann Van Ho
-    uten (voice), Elizabeth Hoover / Helen Lovejoy / Luann Van Houten (voice), Princ
-    ess Kashmir / Fe-Mail-Man / Churchgoer (voice), Miss Hoover / Mrs. Winfield (voi
+    Maude Flanders (voice), Helen Lovejoy (voice), Luann Van Houten (voice), Helen L
+    ovejoy / Luann Van Houten (voice), Elizabeth Hoover (voice), Helen Lovejoy / Eli
+    zabeth Hoover (voice), Luann Van Houten / Maude Flanders (voice), Miss Hoover / 
+    Mrs. Winfield (voice), Princess Kashmir / Fe-Mail-Man / Churchgoer (voice), Eliz
+    abeth Hoover / Helen Lovejoy / Luann Van Houten (voice), Helen Lovejoy / Elizabe
+    th Hoover / Luann Van Houten (voice), Helen Lovejoy / Singing Waiters (voice), G
+    ov. Mary Bailey (voice), Helen Lovejoy / Institute Council Member #3 (voice), Mo
+    ther #1 / Daughter / Mother in Monroe ad (voice), Elizabeth Hoover / Luann Van H
+    outen (voice), Maude Flanders / Helen Lovejoy (voice), Camper #2 / Reporter (voi
     ce)
    thumb: https://image.tmdb.org/t/p/original/d71IVORYLBeBkqCby5ar7Rb4nb9.jpg
    order: 10
@@ -168,9 +171,9 @@ actors: (N>800)
    role:
     Lionel Hutz / Troy McClure / Lyle Lanley / others  (voice), Lionel Hutz (voice),
      Troy McClure (voice), Lionel Hutz / Troy McClure (voice), Lyle Lanley (voice), 
-    Tom / Nelson's Dad / Football Commentator / Announcer (voice), Troy McClure / Li
-    onel Hutz (voice), Stockbroker / Horst (voice), Troy McClure / Joey / Godfather 
-    / Lionel Hutz (voice), Troy McClure / Jimmy Apollo (voice)
+    Troy McClure / Lionel Hutz (voice), Troy McClure / Jimmy Apollo (voice), Tom / N
+    elson's Dad / Football Commentator / Announcer (voice), Troy McClure / Joey / Go
+    dfather / Lionel Hutz (voice), Stockbroker / Horst (voice)
    thumb: https://image.tmdb.org/t/p/original/6LLX6bfWMD1MDN4DV2di8nzFZil.jpg
    order: 12
    imageHasChanged: false
@@ -183,20 +186,20 @@ actors: (N>800)
  - id: 24362
    name: Kevin Michael Richardson
    role:
-    Security Guard / Burns' Cellmate / many minor characters, Dr. Hibbert (voice), N
-    arrator (voice), Devil Moe (voice), Oliver Hardy (voice), Film Student #2 (voice
-    ), SendEx Employee (voice), Jed Hawk (voice), Prison Guard (voice), Nigerian Kin
-    g (voice), Rich Texan Accountant (voice), Mr. Orlando / Mr. McBride (voice), Dr.
-     Hibbert / Shaquille O'Neal (voice), Turtle NFT (voice), Conductor (voice), Co-P
-    ilot (voice), Prison Inmate (voice), Security guard (voice), FBI Agent (voice), 
-    Dr. Hibbert / Bleeding Gums Murphy (voice), Dr. Hibbert / TSA Leader (voice), Gr
-    oot (voice)
+    Dr. Hibbert (voice), Security Guard / Burns' Cellmate / many minor characters, N
+    arrator (voice), Jed Hawk (voice), Nigerian King (voice), Groot (voice), Turtle 
+    NFT (voice), Dr. Hibbert / TSA Leader (voice), FBI Agent (voice), Dr. Hibbert / 
+    Bleeding Gums Murphy (voice), Prison Inmate (voice), Security guard (voice), Co-
+    Pilot (voice), Conductor (voice), Dr. Hibbert / Shaquille O'Neal (voice), Rich T
+    exan Accountant (voice), Mr. Orlando / Mr. McBride (voice), Prison Guard (voice)
+    , Oliver Hardy (voice), SendEx Employee (voice), Devil Moe (voice), Film Student
+     #2 (voice)
    thumb: https://image.tmdb.org/t/p/original/xXt9Nh7RAT5bOen66TaXreNYmCl.jpg
    order: 14
    imageHasChanged: false
  - id: 110141
    name: Alex Désert
-   role: Carl Carlson (voice), Lou (voice), Audrey II (voice), Carl Carlson / Lou (voice)
+   role: Carl Carlson (voice), Lou (voice), Carl Carlson / Lou (voice), Audrey II (voice)
    thumb: https://image.tmdb.org/t/p/original/iz5fLxrOTKYUkpUmGXgVfCfIZxn.jpg
    order: 15
    imageHasChanged: false
@@ -210,18 +213,18 @@ actors: (N>800)
    name: Grey DeLisle
    role:
     Martin Prince (voice), Sherri / Terri (voice), Sherri / Terri / Martin Prince (v
-    oice), Gloria Prince / Martin Prince (voice), Riley (voice), Martin Prince / You
-    ng Woman (voice), Terri / Sherri / Martin Prince (voice), Terri (voice), Martin 
-    / Martin's Brother (voice)
+    oice), Martin Prince / Young Woman (voice), Gloria Prince / Martin Prince (voice
+    ), Terri / Sherri / Martin Prince (voice), Martin / Martin's Brother (voice), Te
+    rri (voice), Riley (voice)
    thumb: https://image.tmdb.org/t/p/original/vrUHaXe1pG56yZkgH7Hs3LGRLTT.jpg
    order: 17
    imageHasChanged: false
  - id: 34521
    name: Maurice LaMarche
    role:
-    Army recruiter 2 / Billy / others characters (voice), Milo (voice), Fox announce
-    r / Chinese #1 / Chinese #4 / Leprechaun (voice), Orson Welles (voice), Vincent 
-    Price (voice)
+    Army recruiter 2 / Billy / others characters (voice), Vincent Price (voice), Ors
+    on Welles (voice), Fox announcer / Chinese #1 / Chinese #4 / Leprechaun (voice),
+     Milo (voice), Hedonismbot Cosplayer (voice)
    thumb: https://image.tmdb.org/t/p/original/qCiL3EYAhLcNo0rNj5pczWo9MwG.jpg
    order: 18
    imageHasChanged: false
@@ -229,9 +232,9 @@ actors: (N>800)
    name: Jon Lovitz
    role:
     Artie Ziff / Llewellyn Sinclair / other minor characters., Artie Ziff (voice), L
-    lewellyn Sinclair / Ms. Sinclair (voice), Enrico Irritazio (voice), Avery Devere
-    aux / Aristotle Amandopoulis (voice), Professor Lombardo / Donut Delivery Man (v
-    oice), Selma's Cigarette (voice), Artie Ziff / Mr. Seckofsky (voice)
+    lewellyn Sinclair / Ms. Sinclair (voice), Artie Ziff / Mr. Seckofsky (voice), Av
+    ery Devereaux / Aristotle Amandopoulis (voice), Enrico Irritazio (voice), Profes
+    sor Lombardo / Donut Delivery Man (voice), Selma's Cigarette (voice)
    thumb: https://image.tmdb.org/t/p/original/jBXSLoDEVwYkNqSVWHV9yDo8whA.jpg
    order: 19
    imageHasChanged: false
@@ -265,306 +268,306 @@ seasonPoster S00: (N=1)
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S01: (N=1)
-  - id: https://image.tmdb.org/t/p/original/ddMpYO4mauQu7IMTjiGw97AtXvY.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/ddMpYO4mauQu7IMTjiGw97AtXvY.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/ddMpYO4mauQu7IMTjiGw97AtXvY.jpg
+  - id: https://image.tmdb.org/t/p/original/t544zSFUNyvmyeP4sHotlcEX3zH.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/t544zSFUNyvmyeP4sHotlcEX3zH.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/t544zSFUNyvmyeP4sHotlcEX3zH.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S02: (N=1)
-  - id: https://image.tmdb.org/t/p/original/yW7Q9Zh2QQjI079cwdqwBMidyiF.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/yW7Q9Zh2QQjI079cwdqwBMidyiF.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/yW7Q9Zh2QQjI079cwdqwBMidyiF.jpg
+  - id: https://image.tmdb.org/t/p/original/4ROAI3tNaRaL8UZWoSO51woN3WE.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/4ROAI3tNaRaL8UZWoSO51woN3WE.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/4ROAI3tNaRaL8UZWoSO51woN3WE.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S03: (N=1)
-  - id: https://image.tmdb.org/t/p/original/PQKmDO7aUftceeyDh06to2mEq7.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/PQKmDO7aUftceeyDh06to2mEq7.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/PQKmDO7aUftceeyDh06to2mEq7.jpg
+  - id: https://image.tmdb.org/t/p/original/9ghmIhWJJuTx3UHyfVVBXQoUGvI.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/9ghmIhWJJuTx3UHyfVVBXQoUGvI.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/9ghmIhWJJuTx3UHyfVVBXQoUGvI.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S04: (N=1)
-  - id: https://image.tmdb.org/t/p/original/5B8plT0VgmQW1sOYgaMgWXrFz2a.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/5B8plT0VgmQW1sOYgaMgWXrFz2a.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/5B8plT0VgmQW1sOYgaMgWXrFz2a.jpg
+  - id: https://image.tmdb.org/t/p/original/99Y4jM3a6cX52DBD2Dw61g1dGh8.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/99Y4jM3a6cX52DBD2Dw61g1dGh8.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/99Y4jM3a6cX52DBD2Dw61g1dGh8.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S05: (N=1)
-  - id: https://image.tmdb.org/t/p/original/5byFzVVUX1APYC1a93KMNrQIAho.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/5byFzVVUX1APYC1a93KMNrQIAho.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/5byFzVVUX1APYC1a93KMNrQIAho.jpg
+  - id: https://image.tmdb.org/t/p/original/p8tRDtrkzquirArGp6S1b7Zxle3.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/p8tRDtrkzquirArGp6S1b7Zxle3.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/p8tRDtrkzquirArGp6S1b7Zxle3.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S06: (N=1)
-  - id: https://image.tmdb.org/t/p/original/2gnDoTCgBwLqgJ1JHw8Ssxlfs5y.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/2gnDoTCgBwLqgJ1JHw8Ssxlfs5y.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/2gnDoTCgBwLqgJ1JHw8Ssxlfs5y.jpg
+  - id: https://image.tmdb.org/t/p/original/qD20BnTxIdF1rcnX4BARmFshzKA.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/qD20BnTxIdF1rcnX4BARmFshzKA.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/qD20BnTxIdF1rcnX4BARmFshzKA.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S07: (N=1)
-  - id: https://image.tmdb.org/t/p/original/xYGX2iSj7zPu74Pc2skbK93LPB3.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/xYGX2iSj7zPu74Pc2skbK93LPB3.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/xYGX2iSj7zPu74Pc2skbK93LPB3.jpg
+  - id: https://image.tmdb.org/t/p/original/blCeZS6BmN3wwmF40fuCZSeFwbB.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/blCeZS6BmN3wwmF40fuCZSeFwbB.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/blCeZS6BmN3wwmF40fuCZSeFwbB.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S08: (N=1)
-  - id: https://image.tmdb.org/t/p/original/e3ZzhSKyBCKf3P09yu9cfHCFjGr.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/e3ZzhSKyBCKf3P09yu9cfHCFjGr.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/e3ZzhSKyBCKf3P09yu9cfHCFjGr.jpg
+  - id: https://image.tmdb.org/t/p/original/xLebCxRHSwXBW39a4OLmMSGChLs.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/xLebCxRHSwXBW39a4OLmMSGChLs.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/xLebCxRHSwXBW39a4OLmMSGChLs.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S09: (N=1)
-  - id: https://image.tmdb.org/t/p/original/bETUFDott6p55CFNYs8FNxYQEkT.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/bETUFDott6p55CFNYs8FNxYQEkT.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/bETUFDott6p55CFNYs8FNxYQEkT.jpg
+  - id: https://image.tmdb.org/t/p/original/6PTYyLD8bSiNZf1PFdCQ9JyiIFW.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/6PTYyLD8bSiNZf1PFdCQ9JyiIFW.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/6PTYyLD8bSiNZf1PFdCQ9JyiIFW.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S10: (N=1)
-  - id: https://image.tmdb.org/t/p/original/oXFElouedRJkMu6v9KNQt6cHjXJ.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/oXFElouedRJkMu6v9KNQt6cHjXJ.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/oXFElouedRJkMu6v9KNQt6cHjXJ.jpg
+  - id: https://image.tmdb.org/t/p/original/A77xKuxA13aXA1mQd6YLAaTIErK.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/A77xKuxA13aXA1mQd6YLAaTIErK.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/A77xKuxA13aXA1mQd6YLAaTIErK.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S11: (N=1)
-  - id: https://image.tmdb.org/t/p/original/zYzsOO6LaqmDcFrHc73A9btOc8N.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/zYzsOO6LaqmDcFrHc73A9btOc8N.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/zYzsOO6LaqmDcFrHc73A9btOc8N.jpg
+  - id: https://image.tmdb.org/t/p/original/swM9G5ojulvLYIF721Y6swoJQGh.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/swM9G5ojulvLYIF721Y6swoJQGh.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/swM9G5ojulvLYIF721Y6swoJQGh.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S12: (N=1)
-  - id: https://image.tmdb.org/t/p/original/2Cy4b4jiKVD45yrwb8GWdC2bE0H.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/2Cy4b4jiKVD45yrwb8GWdC2bE0H.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/2Cy4b4jiKVD45yrwb8GWdC2bE0H.jpg
+  - id: https://image.tmdb.org/t/p/original/xPRZmUukPXqlSZfGMaEI0GyVhjW.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/xPRZmUukPXqlSZfGMaEI0GyVhjW.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/xPRZmUukPXqlSZfGMaEI0GyVhjW.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S13: (N=1)
-  - id: https://image.tmdb.org/t/p/original/cn7aESAxPA3o1OLJbrM7T0ETYIE.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/cn7aESAxPA3o1OLJbrM7T0ETYIE.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/cn7aESAxPA3o1OLJbrM7T0ETYIE.jpg
+  - id: https://image.tmdb.org/t/p/original/xflc3aV1SbP2bGeZNuu4AG6cIqH.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/xflc3aV1SbP2bGeZNuu4AG6cIqH.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/xflc3aV1SbP2bGeZNuu4AG6cIqH.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S14: (N=1)
-  - id: https://image.tmdb.org/t/p/original/nwZc3mBBCGPRqIUSGGL29sTzutx.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/nwZc3mBBCGPRqIUSGGL29sTzutx.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/nwZc3mBBCGPRqIUSGGL29sTzutx.jpg
+  - id: https://image.tmdb.org/t/p/original/9IowK57TpeO09D4B46jd4J3wjPO.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/9IowK57TpeO09D4B46jd4J3wjPO.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/9IowK57TpeO09D4B46jd4J3wjPO.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S15: (N=1)
-  - id: https://image.tmdb.org/t/p/original/dZiUfyxBAs8NizSjaJa8VeFNizj.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/dZiUfyxBAs8NizSjaJa8VeFNizj.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/dZiUfyxBAs8NizSjaJa8VeFNizj.jpg
+  - id: https://image.tmdb.org/t/p/original/svXs3ugVAoKSZoBQNUZ3sQIp1ly.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/svXs3ugVAoKSZoBQNUZ3sQIp1ly.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/svXs3ugVAoKSZoBQNUZ3sQIp1ly.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S16: (N=1)
-  - id: https://image.tmdb.org/t/p/original/dpETtKG5fGAJJZYgPD0m3kQ99WQ.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/dpETtKG5fGAJJZYgPD0m3kQ99WQ.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/dpETtKG5fGAJJZYgPD0m3kQ99WQ.jpg
+  - id: https://image.tmdb.org/t/p/original/iquKGAhJKZ9IkKtKT4JqhAnjDFW.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/iquKGAhJKZ9IkKtKT4JqhAnjDFW.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/iquKGAhJKZ9IkKtKT4JqhAnjDFW.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S17: (N=1)
-  - id: https://image.tmdb.org/t/p/original/qRNdd8RC6gfFfpw9nLteLkxfgmb.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/qRNdd8RC6gfFfpw9nLteLkxfgmb.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/qRNdd8RC6gfFfpw9nLteLkxfgmb.jpg
+  - id: https://image.tmdb.org/t/p/original/9EpBFv9YpKCZhXQhKKTSG1h3OGi.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/9EpBFv9YpKCZhXQhKKTSG1h3OGi.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/9EpBFv9YpKCZhXQhKKTSG1h3OGi.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S18: (N=1)
-  - id: https://image.tmdb.org/t/p/original/1TnYoGE97zaIGqoB718z0imFpEr.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/1TnYoGE97zaIGqoB718z0imFpEr.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/1TnYoGE97zaIGqoB718z0imFpEr.jpg
+  - id: https://image.tmdb.org/t/p/original/kwb8AZAHyhn96dzn17mtTV3l8dl.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/kwb8AZAHyhn96dzn17mtTV3l8dl.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/kwb8AZAHyhn96dzn17mtTV3l8dl.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S19: (N=1)
-  - id: https://image.tmdb.org/t/p/original/r4w44aRKqXkm3ydl0C3naH6qs6O.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/r4w44aRKqXkm3ydl0C3naH6qs6O.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/r4w44aRKqXkm3ydl0C3naH6qs6O.jpg
+  - id: https://image.tmdb.org/t/p/original/nLKZJ1ozVvYFtaOynzkShE8wN4k.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/nLKZJ1ozVvYFtaOynzkShE8wN4k.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/nLKZJ1ozVvYFtaOynzkShE8wN4k.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S20: (N=1)
-  - id: https://image.tmdb.org/t/p/original/o6cljzpJMLYLVIc80xAvZYlkqlY.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/o6cljzpJMLYLVIc80xAvZYlkqlY.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/o6cljzpJMLYLVIc80xAvZYlkqlY.jpg
+  - id: https://image.tmdb.org/t/p/original/2CUdLX4K8fMlcdVPHUbciTYt4ri.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/2CUdLX4K8fMlcdVPHUbciTYt4ri.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/2CUdLX4K8fMlcdVPHUbciTYt4ri.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S21: (N=1)
-  - id: https://image.tmdb.org/t/p/original/aLm242tTStOVW0LmsP6geYYcYJb.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/aLm242tTStOVW0LmsP6geYYcYJb.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/aLm242tTStOVW0LmsP6geYYcYJb.jpg
+  - id: https://image.tmdb.org/t/p/original/fEykf9XN4Cn5tJ17pOD2PObdjoc.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/fEykf9XN4Cn5tJ17pOD2PObdjoc.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/fEykf9XN4Cn5tJ17pOD2PObdjoc.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S22: (N=1)
-  - id: https://image.tmdb.org/t/p/original/vI5vl2gkUQaRTqfbPLerdzdN3Fa.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/vI5vl2gkUQaRTqfbPLerdzdN3Fa.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/vI5vl2gkUQaRTqfbPLerdzdN3Fa.jpg
+  - id: https://image.tmdb.org/t/p/original/xUZeYO9NPkmXCcuRrr8PgXzk2Qd.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/xUZeYO9NPkmXCcuRrr8PgXzk2Qd.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/xUZeYO9NPkmXCcuRrr8PgXzk2Qd.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S23: (N=1)
-  - id: https://image.tmdb.org/t/p/original/ywBjLiOqkpvwIo9BiPOhINRTvVJ.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/ywBjLiOqkpvwIo9BiPOhINRTvVJ.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/ywBjLiOqkpvwIo9BiPOhINRTvVJ.jpg
+  - id: https://image.tmdb.org/t/p/original/wlQnKb3pHBxtMivCjcvM8TDpBbv.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/wlQnKb3pHBxtMivCjcvM8TDpBbv.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/wlQnKb3pHBxtMivCjcvM8TDpBbv.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S24: (N=1)
-  - id: https://image.tmdb.org/t/p/original/K7712Mhu21rjC1W8PiB738tGy4.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/K7712Mhu21rjC1W8PiB738tGy4.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/K7712Mhu21rjC1W8PiB738tGy4.jpg
+  - id: https://image.tmdb.org/t/p/original/qGPFl3X6ukZ6fBQRiLxueLWQh9y.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/qGPFl3X6ukZ6fBQRiLxueLWQh9y.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/qGPFl3X6ukZ6fBQRiLxueLWQh9y.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S25: (N=1)
-  - id: https://image.tmdb.org/t/p/original/iYBMbmaDHIDoKZwmgMu7oouWdwB.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/iYBMbmaDHIDoKZwmgMu7oouWdwB.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/iYBMbmaDHIDoKZwmgMu7oouWdwB.jpg
+  - id: https://image.tmdb.org/t/p/original/sBYXSBgzVwyUXG4QncOv9DoSp5E.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/sBYXSBgzVwyUXG4QncOv9DoSp5E.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/sBYXSBgzVwyUXG4QncOv9DoSp5E.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S26: (N=1)
-  - id: https://image.tmdb.org/t/p/original/2Iv0jHwS9Ay2pDxc2zpSh7Ee7wc.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/2Iv0jHwS9Ay2pDxc2zpSh7Ee7wc.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/2Iv0jHwS9Ay2pDxc2zpSh7Ee7wc.jpg
+  - id: https://image.tmdb.org/t/p/original/9bGpb3vWygBogXpQBnTodFWaQte.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/9bGpb3vWygBogXpQBnTodFWaQte.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/9bGpb3vWygBogXpQBnTodFWaQte.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S27: (N=1)
-  - id: https://image.tmdb.org/t/p/original/egAz2cHUCd8qwPTxvLLFuhNAtkh.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/egAz2cHUCd8qwPTxvLLFuhNAtkh.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/egAz2cHUCd8qwPTxvLLFuhNAtkh.jpg
+  - id: https://image.tmdb.org/t/p/original/AoOVTGxfGyfRpmNJhonfqPeTiY8.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/AoOVTGxfGyfRpmNJhonfqPeTiY8.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/AoOVTGxfGyfRpmNJhonfqPeTiY8.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S28: (N=1)
-  - id: https://image.tmdb.org/t/p/original/8tbhxmdGi65mx8aVtN0mYirCmcr.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/8tbhxmdGi65mx8aVtN0mYirCmcr.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/8tbhxmdGi65mx8aVtN0mYirCmcr.jpg
+  - id: https://image.tmdb.org/t/p/original/Asrn5wh8mHVm8a1ZsIWfwBX00RM.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/Asrn5wh8mHVm8a1ZsIWfwBX00RM.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/Asrn5wh8mHVm8a1ZsIWfwBX00RM.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S29: (N=1)
-  - id: https://image.tmdb.org/t/p/original/dyAmKsbCfZAj5lSnWpYiMazHZ4K.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/dyAmKsbCfZAj5lSnWpYiMazHZ4K.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/dyAmKsbCfZAj5lSnWpYiMazHZ4K.jpg
+  - id: https://image.tmdb.org/t/p/original/9LAihbWybQA2UCLjitES1K3xc3T.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/9LAihbWybQA2UCLjitES1K3xc3T.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/9LAihbWybQA2UCLjitES1K3xc3T.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S30: (N=1)
-  - id: https://image.tmdb.org/t/p/original/d9svqHWZSCv5vQP5CbH6tLSuVyo.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/d9svqHWZSCv5vQP5CbH6tLSuVyo.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/d9svqHWZSCv5vQP5CbH6tLSuVyo.jpg
+  - id: https://image.tmdb.org/t/p/original/l18xQsO27KFJwsj35JaAsG95dN7.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/l18xQsO27KFJwsj35JaAsG95dN7.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/l18xQsO27KFJwsj35JaAsG95dN7.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S31: (N=1)
-  - id: https://image.tmdb.org/t/p/original/2IUYDBYYzjc5mqRZq26KgIActiy.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/2IUYDBYYzjc5mqRZq26KgIActiy.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/2IUYDBYYzjc5mqRZq26KgIActiy.jpg
+  - id: https://image.tmdb.org/t/p/original/1y2zzQhnAuFpRNovNMHWlubOaxw.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/1y2zzQhnAuFpRNovNMHWlubOaxw.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/1y2zzQhnAuFpRNovNMHWlubOaxw.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S32: (N=1)
-  - id: https://image.tmdb.org/t/p/original/y6EII2ExAXxFqM9hm6AURBjWkyu.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/y6EII2ExAXxFqM9hm6AURBjWkyu.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/y6EII2ExAXxFqM9hm6AURBjWkyu.jpg
+  - id: https://image.tmdb.org/t/p/original/ifvEta1mmPGLu3E6lFnPSJAyBhh.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/ifvEta1mmPGLu3E6lFnPSJAyBhh.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/ifvEta1mmPGLu3E6lFnPSJAyBhh.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S33: (N=1)
-  - id: https://image.tmdb.org/t/p/original/tubgEpjTUA7t0kejVMBsNBZDarZ.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/tubgEpjTUA7t0kejVMBsNBZDarZ.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/tubgEpjTUA7t0kejVMBsNBZDarZ.jpg
+  - id: https://image.tmdb.org/t/p/original/sjg9DQMgZzUA0Uqfw7eL89gFXOr.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/sjg9DQMgZzUA0Uqfw7eL89gFXOr.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/sjg9DQMgZzUA0Uqfw7eL89gFXOr.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 
     aspect: 
     season: SeasonNumber=xx
 seasonPoster S34: (N=1)
-  - id: https://image.tmdb.org/t/p/original/zI3E2a3WYma5w8emI35mgq5Iurx.jpg
-    originalUrl: https://image.tmdb.org/t/p/original/zI3E2a3WYma5w8emI35mgq5Iurx.jpg
-    thumbUrl: https://image.tmdb.org/t/p/original/zI3E2a3WYma5w8emI35mgq5Iurx.jpg
+  - id: https://image.tmdb.org/t/p/original/pnoT4SHafalZmf2XNtzjBppVrpj.jpg
+    originalUrl: https://image.tmdb.org/t/p/original/pnoT4SHafalZmf2XNtzjBppVrpj.jpg
+    thumbUrl: https://image.tmdb.org/t/p/original/pnoT4SHafalZmf2XNtzjBppVrpj.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 

--- a/test/resources/scrapers/tvmaze/The-Simpsons-S12.ref.txt
+++ b/test/resources/scrapers/tvmaze/The-Simpsons-S12.ref.txt
@@ -32,7 +32,7 @@ firstAired: 2000-11-01
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173084.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -71,7 +71,7 @@ firstAired: 2000-11-05
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/42/107421.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -112,7 +112,7 @@ firstAired: 2000-11-12
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/42/106357.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -151,7 +151,7 @@ firstAired: 2000-11-19
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173083.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -190,7 +190,7 @@ firstAired: 2000-11-26
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173082.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -229,7 +229,7 @@ firstAired: 2000-12-03
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/41/103758.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -267,7 +267,7 @@ firstAired: 2000-12-10
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/44/110913.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -305,7 +305,7 @@ firstAired: 2000-12-17
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173078.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -344,7 +344,7 @@ firstAired: 2001-01-07
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173076.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -382,7 +382,7 @@ firstAired: 2001-01-14
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173075.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -423,7 +423,7 @@ firstAired: 2001-02-04
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/46/117222.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -461,7 +461,7 @@ firstAired: 2001-02-11
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173074.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -501,7 +501,7 @@ firstAired: 2001-02-18
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173073.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -540,7 +540,7 @@ firstAired: 2001-02-25
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/42/106656.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -579,7 +579,7 @@ firstAired: 2001-03-04
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173072.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -618,7 +618,7 @@ firstAired: 2001-03-11
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/49/124221.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -657,7 +657,7 @@ firstAired: 2001-04-01
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/68/172197.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -696,7 +696,7 @@ firstAired: 2001-04-29
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173071.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -735,7 +735,7 @@ firstAired: 2001-05-06
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173070.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -774,7 +774,7 @@ firstAired: 2001-05-13
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173069.jpg
 actors: (N=0)
 streamDetails: <not loaded>
@@ -813,7 +813,7 @@ firstAired: 2001-05-20
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173068.jpg
 actors: (N=0)
 streamDetails: <not loaded>

--- a/test/resources/scrapers/tvmaze/The-Simpsons-S12E19-all-details.ref.txt
+++ b/test/resources/scrapers/tvmaze/The-Simpsons-S12E19-all-details.ref.txt
@@ -27,7 +27,7 @@ firstAired: 2001-05-06
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173070.jpg
 actors: (N=0)
 streamDetails: <not loaded>

--- a/test/resources/scrapers/tvmaze/The-Simpsons-S12E19-minimal-details.ref.txt
+++ b/test/resources/scrapers/tvmaze/The-Simpsons-S12E19-minimal-details.ref.txt
@@ -27,7 +27,7 @@ firstAired: 2001-05-06
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173070.jpg
 actors: (N=0)
 streamDetails: <not loaded>

--- a/test/resources/scrapers/tvmaze/The-Simpsons-all-details.ref.txt
+++ b/test/resources/scrapers/tvmaze/The-Simpsons-all-details.ref.txt
@@ -24,9 +24,10 @@ genres: (N<6)
   - Family
 tags: (N=0)
 certification: 
-network: FOX
+networks: (N=1)
+  - FOX
 episodeGuideUrl: 
-actors: (N>400)
+actors: (N>1000)
  - id: 14854
    name: Dan Castellaneta
    role: Homer Simpson
@@ -36,13 +37,13 @@ actors: (N>400)
  - id: 14855
    name: Julie Kavner
    role: Marge Simpson
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2114.jpg
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243770.jpg
    order: 1
    imageHasChanged: false
  - id: 14857
    name: Yeardley Smith
    role: Lisa Simpson
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2185.jpg
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243772.jpg
    order: 2
    imageHasChanged: false
  - id: 14856
@@ -60,67 +61,67 @@ actors: (N>400)
  - id: 14859
    name: Harry Shearer
    role: Charles Montgomery Burns
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/42/107112.jpg
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243773.jpg
    order: 5
-   imageHasChanged: false
- - id: 14858
-   name: Hank Azaria
-   role: Chief Clancy Wiggum
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2200.jpg
-   order: 6
    imageHasChanged: false
  - id: 14859
    name: Harry Shearer
    role: Lenny Leonard
    thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2176.jpg
-   order: 7
+   order: 6
    imageHasChanged: false
  - id: 14858
    name: Hank Azaria
-   role: Apu Nahasapeemapetilon
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2186.jpg
-   order: 8
+   role: Chief Clancy Wiggum
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2200.jpg
+   order: 7
    imageHasChanged: false
  - id: 14859
    name: Harry Shearer
    role: Seymour Skinner
    thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2194.jpg
-   order: 9
+   order: 8
    imageHasChanged: false
  - id: 14858
    name: Hank Azaria
    role: Carl Carlson
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2110.jpg
-   order: 10
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243774.jpg
+   order: 9
    imageHasChanged: false
  - id: 14859
    name: Harry Shearer
    role: Carl Carlson
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2110.jpg
-   order: 11
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243774.jpg
+   order: 10
    imageHasChanged: false
- - id: 14856
-   name: Nancy Cartwright
-   role: Nelson Muntz
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2197.jpg
-   order: 12
+ - id: 14858
+   name: Hank Azaria
+   role: Apu Nahasapeemapetilon
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2186.jpg
+   order: 11
    imageHasChanged: false
  - id: 14854
    name: Dan Castellaneta
    role: Abraham Simpson
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2116.jpg
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243779.jpg
+   order: 12
+   imageHasChanged: false
+ - id: 14856
+   name: Nancy Cartwright
+   role: Nelson Muntz
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243777.jpg
    order: 13
    imageHasChanged: false
  - id: 14859
    name: Harry Shearer
    role: Ned Flanders
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2198.jpg
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243778.jpg
    order: 14
    imageHasChanged: false
- - id: 14856
-   name: Nancy Cartwright
-   role: Maggie Simpson
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/42/107111.jpg
+ - id: 14859
+   name: Harry Shearer
+   role: Kent Brockman
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2183.jpg
    order: 15
    imageHasChanged: false
  - id: 14854
@@ -129,29 +130,29 @@ actors: (N>400)
    thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2201.jpg
    order: 16
    imageHasChanged: false
- - id: 14859
-   name: Harry Shearer
-   role: Kent Brockman
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2183.jpg
+ - id: 14856
+   name: Nancy Cartwright
+   role: Maggie Simpson
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243780.jpg
    order: 17
+   imageHasChanged: false
+ - id: 14857
+   name: Yeardley Smith
+   role: Maggie Simpson
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243780.jpg
+   order: 18
    imageHasChanged: false
  - id: 14854
    name: Dan Castellaneta
    role: Barney Gumble
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2108.jpg
-   order: 18
-   imageHasChanged: false
- - id: 14856
-   name: Nancy Cartwright
-   role: Ralph Wiggum
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2190.jpg
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243782.jpg
    order: 19
    imageHasChanged: false
-  - ... and >300 more
+  - ... and >1000 more
 posters: (N>30)
-  - id: https://static.tvmaze.com/uploads/images/original_untouched/476/1192162.jpg
-    originalUrl: https://static.tvmaze.com/uploads/images/original_untouched/476/1192162.jpg
-    thumbUrl: https://static.tvmaze.com/uploads/images/medium_portrait/476/1192162.jpg
+  - id: https://static.tvmaze.com/uploads/images/original_untouched/488/1222067.jpg
+    originalUrl: https://static.tvmaze.com/uploads/images/original_untouched/488/1222067.jpg
+    thumbUrl: https://static.tvmaze.com/uploads/images/medium_portrait/488/1222067.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 

--- a/test/resources/scrapers/tvmaze/The-Simpsons-minimal-details.ref.txt
+++ b/test/resources/scrapers/tvmaze/The-Simpsons-minimal-details.ref.txt
@@ -24,9 +24,10 @@ genres: (N<6)
   - Family
 tags: (N=0)
 certification: 
-network: FOX
+networks: (N=1)
+  - FOX
 episodeGuideUrl: 
-actors: (N>400)
+actors: (N>1000)
  - id: 14854
    name: Dan Castellaneta
    role: Homer Simpson
@@ -36,13 +37,13 @@ actors: (N>400)
  - id: 14855
    name: Julie Kavner
    role: Marge Simpson
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2114.jpg
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243770.jpg
    order: 1
    imageHasChanged: false
  - id: 14857
    name: Yeardley Smith
    role: Lisa Simpson
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2185.jpg
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243772.jpg
    order: 2
    imageHasChanged: false
  - id: 14856
@@ -60,67 +61,67 @@ actors: (N>400)
  - id: 14859
    name: Harry Shearer
    role: Charles Montgomery Burns
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/42/107112.jpg
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243773.jpg
    order: 5
-   imageHasChanged: false
- - id: 14858
-   name: Hank Azaria
-   role: Chief Clancy Wiggum
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2200.jpg
-   order: 6
    imageHasChanged: false
  - id: 14859
    name: Harry Shearer
    role: Lenny Leonard
    thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2176.jpg
-   order: 7
+   order: 6
    imageHasChanged: false
  - id: 14858
    name: Hank Azaria
-   role: Apu Nahasapeemapetilon
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2186.jpg
-   order: 8
+   role: Chief Clancy Wiggum
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2200.jpg
+   order: 7
    imageHasChanged: false
  - id: 14859
    name: Harry Shearer
    role: Seymour Skinner
    thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2194.jpg
-   order: 9
+   order: 8
    imageHasChanged: false
  - id: 14858
    name: Hank Azaria
    role: Carl Carlson
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2110.jpg
-   order: 10
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243774.jpg
+   order: 9
    imageHasChanged: false
  - id: 14859
    name: Harry Shearer
    role: Carl Carlson
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2110.jpg
-   order: 11
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243774.jpg
+   order: 10
    imageHasChanged: false
- - id: 14856
-   name: Nancy Cartwright
-   role: Nelson Muntz
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2197.jpg
-   order: 12
+ - id: 14858
+   name: Hank Azaria
+   role: Apu Nahasapeemapetilon
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2186.jpg
+   order: 11
    imageHasChanged: false
  - id: 14854
    name: Dan Castellaneta
    role: Abraham Simpson
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2116.jpg
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243779.jpg
+   order: 12
+   imageHasChanged: false
+ - id: 14856
+   name: Nancy Cartwright
+   role: Nelson Muntz
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243777.jpg
    order: 13
    imageHasChanged: false
  - id: 14859
    name: Harry Shearer
    role: Ned Flanders
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2198.jpg
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243778.jpg
    order: 14
    imageHasChanged: false
- - id: 14856
-   name: Nancy Cartwright
-   role: Maggie Simpson
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/42/107111.jpg
+ - id: 14859
+   name: Harry Shearer
+   role: Kent Brockman
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2183.jpg
    order: 15
    imageHasChanged: false
  - id: 14854
@@ -129,29 +130,29 @@ actors: (N>400)
    thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2201.jpg
    order: 16
    imageHasChanged: false
- - id: 14859
-   name: Harry Shearer
-   role: Kent Brockman
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2183.jpg
+ - id: 14856
+   name: Nancy Cartwright
+   role: Maggie Simpson
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243780.jpg
    order: 17
+   imageHasChanged: false
+ - id: 14857
+   name: Yeardley Smith
+   role: Maggie Simpson
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243780.jpg
+   order: 18
    imageHasChanged: false
  - id: 14854
    name: Dan Castellaneta
    role: Barney Gumble
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2108.jpg
-   order: 18
-   imageHasChanged: false
- - id: 14856
-   name: Nancy Cartwright
-   role: Ralph Wiggum
-   thumb: https://static.tvmaze.com/uploads/images/original_untouched/0/2190.jpg
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/497/1243782.jpg
    order: 19
    imageHasChanged: false
-  - ... and >300 more
+  - ... and >1000 more
 posters: (N>30)
-  - id: https://static.tvmaze.com/uploads/images/original_untouched/476/1192162.jpg
-    originalUrl: https://static.tvmaze.com/uploads/images/original_untouched/476/1192162.jpg
-    thumbUrl: https://static.tvmaze.com/uploads/images/medium_portrait/476/1192162.jpg
+  - id: https://static.tvmaze.com/uploads/images/original_untouched/488/1222067.jpg
+    originalUrl: https://static.tvmaze.com/uploads/images/original_untouched/488/1222067.jpg
+    thumbUrl: https://static.tvmaze.com/uploads/images/medium_portrait/488/1222067.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 

--- a/test/resources/scrapers/tvmaze/The-Simpsons-tvmaze5264-all-details.ref.txt
+++ b/test/resources/scrapers/tvmaze/The-Simpsons-tvmaze5264-all-details.ref.txt
@@ -27,7 +27,7 @@ firstAired: 2001-05-06
 tags: (N=0)
 epBookmark: <not set or invalid>
 certification: 
-network: 
+networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173070.jpg
 actors: (N=0)
 streamDetails: <not loaded>

--- a/test/resources/scrapers/video-buster/Findet-Dorie-183469.ref.txt
+++ b/test/resources/scrapers/video-buster/Findet-Dorie-183469.ref.txt
@@ -28,7 +28,7 @@ movie set: tmdbid= | name=
 movie set overview: 
 tagline: Alles andere kannste vergessen.
 ratings (N=1)
-  source=VideoBuster | rating=3.6 | votes=300 | min=0 | max=10
+  source=VideoBuster | rating=3.6 | votes=400 | min=0 | max=10
 userRating: 0
 imdbTop250: 0
 released: 2016-01-01

--- a/test/scrapers/thetvdb/testTheTvDbShowLoader.cpp
+++ b/test/scrapers/thetvdb/testTheTvDbShowLoader.cpp
@@ -61,7 +61,7 @@ TEST_CASE("TheTvDb scrapes show details", "[show][TheTvDb][load_data]")
         CHECK(show.imdbId() == ImdbId("tt0285403"));
         CHECK(show.certification() == Certification("TV-PG"));
         CHECK(show.firstAired() == QDate(2001, 10, 2));
-        CHECK(show.network() == "ABC (US)"); // Could also be NBC
+        CHECK_THAT(show.networks(), Contains("ABC (US)")); // Could also be NBC
         CHECK_THAT(show.overview(), Contains("Scrubs focuses on the lives of several people"));
 
         REQUIRE_FALSE(show.ratings().isEmpty());


### PR DESCRIPTION
At least since Kodi v16, there can be multiple `<studio>` tags.
Internally, we call studios "networks": We now support multiple
of them.

There is no automatic update: Existing `<studio>` tags with comma separate lists will remain that way. Only once you edit it in the UI (e.g. click in the studio field, add a character), will we store multiple `<studio>` tags. I want to avoid too many changes in user NFOs.

Fix #1705