### PR TITLE
fix(macOS): Support building and running on macOS 10.13 again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - IMDb: 
   - Episode's overviews are scraped again (#1724, #1751)
   - TV show titles did not properly decode HTML entities (#1754)
+  - The year in search results works again.
 - fernsehserien.de: Fix scraping of episode's thumbnails.
 - TV Show: The custom episode scraper may not have loaded details from IMDb.
 - Possible crash when clicking on empty episode thumbnails.
@@ -30,7 +31,8 @@
 - debian: Now uses Qt 6 on Ubuntu Lunar (23.04) and later (#1697)
   Thank you, Philipp (GitHub user `iluminat23`) for this change!
 - UI: Navigation and menu bar icons now have a hover effect.
-- IMDb: The year in search results works again.
+- macOS: The Qt5 build for macOS X no longer supports automatic dark mode
+  detection.  Reason being that it doesn't work on macOS 10.13 (#1742)
 
 ### Removed
 

--- a/src/ui/MacUiUtilities.mm
+++ b/src/ui/MacUiUtilities.mm
@@ -2,19 +2,27 @@
 
 #undef slots
 #import <Cocoa/Cocoa.h>
+#include <QtVersionChecks>
 
 namespace mediaelch {
 namespace ui {
 
 bool macIsInDarkTheme()
 {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // macOS 10.13 doesn't support NSAppearanceNameDarkAqua and we can't build it on it.
+    // The easiest way I found was to just drop support for dark mode on macOS 10.X.
+    // With macOS 11 and later, users can use our Qt6 version.
+    return false;
+#else
     // See tutorial at <https://successfulsoftware.net/2021/03/31/how-to-add-a-dark-theme-to-your-qt-application/>
     if (__builtin_available(macOS 10.14, *)) {
         auto appearance = [NSApp.effectiveAppearance
-            bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
+            bestMatchFromAppearancesWithNames:@[ NSAppearanceNameAqua, NSAppearanceNameDarkAqua ]];
         return [appearance isEqualToString:NSAppearanceNameDarkAqua];
     }
     return false;
+#endif
 }
 
 } // namespace ui


### PR DESCRIPTION
We don't support darkmode on macOS 10.x anymore.  Users can use our Qt6 build instead.

Fix #1695