### PR TITLE
build: Fix build for Qt < 5.15

### DIFF
--- a/src/ui/tv_show/TvShowWidgetEpisode.cpp
+++ b/src/ui/tv_show/TvShowWidgetEpisode.cpp
@@ -1028,7 +1028,7 @@ void TvShowWidgetEpisode::onLastPlayedChange(QDateTime dateTime)
 
 void TvShowWidgetEpisode::onStudioChange(QString text)
 {
-    QStringList networks = text.split(",", Qt::SkipEmptyParts);
+    QStringList networks = text.split(",", ElchSplitBehavior::SkipEmptyParts);
     for (auto& network : networks) {
         network = network.trimmed();
     }

--- a/src/ui/tv_show/TvShowWidgetTvShow.cpp
+++ b/src/ui/tv_show/TvShowWidgetTvShow.cpp
@@ -1114,7 +1114,7 @@ void TvShowWidgetTvShow::onFirstAiredChange(QDate date)
 
 void TvShowWidgetTvShow::onStudioChange(QString studios)
 {
-    QStringList networks = studios.split(",", Qt::SkipEmptyParts);
+    QStringList networks = studios.split(",", ElchSplitBehavior::SkipEmptyParts);
     for (auto& network : networks) {
         network = network.trimmed();
     }


### PR DESCRIPTION
`Qt::SkipEmptyParts` was introduced in Qt 5.15.  I accidentally used it instead of our adapter variant.