### PR TITLE
fix(music): Don't assume that an album can be found; fix crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
   aborted scraping after failing to load the unknown season (#1692)
 - Improved media codec detection for HDR10 and dolby vision (#1883).
   Thanks to GitHub user `@Quppa` for the help!
+- Music: If an album's cover can't be found, MediaElch may have crashed (#1918)
 
 ### Changed
 

--- a/src/scrapers/image/FanartTvMusic.cpp
+++ b/src/scrapers/image/FanartTvMusic.cpp
@@ -278,11 +278,13 @@ QVector<Poster> FanartTvMusic::parseData(QString json, ImageType type) const
         auto jsonObj = parsedJson.object();
 
         // The JSON for CD Art and Thumbs has a different structure. This is a "hack"
-        // to get a uniform one. We grab the last album (sorted lexicographical by key).
+        // to get a uniform one. We grab the last album, if there is one (sorted lexicographical by key).
         if (type == ImageType::AlbumCdArt || type == ImageType::AlbumThumb) {
             const auto albums = jsonObj.value("albums").toObject();
-            const auto key = albums.keys().back();
-            return albums.value(key).toObject();
+            if (!albums.isEmpty()) {
+                const auto key = albums.keys().back();
+                return albums.value(key).toObject();
+            }
         }
 
         return jsonObj;


### PR DESCRIPTION
MediaElch assumed that there is at least one album when searching for Fanart.  That's not always the case and `.back()` throws an assertion.

Fix #1918
