### PR TITLE
fix(TMDB): Don't abort after failing to load unknown season

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   - If a scraper returns an error, in some cases the search bar remained stuck.
 - HotMovies/AdultDvdEmpire: Search works again (#1811)
 - IMDb: Writers/Directors are scraped again for TV show episodes (#1832)
+- TMDB: If there is an unknown season, and you want to load _all_ episodes, MediaElch
+  aborted scraping after failing to load the unknown season (#1692)
 
 ### Changed
 

--- a/src/scrapers/tv_show/SeasonScrapeJob.h
+++ b/src/scrapers/tv_show/SeasonScrapeJob.h
@@ -76,7 +76,7 @@ signals:
     /// \details A simple wrapper around finished() to avoid static_asserts
     ///          from Job* to SeasonScrapeJob*.
     ///          Use hasError() and tvShow() to know whether the request was successful.
-    void loadFinished(mediaelch::scraper::SeasonScrapeJob* scrapeJob, QPrivateSignal);
+    void loadFinished(SeasonScrapeJob* scrapeJob, QPrivateSignal);
 
 protected:
     void setScraperError(ScraperError error);

--- a/src/scrapers/tv_show/custom/CustomSeasonScrapeJob.cpp
+++ b/src/scrapers/tv_show/custom/CustomSeasonScrapeJob.cpp
@@ -84,6 +84,7 @@ void CustomSeasonScrapeJob::loadWithScraper(const QString& scraperId, const Show
     connect(scrapeJob, &SeasonScrapeJob::loadFinished, this, [this](SeasonScrapeJob* job) {
         {
             // locking to avoid concurrent access to m_episodes
+            // FIXME: We're not multithreaded here!
             QMutexLocker locker(&m_loadMutex);
             copyDetailsToEpisodeMap(m_episodes, job->episodes(), job->config().details, this);
         }


### PR DESCRIPTION
If there is an unknown season, and you want to load _all_ episodes, MediaElch aborted scraping after failing to load the unknown season.

Fix #1692