### PR TITLE
feat: Add Kodi NFO `<hdrtype>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Added
 
 - Renamer: Placeholder `<tmdbId>` is now also available for TV shows and episodes (#1814)
+- NFO: `<hdrtype>` is now supported (#1810)
 
 ## 2.12.0 - 2024-10-13
 

--- a/MediaElch.pro
+++ b/MediaElch.pro
@@ -490,6 +490,7 @@ SOURCES += \
     src/ui/small_widgets/SlidingStackedWidget.cpp \
     src/ui/small_widgets/SpinBoxDelegate.cpp \
     src/ui/small_widgets/StereoModeComboBox.cpp \
+    src/ui/small_widgets/HdrTypeComboBox.cpp \
     src/ui/small_widgets/TagCloud.cpp \
     src/ui/small_widgets/TvShowTreeView.cpp \
     src/ui/small_widgets/WebImageLabel.cpp \
@@ -882,6 +883,7 @@ HEADERS += Version.h \
     src/ui/small_widgets/SlidingStackedWidget.h \
     src/ui/small_widgets/SpinBoxDelegate.h \
     src/ui/small_widgets/StereoModeComboBox.h \
+    src/ui/small_widgets/HdrTypeComboBox.h \
     src/ui/small_widgets/TagCloud.h \
     src/ui/small_widgets/TvShowTreeView.h \
     src/ui/small_widgets/WebImageLabel.h \

--- a/src/globals/Helper.cpp
+++ b/src/globals/Helper.cpp
@@ -485,26 +485,6 @@ QIcon iconForLabel(ColorLabel label)
     return QIcon(pixmap);
 }
 
-QMap<QString, QString> stereoModes()
-{
-    QMap<QString, QString> modes;
-    modes.insert("left_right", "side by side (left eye first)");
-    modes.insert("bottom_top", "top-bottom (right eye first)");
-    modes.insert("bottom_top", "top-bottom (left eye first)");
-    modes.insert("checkerboard_rl", "checkboard (right eye first)");
-    modes.insert("checkerboard_lr", "checkboard (left eye first)");
-    modes.insert("row_interleaved_rl", "row interleaved (right eye first)");
-    modes.insert("row_interleaved_lr", "row interleaved (left eye first)");
-    modes.insert("col_interleaved_rl", "column interleaved (right eye first)");
-    modes.insert("col_interleaved_lr", "column interleaved (left eye first)");
-    modes.insert("anaglyph_cyan_red", "anaglyph (cyan/red)");
-    modes.insert("right_left", "side by side (right eye first)");
-    modes.insert("anaglyph_green_magenta", "anaglyph (green/magenta)");
-    modes.insert("block_lr", "both eyes laced in one block (left eye first)");
-    modes.insert("block_rl", "both eyes laced in one block (right eye first)");
-    return modes;
-}
-
 QString matchResolution(int width, int height, const QString& scanType)
 {
     QString res;

--- a/src/globals/Helper.h
+++ b/src/globals/Helper.h
@@ -49,7 +49,6 @@ qreal similarity(const QString& s1, const QString& s2);
 QMap<ColorLabel, QString> labels();
 QColor colorForLabel(ColorLabel label, QString theme);
 QIcon iconForLabel(ColorLabel label);
-QMap<QString, QString> stereoModes();
 QString matchResolution(int width, int height, const QString& scanType);
 
 /// \brief Take the given URL and make an HTML link tag.

--- a/src/media/MediaInfoFile.cpp
+++ b/src/media/MediaInfoFile.cpp
@@ -111,18 +111,37 @@ QString MediaInfoFile::scanType(int streamIndex) const
     if (getVideo(streamIndex, "CodecID") == "V_MPEGH/ISO/HEVC") {
         return "progressive";
     }
-    QString scanType = getVideo(streamIndex, "ScanType");
+    const QString scanType = getVideo(streamIndex, "ScanType");
     if (scanType == "MBAFF") {
         return "interlaced";
     }
     return scanType.toLower();
 }
 
+QString MediaInfoFile::hdrType(int streamIndex) const
+{
+    // See https://en.wikipedia.org/wiki/High-dynamic-range_television for values.
+    // We map them to https://kodi.wiki/view/NFO_files/Movies -> `<hdrtype>`
+    const QString scanType = getVideo(streamIndex, "HDR_Format_Compatibility").toLower();
+
+    if (scanType.contains("hdr10")) {
+        return "hdr10";
+    }
+    if (scanType.contains("dolby")) {
+        return "dolbyvision";
+    }
+    if (scanType.contains("hlg")) {
+        return "hlg";
+    }
+
+    return scanType.toLower();
+}
+
 QString MediaInfoFile::stereoFormat(int streamIndex) const
 {
-    QString multiView = getVideo(streamIndex, "MultiView_Layout").toLower();
-    if (helper::stereoModes().values().contains(multiView)) {
-        return helper::stereoModes().key(multiView);
+    const QString multiView = getVideo(streamIndex, "MultiView_Layout").toLower();
+    if (StreamDetails::stereoModes().values().contains(multiView)) {
+        return StreamDetails::stereoModes().key(multiView);
     }
     return "";
 }

--- a/src/media/MediaInfoFile.h
+++ b/src/media/MediaInfoFile.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "media/Path.h"
+
 #include <QString>
 #include <chrono>
 #include <memory>
@@ -52,36 +54,37 @@ public:
 
     static bool hasMediaInfo();
 
-    bool isReady() const;
+    ELCH_NODISCARD bool isReady() const;
 
-    int subtitleCount() const;
-    int videoStreamCount() const;
-    int audioStreamCount() const;
+    ELCH_NODISCARD int subtitleCount() const;
+    ELCH_NODISCARD int videoStreamCount() const;
+    ELCH_NODISCARD int audioStreamCount() const;
 
     std::chrono::milliseconds duration(int streamIndex) const;
     std::size_t videoWidth(int streamIndex) const;
     std::size_t videoHeight(int streamIndex) const;
     double aspectRatio(int streamIndex) const;
-    QString codec(int streamIndex) const;
-    QString mpegVersion(int streamIndex) const;
-    QString scanType(int streamIndex) const;
-    QString stereoFormat(int streamIndex) const;
-    QString format(int streamIndex) const;
+    ELCH_NODISCARD QString codec(int streamIndex) const;
+    ELCH_NODISCARD QString mpegVersion(int streamIndex) const;
+    ELCH_NODISCARD QString scanType(int streamIndex) const;
+    ELCH_NODISCARD QString stereoFormat(int streamIndex) const;
+    ELCH_NODISCARD QString format(int streamIndex) const;
+    ELCH_NODISCARD QString hdrType(int streamIndex) const;
 
-    QString audioLanguage(int streamIndex) const;
-    QString audioCodec(int streamIndex) const;
-    QString audioChannels(int streamIndex) const;
+    ELCH_NODISCARD QString audioLanguage(int streamIndex) const;
+    ELCH_NODISCARD QString audioCodec(int streamIndex) const;
+    ELCH_NODISCARD QString audioChannels(int streamIndex) const;
 
-    QString subtitleLang(int streamIndex) const;
+    ELCH_NODISCARD QString subtitleLang(int streamIndex) const;
 
 private:
-    QString parseVideoFormat(QString format, QString version) const;
+    ELCH_NODISCARD QString parseVideoFormat(QString format, QString version) const;
 
-    QString getGeneral(int streamIndex, const char* parameter) const;
-    QString getVideo(int streamIndex, const char* parameter) const;
-    QString getAudio(int streamIndex, const char* parameter) const;
-    QStringList getAudio(int streamIndex, QStringList parameters) const;
-    QString getText(int streamIndex, const char* parameter) const;
+    ELCH_NODISCARD QString getGeneral(int streamIndex, const char* parameter) const;
+    ELCH_NODISCARD QString getVideo(int streamIndex, const char* parameter) const;
+    ELCH_NODISCARD QString getAudio(int streamIndex, const char* parameter) const;
+    ELCH_NODISCARD QStringList getAudio(int streamIndex, QStringList parameters) const;
+    ELCH_NODISCARD QString getText(int streamIndex, const char* parameter) const;
 
 private:
     // We don't want the MediaInfoLib include here so we avoid it by

--- a/src/media/StreamDetails.h
+++ b/src/media/StreamDetails.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "media/Path.h"
+#include "utils/Meta.h"
 
 #include <QMap>
 #include <QObject>
@@ -22,22 +23,36 @@ public:
         Width,
         Height,
         ScanType,
-        StereoMode
+        StereoMode,
+        HdrType, // added in v2.12.1
+        Unknown, // added in v2.12.1
     };
     enum class AudioDetails
     {
         Language,
         Codec,
-        Channels
+        Channels,
+        Unknown, // added in v2.12.1
     };
     enum class SubtitleDetails
     {
-        Language
+        Language,
+        Unknown, // added in v2.12.1
     };
 
-    static QString detailToString(VideoDetails details);
-    static QString detailToString(AudioDetails details);
-    static QString detailToString(SubtitleDetails details);
+    ELCH_NODISCARD static QVector<VideoDetails> allVideoDetailsAsList();
+    ELCH_NODISCARD static QVector<AudioDetails> allAudioDetailsAsList();
+    ELCH_NODISCARD static QVector<SubtitleDetails> allSubtitleDetailsAsList();
+
+    ELCH_NODISCARD static QString detailToString(VideoDetails details);
+    ELCH_NODISCARD static QString detailToString(AudioDetails details);
+    ELCH_NODISCARD static QString detailToString(SubtitleDetails details);
+    ELCH_NODISCARD static VideoDetails stringToVideoDetail(QString detail);
+    ELCH_NODISCARD static AudioDetails stringToAudioDetail(QString detail);
+    ELCH_NODISCARD static SubtitleDetails stringToSubtitleDetail(QString detail);
+
+    ELCH_NODISCARD static QMap<QString, QString> stereoModes();
+    ELCH_NODISCARD static QVector<QString> hdrTypes();
 
     /// \brief Loads stream details from the file. Returns true if successful.
     ELCH_NODISCARD bool loadStreamDetails();

--- a/src/media_center/KodiXml.h
+++ b/src/media_center/KodiXml.h
@@ -103,6 +103,11 @@ public:
 
     void loadBooklets(Album* album) override;
 
+    static void parseStreamDetails(QXmlStreamReader& reader, StreamDetails* streamDetails);
+    static void parseVideoStreamDetails(QXmlStreamReader& reader, StreamDetails* streamDetails);
+    static void parseAudioStreamDetails(QXmlStreamReader& reader, int streamNumber, StreamDetails* streamDetails);
+    static void parseSubtitleStreamDetails(QXmlStreamReader& reader, int streamNumber, StreamDetails* streamDetails);
+
 private:
     QByteArray getMovieXml(Movie* movie);
     QByteArray getConcertXml(Concert* concert);

--- a/src/media_center/kodi/ConcertXmlReader.cpp
+++ b/src/media_center/kodi/ConcertXmlReader.cpp
@@ -2,6 +2,7 @@
 
 #include "data/concert/Concert.h"
 #include "media/StreamDetails.h"
+#include "media_center/KodiXml.h"
 
 #include <QDate>
 #include <QDomDocument>
@@ -123,7 +124,7 @@ void ConcertXmlReader::parseConcert(QXmlStreamReader& reader)
         } else if (reader.name() == QLatin1String("fileinfo")) {
             while (reader.readNextStartElement()) {
                 if (reader.name() == QLatin1String("streamdetails")) {
-                    parseStreamDetails(reader);
+                    KodiXml::parseStreamDetails(reader, m_concert.streamDetails());
 
                 } else {
                     reader.skipCurrentElement();
@@ -252,115 +253,6 @@ void ConcertXmlReader::parsePoster(QXmlStreamReader& reader)
     }
 }
 
-void ConcertXmlReader::parseStreamDetails(QXmlStreamReader& reader)
-{
-    auto* streamDetails = m_concert.streamDetails();
-
-    int audioStreamNumber = 0;
-    int subtitleStreamNumber = 0;
-
-    while (reader.readNextStartElement()) {
-        if (reader.name() == QLatin1String("video")) {
-            parseVideoStreamDetails(reader, streamDetails);
-
-        } else if (reader.name() == QLatin1String("audio")) {
-            parseAudioStreamDetails(reader, audioStreamNumber, streamDetails);
-            ++audioStreamNumber;
-
-        } else if (reader.name() == QLatin1String("subtitle")) {
-            parseSubtitleStreamDetails(reader, subtitleStreamNumber, streamDetails);
-            ++subtitleStreamNumber;
-
-        } else {
-            reader.skipCurrentElement();
-        }
-    }
-
-    m_concert.streamDetails()->setLoaded(true);
-}
-
-void ConcertXmlReader::parseVideoStreamDetails(QXmlStreamReader& reader, StreamDetails* streamDetails)
-{
-    const auto readAndStore = [&reader, &streamDetails](StreamDetails::VideoDetails detail) {
-        const QString value = reader.readElementText();
-        if (!value.isEmpty()) {
-            streamDetails->setVideoDetail(detail, value);
-        }
-    };
-
-    while (reader.readNextStartElement()) {
-        if (reader.name() == StreamDetails::detailToString(StreamDetails::VideoDetails::Codec)) {
-            readAndStore(StreamDetails::VideoDetails::Codec);
-
-        } else if (reader.name() == StreamDetails::detailToString(StreamDetails::VideoDetails::Aspect)) {
-            readAndStore(StreamDetails::VideoDetails::Aspect);
-
-        } else if (reader.name() == StreamDetails::detailToString(StreamDetails::VideoDetails::Width)) {
-            readAndStore(StreamDetails::VideoDetails::Width);
-
-        } else if (reader.name() == StreamDetails::detailToString(StreamDetails::VideoDetails::Height)) {
-            readAndStore(StreamDetails::VideoDetails::Height);
-
-        } else if (reader.name() == StreamDetails::detailToString(StreamDetails::VideoDetails::DurationInSeconds)) {
-            readAndStore(StreamDetails::VideoDetails::DurationInSeconds);
-
-        } else if (reader.name() == StreamDetails::detailToString(StreamDetails::VideoDetails::ScanType)) {
-            readAndStore(StreamDetails::VideoDetails::ScanType);
-
-        } else if (reader.name() == StreamDetails::detailToString(StreamDetails::VideoDetails::StereoMode)) {
-            readAndStore(StreamDetails::VideoDetails::StereoMode);
-
-        } else {
-            reader.skipCurrentElement();
-        }
-    }
-}
-
-void ConcertXmlReader::parseAudioStreamDetails(QXmlStreamReader& reader, int streamNumber, StreamDetails* streamDetails)
-{
-    const auto readAndStore = [&](StreamDetails::AudioDetails detail) {
-        const QString value = reader.readElementText();
-        if (!value.isEmpty()) {
-            streamDetails->setAudioDetail(streamNumber, detail, value);
-        }
-    };
-
-    while (reader.readNextStartElement()) {
-        if (reader.name() == StreamDetails::detailToString(StreamDetails::AudioDetails::Codec)) {
-            readAndStore(StreamDetails::AudioDetails::Codec);
-
-        } else if (reader.name() == StreamDetails::detailToString(StreamDetails::AudioDetails::Language)) {
-            readAndStore(StreamDetails::AudioDetails::Language);
-
-        } else if (reader.name() == StreamDetails::detailToString(StreamDetails::AudioDetails::Channels)) {
-            readAndStore(StreamDetails::AudioDetails::Channels);
-
-        } else {
-            reader.skipCurrentElement();
-        }
-    }
-}
-
-void ConcertXmlReader::parseSubtitleStreamDetails(QXmlStreamReader& reader,
-    int streamNumber,
-    StreamDetails* streamDetails)
-{
-    const auto readAndStore = [&](StreamDetails::SubtitleDetails detail) {
-        const QString value = reader.readElementText();
-        if (!value.isEmpty()) {
-            streamDetails->setSubtitleDetail(streamNumber, detail, value);
-        }
-    };
-
-    while (reader.readNextStartElement()) {
-        if (reader.name() == StreamDetails::detailToString(StreamDetails::SubtitleDetails::Language)) {
-            readAndStore(StreamDetails::SubtitleDetails::Language);
-
-        } else {
-            reader.skipCurrentElement();
-        }
-    }
-}
 
 } // namespace kodi
 } // namespace mediaelch

--- a/src/media_center/kodi/ConcertXmlReader.h
+++ b/src/media_center/kodi/ConcertXmlReader.h
@@ -21,11 +21,6 @@ private:
     void parseFanart(QXmlStreamReader& reader);
     void parsePoster(QXmlStreamReader& reader);
 
-    void parseStreamDetails(QXmlStreamReader& reader);
-    void parseVideoStreamDetails(QXmlStreamReader& reader, StreamDetails* streamDetails);
-    void parseAudioStreamDetails(QXmlStreamReader& reader, int streamNumber, StreamDetails* streamDetails);
-    void parseSubtitleStreamDetails(QXmlStreamReader& reader, int streamNumber, StreamDetails* streamDetails);
-
 private:
     Concert& m_concert;
 };

--- a/src/ui/concerts/ConcertStreamDetailsWidget.ui
+++ b/src/ui/concerts/ConcertStreamDetailsWidget.ui
@@ -7,19 +7,24 @@
     <x>0</x>
     <y>0</y>
     <width>675</width>
-    <height>400</height>
+    <height>401</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <layout class="QGridLayout" name="streamDetails">
-     <item row="1" column="0">
-      <widget class="QLabel" name="lblCodec">
+     <item row="0" column="0">
+      <widget class="QLabel" name="lblVideo">
+       <property name="font">
+        <font>
+         <bold>true</bold>
+        </font>
+       </property>
        <property name="text">
-        <string>Codec</string>
+        <string>Video</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
        </property>
       </widget>
      </item>
@@ -32,66 +37,10 @@
         </size>
        </property>
        <property name="buttonSymbols">
-        <enum>QAbstractSpinBox::NoButtons</enum>
+        <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
        </property>
        <property name="decimals">
         <number>3</number>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QTimeEdit" name="videoDuration">
-       <property name="maximumSize">
-        <size>
-         <width>200</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="buttonSymbols">
-        <enum>QAbstractSpinBox::NoButtons</enum>
-       </property>
-       <property name="displayFormat">
-        <string>HH:mm:ss</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QLineEdit" name="videoScantype">
-       <property name="maximumSize">
-        <size>
-         <width>200</width>
-         <height>16777215</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="lblVideo">
-       <property name="font">
-        <font>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Video</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="labelStreamDetailsAudio">
-       <property name="font">
-        <font>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Audio</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
       </widget>
      </item>
@@ -101,17 +50,53 @@
         <string>Scantype</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
        </property>
       </widget>
      </item>
      <item row="6" column="0">
-      <widget class="QLabel" name="lblDuration">
+      <widget class="QLabel" name="lblHdrType">
        <property name="text">
-        <string>Duration</string>
+        <string>HDR Type</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QTimeEdit" name="videoDuration">
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+       </property>
+       <property name="displayFormat">
+        <string>HH:mm:ss</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="lblResolution">
+       <property name="text">
+        <string>Resolution</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="videoCodec">
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
        </property>
       </widget>
      </item>
@@ -120,7 +105,7 @@
        <item>
         <widget class="QSpinBox" name="videoWidth">
          <property name="buttonSymbols">
-          <enum>QAbstractSpinBox::NoButtons</enum>
+          <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
          </property>
          <property name="maximum">
           <number>9999</number>
@@ -137,7 +122,7 @@
        <item>
         <widget class="QSpinBox" name="videoHeight">
          <property name="buttonSymbols">
-          <enum>QAbstractSpinBox::NoButtons</enum>
+          <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
          </property>
          <property name="maximum">
           <number>99999</number>
@@ -147,7 +132,7 @@
        <item>
         <spacer name="horizontalSpacer_10">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -159,33 +144,58 @@
        </item>
       </layout>
      </item>
+     <item row="4" column="1">
+      <widget class="QLineEdit" name="videoScantype">
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>16777215</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="labelStreamDetailsAudio">
+       <property name="font">
+        <font>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Audio</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
      <item row="3" column="0">
       <widget class="QLabel" name="lblAspectRatio">
        <property name="text">
         <string>Aspect Ratio</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="videoCodec">
-       <property name="maximumSize">
-        <size>
-         <width>100</width>
-         <height>16777215</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="lblResolution">
+     <item row="1" column="0">
+      <widget class="QLabel" name="lblCodec">
        <property name="text">
-        <string>Resolution</string>
+        <string>Codec</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="lblDuration">
+       <property name="text">
+        <string>Duration</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
        </property>
       </widget>
      </item>
@@ -195,12 +205,29 @@
         <string>Stereo Mode</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
        </property>
       </widget>
      </item>
      <item row="5" column="1">
       <widget class="StereoModeComboBox" name="stereoMode"/>
+     </item>
+     <item row="6" column="1">
+      <widget class="HdrTypeComboBox" name="hdrType"/>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="lblVideoEmpty">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QLabel" name="lblAudioEmpty">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -227,7 +254,7 @@
      <item>
       <spacer name="horizontalSpacer_9">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -242,7 +269,7 @@
    <item>
     <spacer name="verticalSpacer_8">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -259,6 +286,11 @@
    <class>StereoModeComboBox</class>
    <extends>QComboBox</extends>
    <header>ui/small_widgets/StereoModeComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>HdrTypeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>ui/small_widgets/HdrTypeComboBox.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/ui/movies/MovieWidget.ui
+++ b/src/ui/movies/MovieWidget.ui
@@ -806,6 +806,75 @@
            <layout class="QVBoxLayout" name="verticalLayout_12">
             <item>
              <layout class="QGridLayout" name="streamDetails">
+              <item row="7" column="1">
+               <widget class="QTimeEdit" name="videoDuration">
+                <property name="maximumSize">
+                 <size>
+                  <width>200</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="buttonSymbols">
+                 <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                </property>
+                <property name="displayFormat">
+                 <string>HH:mm:ss</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="QLineEdit" name="videoScantype">
+                <property name="maximumSize">
+                 <size>
+                  <width>200</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="lblAspectRatio">
+                <property name="text">
+                 <string>Aspect Ratio</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QDoubleSpinBox" name="videoAspectRatio">
+                <property name="maximumSize">
+                 <size>
+                  <width>100</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="buttonSymbols">
+                 <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="0">
+               <widget class="QLabel" name="lblStereoMode">
+                <property name="text">
+                 <string>Stereo Mode</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="1">
+               <widget class="StereoModeComboBox" name="stereoMode">
+                <property name="sizeAdjustPolicy">
+                 <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
+                </property>
+               </widget>
+              </item>
               <item row="1" column="1">
                <widget class="QLineEdit" name="videoCodec">
                 <property name="maximumSize">
@@ -813,6 +882,41 @@
                   <width>100</width>
                   <height>16777215</height>
                  </size>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="0">
+               <widget class="QLabel" name="lblDuration">
+                <property name="text">
+                 <string>Duration</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="lblVideo">
+                <property name="font">
+                 <font>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Video</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="lblCodec">
+                <property name="text">
+                 <string>Codec</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                 </property>
                </widget>
               </item>
@@ -836,44 +940,8 @@
                 </property>
                </widget>
               </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="lblAspectRatio">
-                <property name="text">
-                 <string>Aspect Ratio</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="1">
-               <widget class="QLineEdit" name="videoScantype">
-                <property name="maximumSize">
-                 <size>
-                  <width>200</width>
-                  <height>16777215</height>
-                 </size>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QDoubleSpinBox" name="videoAspectRatio">
-                <property name="maximumSize">
-                 <size>
-                  <width>100</width>
-                  <height>16777215</height>
-                 </size>
-                </property>
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
-                </property>
-                <property name="decimals">
-                 <number>3</number>
-                </property>
-               </widget>
-              </item>
-              <item row="7" column="0">
-               <widget class="QLabel" name="labelStreamDetailsAudio">
+              <item row="8" column="0">
+               <widget class="QLabel" name="lblStreamDetailsAudio">
                 <property name="font">
                  <font>
                   <bold>true</bold>
@@ -881,47 +949,6 @@
                 </property>
                 <property name="text">
                  <string>Audio</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="lblVideo">
-                <property name="font">
-                 <font>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Video</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="1">
-               <widget class="QTimeEdit" name="videoDuration">
-                <property name="maximumSize">
-                 <size>
-                  <width>200</width>
-                  <height>16777215</height>
-                 </size>
-                </property>
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
-                </property>
-                <property name="displayFormat">
-                 <string>HH:mm:ss</string>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="0">
-               <widget class="QLabel" name="lblDuration">
-                <property name="text">
-                 <string>Duration</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
@@ -972,30 +999,30 @@
                 </item>
                </layout>
               </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="lblCodec">
+              <item row="6" column="1">
+               <widget class="HdrTypeComboBox" name="hdrType"/>
+              </item>
+              <item row="6" column="0">
+               <widget class="QLabel" name="lblHdrType">
                 <property name="text">
-                 <string>Codec</string>
+                 <string>HDR Type</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                 </property>
                </widget>
               </item>
-              <item row="5" column="0">
-               <widget class="QLabel" name="lblStereoMode">
+              <item row="0" column="1">
+               <widget class="QLabel" name="lblVideoEmpty">
                 <property name="text">
-                 <string>Stereo Mode</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                 <string/>
                 </property>
                </widget>
               </item>
-              <item row="5" column="1">
-               <widget class="StereoModeComboBox" name="stereoMode">
-                <property name="sizeAdjustPolicy">
-                 <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
+              <item row="8" column="1">
+               <widget class="QLabel" name="lblAudioEmpty">
+                <property name="text">
+                 <string/>
                 </property>
                </widget>
               </item>
@@ -1632,6 +1659,16 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>StereoModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>ui/small_widgets/StereoModeComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>HdrTypeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>ui/small_widgets/HdrTypeComboBox.h</header>
+  </customwidget>
+  <customwidget>
    <class>ImageGallery</class>
    <extends>QWidget</extends>
    <header>ui/small_widgets/ImageGallery.h</header>
@@ -1664,11 +1701,6 @@
    <extends>QWidget</extends>
    <header>ui/small_widgets/RatingsWidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>StereoModeComboBox</class>
-   <extends>QComboBox</extends>
-   <header>ui/small_widgets/StereoModeComboBox.h</header>
   </customwidget>
   <customwidget>
    <class>MediaFlags</class>

--- a/src/ui/small_widgets/CMakeLists.txt
+++ b/src/ui/small_widgets/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(
   SlidingStackedWidget.cpp
   SpinBoxDelegate.cpp
   StereoModeComboBox.cpp
+  HdrTypeComboBox.cpp
   TagCloud.cpp
   TvShowTreeView.cpp
   WebImageLabel.cpp

--- a/src/ui/small_widgets/HdrTypeComboBox.cpp
+++ b/src/ui/small_widgets/HdrTypeComboBox.cpp
@@ -1,0 +1,15 @@
+#include "ui/small_widgets/HdrTypeComboBox.h"
+
+#include "media/StreamDetails.h"
+
+HdrTypeComboBox::HdrTypeComboBox(QWidget* parent) : QComboBox(parent)
+{
+    blockSignals(true);
+
+    addItem("", "");
+    QList<QString> types = StreamDetails::hdrTypes();
+    for (QString& type : types) {
+        addItem(type, type);
+    }
+    blockSignals(false);
+}

--- a/src/ui/small_widgets/HdrTypeComboBox.h
+++ b/src/ui/small_widgets/HdrTypeComboBox.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <QComboBox>
+
+/// \brief A combo box that lists HDR types.
+class HdrTypeComboBox : public QComboBox
+{
+    Q_OBJECT
+
+public:
+    explicit HdrTypeComboBox(QWidget* parent = nullptr);
+    ~HdrTypeComboBox() override = default;
+};

--- a/src/ui/small_widgets/StereoModeComboBox.cpp
+++ b/src/ui/small_widgets/StereoModeComboBox.cpp
@@ -1,13 +1,13 @@
 #include "ui/small_widgets/StereoModeComboBox.h"
 
-#include "globals/Helper.h"
+#include "media/StreamDetails.h"
 
 StereoModeComboBox::StereoModeComboBox(QWidget* parent) : QComboBox(parent)
 {
     blockSignals(true);
 
     addItem("", "");
-    QMap<QString, QString> modes = helper::stereoModes();
+    QMap<QString, QString> modes = StreamDetails::stereoModes();
     QMapIterator<QString, QString> it(modes);
     while (it.hasNext()) {
         it.next();

--- a/src/ui/tv_show/TvShowWidgetEpisode.ui
+++ b/src/ui/tv_show/TvShowWidgetEpisode.ui
@@ -1074,51 +1074,45 @@
          <layout class="QVBoxLayout" name="verticalLayout_6">
           <item>
            <layout class="QGridLayout" name="streamDetails">
-            <item row="4" column="0">
-             <widget class="QLabel" name="lblScanType">
-              <property name="text">
-               <string>Scantype</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="6" column="1">
-             <widget class="QTimeEdit" name="videoDuration">
+            <item row="1" column="1">
+             <widget class="QLineEdit" name="videoCodec">
               <property name="maximumSize">
                <size>
-                <width>200</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="buttonSymbols">
-               <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
-              </property>
-              <property name="displayFormat">
-               <string>HH:mm:ss</string>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="1">
-             <widget class="QLineEdit" name="videoScantype">
-              <property name="maximumSize">
-               <size>
-                <width>200</width>
+                <width>100</width>
                 <height>16777215</height>
                </size>
               </property>
              </widget>
             </item>
-            <item row="7" column="0">
-             <widget class="QLabel" name="labelStreamDetailsAudio">
+            <item row="0" column="0">
+             <widget class="QLabel" name="lblVideo">
               <property name="font">
                <font>
                 <bold>true</bold>
                </font>
               </property>
               <property name="text">
-               <string>Audio</string>
+               <string>Video</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="lblResolution">
+              <property name="text">
+               <string>Resolution</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="lblScanType">
+              <property name="text">
+               <string>Scantype</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
@@ -1179,13 +1173,19 @@
               </item>
              </layout>
             </item>
-            <item row="6" column="0">
-             <widget class="QLabel" name="lblDuration">
-              <property name="text">
-               <string>Duration</string>
+            <item row="7" column="1">
+             <widget class="QTimeEdit" name="videoDuration">
+              <property name="maximumSize">
+               <size>
+                <width>200</width>
+                <height>16777215</height>
+               </size>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+              <property name="buttonSymbols">
+               <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+              </property>
+              <property name="displayFormat">
+               <string>HH:mm:ss</string>
               </property>
              </widget>
             </item>
@@ -1205,48 +1205,10 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
-             <widget class="QLineEdit" name="videoCodec">
-              <property name="maximumSize">
-               <size>
-                <width>100</width>
-                <height>16777215</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="lblResolution">
-              <property name="text">
-               <string>Resolution</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="lblVideo">
-              <property name="font">
-               <font>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>Video</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="lblCodec">
-              <property name="text">
-               <string>Codec</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+            <item row="5" column="1">
+             <widget class="StereoModeComboBox" name="stereoMode">
+              <property name="sizeAdjustPolicy">
+               <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
               </property>
              </widget>
             </item>
@@ -1260,10 +1222,75 @@
               </property>
              </widget>
             </item>
-            <item row="5" column="1">
-             <widget class="StereoModeComboBox" name="stereoMode">
-              <property name="sizeAdjustPolicy">
-               <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
+            <item row="8" column="0">
+             <widget class="QLabel" name="lblStreamDetailsAudio">
+              <property name="font">
+               <font>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Audio</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="0">
+             <widget class="QLabel" name="lblDuration">
+              <property name="text">
+               <string>Duration</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QLineEdit" name="videoScantype">
+              <property name="maximumSize">
+               <size>
+                <width>200</width>
+                <height>16777215</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="lblCodec">
+              <property name="text">
+               <string>Codec</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="0">
+             <widget class="QLabel" name="lblHdrType">
+              <property name="text">
+               <string>HDR Type</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="1">
+             <widget class="HdrTypeComboBox" name="hdrType"/>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLabel" name="lblVideoEmpty">
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item row="8" column="1">
+             <widget class="QLabel" name="lblAudioEmpty">
+              <property name="text">
+               <string/>
               </property>
              </widget>
             </item>
@@ -1411,6 +1438,16 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>StereoModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>ui/small_widgets/StereoModeComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>HdrTypeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>ui/small_widgets/HdrTypeComboBox.h</header>
+  </customwidget>
+  <customwidget>
    <class>TagCloud</class>
    <extends>QWidget</extends>
    <header>ui/small_widgets/TagCloud.h</header>
@@ -1426,11 +1463,6 @@
    <extends>QWidget</extends>
    <header>ui/small_widgets/RatingsWidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>StereoModeComboBox</class>
-   <extends>QComboBox</extends>
-   <header>ui/small_widgets/StereoModeComboBox.h</header>
   </customwidget>
   <customwidget>
    <class>MediaFlags</class>


### PR DESCRIPTION
Kodi's `<hdrtype>` tag is now supported. We load the HDR type via mediainfolib's `HDR_Format_Compatibility`.  Tested for HDR10 files.

Fix #1810