### PR TITLE
fix(CustomEpisodeScraper): Use episode-config for episode loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 ### Fixed
 
 - IMDb: Episode's overviews are scraped again (#1724)
-- fernsehserien.de: Fix scraping of episode's thumbnails
+- fernsehserien.de: Fix scraping of episode's thumbnails.
+- TV Show: The custom episode scraper may not have loaded details from IMDb.
 - Possible crash when clicking on empty episode thumbnails.
 
 ### Changed

--- a/src/scrapers/tv_show/custom/CustomEpisodeScrapeJob.cpp
+++ b/src/scrapers/tv_show/custom/CustomEpisodeScrapeJob.cpp
@@ -46,7 +46,7 @@ void CustomEpisodeScrapeJob::onTmdbLoaded(EpisodeScrapeJob* job)
     copyDetailsToEpisode(episode(), job->episode(), job->config().details);
     job->deleteLater();
 
-    const QStringList scrapersToUse = m_customConfig.scraperForShowDetails.values();
+    const QStringList scrapersToUse = m_customConfig.scraperForEpisodeDetails.values();
     const bool loadImdb = episode().imdbId().isValid() && scrapersToUse.contains(ImdbTv::ID);
 
     m_loadCounter = 1;


### PR DESCRIPTION
We accidentally used TV show config instead.

Fix #1725