### PR TITLE
fix(TVMaze): Use TV shows actor's image by default, not the character's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@
   - The year in search results works again.
   - Loading of all tags works again.
 - fernsehserien.de: Fix scraping of episode's thumbnails.
-- TVMaze: The premiered-date of TV shows was not properly scraped (#1767).
+- TVMaze:
+  - The premiered-date of TV shows was not properly scraped (#1767)
+  - By default, the actor's image will be used, not the character's (#1800)
 - TV Show: The custom episode scraper may not have loaded details from IMDb.
 - Possible crash when clicking on empty episode thumbnails.
 - ADE: Search works again (#1737)

--- a/src/scrapers/tv_show/tvmaze/TvMazeShowParser.cpp
+++ b/src/scrapers/tv_show/tvmaze/TvMazeShowParser.cpp
@@ -155,10 +155,10 @@ void TvMazeShowParser::parseInfos(const QJsonDocument& json)
             actor.name = person["name"].toString();
             actor.role = character["name"].toString();
             actor.id = QString::number(person["id"].toInt());
-            if (character.contains("image")) {
-                actor.thumb = character["image"].toObject()["original"].toString();
-            } else {
+            if (person.contains("image")) {
                 actor.thumb = person["image"].toObject()["original"].toString();
+            } else {
+                actor.thumb = character["image"].toObject()["original"].toString();
             }
             m_show.addActor(actor);
         }


### PR DESCRIPTION
Fix #1800