### PR TITLE
ci: Fix nightly builds for Windows: use Git to clone ZenLib

### DIFF
--- a/.ci/docker/Dockerfile.ci.qt5.windows
+++ b/.ci/docker/Dockerfile.ci.qt5.windows
@@ -25,7 +25,6 @@ RUN apt-get update && apt-get upgrade -y && \
         g++-multilib \
         gettext \
         git \
-        subversion \
         gperf \
         intltool \
         libc6-dev-i386 \

--- a/.ci/docker/Dockerfile.ci.qt6.windows
+++ b/.ci/docker/Dockerfile.ci.qt6.windows
@@ -27,7 +27,6 @@ RUN apt-get update && apt-get upgrade -y && \
         g++-multilib \
         gettext \
         git \
-        subversion \
         gperf \
         intltool \
         libc6-dev-i386 \

--- a/.ci/macOS/build_macOS_release_Qt5.sh
+++ b/.ci/macOS/build_macOS_release_Qt5.sh
@@ -95,12 +95,16 @@ git submodule update --init
 
 if [[ ! -d "MediaInfoDLL" ]]; then
 	print_info "Loading MediaInfoDLL"
-	svn checkout https://github.com/MediaArea/MediaInfoLib/trunk/Source/MediaInfoDLL
+	mkdir -p tmp
+	git clone --quiet --depth=1 --branch="v${MAC_MEDIAINFO_VERSION:?}" https://github.com/MediaArea/MediaInfoLib/ tmp/MediaInfoLib
+	mv tmp/MediaInfoLib/Source/MediaInfoDLL ./MediaInfoDLL
 fi
 
 if [[ ! -d "ZenLib" ]]; then
 	print_info "Loading ZenLib"
-	svn checkout https://github.com/MediaArea/ZenLib/trunk/Source/ZenLib
+	mkdir -p tmp
+	git clone --depth=1 --single-branch --branch=master https://github.com/MediaArea/ZenLib/ tmp/ZenLib
+	mv tmp/MediaInfoLib/Source/ZenLib ./ZenLib
 fi
 
 

--- a/.ci/macOS/build_macOS_release_Qt6.sh
+++ b/.ci/macOS/build_macOS_release_Qt6.sh
@@ -95,12 +95,16 @@ git submodule update --init
 
 if [[ ! -d "MediaInfoDLL" ]]; then
 	print_info "Loading MediaInfoDLL"
-	svn checkout https://github.com/MediaArea/MediaInfoLib/trunk/Source/MediaInfoDLL
+	mkdir -p tmp
+	git clone --quiet --depth=1 --branch="v${MAC_MEDIAINFO_VERSION:?}" https://github.com/MediaArea/MediaInfoLib/ tmp/MediaInfoLib
+	mv tmp/MediaInfoLib/Source/MediaInfoDLL ./MediaInfoDLL
 fi
 
 if [[ ! -d "ZenLib" ]]; then
 	print_info "Loading ZenLib"
-	svn checkout https://github.com/MediaArea/ZenLib/trunk/Source/ZenLib
+	mkdir -p tmp
+	git clone --quiet --depth=1 --single-branch --branch=master https://github.com/MediaArea/ZenLib/ tmp/ZenLib
+	mv tmp/MediaInfoLib/Source/ZenLib ./ZenLib
 fi
 
 

--- a/.ci/macOS/check_macOS_dependencies.sh
+++ b/.ci/macOS/check_macOS_dependencies.sh
@@ -16,7 +16,6 @@ require_command git
 require_command cmake
 require_command ninja
 require_command clang++
-require_command svn
 require_command tar
 require_command wget
 require_command 7za

--- a/.ci/third_party_versions.sh
+++ b/.ci/third_party_versions.sh
@@ -9,6 +9,7 @@ export MAC_QT_6_VERSION="6.6.1"
 export MAC_QT_5_VERSION="5.15.2"
 # From https://mediaarea.net/download/binary/libmediainfo0/${MAC_MEDIAINFO_VERSION}/MediaInfo_DLL_${MAC_MEDIAINFO_VERSION}_Mac_x86_64+arm64.tar.bz2
 # Mirror at https://files.ameyering.de/binaries/macOS/mediainfo/
+# Version is also used as Git tag for downloading header files.
 export MAC_MEDIAINFO_VERSION="23.07"
 export MAC_MEDIAINFO_URL="https://files.ameyering.de/binaries/macOS/mediainfo/MediaInfo_DLL_${MAC_MEDIAINFO_VERSION}_Mac_x86_64+arm64.tar.bz2"
 export MAC_MEDIAINFO_SHA512="d5ce0996d6ef7b5fc9fcbb4cb4a8bbd1957858a65e9773f4f520a156ed8c25b33e73c164baffafa67ec2f72dc5807644eb83dc27463792be0d63e8b539fc456e"

--- a/.ci/win/build_windows_release.sh
+++ b/.ci/win/build_windows_release.sh
@@ -26,7 +26,7 @@ mkdir -p third_party/packaging_win
 if [[ ! -f third_party/packaging_win/MediaInfoDLL.7z ]]; then
 	wget --no-verbose --output-document \
 		third_party/packaging_win/MediaInfoDLL.7z \
-		${WIN_MEDIAINFO_URL}
+		"${WIN_MEDIAINFO_URL}"
 	validate_sha512 "third_party/packaging_win/MediaInfoDLL.7z" "${WIN_MEDIAINFO_SHA512}"
 fi
 
@@ -40,8 +40,11 @@ if [[ ! -d MediaInfoDLL ]] || [[ ! -f third_party/packaging_win/MediaInfo.dll ]]
 	mv third_party/packaging_win/MediaInfo/MediaInfo.dll third_party/packaging_win/MediaInfo.dll
 fi
 
-if [[ ! -d ZenLib ]]; then
-	svn checkout --quiet --depth files https://github.com/MediaArea/ZenLib/trunk/Source/ZenLib ./ZenLib
+if [[ ! -d "ZenLib" ]]; then
+	print_info "Loading ZenLib"
+	mkdir -p tmp
+	git clone --quiet --depth=1 --single-branch --branch=master https://github.com/MediaArea/ZenLib/ tmp/ZenLib
+	mv tmp/MediaInfoLib/Source/ZenLib ./ZenLib
 fi
 
 cd "${PROJECT_DIR}"


### PR DESCRIPTION
`svn` seems to no longer work. Instead, we now use `git` to clone `ZenLib`.  Use `--depth=1` to avoid unnecessary cloning.