### PR TITLE
fix(debian: Add libqt6svg6 to the package dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Package: mediaelch
 Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
+         libqt6svg6,
          libmediainfo0v5,
          libzen0v5,
 Description: Media Manager for Kodi


### PR DESCRIPTION
It seems that ${shlibs:Depends} missed the dependency on libqt6svg6. Put it in the Depends to fix issues with svg images.

This should fix: https://github.com/Komet/MediaElch/issues/1859