### PR TITLE
fix(TvShow): Properly reset navigation bar after downloads are finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   - If a scraper returns an error, in some cases the search bar remained stuck.
   - A quick-open menu for concerts was added, similar to movies.
     Open it by clicking <kbd>Ctrl+O</kbd> (<kbd>⌘+O</kbd> on macOS)
+  - After scraping a single episode, the UI did not allow saving.
+    You had to select another episode again (#1896)
 - HotMovies/AdultDvdEmpire: Search works again (#1811)
 - IMDb: Writers/Directors are scraped again for TV show episodes (#1832)
 - TMDB: If there is an unknown season, and you want to load _all_ episodes, MediaElch

--- a/src/network/DownloadManager.cpp
+++ b/src/network/DownloadManager.cpp
@@ -193,7 +193,7 @@ void DownloadManager::startNextDownload()
         } else if (download.imageType == ImageType::TvShowEpisodeThumb && !download.directDownload) {
             download.episode->setThumbnailImage(data);
 
-        } else {
+        } else { // TODO: Why the "else"?
             emit sigDownloadFinished(download);
         }
         startNextDownload();
@@ -285,7 +285,7 @@ void DownloadManager::downloadFinished()
     } else if (downloadElelement.imageType == ImageType::TvShowEpisodeThumb && !downloadElelement.directDownload) {
         downloadElelement.episode->setThumbnailImage(data);
 
-    } else {
+    } else { // TODO: Why the "else"?
         emit sigDownloadFinished(downloadElelement);
     }
 

--- a/src/ui/tv_show/TvShowWidgetEpisode.cpp
+++ b/src/ui/tv_show/TvShowWidgetEpisode.cpp
@@ -76,6 +76,11 @@ TvShowWidgetEpisode::TvShowWidgetEpisode(QWidget* parent) :
         this,
         &TvShowWidgetEpisode::onPosterDownloadFinished,
         static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
+    connect(m_imageDownloadManager,
+        &DownloadManager::allDownloadsFinished,
+        this,
+        &TvShowWidgetEpisode::onAllPosterDownloadFinished,
+        static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
     connect(ui->buttonRevert, &QAbstractButton::clicked, this, &TvShowWidgetEpisode::onRevertChanges);
     connect(ui->buttonPlay, &QAbstractButton::clicked, this, &TvShowWidgetEpisode::onPlayEpisode);
     connect(
@@ -849,11 +854,14 @@ void TvShowWidgetEpisode::onPosterDownloadFinished(DownloadManagerElement elem)
             Manager::instance()->mediaCenterInterface()->imageFileName(elem.episode, ImageType::TvShowEpisodeThumb)));
         elem.episode->setThumbnailImage(elem.data);
     }
-    if (m_imageDownloadManager->downloadQueueSize() == 0) {
-        emit sigSetActionSaveEnabled(true, MainWidgets::TvShows);
-        emit sigSetActionSearchEnabled(true, MainWidgets::TvShows);
-    }
 }
+
+void TvShowWidgetEpisode::onAllPosterDownloadFinished()
+{
+    emit sigSetActionSaveEnabled(true, MainWidgets::TvShows);
+    emit sigSetActionSearchEnabled(true, MainWidgets::TvShows);
+}
+
 
 /**
  * \brief Adds a director

--- a/src/ui/tv_show/TvShowWidgetEpisode.h
+++ b/src/ui/tv_show/TvShowWidgetEpisode.h
@@ -45,6 +45,7 @@ private slots:
     void onDeleteThumbnail();
     void onImageDropped(ImageType imageType, QUrl imageUrl);
     void onPosterDownloadFinished(DownloadManagerElement elem);
+    void onAllPosterDownloadFinished();
     void onLoadDone(QSet<EpisodeScraperInfo> details);
     void onRevertChanges();
     void onCaptureImage(ImageType type);


### PR DESCRIPTION
We did not reset the navigation bar, i.e. all navigation icons remained greyed out.

Fix #1896
