### PR TITLE
fix(movies): Remove `uhd` from a movie's filename when setting a title

### DIFF
--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -212,13 +212,17 @@ void Settings::loadSettings()
         settings()->value(KEY_EXCLUDE_WORDS).toString().remove(" ").split(",", ElchSplitBehavior::SkipEmptyParts);
 
     if (m_excludeWords.isEmpty()) {
+        // TODO: Add upgrade-process;
+        //   currently, new entries won't reach the user because the values are stored on the system.
+        //   New:
+        //     2024-07-21: uhd
         m_excludeWords = QStringLiteral(
             "ac3,dts,ddp5.1,custom,dc,divx,divx5,dsr,dsrip,dutch,dvd,dvdrip,dvdscr,dvdscreener,screener,dvdivx,"
             "cam,fragment,fs,hdtv,hdrip,hdtvrip,internal,limited,"
             "multisubs,ntsc,ogg,ogm,pal,pdtv,proper,repack,rerip,retail,r3,r5,bd5,se,svcd,swedish,german,"
             "nfofix,unrated,ws,telesync,ts,telecine,tc,"
             "brrip,bdrip,480p,480i,576p,576i,720p,720i,1080p,1080i,2160p,"
-            "hrhd,hrhdtv,hddvd,uhdtv,uhdv,bluray,"
+            "hrhd,hrhdtv,hddvd,uhdtv,uhdv,bluray,uhd,"
             "x264,h264,h.264,h.265,h265,hevc,web-dl,"
             "xvid,xvidvd,xxx,www,mkv")
                              .split(",", ElchSplitBehavior::SkipEmptyParts);

--- a/test/unit/file/testNameFormatter.cpp
+++ b/test/unit/file/testNameFormatter.cpp
@@ -7,7 +7,22 @@ TEST_CASE("NameFormatter formats names", "[rename]")
 {
     // Just some words to search for.
     QStringList defaultExcludeWords{
-        "ac3", "dts", "divx5", "dsr", "dvd", "dvdrip", "fs", "hdtv", "480i", "720p", "1080p", "bluray", "h264", "mkv"};
+        "ac3",
+        "dts",
+        "divx5",
+        "dsr",
+        "dvd",
+        "dvdrip",
+        "fs",
+        "hdtv",
+        "480i",
+        "720p",
+        "1080p",
+        "bluray",
+        "h264",
+        "mkv",
+        "uhd", //
+    };
 
     SECTION("excludeWords works as expected")
     {
@@ -25,6 +40,10 @@ TEST_CASE("NameFormatter formats names", "[rename]")
             CHECK(NameFormatter::excludeWords("my-480i-movie") == "my movie");
             CHECK(NameFormatter::excludeWords("my.dsr.divx5.480i.movie") == "my movie");
             CHECK(NameFormatter::excludeWords("my[480i]movie") == "my movie");
+
+            // Issue #1773
+            CHECK(NameFormatter::excludeWords("THE_MATRIX_(1999)_(BLURAY)") == "THE_MATRIX_(1999)");
+            CHECK(NameFormatter::excludeWords("THE_MATRIX_(1999)_(UHD)") == "THE_MATRIX_(1999)");
         }
 
         SECTION("Only match basic words and not regex special characters")


### PR DESCRIPTION
Fix #1773