### PR TITLE
feat(TvMaze): Allow loading actor images for single-episode scrape jobs

### DIFF
--- a/src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.cpp
+++ b/src/scrapers/tv_show/tvmaze/TvMazeEpisodeScrapeJob.cpp
@@ -50,10 +50,19 @@ void TvMazeEpisodeScrapeJob::loadAllEpisodes(const TvMazeId& showId)
     m_api.loadAllEpisodes(showId, [this, showId](QJsonDocument json, ScraperError error) {
         if (error.hasError()) {
             setScraperError(error);
+            emitFinished();
         } else {
             TvMazeEpisodeParser::parseEpisodeFromOverview(episode(), json);
+            // The "all episodes" page only contains basic details.
+            // To get all details we need, load details based on the episode's ID.
+            if (episode().tvmazeId().isValid()) {
+               const TvMazeId id = episode().tvmazeId();
+                episode().clear(); // avoid re-loading ratings, etc.
+                loadEpisode(id);
+            } else {
+                emitFinished();
+            }
         }
-        emitFinished();
     });
 }
 

--- a/src/scrapers/tv_show/tvmaze/TvMazeSeasonScrapeJob.cpp
+++ b/src/scrapers/tv_show/tvmaze/TvMazeSeasonScrapeJob.cpp
@@ -30,7 +30,7 @@ void TvMazeSeasonScrapeJob::doStart()
 
     // Simply load all episodes for the show.
     // TVmaze does not have an API for scraping a single season.
-    // Furthermore this makes it possible to use the cache and avoid reaching
+    // Furthermore, this makes it possible to use the cache and avoid reaching
     // their rate limit.
 
     m_api.loadAllEpisodes(m_showId, [this](QJsonDocument json, ScraperError error) {

--- a/test/resources/scrapers/tvmaze/The-Simpsons-S12E19-all-details.ref.txt
+++ b/test/resources/scrapers/tvmaze/The-Simpsons-S12E19-all-details.ref.txt
@@ -29,6 +29,30 @@ epBookmark: <not set or invalid>
 certification: 
 networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173070.jpg
-actors: (N=0)
+actors: (N<6)
+ - id: 44735
+   name: Tress MacNeille
+   role: Agnes Skinner
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/123/307705.jpg
+   order: 0
+   imageHasChanged: false
+ - id: 53565
+   name: Marcia Mitzman Gaven
+   role: Helen Lovejoy
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/196/491653.jpg
+   order: 1
+   imageHasChanged: false
+ - id: 53571
+   name: Shawn Colvin
+   role: Rachel Jordan
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/498/1245834.jpg
+   order: 2
+   imageHasChanged: false
+ - id: 47222
+   name: Karl Wiedergott
+   role: Travolta
+   thumb: 
+   order: 3
+   imageHasChanged: false
 streamDetails: <not loaded>
 files: (N=0)

--- a/test/resources/scrapers/tvmaze/The-Simpsons-S12E19-minimal-details.ref.txt
+++ b/test/resources/scrapers/tvmaze/The-Simpsons-S12E19-minimal-details.ref.txt
@@ -29,6 +29,30 @@ epBookmark: <not set or invalid>
 certification: 
 networks: (N=0)
 thumbnail: https://static.tvmaze.com/uploads/images/original_untouched/69/173070.jpg
-actors: (N=0)
+actors: (N<6)
+ - id: 44735
+   name: Tress MacNeille
+   role: Agnes Skinner
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/123/307705.jpg
+   order: 0
+   imageHasChanged: false
+ - id: 53565
+   name: Marcia Mitzman Gaven
+   role: Helen Lovejoy
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/196/491653.jpg
+   order: 1
+   imageHasChanged: false
+ - id: 53571
+   name: Shawn Colvin
+   role: Rachel Jordan
+   thumb: https://static.tvmaze.com/uploads/images/original_untouched/498/1245834.jpg
+   order: 2
+   imageHasChanged: false
+ - id: 47222
+   name: Karl Wiedergott
+   role: Travolta
+   thumb: 
+   order: 3
+   imageHasChanged: false
 streamDetails: <not loaded>
 files: (N=0)


### PR DESCRIPTION
Follow up to b4c73e76d322dc20d61c73f373112779f09f5d16

With this change, if a user selects a single episode, more details can be loaded.

I did not yet implement it for full TV show / season loading, as we would likely hit TvMaze's rate limiting.

Before we can do that, we need to implement a custom rate limiter.

For #1801
