### PR TITLE
refactor: Replace sigImageDropped by sigImagesDropped for multi-images

### DIFF
--- a/src/ui/concerts/ConcertWidget.cpp
+++ b/src/ui/concerts/ConcertWidget.cpp
@@ -111,7 +111,7 @@ ConcertWidget::ConcertWidget(QWidget* parent) : QWidget(parent), ui(new Ui::Conc
         this,
         elchOverload<QString>(&ConcertWidget::onRemoveExtraFanart));
     connect(ui->btnAddExtraFanart, &QAbstractButton::clicked, this, &ConcertWidget::onAddExtraFanart);
-    connect(ui->fanarts, &ImageGallery::sigImageDropped, this, &ConcertWidget::onExtraFanartDropped);
+    connect(ui->fanarts, &ImageGallery::sigImagesDropped, this, &ConcertWidget::onExtraFanartDropped);
 
     QPainter p;
     QPixmap revert(":/img/arrow_circle_left.png");
@@ -607,14 +607,14 @@ void ConcertWidget::onAddExtraFanart()
     }
 }
 
-void ConcertWidget::onExtraFanartDropped(QUrl imageUrl)
+void ConcertWidget::onExtraFanartDropped(QVector<QUrl> imageUrls)
 {
     if (m_concert == nullptr) {
         return;
     }
     ui->fanarts->setLoading(true);
     emit setActionSaveEnabled(false, MainWidgets::Concerts);
-    m_concert->controller()->loadImages(ImageType::ConcertExtraFanart, QVector<QUrl>() << imageUrl);
+    m_concert->controller()->loadImages(ImageType::ConcertExtraFanart, imageUrls);
     onInfoChanged();
 }
 

--- a/src/ui/concerts/ConcertWidget.h
+++ b/src/ui/concerts/ConcertWidget.h
@@ -72,7 +72,7 @@ private slots:
     void onRemoveExtraFanart(QString file);
     void onRemoveExtraFanart(QByteArray image);
     void onAddExtraFanart();
-    void onExtraFanartDropped(QUrl imageUrl);
+    void onExtraFanartDropped(QVector<QUrl> imageUrl);
 
     void updateImage(ImageType imageType, ClosableImage* image);
 

--- a/src/ui/music/MusicWidgetArtist.cpp
+++ b/src/ui/music/MusicWidgetArtist.cpp
@@ -92,7 +92,7 @@ MusicWidgetArtist::MusicWidgetArtist(QWidget* parent) : QWidget(parent), ui(new 
             this, elchOverload<QString>(&MusicWidgetArtist::onRemoveExtraFanart));
 
     connect(ui->btnAddExtraFanart, &QAbstractButton::clicked,          this, &MusicWidgetArtist::onAddExtraFanart);
-    connect(ui->fanarts,           &ImageGallery::sigImageDropped,     this, &MusicWidgetArtist::onExtraFanartDropped);
+    connect(ui->fanarts,           &ImageGallery::sigImagesDropped,    this, &MusicWidgetArtist::onExtraFanartDropped);
 
     connect(ui->btnAddAlbum,    &QAbstractButton::clicked,  this, &MusicWidgetArtist::onAddAlbum);
     connect(ui->btnRemoveAlbum, &QAbstractButton::clicked,  this, &MusicWidgetArtist::onRemoveAlbum);
@@ -563,14 +563,14 @@ void MusicWidgetArtist::onAddExtraFanart()
     }
 }
 
-void MusicWidgetArtist::onExtraFanartDropped(QUrl imageUrl)
+void MusicWidgetArtist::onExtraFanartDropped(QVector<QUrl> imageUrls)
 {
     if (m_artist.isNull()) {
         return;
     }
     ui->fanarts->setLoading(true);
     emit sigSetActionSaveEnabled(false, MainWidgets::Music);
-    m_artist->controller()->loadImages(ImageType::ArtistExtraFanart, QVector<QUrl>() << imageUrl);
+    m_artist->controller()->loadImages(ImageType::ArtistExtraFanart, imageUrls);
     ui->buttonRevert->setVisible(true);
 }
 

--- a/src/ui/music/MusicWidgetArtist.h
+++ b/src/ui/music/MusicWidgetArtist.h
@@ -7,6 +7,7 @@
 #include <QPointer>
 #include <QString>
 #include <QTableWidgetItem>
+#include <QVector>
 #include <QWidget>
 
 namespace Ui {
@@ -54,7 +55,7 @@ private slots:
     void onRemoveExtraFanart(QString file);
     void onRemoveExtraFanart(QByteArray image);
     void onAddExtraFanart();
-    void onExtraFanartDropped(QUrl imageUrl);
+    void onExtraFanartDropped(QVector<QUrl> imageUrls);
     void onAddAlbum();
     void onRemoveAlbum();
     void onAlbumEdited(QTableWidgetItem* item);

--- a/src/ui/small_widgets/ImageGallery.cpp
+++ b/src/ui/small_widgets/ImageGallery.cpp
@@ -382,7 +382,6 @@ void ImageGallery::dropEvent(QDropEvent* event)
         }
     }
     if (!imageUrls.isEmpty()) {
-        emit sigImageDropped(imageUrls.first());
         emit sigImagesDropped(imageUrls);
     }
 }

--- a/src/ui/small_widgets/ImageGallery.h
+++ b/src/ui/small_widgets/ImageGallery.h
@@ -26,8 +26,6 @@ public:
 signals:
     void sigRemoveImage(QByteArray);
     void sigRemoveImage(QString);
-    /// \deprecated Use sigImagesDropped() instead.
-    void sigImageDropped(QUrl imageUrl);
     void sigImagesDropped(QVector<QUrl> imageUrls);
 
 protected:

--- a/src/ui/tv_show/TvShowWidgetTvShow.cpp
+++ b/src/ui/tv_show/TvShowWidgetTvShow.cpp
@@ -145,7 +145,7 @@ TvShowWidgetTvShow::TvShowWidgetTvShow(QWidget* parent) :
         this,
         elchOverload<QString>(&TvShowWidgetTvShow::onRemoveExtraFanart));
     connect(ui->btnAddExtraFanart, &QAbstractButton::clicked, this, &TvShowWidgetTvShow::onAddExtraFanart);
-    connect(ui->fanarts, &ImageGallery::sigImageDropped, this, &TvShowWidgetTvShow::onExtraFanartDropped);
+    connect(ui->fanarts, &ImageGallery::sigImagesDropped, this, &TvShowWidgetTvShow::onExtraFanartDropped);
 
     onClear();
 
@@ -1178,18 +1178,23 @@ void TvShowWidgetTvShow::onAddExtraFanart()
     }
 }
 
-void TvShowWidgetTvShow::onExtraFanartDropped(QUrl imageUrl)
+void TvShowWidgetTvShow::onExtraFanartDropped(QVector<QUrl> imageUrls)
 {
     if (m_show == nullptr) {
         return;
     }
-    emit sigSetActionSaveEnabled(false, MainWidgets::TvShows);
-    DownloadManagerElement d;
-    d.imageType = ImageType::TvShowExtraFanart;
-    d.url = std::move(imageUrl);
-    d.show = m_show;
-    m_posterDownloadManager->addDownload(d);
+
+    for (const QUrl& url : imageUrls) {
+        DownloadManagerElement d;
+        d.imageType = ImageType::TvShowExtraFanart;
+        d.url = url;
+        d.show = m_show;
+        m_posterDownloadManager->addDownload(d);
+    }
+
     ui->buttonRevert->setVisible(true);
+
+    emit sigSetActionSaveEnabled(false, MainWidgets::TvShows);
 }
 
 void TvShowWidgetTvShow::onDownloadTune()

--- a/src/ui/tv_show/TvShowWidgetTvShow.h
+++ b/src/ui/tv_show/TvShowWidgetTvShow.h
@@ -84,7 +84,7 @@ private slots:
     void onRemoveExtraFanart(QString file);
     void onRemoveExtraFanart(QByteArray image);
     void onAddExtraFanart();
-    void onExtraFanartDropped(QUrl imageUrl);
+    void onExtraFanartDropped(QVector<QUrl> imageUrls);
 
     void onImdbIdOpen();
     void onTmdbIdOpen();


### PR DESCRIPTION
The image gallery supports dropping _multiple_ images by now. We should use that throughout MediaElch.