### PR TITLE
fix(TVMaze): Add UI option to scrape episode's writer/director

### DIFF
--- a/src/scrapers/tv_show/tvmaze/TvMaze.cpp
+++ b/src/scrapers/tv_show/tvmaze/TvMaze.cpp
@@ -40,6 +40,8 @@ TvMaze::TvMaze(TvMazeConfiguration& settings, QObject* parent) : TvScraper(paren
     };
     m_meta.supportedEpisodeDetails = {
         EpisodeScraperInfo::Actors,
+        EpisodeScraperInfo::Writer,
+        EpisodeScraperInfo::Director,
         EpisodeScraperInfo::Title,
         EpisodeScraperInfo::FirstAired,
         EpisodeScraperInfo::Thumbnail,


### PR DESCRIPTION
Follow up to 4c113d53cff18a3408097606e7d6966771ea238f / #1880

Fix #1877

<img width="784" alt="Screenshot 2025-06-16 at 19 04 42" src="https://github.com/user-attachments/assets/d95ee0fa-69dc-40c4-b262-1e682407a9df" />
