### PR TITLE
feat(movies): Add TV show link field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
 
 - TV shows and episodes: If there is more than one network (separated by `,`),
   they will be stored as separate `<studio>` tags in the NFO file (#1705)
+- Movies have a new field "TV Show Link" which is stored as a `<showlink>` in Kodi.  
+  It is available in the UI via the movie's "Extended" tab (#1753).
 - Added Kodi v22 to Kodi selection menu.
 
 ## 2.10.6 - 2023-12-03

--- a/src/data/movie/Movie.cpp
+++ b/src/data/movie/Movie.cpp
@@ -85,7 +85,8 @@ void Movie::clear()
           << MovieScraperInfo::CdArt         //
           << MovieScraperInfo::Banner        //
           << MovieScraperInfo::Thumb         //
-          << MovieScraperInfo::ClearArt;
+          << MovieScraperInfo::ClearArt      //
+          << MovieScraperInfo::TvShowLink;
     clear(infos);
     m_nfoContent.clear();
 }
@@ -132,7 +133,10 @@ void Movie::clear(QSet<MovieScraperInfo> infos)
         m_runtime = 0min;
     }
     if (infos.contains(MovieScraperInfo::Trailer)) {
-        m_trailer = "";
+        m_trailer.clear();
+    }
+    if (infos.contains(MovieScraperInfo::TvShowLink)) {
+        m_tvShowLink.clear();
     }
     if (infos.contains(MovieScraperInfo::Certification)) {
         m_certification = Certification::NoCertification;
@@ -186,6 +190,7 @@ void Movie::exportTo(Movie::Exporter& exporter) const
     exporter.exportCountries(m_countries);
     exporter.exportStudios(m_studios);
     exporter.exportTrailer(m_trailer);
+    exporter.exportTvShowLink(m_tvShowLink);
     exporter.exportPlaycount(m_playcount);
     exporter.exportLastPlayed(m_lastPlayed);
     exporter.exportDateAdded(m_dateAdded);
@@ -381,6 +386,11 @@ QVector<QString*> Movie::studiosPointer()
 QUrl Movie::trailer() const
 {
     return m_trailer;
+}
+
+QString Movie::tvShowLink() const
+{
+    return m_tvShowLink;
 }
 
 const Actors& Movie::actors() const
@@ -705,6 +715,12 @@ void Movie::setDirector(QString director)
 void Movie::setTrailer(QUrl trailer)
 {
     m_trailer = std::move(trailer);
+    setChanged(true);
+}
+
+void Movie::setTvShowLink(QString tvShowLink)
+{
+    m_tvShowLink = std::move(tvShowLink);
     setChanged(true);
 }
 

--- a/src/data/movie/Movie.h
+++ b/src/data/movie/Movie.h
@@ -72,6 +72,7 @@ public:
     QStringList tags() const;
     QVector<QString*> studiosPointer();
     QUrl trailer() const;
+    QString tvShowLink() const;
 
     const Actors& actors() const;
     Actors& actors();
@@ -119,6 +120,7 @@ public:
     void addStudio(QString studio);
     void addTag(QString tag);
     void setTrailer(QUrl trailer);
+    void setTvShowLink(QString tvShowLink);
     void setActors(QVector<Actor> actors);
     void addActor(Actor actor);
     void addGenre(QString genre);
@@ -214,6 +216,7 @@ public:
         virtual void exportStudios(const QStringList& studios) = 0;
         virtual void exportTags(const QStringList& tags) = 0;
         virtual void exportTrailer(const QUrl& trailer) = 0;
+        virtual void exportTvShowLink(const QString& tvShowLink) = 0;
         virtual void exportPlaycount(int playcount) = 0;
         virtual void exportLastPlayed(const QDateTime& lastPlayed) = 0;
         virtual void exportMovieSet(const MovieSet& set) = 0;
@@ -255,6 +258,7 @@ private:
     QStringList m_studios;
     QStringList m_tags;
     QUrl m_trailer;
+    QString m_tvShowLink;
     int m_playcount = 0;
     QDateTime m_lastPlayed;
     ImdbId m_imdbId;

--- a/src/export/CsvExport.cpp
+++ b/src/export/CsvExport.cpp
@@ -146,6 +146,7 @@ void CsvMovieExport::exportMovies(const QVector<Movie*>& movies, std::function<v
             {s(Field::PlayCount), QString::number(movie->playcount())},
             {s(Field::LastPlayed), movie->lastPlayed().toString(Qt::ISODate)},
             {s(Field::MovieSet), movie->set().name},
+            {s(Field::TvShowLink), movie->tvShowLink()},
             {s(Field::Directory), dirFromFileList(movie->files())},
             {s(Field::Filenames), filesToString(movie->files())},
             {s(Field::LastModified), movie->fileLastModified().toString(Qt::ISODate)},
@@ -204,6 +205,7 @@ QString CsvMovieExport::fieldToString(Field field)
     case Field::PlayCount: return "movie_playcount";
     case Field::LastPlayed: return "movie_last_played";
     case Field::MovieSet: return "movie_set";
+    case Field::TvShowLink: return "tv_show_link";
     case Field::Directory: return "movie_directory";
     case Field::Filenames: return "movie_filenames";
     case Field::LastModified: return "movie_date_added";

--- a/src/export/CsvExport.h
+++ b/src/export/CsvExport.h
@@ -77,6 +77,7 @@ public:
         Type,         // @since 2.8.17
         LastModified, // @since 2.8.17
         WikidataId,   // @since 2.10.1
+        TvShowLink,   // @since 2.10.8
     };
 
 public:

--- a/src/media_center/kodi/MovieXmlReader.cpp
+++ b/src/media_center/kodi/MovieXmlReader.cpp
@@ -40,6 +40,7 @@ bool MovieXmlReader::parseNfoDom(QDomDocument domDoc)
     tagParsers.insert("plot",          &MovieXmlReader::simpleString<&Movie::setOverview>);
     tagParsers.insert("outline",       &MovieXmlReader::simpleString<&Movie::setOutline>);
     tagParsers.insert("tagline",       &MovieXmlReader::simpleString<&Movie::setTagline>);
+    tagParsers.insert("showlink",      &MovieXmlReader::simpleString<&Movie::setTvShowLink>);
     tagParsers.insert("set",           &MovieXmlReader::movieSet);
     tagParsers.insert("actor",         &MovieXmlReader::movieActor);
     tagParsers.insert("thumb",         &MovieXmlReader::movieThumbnail);

--- a/src/media_center/kodi/MovieXmlWriter.cpp
+++ b/src/media_center/kodi/MovieXmlWriter.cpp
@@ -142,6 +142,10 @@ QByteArray MovieXmlWriterGeneric::getMovieXml(bool testMode)
 
     writeActors(xml, m_movie.actors());
 
+    if (!m_movie.tvShowLink().isEmpty()) {
+        xml.writeTextElement("showlink", m_movie.tvShowLink());
+    }
+
     // <resume>
     //   <position>0.000000</position>
     //   <total>0.000000</total>

--- a/src/scrapers/ScraperInfos.h
+++ b/src/scrapers/ScraperInfos.h
@@ -39,8 +39,9 @@ enum class MovieScraperInfo : int
     ClearArt = 23,
     Banner = 24,
     Thumb = 25,
+    TvShowLink = 26, // not used for scraping
     First = 1,
-    Last = 25
+    Last = 26
 };
 
 namespace mediaelch {

--- a/src/ui/export/CsvExportDialog.cpp
+++ b/src/ui/export/CsvExportDialog.cpp
@@ -315,6 +315,7 @@ void CsvExportDialog::initializeItems()
         addField(Field::PlayCount, tr("Playcount"));
         addField(Field::LastPlayed, tr("Last played"));
         addField(Field::MovieSet, tr("Movie Set"));
+        addField(Field::TvShowLink, tr("TV Show Link"));
         addField(Field::Directory, tr("Directory"));
         addField(Field::Filenames, tr("Filename(s)"));
         addField(Field::LastModified, tr("Last Modified Date"));

--- a/src/ui/movies/MovieWidget.cpp
+++ b/src/ui/movies/MovieWidget.cpp
@@ -184,6 +184,7 @@ MovieWidget::MovieWidget(QWidget* parent) : QWidget(parent), ui(new Ui::MovieWid
     connect(ui->playcount,        elchOverload<int>(&QSpinBox::valueChanged),          this, &MovieWidget::onPlayCountChange);
 
     connect(ui->trailer,          &QLineEdit::textEdited,           this, &MovieWidget::onTrailerChange);
+    connect(ui->tvShowLink,       &QLineEdit::textEdited,           this, &MovieWidget::onTvShowLinkChange);
     connect(ui->certification,    &QComboBox::editTextChanged,      this, &MovieWidget::onCertificationChange);
     connect(ui->set,              &QComboBox::editTextChanged,      this, &MovieWidget::onSetChange);
     connect(ui->badgeWatched,     &Badge::clicked,                  this, &MovieWidget::onWatchedClicked);
@@ -270,6 +271,7 @@ void MovieWidget::clear()
     clear(ui->top250);
     clear(ui->runtime);
     clear(ui->trailer);
+    clear(ui->tvShowLink);
     clear(ui->playcount);
     clear(ui->overview);
     clear(ui->outline);
@@ -583,6 +585,7 @@ void MovieWidget::updateMovieInfo()
     ui->releaseDate->setDate(m_movie->released());
     ui->runtime->setValue(static_cast<int>(m_movie->runtime().count()));
     ui->trailer->setText(m_movie->trailer().toString());
+    ui->tvShowLink->setText(m_movie->tvShowLink());
     ui->playcount->setValue(m_movie->playcount());
     ui->lastPlayed->setDateTime(m_movie->lastPlayed());
     ui->overview->setPlainText(m_movie->overview());
@@ -1281,6 +1284,15 @@ void MovieWidget::onTrailerChange(QString text)
         return;
     }
     m_movie->setTrailer(text);
+    ui->buttonRevert->setVisible(true);
+}
+
+void MovieWidget::onTvShowLinkChange(QString text)
+{
+    if (m_movie == nullptr) {
+        return;
+    }
+    m_movie->setTvShowLink(text);
     ui->buttonRevert->setVisible(true);
 }
 

--- a/src/ui/movies/MovieWidget.h
+++ b/src/ui/movies/MovieWidget.h
@@ -92,6 +92,7 @@ private slots:
     void onRuntimeChange(int value);
     void onCertificationChange(QString text);
     void onTrailerChange(QString text);
+    void onTvShowLinkChange(QString text);
     void onWatchedClicked();
     void onPlayCountChange(int value);
     void onLastWatchedChange(QDateTime dateTime);

--- a/src/ui/movies/MovieWidget.ui
+++ b/src/ui/movies/MovieWidget.ui
@@ -662,7 +662,7 @@
            <attribute name="title">
             <string>Extended</string>
            </attribute>
-           <layout class="QVBoxLayout" name="verticalLayout_3" stretch="2,2,2,1,0">
+           <layout class="QVBoxLayout" name="verticalLayout_3" stretch="2,2,2,1,0,0">
             <item>
              <widget class="TagCloud" name="genreCloud" native="true"/>
             </item>
@@ -674,6 +674,23 @@
             </item>
             <item>
              <widget class="TagCloud" name="studioCloud" native="true"/>
+            </item>
+            <item>
+             <layout class="QFormLayout" name="formLayoutExtended">
+              <item row="0" column="0">
+               <widget class="QLabel" name="lvlTvShowLink">
+                <property name="toolTip">
+                 <string>Name of a related TV show</string>
+                </property>
+                <property name="text">
+                 <string>TV Show Link</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLineEdit" name="tvShowLink"/>
+              </item>
+             </layout>
             </item>
             <item>
              <spacer name="verticalSpacer_3">
@@ -1613,20 +1630,9 @@
    <header>ui/small_widgets/ClosableImage.h</header>
   </customwidget>
   <customwidget>
-   <class>StereoModeComboBox</class>
-   <extends>QComboBox</extends>
-   <header>ui/small_widgets/StereoModeComboBox.h</header>
-  </customwidget>
-  <customwidget>
    <class>SlidingStackedWidget</class>
    <extends>QStackedWidget</extends>
    <header>ui/small_widgets/SlidingStackedWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>MediaFlags</class>
-   <extends>QWidget</extends>
-   <header>ui/small_widgets/MediaFlags.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -1638,6 +1644,17 @@
    <class>RatingsWidget</class>
    <extends>QWidget</extends>
    <header>ui/small_widgets/RatingsWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>StereoModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>ui/small_widgets/StereoModeComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>MediaFlags</class>
+   <extends>QWidget</extends>
+   <header>ui/small_widgets/MediaFlags.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/test/helpers/reference_file.cpp
+++ b/test/helpers/reference_file.cpp
@@ -459,6 +459,7 @@ public:
     void exportStudios(const QStringList& studios) override { writeToReference(m_out, "studios", studios); }
     void exportTags(const QStringList& tags) override { writeToReference(m_out, "tags", tags); }
     void exportTrailer(const QUrl& trailer) override { writeToReference(m_out, "trailer", trailer); }
+    void exportTvShowLink(const QString& tvShowLink) override { writeToReference(m_out, "showlink", tvShowLink); }
     void exportPlaycount(int playcount) override { writeToReference(m_out, "playcount", playcount); }
     void exportLastPlayed(const QDateTime& lastPlayed) override { writeToReference(m_out, "lastPlayed", lastPlayed); }
     void exportMovieSet(const MovieSet& set) override

--- a/test/integration/media_center/testKodi_v18_movie.cpp
+++ b/test/integration/media_center/testKodi_v18_movie.cpp
@@ -160,6 +160,7 @@ TEST_CASE("Movie XML writer for Kodi v18", "[data][movie][kodi][nfo]")
         movie.setReleased(QDate::fromString("2016-03-09", Qt::ISODate));
         movie.addStudio("Summit Entertainment");
         movie.setTrailer(QUrl("TmovieFc19"));
+        movie.setTvShowLink("Some Allegiant show");
         // requires that setFiles() was called
         movie.streamDetails()->setVideoDetail(StreamDetails::VideoDetails::Codec, "h264");
         movie.streamDetails()->setVideoDetail(StreamDetails::VideoDetails::Aspect, "1.777778");

--- a/test/resources/movie/kodi_v18_Toy_Story_3_2010.nfo
+++ b/test/resources/movie/kodi_v18_Toy_Story_3_2010.nfo
@@ -504,6 +504,7 @@
         <role>Children (voice) (archive sound)</role>
         <order>58</order>
     </actor>
+    <showlink>Toy Story Tv Show</showlink>
     <resume>
         <position>0.15</position>
         <total>22.34</total>

--- a/test/resources/movie/kodi_v18_movie_all.nfo
+++ b/test/resources/movie/kodi_v18_movie_all.nfo
@@ -82,6 +82,7 @@
         <order>1</order>
         <thumb>http://image.tmdb.org/t/p/original/hLNSoQ3gc52X5VVb172yO3CuUEq.jpg</thumb>
     </actor>
+    <showlink>Some Allegiant show</showlink>
     <resume>
         <position>0</position>
         <total>0</total>

--- a/test/resources/scrapers/ade/DVD-Magic-Mike-1745335.ref.txt
+++ b/test/resources/scrapers/ade/DVD-Magic-Mike-1745335.ref.txt
@@ -177,6 +177,7 @@ countries: (N=0)
 studios: (N=1)
   - Wicked Pictures
 trailer: 
+showlink: 
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>

--- a/test/resources/scrapers/ade/VOD-50-Shades-1670507.ref.txt
+++ b/test/resources/scrapers/ade/VOD-50-Shades-1670507.ref.txt
@@ -79,6 +79,7 @@ countries: (N=0)
 studios: (N=1)
   - Pure XXX Films
 trailer: 
+showlink: 
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>

--- a/test/resources/scrapers/aebn/M-Is-For-Mischief-159236.ref.txt
+++ b/test/resources/scrapers/aebn/M-Is-For-Mischief-159236.ref.txt
@@ -73,6 +73,7 @@ countries: (N=0)
 studios: (N=1)
   - Innocent High
 trailer: 
+showlink: 
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>

--- a/test/resources/scrapers/aebn/Magic-Mike-188623.ref.txt
+++ b/test/resources/scrapers/aebn/Magic-Mike-188623.ref.txt
@@ -161,6 +161,7 @@ countries: (N=0)
 studios: (N=1)
   - Wicked Pictures
 trailer: 
+showlink: 
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>

--- a/test/resources/scrapers/discogs/metallica-details-18839.ref.txt
+++ b/test/resources/scrapers/discogs/metallica-details-18839.ref.txt
@@ -155,6 +155,8 @@ discography: (N>100)
     year: 1993
   - title: Metallica "Live" Video Press Kit 1993
     year: 1993
+  - title: 6 Videos
+    year: 1993
   - title: One / Eye Of The Beholder
     year: 1993
   - title: Live Shit: Binge & Purge
@@ -250,8 +252,6 @@ discography: (N>100)
   - title: S & M Documentary
     year: 1999
   - title:  "S & M"  - Interview
-    year: 1999
-  - title: In The Studio "Load / Reload"
     year: 1999
 genres: (N=0)
 styles: (N=0)

--- a/test/resources/scrapers/discogs/rammstein-details-11771.ref.txt
+++ b/test/resources/scrapers/discogs/rammstein-details-11771.ref.txt
@@ -67,8 +67,6 @@ discography: (N>90)
     year: 1997
   - title: Sehnsucht
     year: 1997
-  - title: Sehnsucht
-    year: 1997
   - title: Das Modell
     year: 1997
   - title: Du Hast
@@ -228,6 +226,8 @@ discography: (N>90)
   - title: Adieu
     year: 2022
   - title: MTV / VOX
+    year: 
+  - title: Zeig Dich
     year: 
 genres: (N=0)
 styles: (N=0)

--- a/test/resources/scrapers/fernsehserien_de/Scrubs.ref.txt
+++ b/test/resources/scrapers/fernsehserien_de/Scrubs.ref.txt
@@ -39,25 +39,25 @@ episodeGuideUrl:
 actors: (N>5)
  - id: 
    name: Sarah Chalke
-   role: Elliot Reid (179 Folgen, 2001–2010)
+   role: Elliot Reid (197 Folgen, 2001–2010)
    thumb: https://bilder.fernsehserien.de/gfx/person_1000/s/sarah-chalke.jpg
    order: 0
    imageHasChanged: false
  - id: 
    name: Donald Faison
-   role: Chris Turk (182 Folgen, 2001–2010)
+   role: Chris Turk (185 Folgen, 2001–2010)
    thumb: https://bilder.fernsehserien.de/gfx/person_1000/d/donald-faison.jpg
    order: 1
    imageHasChanged: false
  - id: 
    name: John C. McGinley
-   role: Dr. Perry Cox (182 Folgen, 2001–2010)
+   role: Dr. Perry Cox (185 Folgen, 2001–2010)
    thumb: https://bilder.fernsehserien.de/gfx/person_1000/j/john-c-mcginley.jpg
    order: 2
    imageHasChanged: false
  - id: 
    name: Zach Braff
-   role: Dr. John „J.D.“ Dorian (178 Folgen, 2001–2010)
+   role: Dr. John „J.D.“ Dorian (181 Folgen, 2001–2010)
    thumb: https://bilder.fernsehserien.de/gfx/person_1000/z/zach-braff.jpg
    order: 3
    imageHasChanged: false

--- a/test/resources/scrapers/hot-movies/M-Is-For-Mischief-214343.ref.txt
+++ b/test/resources/scrapers/hot-movies/M-Is-For-Mischief-214343.ref.txt
@@ -65,6 +65,7 @@ tags: (N=0)
 countries: (N=0)
 studios: (N=0)
 trailer: 
+showlink: 
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>

--- a/test/resources/scrapers/hot-movies/Magic-Mike-292788.ref.txt
+++ b/test/resources/scrapers/hot-movies/Magic-Mike-292788.ref.txt
@@ -151,6 +151,7 @@ tags: (N=0)
 countries: (N=0)
 studios: (N=0)
 trailer: 
+showlink: 
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>

--- a/test/resources/scrapers/imdb/Finding_Dory_tt2277860.ref.txt
+++ b/test/resources/scrapers/imdb/Finding_Dory_tt2277860.ref.txt
@@ -202,6 +202,7 @@ studios: (N<6)
   - Pixar Animation Studios
   - Walt Disney Pictures
 trailer: 
+showlink: 
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>

--- a/test/resources/scrapers/imdb/Godfather_tt0068646.ref.txt
+++ b/test/resources/scrapers/imdb/Godfather_tt0068646.ref.txt
@@ -210,6 +210,7 @@ studios: (N<6)
   - Albert S. Ruddy Productions
   - Alfran Productions
 trailer: 
+showlink: 
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>

--- a/test/resources/scrapers/imdb/Pacific_Rim_tt1663662.ref.txt
+++ b/test/resources/scrapers/imdb/Pacific_Rim_tt1663662.ref.txt
@@ -215,6 +215,7 @@ studios: (N<6)
   - Legendary Entertainment
   - Double Dare You (DDY)
 trailer: 
+showlink: 
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>

--- a/test/resources/scrapers/imdb/The_Shawshank_Redemption_tt0111161.ref.txt
+++ b/test/resources/scrapers/imdb/The_Shawshank_Redemption_tt0111161.ref.txt
@@ -196,6 +196,7 @@ countries: (N=1)
 studios: (N=1)
   - Castle Rock Entertainment
 trailer: 
+showlink: 
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>

--- a/test/resources/scrapers/imdb/Welcome_Back_tt3159708.ref.txt
+++ b/test/resources/scrapers/imdb/Welcome_Back_tt3159708.ref.txt
@@ -205,6 +205,7 @@ countries: (N<6)
 studios: (N=1)
   - Base Industries Group
 trailer: 
+showlink: 
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>

--- a/test/resources/scrapers/musicbrainz/metallica-biography-french.ref.txt
+++ b/test/resources/scrapers/musicbrainz/metallica-biography-french.ref.txt
@@ -6,54 +6,54 @@ allMusicId:
 name: 
 biography:
     Metallica est un groupe de heavy metal américain originaire de Californie et con
-    sidéré comme le plus grand groupe de metal de tous les temps. C’est également le
-     groupe du style à avoir vendu le plus d’albums dans le monde. Formé à Los Angel
-    es en 1981, le groupe est composé de James Hetfield (chant, guitare rythmique) e
-    t Lars Ulrich (batterie), ainsi que du guitariste Kirk Hammett (arrivé en 1983) 
-    et du bassiste Robert Trujillo, qui a rejoint le groupe en 2003. Les précédents 
-    membres du groupe incluent Dave Mustaine (après son exclusion, membre fondateur 
-    de Megadeth), les bassistes Ron McGovney (uniquement pour les démos), Cliff Burt
-    on (pour les trois premiers albums ; décédé en 1986) et Jason Newsted (prenant l
-    a suite de Burton jusqu'à son départ du groupe en 2001 et remplacé en 2003 par T
-    rujillo). Le groupe a longtemps collaboré avec le producteur Bob Rock, qui a pro
-    duit leurs albums de 1990 à 2003 et est devenu temporairement le bassiste studio
-     intérimaire du groupe, entre le départ de Newsted et l'arrivée de Trujillo. Le 
-    groupe se forme au début des années 1980 lorsque Hetfield se rend à une annonce 
-    postée dans un journal local par le batteur Lars Ulrich. 
-Metallica est renommé 
-    entre autres pour sa musique metal, rapide et puissante, qui le place comme le l
-    eader des « Big Four of Thrash » (l'un des quatre plus grands groupes de thrash 
-    metal) avec Slayer, Megadeth et Anthrax. Le groupe s'est forgé une réputation mo
-    ndiale chez les fans de musique underground et chez les critiques de la presse s
-    pécialisée grâce à leurs cinq premiers albums, dont le troisième, Master of Pupp
-    ets (1986), est décrit comme l'un des albums les plus influents de la scène heav
-    y thrash metal. En 1991, le groupe accède à une plus grande popularité grâce au 
-    succès commercial de leur cinquième album éponyme — surnommé « The Black Album »
-     — qui arrive à la première place du classement Billboard 200 dès sa sortie. Dan
-    s cet album, le groupe explore diverses voies musicales avec des tempos plus lon
-    gs et des rythmes massifs, ayant attiré l'attention d'une audience plus large. I
-    l est l'album le plus vendu du groupe et s'est écoulé à 30 millions d'exemplaire
-    s dans le monde, ce qui en fait un des albums les plus vendus de l'histoire de l
-    a musique. 
-Depuis sa création, Metallica a produit onze albums studio, quatre a
-    lbums live, cinq EP, 25 vidéoclips et 37 singles. Le groupe a remporté dix Gramm
-    y Awards et a classé six albums consécutifs directement à la première place du B
-    illboard 200. Il se classe comme un des groupes les plus rentables de tous les t
-    emps, avec plus de 200 millions de disques vendus dans le monde,. Metallica a ég
-    alement été classé comme l'un des meilleurs groupes musicaux dans un bon nombre 
-    de magazines spécialisés, dont Rolling Stone qui le classe 61e dans son Top 100 
-    des meilleurs groupes de tous les temps. 
-En 2012, Metallica fonde son propre la
-    bel discographique indépendant, Blackened Recordings, et acquiert tous les droit
-    s de ses albums en studio. En 2014, Nielsen Soundscan annonce que l'album Metall
-    ica est devenu le premier depuis 1991 et le début de l'ère Soundscan à dépasser 
-    les 16 millions d'exemplaires vendus aux États-Unis, faisant de lui l’œuvre musi
-    cale la plus achetée, tous genres confondus (chiffre dépassé depuis par l'album 
-    Come On Over de Shania Twain sorti en 1997 et vendu à 17 millions d'exemplaires)
-    . En 2016, selon le magazine Billboard, Metallica est le 3e plus gros vendeurs d
-    e disques aux États-Unis depuis 1991 avec 54,26 millions d'unités écoulées - der
-    rière la star de la musique country Garth Brooks (69,52 millions) et les Beatles
-     (65,55 millions).
+    sidéré comme l'un des plus grand groupe de metal de tous les temps. C’est égalem
+    ent le groupe du style à avoir vendu le plus d’albums dans le monde. Formé à Los
+     Angeles en 1981, le groupe est composé de James Hetfield (chant, guitare rythmi
+    que) et Lars Ulrich (batterie), ainsi que du guitariste Kirk Hammett (arrivé en 
+    1983) et du bassiste Robert Trujillo, qui a rejoint le groupe en 2003. Les précé
+    dents membres du groupe incluent Dave Mustaine (après son exclusion, membre fond
+    ateur de Megadeth), les bassistes Ron McGovney (uniquement pour les démos), Clif
+    f Burton (pour les trois premiers albums ; décédé en 1986) et Jason Newsted (pre
+    nant la suite de Burton jusqu'à son départ du groupe en 2001 et remplacé en 2003
+     par Trujillo). Le groupe a longtemps collaboré avec le producteur Bob Rock, qui
+     a produit leurs albums de 1990 à 2003 et est devenu temporairement le bassiste 
+    studio intérimaire du groupe, entre le départ de Newsted et l'arrivée de Trujill
+    o. Le groupe se forme au début des années 1980 lorsque Hetfield se rend à une an
+    nonce postée dans un journal local par le batteur Lars Ulrich. 
+Metallica est re
+    nommé entre autres pour sa musique metal, rapide et puissante, qui le place comm
+    e le leader des « Big Four of Thrash » (l'un des quatre plus grands groupes de t
+    hrash metal) avec Slayer, Megadeth et Anthrax. Le groupe s'est forgé une réputat
+    ion mondiale chez les fans de musique underground et chez les critiques de la pr
+    esse spécialisée grâce à leurs cinq premiers albums, dont le troisième, Master o
+    f Puppets (1986), est décrit comme l'un des albums les plus influents de la scèn
+    e heavy thrash metal. En 1991, le groupe accède à une plus grande popularité grâ
+    ce au succès commercial de leur cinquième album éponyme — surnommé « The Black A
+    lbum » — qui arrive à la première place du classement Billboard 200 dès sa sorti
+    e. Dans cet album, le groupe explore diverses voies musicales avec des tempos pl
+    us longs et des rythmes massifs, ayant attiré l'attention d'une audience plus la
+    rge. Il est l'album le plus vendu du groupe et s'est écoulé à 30 millions d'exem
+    plaires dans le monde, ce qui en fait un des albums les plus vendus de l'histoir
+    e de la musique. 
+Depuis sa création, Metallica a produit onze albums studio, qu
+    atre albums live, cinq EP, 25 vidéoclips et 37 singles. Le groupe a remporté dix
+     Grammy Awards et a classé six albums consécutifs directement à la première plac
+    e du Billboard 200. Il se classe comme un des groupes les plus rentables de tous
+     les temps, avec plus de 200 millions de disques vendus dans le monde,. Metallic
+    a a également été classé comme l'un des meilleurs groupes musicaux dans un bon n
+    ombre de magazines spécialisés, dont Rolling Stone qui le classe 61e dans son To
+    p 100 des meilleurs groupes de tous les temps. 
+En 2012, Metallica fonde son pro
+    pre label discographique indépendant, Blackened Recordings, et acquiert tous les
+     droits de ses albums en studio. En 2014, Nielsen Soundscan annonce que l'album 
+    Metallica est devenu le premier depuis 1991 et le début de l'ère Soundscan à dép
+    asser les 16 millions d'exemplaires vendus aux États-Unis, faisant de lui l’œuvr
+    e musicale la plus achetée, tous genres confondus (chiffre dépassé depuis par l'
+    album Come On Over de Shania Twain sorti en 1997 et vendu à 17 millions d'exempl
+    aires). En 2016, selon le magazine Billboard, Metallica est le 3e plus gros vend
+    eurs de disques aux États-Unis depuis 1991 avec 54,26 millions d'unités écoulées
+     - derrière la star de la musique country Garth Brooks (69,52 millions) et les B
+    eatles (65,55 millions).
 discography: (N=0)
 genres: (N=0)
 styles: (N=0)

--- a/test/resources/scrapers/musicbrainz/metallica-biography-german.ref.txt
+++ b/test/resources/scrapers/musicbrainz/metallica-biography-german.ref.txt
@@ -17,7 +17,541 @@ Neben Slayer, Megadeth und Anthrax zählte Metallica
     Metallica neuen musikalischen Einflüssen wie Bluesrock und anderen Rockstilen, w
     omit sie ein breiteres Publikum ansprach und zugleich ihre bisherigen Fans irrit
     ierte, bevor die Band ab 2002 wieder zu ihren musikalischen Wurzeln zurückkehrte
-    .
+    . 
+Im April 1981 schaltete der aus Dänemark stammende Schlagzeuger Lars Ulrich e
+    ine Anzeige in der südkalifornischen Lokalzeitung The Recycler, um nach Musikern
+     für eine Band zu suchen: 
+Der Rhythmusgitarrist und Sänger James Hetfield und d
+    er Bassist Ron McGovney, beide von der Band Leather Charm, luden Ulrich daraufhi
+    n in ihren Proberaum ein und spielten einige Coverversionen von Judas-Priest-Lie
+    dern. Da Hetfield und McGovney Ulrich für einen schlechten Schlagzeuger hielten,
+     trennten sich die Wege der Musiker vorerst wieder. Ulrich freundete sich derwei
+    l mit Brian Slagel an, der das Metalfanzine Heavy Metal Revue herausgab und mit 
+    Metal Blade Records ein eigenes Musiklabel gegründet hatte. Dessen erste Veröffe
+    ntlichung sollte der Sampler Metal Massacre mit lokalen Bands werden. Obwohl Ulr
+    ich selbst noch keine Band hatte, bat er Slagel um einen Platz auf dem Sampler. 
+    Nachdem er Ende 1981 die Zusage erhalten hatte, nahm er wieder Kontakt zu Hetfie
+    ld auf und gründete die Band. 
+Ulrich und Hetfield beschlossen im Folgenden, ihr
+    e erste Eigenkomposition Hit the Lights für den Sampler zu verwenden. Mit einer 
+    weiteren Anzeige suchte die Band nach einem Leadgitarristen, man wurde mit dem J
+    amaikaner Lloyd Grant (* 17. September 1961) fündig. Nach Abschluss der Aufnahme
+    n meldete sich der Gitarrist Dave Mustaine, der schließlich an Stelle von Grant 
+    in die Band aufgenommen wurde. Aus Zeitgründen fand jedoch die Version mit Grant
+    s Solo ihren Weg auf die erste Auflage des Samplers. Für den Sampler brauchte ma
+    n kurzfristig einen Bandnamen; die Vorschläge Thunderfuck, Helldriver, Grinder, 
+    Blitzer, Red Vette, Deathchamber und Flying Tigers wurden verworfen. 
+Zu ihrem N
+    amen kam die Band durch Ulrichs Freund Ron Quintana. Dieser war auf der Suche na
+    ch einem Namen für sein Fanzine und hatte Ulrich eine Liste mit möglichen Namen 
+    vorgelegt. Der darauf befindliche Name Metallica gefiel Ulrich so sehr, dass er 
+    Quintana überredete, sein Fanzine Metal Mania zu nennen und so Metallica als Vor
+    schlag für seine eigene Band übernehmen zu können. Ulrichs Bandkollegen reagiert
+    en begeistert und Hetfield entwarf das dazugehörige Bandlogo. Kleinere Auftritte
+     hatte die Band im Vorprogramm der britischen Gruppe Saxon, der Band Y&T sowie a
+    ls „Festival-Anheizer“ in San Francisco. Am 14. März 1982 spielte Metallica ihr 
+    erstes Konzert in der Radio City Hall in Anaheim. Einen Monat später nahm die Ba
+    nd ihr erstes Demo Power Metal auf, dessen Name von der beigelegten Visitenkarte
+     abgeleitet wurde. Der Metal Massacre-Sampler erschien am 14. Juni 1982. Wegen e
+    ines Druckfehlers wurde die Band als Mettallica angekündigt. Im Juli 1982 nahm d
+    ie Band ihr zweites Demo No Life ’Til Leather auf, das in der Undergroundszene d
+    er San Francisco Bay Area euphorisch aufgenommen wurde. 
+Im Herbst 1982 verließ 
+    McGovney die Band. Sein Nachfolger wurde Cliff Burton, der seine ehemalige Band 
+    Trauma zu Gunsten von Metallica verließ. Burton stellte jedoch die Bedingung, da
+    ss die restlichen Metallica-Mitglieder zu ihm nach San Francisco umziehen müsste
+    n. Zur gleichen Zeit gelangte das No Life ’Til Leather-Demo in die Hände des ehe
+    maligen Börsenspekulanten Jon Zazula (auch Johny „Z“ Zazula). Er kontaktierte di
+    e Band und verschaffte ihr Auftrittsmöglichkeiten an der Ostküste. Da die Streit
+    igkeiten mit dem stark dem Alkohol zugeneigten Dave Mustaine überhandnahmen, bes
+    chlossen Ulrich, Hetfield und Burton noch auf der Reise nach New York, Mustaine 
+    aus der Band zu werfen. Mustaine wurde später mit Megadeth selbst erfolgreich. 
+
+    Neuer Leadgitarrist wurde Kirk Hammett, der zuvor bei Exodus gespielt hatte. Am 
+    16. April 1983 fand in Dover das erste Metallica-Konzert mit Hammett statt. Die 
+    Band wohnte zu dieser Zeit in einem alten New Yorker Fabrikgebäude, in dem Anthr
+    ax ihren Proberaum hatten. 
+Zazula bemühte sich, für Metallica einen Plattenvert
+    rag zu besorgen. Da er von allen Labels nur Absagen erhielt, gründete er ein eig
+    enes Label, das er auf Burtons Vorschlag hin Megaforce Records nannte. 
+Zazula l
+    ieh sich 12.000 Dollar und finanzierte der Band Studiozeit in den Music America 
+    Studios in Rochester. Da Hetfield Zweifel an seinem Gesangstalent hatte, dachte 
+    die Band über die Verpflichtung eines festen Sängers nach. Jess Cox von den Tyge
+    rs of Pan Tang war nach Meinung der Band zu alt, während Armored-Saint-Sänger Jo
+    hn Bush das Angebot ausschlug. Deshalb begann die Band die Aufnahmen zu viert un
+    d schloss diese nach 17 Tagen ab. Das Album enthält unter anderem vier von Dave 
+    Mustaine mitkomponierte Lieder, der zu dieser Zeit kein Bandmitglied mehr war. U
+    rsprünglich sollte das Album Metal Up Your Ass heißen und das Cover einen aus ei
+    ner Toilette auftauchenden Dolch zeigen. Zazulas Vertriebspartner Relativity leh
+    nte beides ab. 
+Auf Burtons trotzigen Ausruf: „Well, let’s kill ’em all!“ folgte
+     Metallicas Vorschlag, Kill ’Em All als Albumtitel zu wählen. Dieser Titel wurde
+     von Relativity problemlos angenommen. Das Album wurde am 25. Juli 1983 veröffen
+    tlicht und verkaufte sich in den USA zunächst schleppend. Dagegen wurde Metallic
+    a in England als Band der Stunde gefeiert. Auf einer fünfwöchigen Tournee durch 
+    die USA wurde die Band Raven von Metallica als Vorgruppe unterstützt. Bis Ende 1
+    983 hatte sich Kill ’Em All in den USA etwa 17.000 Mal verkauft. Während der Kon
+    zertreisen schrieb die Band neue Lieder, die progressiver und langsamer als die 
+    des Debütalbums ausfielen. Im Vorprogramm von Venom fanden Metallicas erste Konz
+    erte in Europa statt. 
+Aufgrund des günstigen Wechselkurses zwischen dem US-Doll
+    ar und der Dänischen Krone fanden die Aufnahmen zum zweiten Studioalbum Ride the
+     Lightning in den Sweet-Silence-Studios der dänischen Hauptstadt Kopenhagen stat
+    t. Ebenfalls aus Kostengründen erfolgten die Aufnahmen in der Nacht. Das Album z
+    eigte die Musiker deutlich gereift; Songs wie For Whom the Bell Tolls avancierte
+    n zu Genreklassikern. Textlich entfernte sich die Band von den üblichen Metalkli
+    schees. So handelt z. B. das Lied Creeping Death vom Auszug der Israeliten aus d
+    er ägyptischen Sklaverei, und For Whom the Bell Tolls bezieht sich auf einen Rom
+    an von Ernest Hemingway. Metallicas erste Headlinertour durch Europa folgte Ende
+     1984. Auf der Tour mit Twisted Sister wurde vor allem das Album Ride the Lightn
+    ing vorgestellt, das sich zunächst etwa 100.000 Mal verkaufte. In Großbritannien
+     wurde es mit einer Silbernen Schallplatte ausgezeichnet. 
+Metallica wurde vom M
+    ajor-Label Elektra Records unter Vertrag genommen und erhielt mit Q Prime ein pr
+    ofessionelles Management. Ride the Lightning wurde in den USA neu veröffentlicht
+     und erreichte ohne Radioairplay Platz 100 der US-amerikanischen Albumcharts. An
+    fang 1985 spielte Metallica weitere US-Touren mit W.A.S.P. und Armored Saint, be
+    vor man an neuen Liedern arbeitete. Die vier Musiker von Metallica wurden seit d
+    ieser Zeit auch als „The Four Horsemen“ bekannt. Im August 1985 spielte die Band
+     erstmals beim Monsters of Rock im Donington Park. 
+Im September 1985 kehrte die
+     Band in die Sweet Silence Studios zurück, um mit den Aufnahmen ihres dritten Al
+    bums Master of Puppets zu beginnen. Von ihrer Plattenfirma erhielten sie einen h
+    ohen Vorschuss, weswegen Metallica kurzzeitig darüber nachdachte, den durch sein
+    e Arbeiten mit Iron Maiden bekannten Martin Birch als Produzenten zu verpflichte
+    n. Man entschied sich jedoch, erneut mit Flemming Rasmussen zusammenzuarbeiten. 
+    Die Aufnahmen dauerten insgesamt drei Monate und wurden nur durch einen Auftritt
+     beim Loreley-Festival in Deutschland unterbrochen. 
+Master of Puppets wurde im 
+    März 1986 veröffentlicht und erreichte Platz 29 der US-Albumcharts. Bereits eine
+    n Monat später erhielt das Album eine Goldene Schallplatte. Metallica ging als V
+    orgruppe von Ozzy Osbourne auf Tournee durch Nordamerika. Vor dem Konzert in Eva
+    nsville brach sich Hetfield beim Skateboardfahren das Handgelenk. Hetfield besch
+    ränkte sich bei einigen Konzerten auf das Singen, während der Gitarrentechniker 
+    John Marshall (später Metal Church) die Rhythmusgitarre spielte. 
+Am 16. Septemb
+    er 1986 in London startend, ging Metallica zusammen mit Anthrax auf Europatourne
+    e. Am 27. September 1986 befand sich der Tourtross auf dem Weg von Stockholm nac
+    h Kopenhagen. In der Nähe von Ljungby kam der Bandbus von Metallica, dessen Fahr
+    er möglicherweise am Steuer eingeschlafen war, auf der vereisten Straße ins Schl
+    eudern, von der Straße ab und überschlug sich. Dabei wurde Burton aus seiner Koj
+    e ins Freie geschleudert, bevor der Bus auf ihn stürzte, was zum sofortigen Tod 
+    Burtons führte. 
+Eine Autopsie ergab, dass Burtons Brustkorb eingedrückt und die
+     Lunge zerquetscht worden war. Die anderen Businsassen kamen mit leichten Verlet
+    zungen davon. Glück im Unglück hatte Kirk Hammett, der zuvor immer in Burtons Ko
+    je geschlafen hatte. Vor der Reise nach Kopenhagen hatte die Band beschlossen, m
+    ithilfe von Spielkarten die Kojen neu zu verteilen. Burton zog das Pik-Ass und w
+    ählte Hammetts Koje am Fenster. Burton wurde am 7. Oktober 1986 in Castro Valley
+     beigesetzt. 
+Zurückgekehrt in die USA, begann die Band zwei Wochen später mit d
+    er Suche nach einem Nachfolger. Vom Wunschkandidaten Joey Vera (Armored Saint) e
+    rhielt Metallica eine Absage. Etwa 40 Bassisten, darunter Les Claypool (Primus) 
+    und Greg Christian (Testament), spielten vor. Den Zuschlag erhielt Jason Newsted
+    , der sich mit seiner alten Band Flotsam and Jetsam den Ruf eines exzellenten So
+    ngwriters erarbeitet hatte. 
+Am 8. November 1986 spielte Metallica in Reseda ihr
+     erstes Konzert mit Newsted am Bass im Country Club von Los Angeles. Nach einer 
+    kurzen Tour durch Japan und Kanada holte die Band ab Januar 1987 die wegen Burto
+    ns Unfalltod ausgefallenen Konzerte in Europa nach, was auch zwei Konzerte im da
+    mals noch kommunistisch regierten Polen beinhaltete. Im März 1987 brach sich Het
+    field erneut das Handgelenk beim Skateboardfahren, weshalb die Band ihren Auftri
+    tt bei der Fernsehshow Saturday Night Live absagte. Nach Hetfields Genesung wurd
+    e in Ulrichs Garage die EP The $5.98 E.P. - Garage Days Re-Revisited aufgenommen
+    , die Coverversionen von Diamond Head, Holocaust, Killing Joke, Budgie und den M
+    isfits enthält. Mit der EP erreichte die Band Metallica in Großbritannien ihre e
+    rste Hitnotierung. 
+Ab Oktober 1987 begann die Band mit den Vorbereitungen für i
+    hr viertes Studioalbum …And Justice for All. Da Flemming Rasmussen anderweitig b
+    eschäftigt war, suchte die Band nach einem neuen Produzenten. Die Zusammenarbeit
+     mit Mike Clink, der kurz zuvor das Guns-n’-Roses-Debüt Appetite for Destruction
+     produzierte, entpuppte sich als Fehler, so dass Ulrich Rasmussen drängte, seine
+     Produktionen schnellstmöglich durchzuziehen. …And Justice for All wurde im Augu
+    st 1988 veröffentlicht und erreichte Platz 6 der US-amerikanischen Charts. An Ha
+    lloween wurde das Album mit Platin ausgezeichnet. Kritisch betrachtet wurde …And
+     Justice for All allerdings wegen des klinisch-kühlen Klanges und wegen des fast
+     völlig ausgeblendeten Bassspieles von Jason Newsted. 
+Nachdem sich die Band zuv
+    or jahrelang gegen das Drehen eines Musikvideos gesträubt hatte, wurde dieses Ma
+    l für die Singleauskopplung One aus dem Doppelalbum ... And Justice for All ein 
+    Video erstellt, das Auszüge aus Dalton Trumbos Film Johnny zieht in den Krieg en
+    thält. MTV nahm das Video in die tägliche Rotation und One erreichte Anfang 1989
+     mit Platz 35 die Top 40 der US-Charts und wurde ein Millionenerfolg. Eine Nomin
+    ierung Metallicas für den Grammy in der Kategorie Best Hard Rock/Metal Performan
+    ce blieb erfolglos, der Preis ging an Jethro Tull. Die Band reagierte mit Humor 
+    und versah einen Teil der …And-Justice-for-All-Auflage mit einem Aufkleber mit d
+    er Aufschrift „Grammy Award Losers“. Die Tour zum …And-Justice-for-All-Album umf
+    asste insgesamt 230 Konzerte und dauerte bis Oktober 1989. Anschließend nahm sic
+    h Metallica eine Auszeit und spielte nur vereinzelt Konzerte. 
+Im Februar 1990 e
+    rhielt die Band ihren ersten Grammy in der Kategorie Best Metal Performance für 
+    das Lied One, bevor im Oktober 1990 die Aufnahmen für das fünfte Studioalbum beg
+    annen. Aus einem von Kirk Hammett geschriebenen Riff entwickelte sich das 1991 a
+    uch auf einer Single erschienene Lied Enter Sandman (Platz 16 der US-Charts, in 
+    Großbritannien und Deutschland in den Top-10), das zum Wegweiser für das gesamte
+     Album werden sollte. Die Band strebte einfachere Lieder an, die schneller auf d
+    en Punkt kommen sollten. Zu diesem Zwecke fragte Metallica den Kanadier Bob Rock
+    , der zuvor mit Aerosmith, Bon Jovi und Mötley Crüe gearbeitet hatte, ob er das 
+    neue Album mischen wolle. Letzten Endes produzierte Rock das gesamte Album. Insg
+    esamt ein Jahr verbrachte die Band im Studio. Die gesamten Aufnahmen kosteten ei
+    ne Million US-Dollar und führten bei drei Bandmitgliedern zur Ehescheidung. 
+Ent
+    er Sandman wurde als erste Single ausgekoppelt und erreichte Platz 9 der deutsch
+    en Singlecharts. Das Album Metallica wurde am 12. August 1991 veröffentlicht und
+     stieg auf Platz eins der US-amerikanischen Albumcharts ein. In der ersten Woche
+     wurden in den USA 650.000 Alben verkauft. Durch Metallica konnte die Band neue 
+    Fanschichten außerhalb der Metalszene erschließen. Bis 2013 verkaufte sich das A
+    lbum in den USA über 15 Millionen Mal. Auch bei der Kritik wurde es insgesamt po
+    sitiv aufgenommen. Die Ballade Nothing Else Matters erhielt massives Airplay in 
+    den Mainstreammedien. Sie avancierte mit ihrem von Michael Kamen komponierten Or
+    chesterarrangement zum Wunschlied vieler Hochzeitspaare 
+Im Spätsommer 1991 bega
+    nn die Wherever We May Roam-Tournee. Zunächst spielte Metallica als Co-Headliner
+     vor AC/DC beim Monsters of Rock-Festival in Donington, bevor die Band zusammen 
+    mit AC/DC und Pantera vor ca. 1.500.000 Menschen beim Monsters of Rock - Konzert
+     auf dem Flugplatz Tuschino bei Moskau - dem allerersten Rockfestival in der Sow
+    jetunion überhaupt - auftrat. Es folgte eine Hallentournee durch Nordamerika, be
+    i der die Band ihre Bühne in der Mitte der Halle aufbauen ließ. In der Mitte der
+     Bühne wurde eine „Schlangengrube“ („Snake Pit“) eingerichtet, in der etwa 200 F
+    ans das Konzert aus nächster Nähe verfolgen konnten. Die Band unterbrach im Apri
+    l 1992 die Tournee für die Eröffnung des Freddie Mercury Tribute Concert im Lond
+    oner Wembley-Stadion. Zusammen mit Guns N’ Roses spielte Metallica im Sommer 199
+    2 eine Stadiontour durch Nordamerika. Beide Bands spielten zweieinhalbstündige K
+    onzerte, wobei Guns N’ Roses darauf bestand, nach Metallica auf die Bühne zu geh
+    en. Am 8. August 1992 spielten beide Bands im Olympiastadion von Montreal. Währe
+    nd des Liedes Fade to Black geriet Hetfield in eine sechs Meter hohe Flammensäul
+    e und erlitt dabei Verbrennungen zweiten Grades. Axl Rose sagte das Konzert von 
+    Guns N’ Roses wegen Halsschmerzen ab und löste dadurch Ausschreitungen unter den
+     aufgebrachten Zuschauern aus. Bei den folgenden Metallica-Konzerten übernahm we
+    gen Hetfields Verbrennungen erneut John Marshall die Rhythmusgitarre. Der Tourzy
+    klus zog sich bis zum Juli 1993 hin, wodurch die vier Musiker psychisch und phys
+    isch ausgelaugt waren. Ende 1993 veröffentlichte Metallica mit Live Shit: Binge 
+    & Purge sein erstes Boxset, das u. a. drei Live-CDs und zwei Livevideos enthielt
+    . 
+Abgesehen von einer dreimonatigen Tour durch Nordamerika inklusive eines Head
+    linerauftritts beim Woodstock-II-Festival zogen sich die Metallica-Bandmitgliede
+    r während des Jahres 1994 aus der Öffentlichkeit zurück und kümmerten sich um ih
+    re Familien. Im Oktober begann die Band mit dem Schreiben neuer Lieder. Die Aufn
+    ahmen begannen im Mai 1995. Aufgrund der schlechten Erfahrungen während der Aufn
+    ahmen zum schwarzen Album wollte sich die Band dieses Mal keinen Stress machen u
+    nd legte regelmäßig Pausen ein. Auf einen Auftritt als Headliner des Monsters-of
+    -Rock-Festivals folgte ein Metallica-Konzert am 3. September 1995 in Tuktoyaktuk
+    , der nördlichsten Gemeinde auf dem kanadischen Festland. Zahlreiche Ölheizungen
+     waren nötig, damit die Instrumente überhaupt funktionierten. Anlässlich des 50.
+     Geburtstages des Motörhead-Sängers Lemmy Kilmister spielten Metallica in Los An
+    geles unter dem Decknamen „The Lemmys“ ein Konzert, bei dem ausschließlich Motör
+    headlieder gecovert wurden. 
+Insgesamt 27 Lieder wurden aufgenommen und die Band
+     plante die Veröffentlichung eines Doppelalbums. Stattdessen wurden die Lieder a
+    uf zwei Alben verteilt, die innerhalb von eineinhalb Jahren auf den Markt gebrac
+    ht wurden. Den Anfang machte im Juni 1996 Load. Das von dem Provokationskünstler
+     Andres Serrano entworfene Albumcover zeigt eine Mischung aus Serranos Sperma un
+    d Rinderblut, das er zwischen zwei Scheiben Plexiglas presste. Die neue musikali
+    sche Ausrichtung der Band, die Einflüsse aus Country und Blues aufzeigte, wurde 
+    von vielen Fans ebenso kontrovers diskutiert wie die Kurzhaarschnitte der Bandmi
+    tglieder. 
+Metallica nahm als Headliner an der Lollapalooza-Tour teil. Während d
+    ieser Tour reiste Jason Newsted in einem eigenen Bus, in dem ein mobiles Tonstud
+    io eingebaut war. Zusammen mit dem Exodus-Schlagzeuger Tom Hunting und Devin Tow
+    nsend gründete er das Projekt IR8 (Synonym für das englische Adjektiv irate = zo
+    rnig, wütend) und nahm ein Demo auf. Insbesondere James Hetfield nahm diesen Ans
+    atz zur Nebentätigkeit übel, während Newsted sich darauf berief, bei Metallica a
+    ls Songschreiber nicht erwünscht und daher nicht ausgelastet zu sein. Bei den MT
+    V Europe Video Music Awards 1996 spielte die Band statt King Nothing ein Medley 
+    aus den Liedern So What und Last Caress. Wegen des obszönen Textes von So What s
+    chnitt MTV Metallicas Auftritt bei allen Wiederholungen der Sendung heraus. 
+Im 
+    November 1997 erschien ReLoad. Das ebenfalls von Andres Serrano entworfene Album
+    cover enthielt dieses Mal eine Mischung aus Blut und Urin. Wie bereits Load stie
+    g ReLoad auf Platz 1 der US-amerikanischen Charts ein. Die erste Single The Memo
+    ry Remains beinhaltete ebenso wie der dazugehörige Videoclip einen Gastauftritt 
+    der britischen Sängerin und Schauspielerin Marianne Faithfull. Die Tournee zum A
+    lbum fiel relativ kurz aus. 
+Ohne größere Vorbereitungen nahm die Band im Herbst
+     1998 elf Coverversionen von Bands und Künstlern wie z. B. Black Sabbath, Thin L
+    izzy, Mercyful Fate, Bob Seger und Discharge auf. Zusammen mit allen bisher verö
+    ffentlichten Coverversionen kam das Album unter dem Namen Garage Inc. auf den Ma
+    rkt. Metallica wurde im März 1999 in den Hollywood Walk of Fame in Los Angeles a
+    ufgenommen. Der damalige Bürgermeister Willie Brown proklamierte den 7. März 199
+    9 zum „Offiziellen Metallica-Tag“. 
+Am 21. und 22. April 1999 nahm die Band zwei
+     Auftritte mit dem San Francisco Symphony Orchestra unter Leitung von Michael Ka
+    men auf. Kamen, der über seine klassische Ausbildung und Erfolge als Filmkomponi
+    st hinaus über große Erfahrungen bei der Umsetzung solcher Projekte verfügte, ha
+    tte die Streichinstrumente für das Lied Nothing Else Matters vom schwarzen Album
+     arrangiert. Bereits damals versuchte Kamen die Band davon zu überzeugen, ihre M
+    usik einmal unter Begleitung eines Sinfonieorchesters aufzuführen. Für den Auftr
+    itt komponierte die Band mit No Leaf Clover und Minus Human zwei neue Lieder. De
+    r Mitschnitt der Aufführung wurde im November 1999 unter dem Namen S&M veröffent
+    licht. Nothing Else Matters wurde als Single veröffentlicht und erreichte Platz 
+    2 der deutschen Singlecharts. Weitere Auftritte mit Sinfonieorchestern fanden im
+     November des Jahres in Berlin und New York City statt. 
+Für den Film Mission: I
+    mpossible II nahm Metallica das Lied I Disappear auf. Nachdem die Band herausfan
+    d, dass eine Demoversion von verschiedenen Radiosendern gespielt wurde, stellte 
+    man fest, dass alle bisher veröffentlichten Titel der Band bei der Peer-to-Peer-
+    Tauschbörse Napster zum freien Download zur Verfügung standen. Metallica verklag
+    te Napster und die Universitäten von Southern California, Yale und Indiana darau
+    fhin wegen Urheberrechtsverletzung und Verletzung des Digital Millennium Copyrig
+    ht Act (DMCA). Als Reaktion blockierten Yale und Indiana Napster auf allen Compu
+    tern, woraufhin Metallica die Klagen gegen beide Universitäten zurückzog. 
+Mit H
+    ilfe des Online-Dienstleisters NetPD wurde Napster eine 60.000 Seiten lange List
+    e mit 335.435 Benutzern vorgelegt, mit der Bitte, diese Benutzer zu verbannen. D
+    er Rapper Dr. Dre schloss sich Metallicas Klage an, so dass weitere 230.142 Benu
+    tzer von Napster verbannt wurden. 
+Napster begann darauf ab März 2001, Benutzer 
+    und Metallica-Lieder durch Aktivierung von Filtern anhand von Listen mit IP-Adre
+    ssen zu sperren; im Juli zog die Band darauf ihre Copyright-Klage zurück. In ein
+    em Yahoo-Chat im Jahr 2000 erklärte Ulrich, dass die Band Napster ausschließlich
+     wegen der Verbreitung ihrer Studioalben verklagt hatte. Sie wollen aber weiterh
+    in den Tausch selbst gemachter Live-Aufnahmen, sogenannter Bootlegs, erlauben. 
+
+    Im Sommer 2000 ging die Band zusammen mit Korn, Kid Rock und System of a Down au
+    f die Summer-Sanitarium-Tour durch Nordamerika. Am 4. Juli 2000 stürzte ein Fan 
+    während des Konzerts in Baltimore vom Oberrang des PSINet Stadium und starb. Zwe
+    i Wochen später verstarb ein anderer Fan während eines Geheimkonzerts in Hollywo
+    od. 
+Während der Summer-Sanitarium-Tour kapselte sich Newsted immer weiter von d
+    er Band ab. Auch zwischen Hetfield und Ulrich wuchsen die Spannungen. Auf Anrate
+    n ihres Managers beschloss die Band, den Psychologen Phil Towle zu engagieren. B
+    ereits vor der ersten Sitzung hatte Newsted beschlossen, die Band zu verlassen. 
+    Offiziell wurde der Ausstieg damit begründet, dass Newsted seine Halswirbelsäule
+     durch sein exzessives Headbangen ruiniert habe. Die wahren Beweggründe für News
+    teds Ausstieg lagen jedoch woanders. 
+Bereits seit 1996 arbeitete Newsted mit de
+    r Band Echobrain zusammen. Da Metallica eine längere Pause einlegen wollte, plan
+    ten Echobrain, ein Album aufzunehmen. Hetfield war dagegen und stellte Newsteds 
+    Treue zur Band infrage. 
+Ohne einen Bassisten begann die Band im April 2001 auf 
+    dem Gelände der ehemaligen Militärkaserne Presidio mit den Vorbereitungen auf ei
+    n neues Studioalbum. Dabei wurde Metallica von den Filmemachern Joe Berlinger un
+    d Bruce Sinofsky begleitet, die innerhalb von zwei Jahren über 1.000 Stunden Fil
+    mmaterial aufnahmen. Durch ständige Querelen zwischen Hetfield und Ulrich kam di
+    e Band nur langsam voran. Im Juli klinkte sich Hetfield aus und unterzog sich ei
+    ner Rehabilitation, um seine Alkoholsucht zu therapieren. Der Entzug dauerte bis
+     Dezember. Etwa gleichzeitig bezog die Band in San Rafael einen Gebäudekomplex, 
+    in dem sich Probe- und Aufnahmeräume sowie Büros befanden. 
+Metallica begann mit
+     Bob Rock als Bassisten die Aufnahmen für das achte Studioalbum St. Anger. Die s
+    ich bei den Bandmitgliedern aufgestaute Wut wurde in elf rohe, Hardcore-lastige 
+    Lieder kanalisiert. Auf Gitarrensoli wurde ganz verzichtet, während Ulrichs Snar
+    e wie eine Timbale klingt. Nach Abschluss der Aufnahmen begann die Suche nach ei
+    nem neuen Bassisten. Es spielten unter anderem Pepper Keenan (Corrosion of Confo
+    rmity), Scott Reeder (Kyuss) und Jeordie White (Marilyn Manson) vor, die Wahl fi
+    el jedoch auf den ehemaligen Suicidal-Tendencies- und Ozzy-Osbourne-Bassisten Ro
+    bert Trujillo. Jason Newsted schloss sich der kanadischen Band Voivod an und spi
+    elte 2003 in Ozzy Osbournes Band während der Ozzfest-Tournee. 
+Anlässlich des 20
+    -jährigen Bühnenjubiläums wurde die Band mit dem mtvIcon-Award geehrt. Während d
+    er einstündigen Sendung interpretierten von Metallica beeinflusste Bands wie Kor
+    n, Staind, Limp Bizkit und Sum 41 sowie Snoop Dogg und Avril Lavigne Metallica-L
+    ieder von verschiedenen Alben. Am Ende der Sendung trat Metallica zum ersten Mal
+     mit Robert Trujillo auf und spielte ein Medley aus Hit the Lights, Enter Sandma
+    n, Blackened, Creeping Death und Battery. Im Mai 2003 wurde im Staatsgefängnis S
+    an Quentin das Musikvideo für das Lied St. Anger gedreht. In dem Dokumentarfilm 
+    Metallica: Some Kind of Monster von 2004 spricht Sänger James Hetfield im Innenh
+    of der Haftanstalt zu den Gefangenen und erzählt, als Jugendlicher viel Wut vers
+    pürt zu haben, weshalb er damals selbst im Gefängnis hätte landen können oder in
+    zwischen hätte tot sein können. 
+St. Anger, veröffentlicht am 5. Juni 2003, entw
+    ickelte sich zum kontroversesten Album der Bandgeschichte. Während die einen den
+     rohen Sound des Albums schätzten, stieß St. Anger bei vielen Altfans auf Ablehn
+    ung. Dennoch erreichte das Album in über 30 Ländern Platz eins der Albumcharts. 
+    Bei der folgenden Madly in Anger-Welttournee wurden mit Frantic und dem Titellie
+    d jedoch in der Regel nur zwei Lieder des Albums gespielt. Kurz vor dem Auftritt
+     beim Download-Festival musste Lars Ulrich wegen starker Bauchschmerzen, die sic
+    h allerdings als harmlos herausstellten, in ein Zürcher Krankenhaus eingeliefert
+     werden. Metallica spielte ein verkürztes Konzert, bei dem Dave Lombardo (Slayer
+    ), Joey Jordison (Slipknot) und Ulrichs Schlagzeugtechniker Flemming Larsen aush
+    alfen. 
+Im Sommer 2004 standen zehn Alben von Metallica gleichzeitig in den schw
+    edischen Albumcharts. Insgesamt nahm die Band im Jahr 2004 43 Millionen Dollar e
+    in und war damit nach Prince und Madonna der dritterfolgreichste Act in den USA.
+     Ebenfalls 2004 wurde der Dokumentarfilm Some Kind of Monster veröffentlicht, de
+    r während der Aufnahmen zum St.-Anger-Album entstand. Im Jahre 2005 spielte Meta
+    llica lediglich zwei Konzerte als Vorgruppe der Rolling Stones in San Francisco.
+     Ein Jahr später spielte die Band ihre ersten Konzerte in Südafrika. 
+Nachdem Bo
+    b Rock die letzten sechs Alben der Band produziert hatte, gab die Band im Februa
+    r 2006 bekannt, dass das nächste Studioalbum von Rick Rubin produziert werde. Ru
+    bin hatte sich als Produzent von Künstlern wie AC/DC, Slayer, System of a Down, 
+    den Red Hot Chili Peppers und Johnny Cash einen Namen gemacht. Im Rahmen ihrer E
+    scape from the Studio ’06-Tour trat die Band im Juni 2006 zum dritten Mal bei de
+    n Festivals Rock am Ring / Rock im Park sowie auf der Berliner Waldbühne auf. Da
+    bei wurden zum zwanzigjährigen Jubiläum der Veröffentlichung des Albums Master o
+    f Puppets sämtliche darauf enthaltenen Lieder vorgetragen. In Berlin spielte Met
+    allica zusätzlich ein unbetiteltes neues Lied. Eine Zusammenstellung aller Musik
+    videos wurde unter dem Titel The Videos: 1989–2004 im Dezember 2006 als DVD verö
+    ffentlicht. 
+Metallica nahm eine Coverversion des Liedes The Ecstasy of Gold auf
+    , das auf einem Tributalbum für den Komponisten Ennio Morricone veröffentlicht w
+    urde. The Ecstasy of Gold stammt aus dem Italo-Western Zwei glorreiche Halunken 
+    und wird seit 1983 als Intro für jedes Konzert verwendet. Die Aufnahmen für das 
+    neunte Studioalbum Death Magnetic begannen im März 2007. Im Sommer des gleichen 
+    Jahres spielte Metallica eine kurze Stadiontournee durch Europa. Die Ankündigung
+     des Konzertes in der finnischen Hauptstadt Helsinki führte dazu, dass sich Ende
+     Mai 2007 zehn Metallica-Alben in den finnischen Albumcharts platzierten. Für de
+    n Iron-Maiden-Tributsampler Maiden Heaven nahm Metallica das Lied Remember Tomor
+    row auf, das für die Band eine Blaupause für Lieder wie Fade to Black oder Welco
+    me Home (Sanitarium) war. 
+Am 2. September 2008, zehn Tage vor der geplanten Ver
+    öffentlichung, wurden in Frankreich irrtümlicherweise die ersten Exemplare des n
+    euen Albums verkauft. Sofort tauchte das Album in den Internettauschbörsen auf. 
+    Lars Ulrich blieb wegen dieses vorzeitigen Leaks gelassen und bezeichnete es als
+     einen Erfolg, dass das Album erst zehn Tage vor der Veröffentlichung im Interne
+    t auftauchte. Death Magnetic stieg weltweit in 32 Ländern auf Platz eins der Alb
+    umcharts ein. In den USA schaffte Death Magnetic als fünftes Metallica-Album den
+     direkten Sprung auf Platz eins. Zuvor hatte sich Metallica mit den Beatles, U2 
+    und der Dave Matthews Band den Rekord mit vier Alben geteilt. 
+Am Veröffentlichu
+    ngstag wurde Death Magnetic in der Berliner Multifunktionshalle O2 World durch e
+    in Konzert vorgestellt. Im Oktober 2008 begann die „World Magnetic“-Tour. 
+Am 4.
+     April 2009 wurde Metallica in die Rock and Roll Hall of Fame aufgenommen. Erstm
+    als seit der Trennung 2001 spielte Metallica sowohl Master of Puppets als auch E
+    nter Sandman mit dem ehemaligen Bassisten Jason Newsted. Im April 2010 gewann Me
+    tallica den Revolver Golden God Award in der Kategorie Beste Liveband. Im Juni 2
+    010 ging Metallica mit Slayer, Megadeth und Anthrax auf die The Big Four-Tournee
+    . Am 29. Oktober 2010 erschien die auf dieser Tour entstandene DVD/Blu-ray The B
+    ig Four Live from Sofia, Bulgaria. 
+Anlässlich der Aufnahme von Metallica in die
+     Rock and Roll Hall of Fame trat Metallica im Jahre 2009 unter anderem mit Lou R
+    eed auf. Nach diesem Auftritt entstand die Idee, ein gemeinsames Album zu veröff
+    entlichen. Am 31. Oktober 2011 wurde das Album Lulu weltweit veröffentlicht, erh
+    ielt aber überwiegend schlechte Kritiken. Aufgrund der Eurokrise gab die Band En
+    de 2011 bekannt, ihre Tourpläne zu ändern und verschiedene Auftritte vorzuverleg
+    en. Bandmanager Cliff Burnstein erklärte, dass man mit einer Schwächung des Euro
+    s in den kommenden Jahren rechne und daher Konzerte geben wolle, solange sie noc
+    h möglichst profitabel seien. Daher würde Metallica 2012 und nicht wie geplant 2
+    013 sein schwarzes Album bei verschiedenen Festivals in Europa spielen. 
+Am 14. 
+    Dezember 2011 veröffentlichte Metallica auf digitalem Wege die EP Beyond Magneti
+    c, auf der vier bis dato unveröffentlichte Lieder aus den Death-Magnetic-Aufnahm
+    en zu hören sind. Die Lieder wurden zuvor bei den vier Konzerten zum dreißigjähr
+    igen Bestehen der Band im Dezember 2011 in San Francisco erstmals live gespielt.
+     Die Band arbeitete mit Nimród Antal an dem 3-D-Film Metallica Through the Never
+    , der am 27. September 2013 veröffentlicht wurde. Für den Film wurden unter ande
+    rem die Konzerte der Band im Sommer 2012 in Mexiko und Kanada gefilmt. Jedoch er
+    wies sich der Film aufgrund niedriger Einnahmen als Flop. Metallica steuerte für
+     den Deep-Purple-Tribute-Sampler Re-Machined: A Tribute to Deep Purple's Machine
+     Head das Lied When a Blind Man Cries bei. 
+Am 8. Dezember 2013 spielte Metallic
+    a als erste Band in der Antarktis. Somit sind sie die einzige Band der Welt, die
+     innerhalb eines Jahres auf allen Kontinenten auftrat. 
+Am 26. Januar 2014 trat 
+    Metallica zusammen mit dem chinesischen Pianisten Lang Lang bei den Grammy Award
+    s 2014 auf, wo sie gemeinsam das Lied One spielten. Kurze Zeit später wurde beka
+    nnt, dass Metallica für ein Ronnie-James-Dio-Tribute-Sampler ein Medley einiger 
+    seiner bekannten Rainbow-Hits gemacht hatten. Es soll zirka 9 Minuten dauern und
+     Teile der Lieder A Light in the Black, Tarot Woman, Stargazer und Kill the King
+     enthalten. Das Album wird This Is Your Life heißen. Am 16. März 2014 trat Metal
+    lica in Bogotá auf und stellte ihr neues Lied Lords of Summer vor. Auch wurde be
+    stätigt, dass voraussichtlich
+2016 ein neues Studioalbum erscheinen werde. Bei d
+    en Terroranschlägen am 13. November 2015 in Paris starb Metallicas langjähriger 
+    Projektmanager in Frankreich, Thomas Ayad von Universal Music France, beim Massa
+    ker mit Geiselnahme im Bataclan. 
+Die Auftrittsgagen für Metallica liegen im ein
+    stelligen Millionenbereich. Als Zugpferd für das von der DEAG veranstaltete Zwil
+    lingsfestival Rock im Revier und Rockavaria erhielt Metallica 7,3 Mio. US-Dollar
+     (ca. 6,6 Mio. €). 
+Am 18. November 2016 erschien – acht Jahre nach Death Magnet
+    ic – das zehnte Studioalbum mit dem Titel Hardwired…to Self-Destruct angekündigt
+    : Es handelt sich um ein Doppelalbum mit zwölf neuen Songs, wobei am 18. August 
+    2016 das Lied Hardwired samt Musikvideo vorab als Single ausgekoppelt wurde. Am 
+    12. Februar 2017 trat Metallica bei den Grammy Awards 2017 zusammen mit Lady Gag
+    a auf. Hetfield sang mit dieser im Duett den Song Moth into Flame vom 2016 ersch
+    ienenen Album Hardwired…to Self-Destruct. 
+Aus Anlass des 20-jährigen Jubiläums 
+    des Livealbums erschien am 28. August 2020 S&M2, gleichsam eine Fortsetzung von 
+    S&M, wiederum live eingespielt mit San Francisco Symphony. Anlässlich des Jubilä
+    ums der Veröffentlichung des so genannten Black Albums, veröffentlichte Metallic
+    a am 10. September 2021 ein Tribute Album unter dem Titel The Metallica Blacklis
+    t. 53 Künstler covern darauf die 30 Jahre zuvor erschienenen Songs. 
+Am 28. Nove
+    mber 2022 wurde das Album 72 Seasons angekündigt, welches am 14. April 2023 ersc
+    hienen ist. Zudem kam auch die Single Lux Æterna heraus. Der Albumtitel 72 Seaso
+    ns – also 72 Jahreszeiten – bezieht sich laut James Hetfield auf die ersten 18 J
+    ahre im Leben eines Menschen. Gleichzeitig mit dem neuen Album kündigte die Band
+     ihre M72 World Tour an. Metallica werden dabei von den Bands Five Finger Death 
+    Punch, Ice Nine Kills, Mammoth WVH, Pantera, Architects, Greta Van Fleet und Vol
+    beat begleitet. 
+Metallica zählt zu den einflussreichsten und erfolgreichsten Me
+    talbands weltweit. Korn-Sänger Jonathan Davis bezeichnet Metallica als seine Lie
+    blingsband, da sie „immer die Dinge auf ihre eigene Art und Weise gemacht haben 
+    und über die Jahre durchgehalten haben und es bis heute tun“. Laut Godsmack-Schl
+    agzeuger Shannon Larkin stellt Metallica den größten Einfluss für seine Band dar
+    . Larkin erklärte, dass Metallica sein Leben verändert habe, als er 16 Jahre alt
+     war, da er zuvor nie so etwas Hartes gehört habe. Die Trivium-Gitarristen Matth
+    ew Heafy und Corey Beaulieu erlernten ihr Instrument, nachdem sie zum ersten Mal
+     mit der Musik von Metallica in Berührung kamen. Joey Z., der Gitarrist von Life
+     of Agony, bezeichnet Kirk Hammett als sein Vorbild und gibt an, durch ihn zum G
+    itarre spielen gekommen zu sein. Für Avenged-Sevenfold-Sänger M. Shadows waren d
+    ie gemeinsamen Konzerte der Höhepunkt der Musikerkarriere. Armored-Saint-Sänger 
+    John Bush lobte Metallica dafür, dass die Band „einen vorbildlichen Karriereweg 
+    gegangen ist und sich nie hat reinreden lassen“. Für Kim Thayil von der Band Sou
+    ndgarden ist Metallica ein „Beispiel für ehrlichen Erfolg ohne TV- und Radio-Hyp
+    e“. 
+Das britische Rockmagazin Kerrang veröffentlichte im April 2006 ein Tributa
+    lbum mit dem Titel Master of Puppets: Remastered anlässlich des 20-jährigen Jubi
+    läums des Albums Master of Puppets. Das Album beinhaltet Coverversionen der acht
+     Lieder durch Bands wie Machine Head, Bullet for My Valentine, Chimaira, Mastodo
+    n, Mendeed und Trivium. Im Jahre 1996 veröffentlichte die finnische Band Apocaly
+    ptica ihr Debütalbum Plays Metallica By Four Cellos, auf dem acht Metallicaliede
+    r mit Celli gespielt werden. Die Parodieband Beatallica verbindet die Musik von 
+    Metallica mit der von den Beatles. Die Inhaber der musikalischen Rechte der Beat
+    les, Sony, verklagte Beatallica, da die Band laut Sony einen „substantiellen und
+     irreparablen Schaden“ zugefügt habe. Lars Ulrich bat Metallicas Anwalt Peter Pa
+    terno, Beatallica rechtlichen Beistand zu leisten. 
+MTV platzierte Metallica in 
+    seiner Liste der „Größten Metal-Bands aller Zeiten“ auf Platz drei. Der TV-Sende
+    r VH1 setzte die Band auf Platz fünf ihrer Liste der 100 größten Hard-Rock-Bands
+    . Das Album Master of Puppets belegte Platz eins in der Liste der „100 besten Me
+    talalben“ vom Onlinemagazin Metal Rules. In dem Buch Best of Rock & Metal des de
+    utschen Magazins Rock Hard, in dem die nach Meinung der Rock-Hard-Redaktion 500 
+    stärksten Metal- und Hard-Rock-Alben aller Zeiten aufgeführt werden, ist Metalli
+    ca mit fünf Alben vertreten. Master of Puppets belegt Platz zwei, gefolgt von Ri
+    de the Lightning. Das Debütalbum Kill ’Em All befindet sich auf Platz 12, das se
+    lbstbetitelte fünfte Album auf Platz 79 sowie Garage Inc. auf Platz 500. 
+Der Sp
+    ielehersteller Activision produzierte zusammen mit Neversoft einen Metallica-Abl
+    eger ihrer beliebten Musikspiele-Reihe Guitar Hero. In Guitar Hero: Metallica si
+    nd (Downloadable Content nicht mitgerechnet) 31 Metallica-Lieder sowie 21 von de
+    r Band selbst bestimmte Gastlieder enthalten. Sowohl die Band selbst (die alle A
+    nimationen mit charakteristischen Posen und Bewegungen selbst per Motion Capture
+     ins Spiel brachten) als auch die beiden Gaststars, King Diamond von Mercyful Fa
+    te und Lemmy Kilmister von Motörhead, sind spielbare Charaktere. Das Spiel ersch
+    ien am 22. Mai 2009 in Europa für PlayStation 2, PlayStation 3, Xbox 360 und Wii
+    . Zusätzlich lassen sich weitere Lieder sowie das komplette Album Death Magnetic
+     für dieses Spiel aus dem PlayStation Store und Xbox Live herunterladen. 
+Seit 2
+    008 gibt es das Internet-Projekt A German Tribute to Metallica, bei dem deutsche
+     Bands Coverversionen von Metallica-Liedern zur Verfügung stellen. Teilnehmer wa
+    ren unter anderem In Extremo, Madsen und die Donots. 
+Der Rolling Stone listete 
+    Metallica 2011 auf Rang 61 der 100 größten Musiker aller Zeiten. 
+2021 hat die B
+    ürgermeisterin von San Francisco, London Breed, im Rahmen des 40. Band-Jubiläums
+     von Metallica den 16. Dezember zum „Metallica Day“ erklärt. 
+In der Coming-of-A
+    ge-Komödie Mein etwas anderer Florida Sommer von 2019 trägt der wortkarge Jugend
+    liche Daniel Bagnold, verkörpert von Hauptdarsteller Earl Cave, wechselnde T-Shi
+    rts von Metallica. Außerdem hängen in seinem Jugendzimmer verschiedene Poster mi
+    t den Albumcovern von Kill ’Em All und Master of Puppets als Motiv. Regisseur de
+    s Films ist Simon Bird. 
+Im Februar 2020 benannten die Tiefseeforscher Torben Ri
+    ehl vom Senckenberg Forschungsinstitut und sein Kollege Bart de Smet von der Uni
+    versität Gent Macrostylis metallicola, eine neuentdeckte, in einer Tiefe von 400
+    0 bis 5000 Meter in einem Gebiet mit vielen Manganknollen im Nordpazifik vorkomm
+    ende Tiefseeassel zu Ehren der Band. Riehl erklärte dazu: „Mit ihrer beeindrucke
+    nden Musik hat mich die Heavy Metal-Band den Großteil meines Lebens begleitet. E
+    s begeistert mich daher riesig, die Band mit der Benennung einer neuen Art zu eh
+    ren.“ Bereits 2002 wurde die parasitäre Wespenart Metallichneumon neurospastarch
+    us benannt, deren Namensteil neurospastarchus die altgriechische Übersetzung von
+     Master of Puppets ist. 
+Studioalben
 discography: (N=0)
 genres: (N=0)
 styles: (N=0)

--- a/test/resources/scrapers/tmdb/Finding_Dory_tmdb127380.ref.txt
+++ b/test/resources/scrapers/tmdb/Finding_Dory_tmdb127380.ref.txt
@@ -84,7 +84,7 @@ actors: (N>60)
  - id: 
    name: Dominic West
    role: Rudder (voice)
-   thumb: http://image.tmdb.org/t/p/original/aCzmg3TWIElRFU15bnekttKOsYC.jpg
+   thumb: http://image.tmdb.org/t/p/original/iJIdrZrE57eWlXAtXbntzacW6B8.jpg
    order: 9
    imageHasChanged: false
  - id: 
@@ -160,7 +160,8 @@ countries: (N=1)
 studios: (N<6)
   - Pixar
   - Walt Disney Pictures
-trailer: https://www.youtube.com/watch?v=iG0P6bjyUNI
+trailer: https://www.youtube.com/watch?v=JhvrQeY3doI
+showlink: 
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>

--- a/test/resources/scrapers/tmdb/Finding_Dory_tt2277860.ref.txt
+++ b/test/resources/scrapers/tmdb/Finding_Dory_tt2277860.ref.txt
@@ -84,7 +84,7 @@ actors: (N>60)
  - id: 
    name: Dominic West
    role: Rudder (voice)
-   thumb: http://image.tmdb.org/t/p/original/aCzmg3TWIElRFU15bnekttKOsYC.jpg
+   thumb: http://image.tmdb.org/t/p/original/iJIdrZrE57eWlXAtXbntzacW6B8.jpg
    order: 9
    imageHasChanged: false
  - id: 
@@ -160,7 +160,8 @@ countries: (N=1)
 studios: (N<6)
   - Pixar
   - Walt Disney Pictures
-trailer: https://www.youtube.com/watch?v=JhvrQeY3doI
+trailer: https://www.youtube.com/watch?v=iG0P6bjyUNI
+showlink: 
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>

--- a/test/resources/scrapers/tmdb/The_Rescuers_de-DE_tmdb11319.ref.txt
+++ b/test/resources/scrapers/tmdb/The_Rescuers_de-DE_tmdb11319.ref.txt
@@ -119,7 +119,7 @@ actors: (N>10)
  - id: 
    name: Dub Taylor
    role: Digger (voice)
-   thumb: http://image.tmdb.org/t/p/original/gDgTAXPq5vOW5CWxF2MaeQ9Kjkn.jpg
+   thumb: http://image.tmdb.org/t/p/original/kaVczv72Xu6OlyFdA7uxTKRJNMN.jpg
    order: 14
    imageHasChanged: false
  - id: 
@@ -158,6 +158,7 @@ countries: (N=1)
 studios: (N=1)
   - Walt Disney Productions
 trailer: https://www.youtube.com/watch?v=9d3At0Zng3k
+showlink: 
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>

--- a/test/resources/scrapers/tmdb_concert/Rammstein_in_Amerika_tmdb361631.ref.txt
+++ b/test/resources/scrapers/tmdb_concert/Rammstein_in_Amerika_tmdb361631.ref.txt
@@ -16,7 +16,7 @@ overview:
      various periods in the band’s history, the band members speak about their exper
     iences across the Atlantic.
 ratings (N=1)
-  source=themoviedb | rating=8 | votes=49 | min=0 | max=10
+  source=themoviedb | rating=7.94 | votes=50 | min=0 | max=10
 userRating: 0
 releaseDate: 2015-09-25
 tagline: 

--- a/test/resources/scrapers/tmdbtv/Scrubs-tmdb4556-all-details-DE.ref.txt
+++ b/test/resources/scrapers/tmdbtv/Scrubs-tmdb4556-all-details-DE.ref.txt
@@ -39,7 +39,7 @@ actors: (N>800)
  - id: 5367
    name: Zach Braff
    role: John 'J.D.' Dorian
-   thumb: https://image.tmdb.org/t/p/original/wUAj6juL6HErqEJ1GtuI63rbVea.jpg
+   thumb: https://image.tmdb.org/t/p/original/2AAnPoazqQRzC9Xyq3QkbnOlrtV.jpg
    order: 0
    imageHasChanged: false
  - id: 49002

--- a/test/resources/scrapers/tmdbtv/Scrubs-tmdb4556-all-details.ref.txt
+++ b/test/resources/scrapers/tmdbtv/Scrubs-tmdb4556-all-details.ref.txt
@@ -36,7 +36,7 @@ actors: (N>800)
  - id: 5367
    name: Zach Braff
    role: John 'J.D.' Dorian
-   thumb: https://image.tmdb.org/t/p/original/wUAj6juL6HErqEJ1GtuI63rbVea.jpg
+   thumb: https://image.tmdb.org/t/p/original/2AAnPoazqQRzC9Xyq3QkbnOlrtV.jpg
    order: 0
    imageHasChanged: false
  - id: 49002

--- a/test/resources/scrapers/tmdbtv/Scrubs-tmdb4556-minimal-details-DE.ref.txt
+++ b/test/resources/scrapers/tmdbtv/Scrubs-tmdb4556-minimal-details-DE.ref.txt
@@ -39,7 +39,7 @@ actors: (N>800)
  - id: 5367
    name: Zach Braff
    role: John 'J.D.' Dorian
-   thumb: https://image.tmdb.org/t/p/original/wUAj6juL6HErqEJ1GtuI63rbVea.jpg
+   thumb: https://image.tmdb.org/t/p/original/2AAnPoazqQRzC9Xyq3QkbnOlrtV.jpg
    order: 0
    imageHasChanged: false
  - id: 49002

--- a/test/resources/scrapers/tmdbtv/Stargate-SG-1-tmdb4629.ref.txt
+++ b/test/resources/scrapers/tmdbtv/Stargate-SG-1-tmdb4629.ref.txt
@@ -120,9 +120,9 @@ actors: (N>800)
  - id: 118463
    name: Peter DeLuise
    role:
-    Director / Peter DeLuise, Airman, SF Guard (Uncredited), Lieutenant, Man Leaving
-     Cafe, Free Jaffa (Voice only) (Uncredited), Interviewer, Tok'ra Guard, Screamin
-    g Villager, Machine Gun Guard, Young Urgo in Uniform
+    Director / Peter DeLuise, Airman, SF Guard (Uncredited), Lieutenant, Interviewer
+    , Man Leaving Cafe, Screaming Villager, Tok'ra Guard, Machine Gun Guard, Young U
+    rgo in Uniform, Free Jaffa (Voice only) (Uncredited)
    thumb: https://image.tmdb.org/t/p/original/sLkSOm6HBLB4VCfshQLdSEq63tr.jpg
    order: 13
    imageHasChanged: false
@@ -146,17 +146,17 @@ actors: (N>800)
    imageHasChanged: false
  - id: 59245
    name: Laara Sadiq
-   role: Technician #2, Technican, Technician, Technician Davis
+   role: Technician #2, Technician Davis, Technican, Technician
    thumb: https://image.tmdb.org/t/p/original/l7MkydwslaXo1EmYrRpJARnaFKs.jpg
    order: 17
    imageHasChanged: false
  - id: 1366510
    name: Fraser Aitcheson
    role:
-    Hathor's Jaffa, Jaffa Commander, Dakara Jaffa 3 (Uncredited), Ares' Jaffa comman
-    der (Uncredited), Jaffa Guard, Free Jaffa 2 (Uncredited), Apophis' Red Jaffa, An
-    ubis' Jaffa, Orderly, Tagrean Worker, Jaffa Warrior, Jaffa, Free Jaffa (Uncredit
-    ed)
+    Hathor's Jaffa, Ares' Jaffa commander (Uncredited), Tagrean Worker, Free Jaffa 2
+     (Uncredited), Jaffa Guard, Apophis' Red Jaffa, Orderly, Jaffa Warrior, Dakara J
+    affa 3 (Uncredited), Anubis' Jaffa, Free Jaffa (Uncredited), Jaffa Commander, Ja
+    ffa
    thumb: https://image.tmdb.org/t/p/original/j0fou5tZvXHe3GcVr24UnYQLg6S.jpg
    order: 18
    imageHasChanged: false

--- a/test/resources/scrapers/tmdbtv/The-Simpsons-S12.ref.txt
+++ b/test/resources/scrapers/tmdbtv/The-Simpsons-S12.ref.txt
@@ -28,9 +28,9 @@ overview:
     a dolphin in "Night of the Dolphin."
 writers: (N<6)
   - Don Payne
-  - Rob LaZebnik
   - Carolyn Omine
   - John Frink
+  - Rob LaZebnik
 directors: (N=1)
   - Matthew Nastuk
 playCount: 0
@@ -266,7 +266,7 @@ actors: (N>10)
  - id: 69597
    name: Drew Barrymore
    role: 
-   thumb: https://image.tmdb.org/t/p/original/mVQdb6w6gXmLZ6nZ3K9Fw3vzawM.jpg
+   thumb: https://image.tmdb.org/t/p/original/9xMu2GLC5otUcC11sEWC5aEAERQ.jpg
    order: 5
    imageHasChanged: false
  - id: 3266
@@ -980,41 +980,47 @@ actors: (N>5)
    thumb: https://image.tmdb.org/t/p/original/zBYnzxzlAIEoanEU00bGYJmRS6k.jpg
    order: 0
    imageHasChanged: false
+ - id: 27765
+   name: Richard Nixon
+   role: Self (Archive Footage)
+   thumb: https://image.tmdb.org/t/p/original/uCJeC6LXnv3KVA1YUNTpBh8uAhC.jpg
+   order: 1
+   imageHasChanged: false
  - id: 198
    name: Dan Castellaneta
    role: Homer Simpson / Abe Simpson / Barney Gumble / Krusty (voice)
    thumb: https://image.tmdb.org/t/p/original/AmeqWhP4A46AWkM4kVphg6jOTQX.jpg
-   order: 1
+   order: 2
    imageHasChanged: false
  - id: 199
    name: Julie Kavner
    role: Marge Simpson / Patty Bouvier / Selma Bouvier (voice)
    thumb: https://image.tmdb.org/t/p/original/xxiu7PC7RDOJmCuB6i81gEVrDQW.jpg
-   order: 2
+   order: 3
    imageHasChanged: false
  - id: 200
    name: Nancy Cartwright
    role: Bart Simpson / Nelson Muntz / Ralph Wiggum (voice)
    thumb: https://image.tmdb.org/t/p/original/40qNhyYJhSE2Yiy4pnXSZhdufO6.jpg
-   order: 3
+   order: 4
    imageHasChanged: false
  - id: 5586
    name: Yeardley Smith
    role: Lisa Simpson (voice)
    thumb: https://image.tmdb.org/t/p/original/9AjPwbb3uz4GfgOPBYsy2ILvwkB.jpg
-   order: 4
+   order: 5
    imageHasChanged: false
  - id: 5587
    name: Hank Azaria
    role: Moe Szyslak / Chief Wiggum / Apu / Comic Book Guy / Carl (voice)
    thumb: https://image.tmdb.org/t/p/original/yFDw4b0jucuFWNnGcBPfpYUtn16.jpg
-   order: 5
+   order: 6
    imageHasChanged: false
  - id: 6008
    name: Harry Shearer
    role: Ned Flanders / Mr. Burns / Smithers / Skinner / Lenny (voice)
    thumb: https://image.tmdb.org/t/p/original/7PnGZGVKJNDTUv3DkbaMEnCseT0.jpg
-   order: 6
+   order: 7
    imageHasChanged: false
 streamDetails: <not loaded>
 files: (N=0)

--- a/test/resources/scrapers/tmdbtv/The-Simpsons-tmdb456-minimal-details.ref.txt
+++ b/test/resources/scrapers/tmdbtv/The-Simpsons-tmdb456-minimal-details.ref.txt
@@ -77,21 +77,21 @@ actors: (N>800)
  - id: 6009
    name: Pamela Hayden
    role:
-    Milhouse (voice), Milhouse / Jimbo (voice), Employment Agent / Admitted Fraud #2
-     / Angry Woman (voice), Milhouse / Rod Flanders (voice), Rod Flanders (voice), J
-    imbo (voice), Milhouse / Jimbo / Rod Flanders (voice), Gloria Prince (voice), Pe
-    ople by Death Time (voice), Saultery Stevens (voice), Tortured People (voice), S
-    on #1 / Son #2 (voice), Sarah Wiggum (voice), Milhouse / Jimbo / Janey / Kid / B
-    ad Girl #2 (voice), Oats Crowd (voice), Milhouse / Jimbo / Janey (voice), Milhou
-    se / Janey / Ex-Wife (voice), Milhouse / Announcer (voice), Mediocroto (voice), 
-    Brittany / Merchandiser #1 (voice), Milhouse / Ethan Foley / Boy (voice), Straig
-    ht-Edge Spuckler (voice), Jimbo / Rod Flanders (voice), Janey / Boy with Howie /
-     Howie's Mother (voice), Lard Lad Donuts Employee (voice), Milhouse / Janey / Do
-    lph (voice), Milhouse / Boy (voice), Milhouse / Psychiatrist (voice), Milhouse /
-     Rod Flanders / Santa Woman (voice), Milhouse / Rod Flanders / Jimbo (voice), Mi
-    lhouse / Svetlana / Woman in Audience #2 (voice), Nurse (voice), Milhouse Van Ho
-    uten / Sarah Wiggum (voice), Milhouse / Applicant / Woman in Audience (voice), S
-    ecurity Guard #1 (voice), Wendell (voice)
+    Milhouse (voice), Employment Agent / Admitted Fraud #2 / Angry Woman (voice), Mi
+    lhouse / Jimbo (voice), Milhouse / Rod Flanders (voice), Rod Flanders (voice), J
+    imbo (voice), Milhouse / Jimbo / Rod Flanders (voice), Milhouse / Boy (voice), L
+    ard Lad Donuts Employee (voice), Wendell (voice), Milhouse / Rod Flanders / Sant
+    a Woman (voice), Saultery Stevens (voice), Nurse (voice), Janey / Boy with Howie
+     / Howie's Mother (voice), Gloria Prince (voice), Milhouse / Rod Flanders / Jimb
+    o (voice), Milhouse / Svetlana / Woman in Audience #2 (voice), Milhouse Van Hout
+    en / Sarah Wiggum (voice), Mediocroto (voice), Milhouse / Psychiatrist (voice), 
+    Milhouse / Janey / Ex-Wife (voice), Milhouse / Ethan Foley / Boy (voice), Britta
+    ny / Merchandiser #1 (voice), Oats Crowd (voice), Jimbo / Rod Flanders (voice), 
+    Straight-Edge Spuckler (voice), Milhouse / Janey / Dolph (voice), Milhouse / Ann
+    ouncer (voice), Son #1 / Son #2 (voice), Security Guard #1 (voice), Milhouse / J
+    imbo / Janey (voice), Tortured People (voice), Milhouse / Jimbo / Janey / Kid / 
+    Bad Girl #2 (voice), Sarah Wiggum (voice), Milhouse / Applicant / Woman in Audie
+    nce (voice), People by Death Time (voice)
    thumb: https://image.tmdb.org/t/p/original/mPMtuVB6AEulRhlfn69y5RvgmNT.jpg
    order: 6
    imageHasChanged: false
@@ -99,27 +99,27 @@ actors: (N>800)
    name: Tress MacNeille
    role:
     Ms. Dare / Gwen / Homer's Cousin's Wife (voice), Agnes Skinner (voice), Dolph (v
-    oice), (voice), Brandine Spuckler (voice), Ms. Muntz (voice), Shauna Chalmers (v
+    oice), (voice), Ms. Muntz (voice), Brandine Spuckler (voice), Shauna Chalmers (v
     oice), Doris (voice), Dolph / Shauna Chalmers (voice), Dolph / Agnes Skinner (vo
-    ice), Crazy Cat Lady / Linda / Agnes Skinner (voice), Agnes Skinner / Doris (voi
-    ce), Crazy Cat Lady / Agnes Skinner (voice), Power Plant System (voice), Ms. Mun
-    tz / Mrs. Bad Halloween Candy / Shauna Chalmers (voice), DMV Worker (voice), Dol
-    ph / Madison (voice), Agnes Skinner / Shauna Chalmers /Brandine Spuckler (voice)
-    , Crazy Cat Lady / Shauna Chalmers (voice), Female Doctor (voice), Brunella Pomm
-    elhorst / Doris (voice), Ms. Mints (voice), Kaitlyn (voice), Shauna Chalmers / D
-    olph (voice), Dr. Spivak's Mother (voice), Gary (voice), Mother (voice), Greta W
-    olfcastle / Mopey Mary (voice), Crazy Cat Lady (voice), Hazel (voice), Mabel (vo
-    ice), Mrs. Vanderbilt (voice), Female Narrator (voice), Moira (voice), Dolph / C
-    uddle Kitten NFT Leader (voice), Miss Springfield / Martha / Tracey (voice), Lad
-    y in Audience (voice), Lindsay Naegle / Manjula / Lunchlady Doris / Cookie Kwan 
-    (voice), Agnes Skinner / Adil Hoxha / Airport Announcer (voice), Kumiko Nakamura
-     / News Reporter / Dolph / Wendell Borton (voice), Ms. Albright / Churchgoer / J
-    imbo (voice), Brandine Spuckler / Ms. York (voice), Shauna Chalmers /Brandine Sp
-    uckler / Crazy Cat Lady (voice), Cora (voice), Brandine Del Roy / Plopper / Duby
-    a Spuckler (voice), Mrs. Chase (voice), Shauna Chalmers / Crazy Cat Lady, Maya /
-     Waitress / Baseball Player (voice), Lindsey Naegle (voice), Bad Girl #1 (voice)
-    , Dolph Shapiro / Shauna Chalmers (voice), Sandra (voice), Luigi's Mother (voice
-    ), Brunella Pommelhorst (voice)
+    ice), Dolph Shapiro / Shauna Chalmers (voice), Agnes Skinner / Adil Hoxha / Airp
+    ort Announcer (voice), Shauna Chalmers / Dolph (voice), Agnes Skinner / Doris (v
+    oice), Crazy Cat Lady / Linda / Agnes Skinner (voice), Shauna Chalmers / Crazy C
+    at Lady, Mabel (voice), Crazy Cat Lady (voice), Ms. Muntz / Mrs. Bad Halloween C
+    andy / Shauna Chalmers (voice), Maya / Waitress / Baseball Player (voice), Gary 
+    (voice), Crazy Cat Lady / Agnes Skinner (voice), Crazy Cat Lady / Shauna Chalmer
+    s (voice), Ms. Mints (voice), Female Narrator (voice), Agnes Skinner / Shauna Ch
+    almers /Brandine Spuckler (voice), Greta Wolfcastle / Mopey Mary (voice), Power 
+    Plant System (voice), Dolph / Madison (voice), Mother (voice), Lindsay Naegle / 
+    Manjula / Lunchlady Doris / Cookie Kwan (voice), Kaitlyn (voice), DMV Worker (vo
+    ice), Brunella Pommelhorst / Doris (voice), Hazel (voice), Sandra (voice), Dr. S
+    pivak's Mother (voice), Moira (voice), Dolph / Cuddle Kitten NFT Leader (voice),
+     Kumiko Nakamura / News Reporter / Dolph / Wendell Borton (voice), Ms. Albright 
+    / Churchgoer / Jimbo (voice), Brunella Pommelhorst (voice), Cora (voice), Brandi
+    ne Del Roy / Plopper / Dubya Spuckler (voice), Female Doctor (voice), Mrs. Chase
+     (voice), Mrs. Vanderbilt (voice), Lindsey Naegle (voice), Lady in Audience (voi
+    ce), Brandine Spuckler / Ms. York (voice), Miss Springfield / Martha / Tracey (v
+    oice), Luigi's Mother (voice), Shauna Chalmers /Brandine Spuckler / Crazy Cat La
+    dy (voice), Bad Girl #1 (voice)
    thumb: https://image.tmdb.org/t/p/original/gI2LsgByvSffQY34vabVnPmrHzw.jpg
    order: 7
    imageHasChanged: false
@@ -133,13 +133,13 @@ actors: (N>800)
    name: Chris Edgerly
    role:
     Viking Masseuse / Admitted Fraud #1 / Admitted Fraud #4 (voice), Tucker Carlson 
-    (voice), Stan Laurel (voice), Springfield Retirement Home Receptionist (voice), 
-    Helicopter Man #2 (voice), Doctor (voice), Weinstein (voice), Flexulon / Halluci
-    nation Otto (voice), Bowling Alley Manager (voice), Boat Owner / Neighborhood Me
-    eting Notification (voice), Nutz Therapist (voice), Uber Hombre / Scarlet Pimper
-    nel (voice), Male Doctor (voice), Scotus Szyslak (voice), Beyond Bullying Profes
-    sor (voice), Commercial Guy at the Beach / Award Man (voice), George Harrison / 
-    Coal Manager (voice)
+    (voice), George Harrison / Coal Manager (voice), Boat Owner / Neighborhood Meeti
+    ng Notification (voice), Flexulon / Hallucination Otto (voice), Commercial Guy a
+    t the Beach / Award Man (voice), Beyond Bullying Professor (voice), Male Doctor 
+    (voice), Uber Hombre / Scarlet Pimpernel (voice), Weinstein (voice), Bowling All
+    ey Manager (voice), Nutz Therapist (voice), Scotus Szyslak (voice), Springfield 
+    Retirement Home Receptionist (voice), Stan Laurel (voice), Doctor (voice), Helic
+    opter Man #2 (voice)
    thumb: https://image.tmdb.org/t/p/original/bjkN9Ugv6Kd3Z3y9p9DgWAc10Q7.jpg
    order: 9
    imageHasChanged: false
@@ -147,14 +147,14 @@ actors: (N>800)
    name: Maggie Roswell
    role:
     Maude Flanders (voice), Helen Lovejoy (voice), Luann Van Houten (voice), Helen L
-    ovejoy / Luann Van Houten (voice), Helen Lovejoy / Elizabeth Hoover (voice), Eli
-    zabeth Hoover (voice), Helen Lovejoy / Institute Council Member #3 (voice), Hele
-    n Lovejoy / Singing Waiters (voice), Miss Hoover / Mrs. Winfield (voice), Mother
-     #1 / Daughter / Mother in Monroe ad (voice), Princess Kashmir / Fe-Mail-Man / C
-    hurchgoer (voice), Luann Van Houten / Maude Flanders (voice), Camper #2 / Report
-    er (voice), Gov. Mary Bailey (voice), Elizabeth Hoover / Helen Lovejoy / Luann V
-    an Houten (voice), Maude Flanders / Helen Lovejoy (voice), Helen Lovejoy / Eliza
-    beth Hoover / Luann Van Houten (voice), Elizabeth Hoover / Luann Van Houten (voi
+    ovejoy / Luann Van Houten (voice), Elizabeth Hoover (voice), Helen Lovejoy / Eli
+    zabeth Hoover (voice), Elizabeth Hoover / Luann Van Houten (voice), Miss Hoover 
+    / Mrs. Winfield (voice), Princess Kashmir / Fe-Mail-Man / Churchgoer (voice), He
+    len Lovejoy / Elizabeth Hoover / Luann Van Houten (voice), Camper #2 / Reporter 
+    (voice), Gov. Mary Bailey (voice), Helen Lovejoy / Institute Council Member #3 (
+    voice), Mother #1 / Daughter / Mother in Monroe ad (voice), Luann Van Houten / M
+    aude Flanders (voice), Helen Lovejoy / Singing Waiters (voice), Elizabeth Hoover
+     / Helen Lovejoy / Luann Van Houten (voice), Maude Flanders / Helen Lovejoy (voi
     ce)
    thumb: https://image.tmdb.org/t/p/original/pLdSmH5HZYSwTd3aiPlZLbNzvPD.jpg
    order: 10
@@ -173,9 +173,9 @@ actors: (N>800)
    role:
     Lionel Hutz / Troy McClure / Lyle Lanley / others  (voice), Lionel Hutz (voice),
      Troy McClure (voice), Lionel Hutz / Troy McClure (voice), Troy McClure / Lionel
-     Hutz (voice), Tom / Nelson's Dad / Football Commentator / Announcer (voice), Tr
-    oy McClure / Jimmy Apollo (voice), Troy McClure / Joey / Godfather / Lionel Hutz
-     (voice), Stockbroker / Horst (voice), Lyle Lanley (voice)
+     Hutz (voice), Troy McClure / Jimmy Apollo (voice), Lyle Lanley (voice), Tom / N
+    elson's Dad / Football Commentator / Announcer (voice), Troy McClure / Joey / Go
+    dfather / Lionel Hutz (voice), Stockbroker / Horst (voice)
    thumb: https://image.tmdb.org/t/p/original/6LLX6bfWMD1MDN4DV2di8nzFZil.jpg
    order: 12
    imageHasChanged: false
@@ -189,19 +189,21 @@ actors: (N>800)
    name: Kevin Michael Richardson
    role:
     Dr. Hibbert (voice), Security Guard / Burns' Cellmate / many minor characters, N
-    arrator (voice), Dr. Hibbert / Bleeding Gums Murphy (voice), Security guard (voi
-    ce), Mr. Orlando / Mr. McBride (voice), Co-Pilot (voice), Oliver Hardy (voice), 
-    Dr. Hibbert / TSA Leader (voice), Devil Moe (voice), FBI Agent (voice), Groot (v
-    oice), Dr. Hibbert / Shaquille O'Neal (voice), Prison Guard (voice), SendEx Empl
-    oyee (voice), Nigerian King (voice), Rich Texan Accountant (voice), Jed Hawk (vo
-    ice), Film Student #2 (voice), Turtle NFT (voice), Prison Inmate (voice), Ghanai
-    an Man (voice), Conductor (voice)
+    arrator (voice), Dr. Hibbert / Bleeding Gums Murphy (voice), Dr. Hibbert / Shaqu
+    ille O'Neal (voice), Nigerian King (voice), SendEx Employee (voice), Film Studen
+    t #2 (voice), Conductor (voice), Dr. Hibbert / TSA Leader (voice), Mr. Orlando /
+     Mr. McBride (voice), Jed Hawk (voice), Rich Texan Accountant (voice), Turtle NF
+    T (voice), Security guard (voice), Co-Pilot (voice), Prison Inmate (voice), Oliv
+    er Hardy (voice), Ghanaian Man (voice), Devil Moe (voice), FBI Agent (voice), Gr
+    oot (voice), Prison Guard (voice)
    thumb: https://image.tmdb.org/t/p/original/xXt9Nh7RAT5bOen66TaXreNYmCl.jpg
    order: 14
    imageHasChanged: false
  - id: 110141
    name: Alex Désert
-   role: Carl Carlson (voice), Lou (voice), Carl Carlson / Lou (voice), Audrey II (voice)
+   role:
+    Carl Carlson (voice), Lou (voice), Audrey II (voice), Carl Carlson / Lou (voice)
+    , Carl Carlson/Fausto (voice)
    thumb: https://image.tmdb.org/t/p/original/iz5fLxrOTKYUkpUmGXgVfCfIZxn.jpg
    order: 15
    imageHasChanged: false
@@ -209,9 +211,9 @@ actors: (N>800)
    name: Grey DeLisle
    role:
     Martin Prince (voice), Sherri / Terri (voice), Sherri / Terri / Martin Prince (v
-    oice), (voice), Terri / Sherri / Martin Prince (voice), Terri (voice), Martin Pr
-    ince / Young Woman (voice), Gloria Prince / Martin Prince (voice), Riley (voice)
-    , Martin / Martin's Brother (voice)
+    oice), (voice), Martin Prince / Young Woman (voice), Terri / Sherri / Martin Pri
+    nce (voice), Martin / Martin's Brother (voice), Gloria Prince / Martin Prince (v
+    oice), Riley (voice), Terri (voice)
    thumb: https://image.tmdb.org/t/p/original/vrUHaXe1pG56yZkgH7Hs3LGRLTT.jpg
    order: 16
    imageHasChanged: false
@@ -225,18 +227,18 @@ actors: (N>800)
    name: Maurice LaMarche
    role:
     Army recruiter 2 / Billy / others characters (voice), Fox announcer / Chinese #1
-     / Chinese #4 / Leprechaun (voice), Orson Welles (voice), Hedonismbot Cosplayer 
-    (voice), Vincent Price (voice), Milo (voice)
+     / Chinese #4 / Leprechaun (voice), Vincent Price (voice), Milo (voice), Orson W
+    elles (voice), Hedonismbot Cosplayer (voice)
    thumb: https://image.tmdb.org/t/p/original/qCiL3EYAhLcNo0rNj5pczWo9MwG.jpg
    order: 18
    imageHasChanged: false
  - id: 16165
    name: Jon Lovitz
    role:
-    Artie Ziff / Llewellyn Sinclair / other minor characters., Artie Ziff (voice), S
-    elma's Cigarette (voice), Artie Ziff / Mr. Seckofsky (voice), Avery Devereaux / 
-    Aristotle Amandopoulis (voice), Llewellyn Sinclair / Ms. Sinclair (voice), Enric
-    o Irritazio (voice), Professor Lombardo / Donut Delivery Man (voice)
+    Artie Ziff / Llewellyn Sinclair / other minor characters., Artie Ziff (voice), A
+    rtie Ziff / Mr. Seckofsky (voice), Selma's Cigarette (voice), Professor Lombardo
+     / Donut Delivery Man (voice), Enrico Irritazio (voice), Llewellyn Sinclair / Ms
+    . Sinclair (voice), Avery Devereaux / Aristotle Amandopoulis (voice)
    thumb: https://image.tmdb.org/t/p/original/jBXSLoDEVwYkNqSVWHV9yDo8whA.jpg
    order: 19
    imageHasChanged: false

--- a/test/resources/scrapers/universalmusicscraper/metallica.ref.txt
+++ b/test/resources/scrapers/universalmusicscraper/metallica.ref.txt
@@ -153,6 +153,8 @@ discography: (N>100)
     year: 1993
   - title: Metallica "Live" Video Press Kit 1993
     year: 1993
+  - title: 6 Videos
+    year: 1993
   - title: One / Eye Of The Beholder
     year: 1993
   - title: Live Shit: Binge & Purge
@@ -248,8 +250,6 @@ discography: (N>100)
   - title: S & M Documentary
     year: 1999
   - title:  "S & M"  - Interview
-    year: 1999
-  - title: In The Studio "Load / Reload"
     year: 1999
 genres: (N=1)
   - Pop/Rock

--- a/test/resources/scrapers/video-buster/Findet-Dorie-183469.ref.txt
+++ b/test/resources/scrapers/video-buster/Findet-Dorie-183469.ref.txt
@@ -76,6 +76,7 @@ countries: (N=1)
 studios: (N=1)
   - Walt Disney Studios
 trailer: 
+showlink: 
 playcount: 0
 lastPlayed: <not set or invalid>
 dateAdded: <not set or invalid>


### PR DESCRIPTION
This commit adds `<showlink>` tag support to MediaElch.

Fix  #1753

The UI does not have a drop-down menu, but only a simple text field as of now.