### PR TITLE
feat(IMDb): Allow scraping actors for TV shows and episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,10 @@
 
 ### Added
 
-- TVMaze can now load episodes' guest cast (actors) for single-episode scraping (#1801)
-- TVMaze can now load episodes' guest crew (directors, writers) for single-episode scraping (#1877)
+- IMDb: Actors can now be loaded for TV shows and episodes (#1898)
+- TVMaze:
+  - TvMaze can now load episodes' guest cast (actors) for single-episode scraping (#1801)
+  - TVMaze can now load episodes' guest crew (directors, writers) for single-episode scraping (#1877)
 - NFO: `<hdrtype>` is now supported (#1810)
 - Renamer:
   - Placeholder `<tmdbId>` is now also available for TV shows and episodes (#1814)

--- a/src/scrapers/tv_show/imdb/ImdbTv.cpp
+++ b/src/scrapers/tv_show/imdb/ImdbTv.cpp
@@ -25,6 +25,7 @@ ImdbTv::ImdbTv(ImdbTvConfiguration& settings, QObject* parent) : TvScraper(paren
     m_meta.privacyPolicy = "https://www.imdb.com/privacy";
     m_meta.help = "https://help.imdb.com";
     m_meta.supportedShowDetails = {ShowScraperInfo::Title,
+        ShowScraperInfo::Actors,
         ShowScraperInfo::Genres,
         ShowScraperInfo::Certification,
         ShowScraperInfo::Overview,
@@ -34,7 +35,7 @@ ImdbTv::ImdbTv(ImdbTvConfiguration& settings, QObject* parent) : TvScraper(paren
         ShowScraperInfo::FirstAired,
         ShowScraperInfo::Poster};
     m_meta.supportedEpisodeDetails = {EpisodeScraperInfo::Title,
-        // EpisodeScraperInfo::Actors,
+        EpisodeScraperInfo::Actors,
         EpisodeScraperInfo::Overview,
         EpisodeScraperInfo::Director,
         EpisodeScraperInfo::Writer,


### PR DESCRIPTION
Since #1912, the IMDb TV scraper can also scrape actors for TV shows and episodes.  This commit makes it possible to enable scraping them in the UI.

Fix #1898
