### PR TITLE
feat(AEBN/HM/ADE): Also load poster back cover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - TV Show: The custom episode scraper may not have loaded details from IMDb.
 - Possible crash when clicking on empty episode thumbnails.
 - ADE: Search works again (#1737)
+- ADE/HM: Back cover is also downloaded (#1743)
 
 ### Changed
 

--- a/src/scrapers/movie/adultdvdempire/AdultDvdEmpireScrapeJob.cpp
+++ b/src/scrapers/movie/adultdvdempire/AdultDvdEmpireScrapeJob.cpp
@@ -154,6 +154,18 @@ void AdultDvdEmpireScrapeJob::parseAndAssignInfos(const QString& html)
         m_movie->images().addPoster(p);
     }
 
+    rx.setPattern(R"re(href="([^"]*)"[\s\n]*class="[^"]+"[\s\n]*sty="[^"]+"[\s\n]*id="back-cover")re");
+    match = rx.match(html);
+    if (match.hasMatch()) {
+        Poster p;
+        p.thumbUrl = match.captured(1);
+        p.originalUrl = match.captured(1);
+        // add both as additional poster and backdrop (fanart)
+        // TODO: Add as "posterN" when we support it
+        m_movie->images().addPoster(p);
+        m_movie->images().addBackdrop(p);
+    }
+
     rx.setPattern(R"(<a href="[^"]*"[\s\r\n]*Category="Item Page" Label="Series">[\s\r\n]*([^<]*)<span)");
     match = rx.match(html);
     if (match.hasMatch()) {

--- a/src/scrapers/movie/hotmovies/HotMoviesScrapeJob.cpp
+++ b/src/scrapers/movie/hotmovies/HotMoviesScrapeJob.cpp
@@ -115,15 +115,17 @@ void HotMoviesScrapeJob::parseAndAssignInfos(const QString& html)
         m_movie->images().addPoster(p);
     }
 
-    // TODO: Backcover (we need a proper HTML parser for that)
-    // rx.setPattern(R"rx(id="back-cover"[^>]+>\n\s+<img src="([^"]+)")rx");
-    // match = rx.match(html);
-    // if (match.hasMatch()) {
-    //     Poster p;
-    //     p.thumbUrl = match.captured(1);
-    //     p.originalUrl = match.captured(1);
-    //     m_movie->images().addBackdrop(p);
-    // }
+    rx.setPattern(R"rx(<a href="([^"]+)"[\s\n]+class="[^"]+"[\s\n]+rel="boxcoverAlt")rx");
+    match = rx.match(html);
+    if (match.hasMatch()) {
+        Poster p;
+        p.thumbUrl = match.captured(1);
+        p.originalUrl = match.captured(1);
+        // add both as additional poster and backdrop (fanart)
+        // TODO: Add as "posterN" when we support it
+        m_movie->images().addPoster(p);
+        m_movie->images().addBackdrop(p);
+    }
 
     rx.setPattern(R"re(<strong>Starring:</strong>(.*)</div>)re");
     match = rx.match(html);

--- a/test/resources/scrapers/ade/DVD-Magic-Mike-1745335.ref.txt
+++ b/test/resources/scrapers/ade/DVD-Magic-Mike-1745335.ref.txt
@@ -188,7 +188,7 @@ subtitles: (N=0)
 fileLastModified: <not set or invalid>
 files: (N=0)
 folderName: 
-posters: (N=1)
+posters: (N<6)
   - id: 
     originalUrl: https://imgs1cdn.adultempire.com/products/35/1745335h.jpg
     thumbUrl: https://imgs1cdn.adultempire.com/products/35/1745335h.jpg
@@ -197,7 +197,23 @@ posters: (N=1)
     hint: 
     aspect: 
     season: SeasonNumber=xx
+  - id: 
+    originalUrl: https://imgs1cdn.adultempire.com/products/35/1745335bh.jpg
+    thumbUrl: https://imgs1cdn.adultempire.com/products/35/1745335bh.jpg
+    originalSize: h=-1 w=-1
+    language: 
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
 backdrops: (N>70)
+  - id: 
+    originalUrl: https://imgs1cdn.adultempire.com/products/35/1745335bh.jpg
+    thumbUrl: https://imgs1cdn.adultempire.com/products/35/1745335bh.jpg
+    originalSize: h=-1 w=-1
+    language: 
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
   - id: 
     originalUrl: https://caps1cdn.adultempire.com/p/5335/1920/1745335_00150_1920c.jpg
     thumbUrl: https://caps1cdn.adultempire.com/p/5335/1920/1745335_00150_1920c.jpg
@@ -225,14 +241,6 @@ backdrops: (N>70)
   - id: 
     originalUrl: https://caps1cdn.adultempire.com/p/5335/1920/1745335_00420_1920c.jpg
     thumbUrl: https://caps1cdn.adultempire.com/p/5335/1920/1745335_00420_1920c.jpg
-    originalSize: h=-1 w=-1
-    language: 
-    hint: 
-    aspect: 
-    season: SeasonNumber=xx
-  - id: 
-    originalUrl: https://caps1cdn.adultempire.com/p/5335/1920/1745335_00510_1920c.jpg
-    thumbUrl: https://caps1cdn.adultempire.com/p/5335/1920/1745335_00510_1920c.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 

--- a/test/resources/scrapers/ade/VOD-50-Shades-1670507.ref.txt
+++ b/test/resources/scrapers/ade/VOD-50-Shades-1670507.ref.txt
@@ -90,7 +90,7 @@ subtitles: (N=0)
 fileLastModified: <not set or invalid>
 files: (N=0)
 folderName: 
-posters: (N=1)
+posters: (N<6)
   - id: 
     originalUrl: https://imgs1cdn.adultempire.com/products/72/1670472h.jpg
     thumbUrl: https://imgs1cdn.adultempire.com/products/72/1670472h.jpg
@@ -99,7 +99,23 @@ posters: (N=1)
     hint: 
     aspect: 
     season: SeasonNumber=xx
+  - id: 
+    originalUrl: https://imgs1cdn.adultempire.com/products/72/1670472bh.jpg
+    thumbUrl: https://imgs1cdn.adultempire.com/products/72/1670472bh.jpg
+    originalSize: h=-1 w=-1
+    language: 
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
 backdrops: (N>40)
+  - id: 
+    originalUrl: https://imgs1cdn.adultempire.com/products/72/1670472bh.jpg
+    thumbUrl: https://imgs1cdn.adultempire.com/products/72/1670472bh.jpg
+    originalSize: h=-1 w=-1
+    language: 
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
   - id: 
     originalUrl: https://caps1cdn.adultempire.com/n/0472/1920/1670472_00170_1920c.jpg
     thumbUrl: https://caps1cdn.adultempire.com/n/0472/1920/1670472_00170_1920c.jpg
@@ -127,14 +143,6 @@ backdrops: (N>40)
   - id: 
     originalUrl: https://caps1cdn.adultempire.com/n/0472/1920/1670472_00590_1920c.jpg
     thumbUrl: https://caps1cdn.adultempire.com/n/0472/1920/1670472_00590_1920c.jpg
-    originalSize: h=-1 w=-1
-    language: 
-    hint: 
-    aspect: 
-    season: SeasonNumber=xx
-  - id: 
-    originalUrl: https://caps1cdn.adultempire.com/n/0472/1920/1670472_00730_1920c.jpg
-    thumbUrl: https://caps1cdn.adultempire.com/n/0472/1920/1670472_00730_1920c.jpg
     originalSize: h=-1 w=-1
     language: 
     hint: 

--- a/test/resources/scrapers/aebn/Magic-Mike-188623.ref.txt
+++ b/test/resources/scrapers/aebn/Magic-Mike-188623.ref.txt
@@ -146,10 +146,10 @@ actors: (N>10)
    imageHasChanged: false
 certification: 
 genres: (N<6)
-  - High Definition
   - Feature
   - Adult Humor
   - Parody
+  - High Definition
 tags: (N>20)
   - Oral Sex
   - Vaginal Sex

--- a/test/resources/scrapers/hot-movies/Magic-Mike-292788.ref.txt
+++ b/test/resources/scrapers/hot-movies/Magic-Mike-292788.ref.txt
@@ -162,7 +162,7 @@ subtitles: (N=0)
 fileLastModified: <not set or invalid>
 files: (N=0)
 folderName: 
-posters: (N=1)
+posters: (N<6)
   - id: 
     originalUrl: https://imgs1cdn.adultempire.com/products/35/1745335h.jpg
     thumbUrl: https://imgs1cdn.adultempire.com/products/35/1745335h.jpg
@@ -171,7 +171,23 @@ posters: (N=1)
     hint: 
     aspect: 
     season: SeasonNumber=xx
-backdrops: (N=0)
+  - id: 
+    originalUrl: https://imgs1cdn.adultempire.com/products/35/1745335bh.jpg
+    thumbUrl: https://imgs1cdn.adultempire.com/products/35/1745335bh.jpg
+    originalSize: h=-1 w=-1
+    language: 
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
+backdrops: (N=1)
+  - id: 
+    originalUrl: https://imgs1cdn.adultempire.com/products/35/1745335bh.jpg
+    thumbUrl: https://imgs1cdn.adultempire.com/products/35/1745335bh.jpg
+    originalSize: h=-1 w=-1
+    language: 
+    hint: 
+    aspect: 
+    season: SeasonNumber=xx
 discArts: (N=0)
 clearArts: (N=0)
 logos: (N=0)


### PR DESCRIPTION
This commits allows users to also load the back cover of movies, not just the front cover.  Because MediaElch does not support multiple posters at once, we load the back cover as a backdrop, even though that is not really correct.  If the user clicks on the poster, the back cover will also appear.  The same applies to extra fanart.

Fix #1743