### PR TITLE
feat(imdb): Load movie's overview/plot from IMDb

### DIFF
--- a/src/scrapers/imdb/ImdbApi.cpp
+++ b/src/scrapers/imdb/ImdbApi.cpp
@@ -109,7 +109,7 @@ QUrl ImdbApi::makeTitleUrl(const ImdbId& id, PageKind page) const
         switch (page) {
         case PageKind::Main: return "";
         case PageKind::Reference: return "reference";
-        case PageKind::PlotSummary: return "plotsummaryre";
+        case PageKind::PlotSummary: return "plotsummary";
         case PageKind::ReleaseInfo: return "releaseinfo";
         case PageKind::Keywords: return "keywords";
         case PageKind::Episodes: return "episodes";

--- a/src/scrapers/imdb/ImdbJsonParser.h
+++ b/src/scrapers/imdb/ImdbJsonParser.h
@@ -55,6 +55,7 @@ class ImdbJsonParser
 {
 public:
     static ImdbData parseFromReferencePage(const QString& html, const mediaelch::Locale& preferredLocale);
+    static Optional<QString> parseOverviewFromPlotSummaryPage(const QString& html);
     static QVector<int> parseSeasonNumbersFromEpisodesPage(const QString& html);
     static QVector<ImdbShortEpisodeData> parseEpisodeIds(const QString& html);
 
@@ -63,10 +64,14 @@ public:
 private:
     ImdbJsonParser() = default;
 
-    void parserAndAssignDetails(const QJsonDocument& json, const mediaelch::Locale& preferredLocale);
+    void parseAndAssignDetails(const QJsonDocument& json, const mediaelch::Locale& preferredLocale);
     void parseAndAssignDirectors(const QJsonDocument& json);
     void parseAndStoreActors(const QJsonDocument& json);
     void parseAndAssignWriters(const QJsonDocument& json);
+    /// \brief   Parse and assign the plot/overview from IMDB's `/plotsummary` page.
+    /// \details IMDB's `/reference` page does not include a movie's plot, only an outline.
+    ///          Hence, we use `/plotsummary` to get the full plot.
+    void parseAndAssignOverviewFromPlotSummary(const QJsonDocument& json);
 
     /// Sanitize the given URL. Return value is the same object as the input string.
     static QString sanitizeAmazonMediaUrl(QString url);

--- a/src/scrapers/movie/imdb/ImdbMovieScrapeJob.h
+++ b/src/scrapers/movie/imdb/ImdbMovieScrapeJob.h
@@ -20,9 +20,11 @@ public:
 
 private:
     void loadTags();
+    void loadPlotSummary();
 
     void parseAndAssignInfos(const QString& html);
     void parseAndAssignTags(const QString& html);
+    void parseAndAssignOverviewFromPlotSummaryPage(const QString& html);
 
     static QString sanitizeAmazonMediaUrl(QString url);
 

--- a/src/ui/small_widgets/ScrapePreview.cpp
+++ b/src/ui/small_widgets/ScrapePreview.cpp
@@ -47,10 +47,11 @@ void ScrapePreview::onScrapeJobFinished(mediaelch::worker::Job* scrapeJob)
         // If it was aborted, do not clear adapter; was done before
         return;
     }
-    if (!scrapeJob->hasError()) {
-        MediaElch_Expects(m_currentAdapter != nullptr);
-        MediaElch_Expects(scrapeJob == m_currentAdapter->scrapeJob());
 
+    MediaElch_Expects(m_currentAdapter != nullptr);
+    MediaElch_Expects(scrapeJob == m_currentAdapter->scrapeJob());
+
+    if (!scrapeJob->hasError()) {
         ui->lblDescriptionContent->setPlainText(m_currentAdapter->description());
         ui->poster->clearAndAbortDownload();
 
@@ -59,6 +60,8 @@ void ScrapePreview::onScrapeJobFinished(mediaelch::worker::Job* scrapeJob)
         if (url.isValid()) {
             ui->poster->showImageFrom(url);
         }
+    } else {
+        clearAndAbortPreview();
     }
     m_currentAdapter = nullptr;
 }

--- a/test/resources/scrapers/imdb/Finding_Dory_tt2277860.ref.txt
+++ b/test/resources/scrapers/imdb/Finding_Dory_tt2277860.ref.txt
@@ -9,11 +9,183 @@ title: Finding Dory
 sortTitle: 
 originalTitle: Finding Dory
 overview:
-    Dory is a wide-eyed, blue tang fish who suffers from memory loss every 10 second
-    s or so. The one thing she can remember is that she somehow became separated fro
-    m her parents as a child. With help from her friends Nemo and Marlin, Dory embar
-    ks on an epic adventure to find them. Her journey brings her to the Marine Life 
-    Institute, a conservatory that houses diverse ocean species.
+    Dory, the regal blue tang, gets separated from her parents, Jenny and Charlie, a
+    s a child. Jenny and Charlie used to play games with Dory to help her overcome h
+    er memory loss. Weeks later, Dory was swimming in the ocean alone, asking other 
+    fish for help, but since she couldn't remember anything, nobody could help her. 
+    As she grows up, she gradually forgets them due to her short-term memory loss. S
+    he eventually meets and joins the clown-fish Marlin, looking for his son, Nemo, 
+    who was taken by divers to Sydney, Australia.
+
+One year after reuniting Nemo wit
+    h his father Marlin (Albert Brooks), Dory (Ellen DeGeneres) has become a helping
+     hand in raising Nemo (Hayden Rolence). They all swim up to Mr. Ray (Bob Peterso
+    n), who is leading the class on a field trip. Dory volunteers to go along as an 
+    assistant and Mr. Ray reluctantly agrees. He talks to the class about migration 
+    and tells them that it's about going home. One kid asks Dory where her home is. 
+    The word "home" triggers a flash of a memory in her mind, but she quickly loses 
+    it. She swims near the rays and gets sucked into the undertow. Dory remembers be
+    ing pulled away from her parents and then everything going black.
+
+Mr. Ray finds
+     her lying in the sand and she murmurs "Jewel of Morro Bay, California." When sh
+    e wakes up, she realizes that she had a memory, something that never happened be
+    fore. She remembers her family and realizes that they're still out in the ocean,
+     somewhere, with no idea where she is. She sets out for the Jewel of Morro Bay w
+    ith Marlin and Nemo following to keep her out of trouble. Marlin has an idea for
+     how to get where they're going quickly.
+
+With the help of Crush (Andrew Stanton
+    ) a sea turtle, they ride a water current to California. They jump off and see a
+     sunken container ship, and a group of hermit crabs taking cover. The crabs shus
+    h Dory when she tries to ask for help, triggering another memory. As a young fis
+    h, she swam past a sunken ship and asked a group of crabs for help finding her p
+    arents, Jenny and Charlie, and they quickly shushed her.
+
+Upon arrival, they are
+     forced to flee from a predatory giant squid that nearly devours Nemo. The three
+     of them swim as fast as they can with the squid in pursuit. Dory gets caught in
+     a plastic six-pack ring. They swim through a small hole into a container and th
+    e squid shakes it, causing other containers to fall. In the scuffle, the squid g
+    rabs Nemo and pulls him toward its mouth. Marlin grabs Nemo and a container hits
+     the floor causing the trio to be launched to safety, landing in a kelp bed.
+
+Ma
+    rlin tends to his son afterwards and is sour toward Dory for getting them into t
+    he mess. Feeling hurt, Dory travels to the surface to seek help and is rescued b
+    y staff from the nearby Marine Life Institute after being caught in six pack rin
+    gs. The humans pull her into their boat and remove the plastic ring around her. 
+    Then they put her in a cooler and shut the lid. The ship heads toward the shore 
+    with Marlin and Nemo frantically swimming after it. They hear a voice say, "Welc
+    ome to the Marine Life Institute" She is separated from Marlin and Nemo.
+
+Dory i
+    s sent to the Quarantine section and tagged. There she meets a grouchy but well-
+    meaning, seven-legged octopus named Hank (Ed O'Neill). Dory's tag shows that she
+     will be sent to a permanent aquarium in Cleveland. Hank tells Dory that she is 
+    in Jewel of Morro Bay.
+
+Due to a traumatic ocean life, Hank wants to live in the
+     aquarium instead of being released back into the ocean, so he agrees to help Do
+    ry find her parents in exchange for her tag. He grabs an empty coffee pot and us
+    es it to scoop her out of the tank. Hank is taking Dory down the hallway and she
+     sees a map on a wall. He brings her closer and she sees a purple shell. That tr
+    iggers another memory of her parents laying purple shells all around their coral
+     home.
+
+In one exhibit, Dory encounters her childhood friend Destiny (Kaitlin Ol
+    son), a nearsighted whale shark who used to communicate with Dory through pipes.
+     Destiny is near-sighted and has trouble swimming around the tank, but Dory stop
+    s her before she smacks the glass. She recognizes Dory's voice and tells her tha
+    t they were childhood friends. Destiny tells Dory that she's from the Open Ocean
+     exhibit and Dory asks her to take her there. Destiny tells her that she doesn't
+     have any way to travel around. She and Hank start to make their way towards the
+     Open Ocean exhibit, despite many challenges.
+
+Bailey (Ty Burrell), a beluga wha
+    le lives in the Open Ocean Exhibit, who believes he has lost his ability to echo
+    -locate. Dory learns that the rest of her regal blue tangs' species are being mo
+    ved to Cleveland. She subsequently has flashbacks of life with her parents and s
+    truggles to recall details but vaguely remembers that her parents taught her to 
+    follow seashells & that purple ones were their favorites. She also remembers tha
+    t her parents were in the Open Ocean exhibit. Destiny tells Dory that she can ge
+    t to the Open Ocean exhibit by going through the pipes, taking two lefts and swi
+    mming straight. Dory worries that she won't remember the directions and Hank tel
+    ls her there's no other way. His words trigger another memory, of young Dory try
+    ing to pry a shell loose from the sand. She thinks there's no other way to get t
+    he shell and is about to give up when her dad tells her that there's always anot
+    her way and uses his tail to wiggle the shell loose.
+
+Marlin and Nemo attempt to
+     rescue Dory. With the help of two sea lions named Fluke (Idris Elba) and Rudder
+     (Dominic West) and a common loon named Becky, they manage to get into the Insti
+    tute. They bump into a boy who spills his popcorn on the floor. Flying in, Becky
+     sees the popcorn, leaves the bucket hanging on a tree branch and flies down to 
+    eat it. Marlin and Nemo are stuck in the bucket with Becky still eating popcorn.
+     Marlin tries to inch the bucket forward to get within Becky's earshot and it ti
+    ps over, dumping them out and into a tank of toy fish in the gift shop.
+
+Dory, m
+    eanwhile, with Hank, finally remembers how she became separated from her parents
+    : she overheard her mother crying one night, left home to retrieve a shell in ho
+    pes of cheering her up, and was pulled away by an undertow current, which dumped
+     her into the pipes system of the exhibit and out into the open ocean. In the Op
+    en Ocean exhibit, 2 crabs tell Dory that all the blue tang fishes are being ship
+    ped to Cleaveland for a new exhibit. Dory believes that her parents are in that 
+    lot & heads to quarantine, where the blue tang fishes are being kept before ship
+    ping.
+
+Nervously, Dory swims into the pipes, quickly forgetting which way she's 
+    going. She calls out to Destiny and asks for help. Destiny tells Bailey to use e
+    cholocation to help Dory. Bailey is convinced that it won't work but gives it a 
+    try anyway and is surprised that he can visualize a map of the pipes. He guides 
+    her toward Quarantine but then he senses something else in the pipes. He tries t
+    o have Dory swim away but she keeps swimming closer.
+
+Dory reunites with Marlin 
+    and Nemo in the pipe system. Together they get back in Quarantine, they locate t
+    he tank of blue tangs who tell them that Dory's parents escaped the Institute a 
+    long time ago to search for Dory but never came back. The tangs tell Dory that w
+    hen a fish doesn't make it back from Quarantine, it means they're gone.
+
+This le
+    aves Dory under the impression that they died. Hank retrieves Dory from the tank
+     (Hank was in Quarantine as he wants to get on the truck going to Cleveland), ac
+    cidentally leaving Marlin and Nemo behind. He is then apprehended by one of the 
+    employees and unintentionally drops Dory into the drain flushing her to the ocea
+    n.
+
+While wandering aimlessly, she comes across a trail of shells, remembering t
+    hat when she was young, her parents had set out a similar trail to teach her how
+     to find her way back home. At the end of the trail, Dory finds an empty home wi
+    th multiple shell trails leading away from it. As she turns to leave, she sees h
+    er parents, Charlie (Eugene Levy) and Jenny (Diane Keaton), in the distance and 
+    joyfully reunites with them. They tell her they have spent years forming trails 
+    for her to follow in the hopes that she would eventually find them.
+
+Marlin and 
+    Nemo end up in the truck taking various aquatic life to Cleveland. Inside the tr
+    uck, Hank reveals himself to Marlin and Nemo and tells them that he lost Dory. D
+    ory is swimming through the water, catching her parents up on everything that's 
+    happened to her. Suddenly, she hears the announcer voice from the Marine Life In
+    stitute. The next thing she hears is a truck starting up and she remembers that 
+    Marlin and Nemo are on it. She calls out to Destiny and she and Bailey jump over
+     the walls of the tank, landing in the ocean next to Dory. They all swim after t
+    he truck, using a group of otters to stop traffic. One of the otters carries Dor
+    y into the back of the truck and Hank puts her in the tank with Marlin and Nemo.
+     Marlin calls out to Becky, who flies in with her bucket. Marlin and Nemo jump i
+    n, but Becky flies off before Dory can join them. Becky dumps them into the ocea
+    n, right next to Destiny. She asks where Dory is, and Marlin tells them she's st
+    ill in the truck.
+
+Marlin calls to Becky and tells her to fly back to the truck 
+    and get Dory. Hank reaches into the tank for Dory, but she doesn't want him to l
+    eave her, and she gets him to agree to join her in the ocean. Just then, a staff
+    er slams the back door and drives the truck away. Destiny swims after them but c
+    an't keep up. Dory sees a vent in the roof and Hank grabs her and moves toward i
+    t. Hank and Dory squeeze through the vent, and Hank plasters himself across the 
+    windshield, forcing the driver to stop. When the driver walks out, Hank shuts th
+    e door and locks it, taking control of the truck. He drives off with Dory naviga
+    ting. She sees a car pulling a boat and follows it. Dory sees a splat on the win
+    dshield and sees that it came from a flock of seagulls heading left. She has Han
+    k follow them and they drive up a hill. Dory sees the ocean at the bottom, and s
+    he tells Hank to floor it. The truck falls off the edge of a cliff and tumbles t
+    oward the ocean, sending all the fish inside flying. Dory and Hank happily plung
+    e into the ocean below.
+
+Back at the Great Barrier Reef, Dory is playing hide-an
+    d-seek with the students. Hank tells them that Mr. Ray is away on migration and 
+    until he gets back, Hank will be their substitute teacher. Bailey and Destiny te
+    ll the kids about Echolocation. Dory tells her parents that she'll see them in a
+     while, but she wants to do something first. She swims off, with Marlin followin
+    g after her, trying to keep himself hidden. She swims up to the edge of the drop
+    -off, then calls out to Marlin, who sheepishly swims up to her. She tells him th
+    at she enjoys the view, and they both look out into the ocean.
+
+The Tank Gang, s
+    till trapped inside their plastic bags, reach California after floating across t
+    he Pacific Ocean for a year. To their dismay, they are picked up by staff member
+    s from the Marine Life Institute.
 outline:
     Friendly but forgetful blue tang Dory begins a search for her long-lost parents 
     and everyone learns a few things about the real meaning of family along the way.
@@ -126,7 +298,7 @@ countries: (N=1)
 studios: (N<6)
   - Walt Disney Pictures
   - Pixar Animation Studios
-trailer: https://imdb-video.media-imdb.com/vi2669917209/1434659454657-dx9ykf-1464098554017.mp4?Expires=1764701327&Signature=IGQwPMsgDXOtuKm2p39-0JabfTlNqJ9AdwhvKoxaHejexqn7X~3D2KTK-IxAu3DBGSzOLfyuP-3X-1rkDOXMj83KfTwrvUu80jIfYbHYV0QpHH2A2jy88ltgKwYtdXP5i3Znis1UyNgr5~La1HvHIM1DmvqOFQ3HD3bsManNHXknICZQ27OMGBl8KRvtwLBt82duj1BkypkDL6MpRIjaYf31PtmULwK2lFeEtvyv4~fRR~CiPq9v0w92Tsplztga3XYMZsQlQe-vo2vSYdp2o9VD1RvpwY0gC5c1BIwBVD8FSYftkxcwaVozt-DpeHHyMTtVNwaatTGHD-s7oPH~1Q__&Key-Pair-Id=APKAIFLZBVQZ24NQH3KA
+trailer: https://imdb-video.media-imdb.com/vi2669917209/1434659454657-dx9ykf-1464098554017.mp4?Expires=1767274805&Signature=ew7lM7CMBoiBMAuyGabEF3YsY54BeS-WrOyNuUmMAy1hZOkv93rbVaxqBc1UAT3cEeYIjfQ6NTiUmQvGcng0G2puLplRrO4FbNtcCvBfHIcpi8GgHZCp7Bt~20tZLzGW~ToLb~lvLjGWgq7uluu0hfpgiIjoc4XcfcS47wrJS4vFj1ESnrajtBy3FAelu1s7SvdAzJ5qSeoODVjqK4HGA2OcU8~aFnDl0Jee7rsz6jmoSgNbcxbx~~Ax1I1F9fv72G2XVbW3aHeKqcfVVG1Mx8-1WczzIteOlIsZ5IQuwSSd6bePC7C9ukZN4YVzsNVQnvZDhAlGK7IpDzPPTqQabA__&Key-Pair-Id=APKAIFLZBVQZ24NQH3KA
 showlink: (N=0)
 playcount: 0
 lastPlayed: <not set or invalid>

--- a/test/resources/scrapers/imdb/Godfather_tt0068646.ref.txt
+++ b/test/resources/scrapers/imdb/Godfather_tt0068646.ref.txt
@@ -9,16 +9,70 @@ title: The Godfather
 sortTitle: 
 originalTitle: The Godfather
 overview:
-    The Godfather "Don" Vito Corleone is the head of the Corleone mafia family in Ne
-    w York. He is at the event of his daughter's wedding. Michael, Vito's youngest s
-    on and a decorated WWII Marine is also present at the wedding. Michael seems to 
-    be uninterested in being a part of the family business. Vito is a powerful man, 
-    and is kind to all those who give him respect but is ruthless against those who 
-    do not. But when a powerful and treacherous rival wants to sell drugs and needs 
-    the Don's influence for the same, Vito refuses to do it. What follows is a clash
-     between Vito's fading old values and the new ways which may cause Michael to do
-     the thing he was most reluctant in doing and wage a mob war against all the oth
-    er mafia families which could tear the Corleone family apart.
+    In 1945, while his daughter Connie is getting married to Carlo Rizzi, Vito Corle
+    one, the Don of the Corleone family in New York City, listens to requests. The r
+    eception is where Vito's youngest son, Michael, a Marine and World War II hero w
+    ho has so far avoided involvement in the family business, presents his girlfrien
+    d, Kay Adams. Vito's godson, well-known singer Johnny Fontane, asks Vito for ass
+    istance in landing a film role. To convince Jack Woltz, the studio president, to
+     give Johnny the role, Vito dispatches his consigliere Tom Hagen. Woltz initiall
+    y rejects Hagen's request, but after discovering the severed head of his beloved
+     stud horse in his bed, he eventually gives in.
+
+Drug lord Virgil "The Turk" Sol
+    lozzo appeals to Vito to invest in his drug business and provide police protecti
+    on as Christmas draws near. Vito refuses, saying that he would lose his politica
+    l network if he got involved in drug use. Vito sends his enforcer Luca Brasi on 
+    an espionage mission to the Tattaglias because he suspects Sollozzo of having a 
+    relationship with the Tattaglia crime family. At the first meeting, Brasi is kil
+    led by garroting. Officers later shoot Vito and force Hagen to attend a meeting.
+     Now that Vito's firstborn son Sonny is in charge, Sollozzo puts pressure on Hag
+    en to convince Sonny to agree to the drug deal. After NYPD officers on Sollozzo'
+    s payroll remove Vito's guards, Michael visits him in the hospital after he surv
+    ives the shooting and discovers that he is unprotected. When Michael stops his f
+    ather's murder attempt, dishonest police captain Mark McCluskey beats him. Sonny
+     hits Bruno Tattaglia in retaliation for the attempted hit at the hospital. In o
+    rder to resolve the conflict, Sollozzo and McCluskey ask to meet with Michael. A
+    fter pretending to be interested and agreeing to meet, Michael plans to kill Son
+    ny and Corleone capo Clemenza and then disappears. At a restaurant in the Bronx,
+     Michael meets Sollozzo and McCluskey. He takes out a gun that Clemenza had hidd
+    en in the restroom and kills both men.
+
+The Five Families engage in open warfare
+     in spite of the government's crackdown on the murder of a police captain. Moe G
+    reene provides sanctuary for Vito's second son Fredo in Las Vegas, while Michael
+     seeks safety in Sicily. Michael meets and weds Apollonia, a local, in Sicily. C
+    arlo is publicly attacked and threatened by Sonny for mistreating Connie physica
+    lly. Sonny rushes to their house after he mistreats her once more, but gangsters
+     ambush and kill him at a highway toll booth. Michael is the target of a car bom
+    b that kills Apollonia shortly after.
+
+Vito arranges a meeting with the Five Fam
+    ilies because he is weary of war and devastated by Sonny's passing. He promises 
+    them he will stop opposing their drug trade and that he will not seek revenge fo
+    r Sonny's death. With his safety assured, Michael goes back to his hometown to m
+    arry Kay and start the family business. At the beginning of the 1950s, Kay gives
+     birth to two children. Michael takes over as the head of the Corleone family si
+    nce his father is dying and Fredo is not fit to be the leader. Michael is inform
+    ed by Vito that Don Barzini ordered the hit on Sonny and that Barzini would atte
+    mpt to kill him during a meeting that a traitor Corleone capo had set up. Since 
+    Hagen is not a "wartime consigliere," Michael assigns him to oversee operations 
+    in Las Vegas with Vito's help. Michael is devastated to discover that Fredo is m
+    ore devoted to Greene than to his own family when he goes to Las Vegas to purcha
+    se Greene's share in the family's casinos.
+
+While playing with Michael's son Ant
+    hony in 1955, Vito suffers a heart attack and passes away. Tessio betrays Michae
+    l by asking him to meet with Barzini at Vito's funeral. The meeting is scheduled
+     for the same day as Connie's baby's baptism. The dons of the Five Families are 
+    killed by Corleone hit men, along with Greene for failing to sell his hotel and 
+    Tessio for betraying Michael, while Michael stands at the baptismal font as the 
+    child's godfather. Michael coerces Carlo into confessing to his role in Sonny's 
+    killing. He tells Carlo that he is not being killed but rather banished. Carlo c
+    onfesses, but shortly after, Clemenza chokes him in a car. With Kay present, Con
+    nie questions Michael about his role in Carlo's demise. Kay is relieved when Mic
+    hael denies responsibility when she asks him if he ordered Carlo's death. Capos 
+    enter the office and honor Michael as "Don Corleone" as she departs.
 outline:
     The aging patriarch of an organized crime dynasty transfers control of his cland
     estine empire to his reluctant son.
@@ -130,7 +184,7 @@ studios: (N<6)
   - Albert S. Ruddy Productions
   - Paramount Pictures
   - Alfran Productions
-trailer: https://imdb-video.media-imdb.com/vi1348706585/1434659529640-260ouz-1616202346191.mp4?Expires=1764701343&Signature=YRJbcbwsCaBMj6aMGaFjs5OUif54id7JJwZgt5iJGfZCXlD0WvqNc1BhMjaWdqiwey2k-Vy-umTDmoVdP4AooVpGG8KFGCSMbgRptf0PBRFK5XrLRIZ15T9wcfZZqkJbo~8nRJoccILupPro8fO-A4HdPWwWfaj2p0M7WEwhDo~9IMKSE-5i1Zu8WOohXjUPSx64YSikAFOFjBNRETg1zMbKMIS9TzA6pb8jojunI1tu74MxXwfoyTgFBUU51c9fq4Lt5MnoidlY2lD3yam1-QrUmeTjKCRIKcon6oHFvG4eUmTD0CsuRVoNA1UPy0IMpuk7i06bcFCpSiaW7G0jqw__&Key-Pair-Id=APKAIFLZBVQZ24NQH3KA
+trailer: https://imdb-video.media-imdb.com/vi1348706585/1434659529640-260ouz-1616202346191.mp4?Expires=1767274998&Signature=GHXfruTfr14Cgdfg~N3lbGaky1yjLQefHurjKweZofVloMPGE6XeOkyMfHeNrwDSWMRTWyhe9X-4ZGAy9tPwluHXQqVgfEHRSf5ZFbPNh4m4rgSSx5AW320TLI0Pb1uZipXnjBsDFCzBb~Im8u-T2-Y0iLy-4mMIeE23GGHOMHaqSf8lU9PBuXM8XYcl-Kh81NJGrseOhDrrxI5oIvn1xBUW76-TeiXsY91GIe3DVkZTN34I34aDkIQUaWSi~-fmC~nobbCkn2fWgtirhmiH1IGjG~WEFqVPGETgyrG9jntd5pKblQpWeKpZMBJJWPkEuPRoDPT64zCmyIMvhapzbQ__&Key-Pair-Id=APKAIFLZBVQZ24NQH3KA
 showlink: (N=0)
 playcount: 0
 lastPlayed: <not set or invalid>

--- a/test/resources/scrapers/imdb/Pacific_Rim_tt1663662.ref.txt
+++ b/test/resources/scrapers/imdb/Pacific_Rim_tt1663662.ref.txt
@@ -9,14 +9,129 @@ title: Pacific Rim
 sortTitle: 
 originalTitle: Pacific Rim
 overview:
-    When monstrous creatures, known as Kaiju, started rising from the sea, a war beg
-    an that would take millions of lives and consume humanity's resources for years 
-    on end. To combat the giant Kaiju, a special type of weapon was devised: massive
-     robots, called Jaegers, which are controlled simultaneously by two pilots. But 
-    even the Jaegers are proving nearly defenseless in the face of the relentless Ka
-    iju. On the verge of defeat, the forces defending mankind have no choice but to 
-    turn to two unlikely heroes, a washed-up former pilot and an untested trainee. T
-    ogether, they stand as mankind's last hope against the mounting Armageddon.
+    In the near future, aliens identified as Kaijus have risen from a portal in a cr
+    evasse beneath the Pacific Ocean and started to attack coastal cities resulting 
+    in a war that takes millions of lives and quickly consumes humanity's resources.
+     To combat the monsters, a special type of weapon is designed: massive, humanoid
+     fighting machines, known as Jaegers, which are controlled simultaneously by two
+     pilots whose minds are bound in a neural link (Through a process known as Drift
+    ing) which lets them share the mental strain which would otherwise overwhelm a s
+    ingle pilot.
+
+The Jaegers are initially successful in fending off Kaiju attacks;
+     however, over time, Kaijus cross through the portal at a faster rate, with each
+     new Kaiju adapted for fighting the Jaegers. As they become less effective, Eart
+    h's united governments lose faith in the Jaegers' ability. Five years later, the
+     Jaeger program is terminated, with resources diverted to building a coastal for
+    tification to protect coastal cities. Kaiju attack frequency is increasing, and 
+    Jaegers are being destroyed faster than they can be built. The walls quickly pro
+    ve ineffective.
+
+The four remaining Jaegers are redeployed to Hong Kong to defen
+    d the unfortified coastline until the wall can be completed. Stacker Pentecost (
+    Idris Elba), commander of the Jaeger forces, devises a plan to end the war by us
+    ing a nuclear warhead to destroy the portal (the breach at the bottom of the oce
+    an from which the Kaijus cross over from their world to Earth), despite unsucces
+    sful previous attempts.
+
+In 2020, brothers Yancy and Raleigh Becket pilot the Am
+    erican Jaeger, Gipsy Danger, to defend Anchorage from a Category-3 Kaiju code-na
+    med Knifehead, who severely damages Gipsy, killing Yancy. Raleigh kills Knifehea
+    d and pilots Gipsy solo to shore before collapsing. Traumatized by the loss of h
+    is brother and the stress of piloting alone, Raleigh quits the Jaeger program.
+
+
+    Pentecost approaches retired pilot Raleigh Becket (Charlie Hunnam) and convinces
+     him to return and pilot Gipsy Danger, the Jaeger he and his brother Yancy (Dieg
+    o Klattenhoff) once piloted. Raleigh, now working in wall construction, is recru
+    ited by Pentecost for the mission of blowing up the breach.
+
+Four Jaegers remain
+     operational - the refurbished Gipsy Danger, the Russian Cherno Alpha (Sasha (Ro
+    bert Maillet) and Alexis Kaidanovsky (Heather Doerksen) from Russia piloting), t
+    he Chinese Crimson Typhoon (The Wei Tang Triplets from China (Charles Luu, Lance
+     Luu and Mark Luu) piloting), and the Australian Striker Eureka piloted by fathe
+    r-and-son team, Chuck Hansen (Robert Kazinsky) and his father Hercules Hansen (M
+    ax Martini). Tendo Choi (Clifton Collins Jr.) is a Jaeger technician of Chinese 
+    and South American descent.
+
+Arriving at Hong Kong, Raleigh tests with potential
+     co-pilots to find one with a strong connection, as the stronger the connection,
+     the better their performance in battle. Raleigh is introduced to Mako Mori, the
+     director of the Jaeger restoration program. Sensing a strong connection, Raleig
+    h demands to be partnered with Mako Mori (Rinko Kikuchi). As a result, Pentecost
+     grounds Mako. Raleigh calls out Pentecost on this. Pentecost reveals he adopted
+     Mako after her parents were lost in the Kaiju attack.
+
+The duo's initial test r
+    un nearly ends in disaster when Mako gets caught up in a childhood memory of a K
+    aiju attack; she inadvertently activates and nearly discharges Gipsy Danger's pr
+    imary weapon, The Plasma Cannon, while in the hangar. The duo is withdrawn from 
+    the field as the remaining Jaegers are tasked with fending off a double Kaiju at
+    tack in Hong Kong. The defense goes badly, with the Kaijus destroying two Jaeger
+    s, Crimson Typhoon and Cherno Alpha, and disabling a third Jaeger, Striker Eurek
+    a. Pentecost sends Raleigh and Mako to mount a last stand, and the duo drive off
+     the assault.
+
+Pentecost consults Kaiju experts Newton Geiszler and Hermann Gott
+    lieb. Hermann claims the Breach will stabilize and the Kaiju will increase in nu
+    mber, but this will allow the assault to succeed. Meanwhile, Dr. Newton Geiszler
+     (Charlie Day), a scientist studying the Kaijus, assembles a machine allowing hi
+    m to establish a mental link with a Kaiju brain fragment. The experience nearly 
+    kills him, but he discovers the Kaijus are actually artificial weapons sent to E
+    arth as an invading force to allow another species to colonize the planet.
+
+With
+     Pentecost's approval, he seeks out Hannibal Chau (Ron Perlman), a major figure 
+    in the trafficking of Kaiju parts, in an attempt to procure an intact Kaiju brai
+    n to repeat the experiment. Chau criticizes Geiszler's merging with the Kaiju br
+    ain, as he has attracted their attention, and the Kaiju attacking Hong Kong are 
+    seeking him. Newton realizes the Kaiju hive mind gained access to his brain, sin
+    ce drifting is a two-way link, and the two newest Kaiju to emerge in Hong Kong, 
+    Leatherback and Otachi, are sent simultaneously to find him in Hong Kong.
+
+All J
+    aegers except Gipsy Danger are dispatched to intervene. Otachi destroys Crimson 
+    Typhoon, while Leatherback destroys Cherno Alpha and disables Striker Eureka wit
+    h an EMP blast, injuring Herc. As the only non-digital Jaeger, the nuclear-power
+    ed Gipsy Danger is sent by Pentecost to help. Gipsy kills both Leatherback and O
+    tachi. Chau and his team move in to harvest parts. Geiszler realizes one of the 
+    Kaiju is pregnant; Chau and his crew are attacked by the newborn, which chokes o
+    n its own umbilical cord after eating Chau. Geiszler and his colleague Hermann G
+    ottlieb (Burn Gorman) merge with the baby Kaiju's intact brain, where they disco
+    ver the secret controlling the flow of Kaijus through the portal.
+
+The Jaeger fo
+    rces reassemble to complete their plan to destroy the portal. Pentecost reveals 
+    to Raleigh he is ill from radiation poisoning due to piloting a first-generation
+     Jaeger alone to save a young Mako, and has been unable to pilot a Jaeger since.
+     Pentecost takes command of Striker Eureka as one of its usual pilots Herc was i
+    njured in the defense of Hong Kong.
+
+Pentecost ventures into the ocean depths, w
+    ith Raleigh and Mako supporting him. Geiszler and Gottlieb inform them the porta
+    l has a fail-safe system to control the passage of Kaijus and will only allow th
+    em to enter if they can mimic a Kaiju's genetic code. Two new Kaiju, Scunner and
+     Raiju, are detected guarding the Breach, Gipsy and the repaired Striker, pilote
+    d by Pentecost and Chuck, approach the Breach, where a new Category-5 Kaiju, Sla
+    ttern, appears.
+
+Before they can process this information, they are attacked by 
+    the three Kaijus, including the largest on record, the category 5. When the Jaeg
+    ers are attacked by the Kaiju, Gipsy kills Raiju, but is crippled. Pentecost and
+     Chuck sacrifice themselves and Striker, killing Scunner. then Gipsy slaughters 
+    Slattern, riding its corpse into the Breach.
+
+Then Gipsy slaughters Slattern, ri
+    ding its corpse into the Breach, intending to overload Gipsy Danger's nuclear re
+    actors to use it as an improvised bomb. With the Jaeger critically damaged by th
+    e fight, Raleigh ejects Mako and manually overrides the safety protocols before 
+    ejecting himself. Gipsy Danger detonates on the other side of the portal, destro
+    ying it and the alien commanders, as the two pilots emerge safely on the sea's s
+    urface.
+
+Chau-revealed to have survived-cuts his way out of the newborn Kaiju's 
+    stomach.
 outline:
     As a war between humankind and monstrous sea creatures wages on, a former pilot 
     and a trainee are paired up to drive a seemingly obsolete special weapon in a de
@@ -85,8 +200,8 @@ actors: (N>5)
    name: Max Martini
    role: Herc Hansen
    thumb:
-    https://m.media-amazon.com/images/M/MV5BNzBkNDI5MDUtZDljYy00YTc4LWE0OTMtZDkzYzMz
-    ZWYwYWMzXkEyXkFqcGc@.jpg
+    https://m.media-amazon.com/images/M/MV5BNDJjZmNkYjItMGQ3ZS00MDIxLWE4MTYtNGVmNTg2
+    ZDA3ZTVlXkEyXkFqcGc@.jpg
    order: 6
    imageHasChanged: false
  - id: 
@@ -130,7 +245,7 @@ studios: (N<6)
   - Warner Bros.
   - Legendary Entertainment
   - Legendary Pictures
-trailer: https://imdb-video.media-imdb.com/vi1369752345/1434659529640-260ouz-1632281728566.mp4?Expires=1764701338&Signature=HZPDsLNw7bJ3erHmOmoj~9YUDhvoaiBsDR0waj-4ooKSsKPtN0wJRvo5OgUCS0WXkROCaBdLqwBMnBGLT7bresHOslHfac6NDpxtqfP8ZRYdcR-CHilXDlPG8UDz2cWCwNvqJ~jptRnutkeXqBZg0b6FXQEdHaDau5f9Rasr~CPVRvadauCFZc-mI7l9lizc~s-AgemgKMTIbI1tm-IorWC4bzx2jXSklG9bg86p68yBcPL8uwvj0WffG0ZAqrTdIHjPG6UN0hqcudVKuT3-spITgN-PJb~of4Ti30p9sReOF~rNk6uey8IA6kFTfLTqpnf6M9ZelSSvmBUqsXZfPQ__&Key-Pair-Id=APKAIFLZBVQZ24NQH3KA
+trailer: https://imdb-video.media-imdb.com/vi1369752345/1434659529640-260ouz-1632281728566.mp4?Expires=1767274992&Signature=I9cA54nWqVvQpQ0tJF4c9DwhVS-NwXU3Xi3tJILg4-mvF8Saq7pqOFGG-vPu09SZln0~yfNCgnTqNmpER1jEMsYJbFogHtYPAOEevCEX2Fmx6X6F8Zt3nKgwOtbj29lqTVVrA9xqWS28zttkKP2WdShm5l5WOvD-n~L-K~YsBxG74bu7pihAiwvz9M6zRj9fZDDK-4glvoXQxkjYYoL-~NNHFLShqcJwP5DpKy~ZWKYagpks-aIEywPOBTOVE1kpm74nOV1iYvhTvYW3DNPCCQM4cuaz6T~NYgDg1VCOKZJnilKaJSaNL0cVBCSF5ZaTDOL-omcxRS-cBZMIEe2bKA__&Key-Pair-Id=APKAIFLZBVQZ24NQH3KA
 showlink: (N=0)
 playcount: 0
 lastPlayed: <not set or invalid>

--- a/test/resources/scrapers/imdb/The_Shawshank_Redemption_tt0111161.ref.txt
+++ b/test/resources/scrapers/imdb/The_Shawshank_Redemption_tt0111161.ref.txt
@@ -9,11 +9,215 @@ title: The Shawshank Redemption
 sortTitle: 
 originalTitle: The Shawshank Redemption
 overview:
-    Chronicles the experiences of a formerly successful banker as a prisoner in the 
-    gloomy jailhouse of Shawshank after being found guilty of a crime he did not com
-    mit. The film portrays the man's unique way of dealing with his new, torturous l
-    ife; along the way he befriends a number of fellow prisoners, most notably a wis
-    e long-term inmate named Red.
+    In 1947, Andy Dufresne (Tim Robbins), a banker, is convicted of murdering his wi
+    fe and her lover, a golf professional. He is sent to the notoriously harsh Shaws
+    hank Prison to serve two consecutive life sentences, since the state of Maine ha
+    s no death penalty. Andy keeps claiming his innocence, but his cold and calculat
+    ing demeanor leads everyone to believe he did it.
+
+Ellis Redding (Morgan Freeman
+    ), also known as Red, was a contraband smuggler serving a life sentence. Red is 
+    being interviewed for parole after having spent 20 years at Shawshank for murder
+    . Despite his best efforts and behavior, Red's parole is rejected which doesn't 
+    phase him all that much.
+
+An alarm goes off alerting all prisoners of new arriva
+    ls. Red and his friends bet on whichever "new fish" will have a nervous break do
+    wn during his first night in prison. Red places a huge bet on Andy. During the f
+    irst night, an overweight newly arrived inmate, nicknamed ''fat ass', breaks dow
+    n and cries hysterically allowing Heywood (William Sadler) to win the bet. Howev
+    er, the celebration is short lived when the chief guard, Byron Hadley, savagely 
+    beats up the fat man for not keeping quiet when he is asked to. Meanwhile, Andy 
+    remains steadfast and composed. The next morning, the inmates learn that ''fat a
+    ss'' died in the infirmary because the prison doctor had already left for the ni
+    ght. Andy inquires about the man's name only to get put down by Heywood.
+
+Though
+     other prisoners consider Andy "a really cold fish," Red sees something in Andy,
+     and likes him from the start. Andy approaches Red to smuggle a pick for him, an
+     instrument he claims is necessary for his hobby of rock collecting and sculptin
+    g. Red believes that Andy intends to use the pick for his escape. But then Red s
+    ees how small the pick is.
+
+Andy is beaten and sexually assaulted on a regular b
+    asis by other stronger inmates led by Bogs Diamond (Mark Rolston). During the fi
+    rst two years of his incarceration, Andy spends most of his time working in the 
+    prison laundry or fighting off Boggs.
+
+In 1949, when a work detail for tarring t
+    he roof of one of the prison's buildings is announced, Red pulls some strings to
+     get Andy and a few of their mutual friends assigned to the job, giving everyone
+     a break from the usual routine and a chance to "enjoy" the fine weather. Andy o
+    verhears the captain of the guards, Byron Hadley, complaining about being taxed 
+    on an inheritance and offers to help him shelter the money legally. Andy informs
+     Hadley of how he can shelter his money from the IRS by turning it into a one-ti
+    me gift for his wife. He then offers to assist Hadley in filling out the paperwo
+    rk in exchange for some cold beers for his fellow inmates while on the tarring j
+    ob. Hadley first threatens to throw Andy off the roof, but eventually agrees and
+     do provide the working inmates with cold beers before the job is finished. Red 
+    remarks that Andy may have engineered the privilege to build favor with the pris
+    on guards as much as with his fellow inmates, but he also thinks Andy did it sim
+    ply to "feel normal again."
+
+Andy then helps jailer Hadley (Clancy Brown) save t
+    axes. While watching a movie, Andy approaches Red with another unusual demand an
+    d asks for a large poster of the actress Rita Hayworth. Red is surprised by the 
+    demand but agrees to place the order. As he exits the theater, Andy once more en
+    counters his tormentors. Although he is able to talk his way out of being sexual
+    ly assaulted, he is brutally beaten within an inch of his life, putting him in t
+    he infirmary for a month. Boggs spends a week in solitary for the beating.
+
+When
+     he comes out, he finds Hadley and his men waiting in his cell. They beat him so
+     badly that he's left unable to walk or eat solid food for the rest of his life 
+    and is transferred to a prison hospital upstate. The Sisters move on and never b
+    other Andy again. When Andy gets out of the infirmary, he finds a bunch of rocks
+     for him to sculpt and a giant poster of Rita Hayworth in his cell; presents fro
+    m Red and his friends.
+
+Warden Samuel Norton (Bob Gunton) hears about how Andy h
+    elped Hadley and uses a surprise cell inspection to size Andy up. He finds Andy 
+    reading his copy of the Holy Bible and they talk about their favorite verses whi
+    le the guards are turning the cell upside down looking for illegal possessions. 
+    Satisfied with their encounter, the warden leaves and almost forget to give Andy
+     his Bible back. He then encourages Andy to keep reading the Bible saying ''salv
+    ation lays within''.
+
+Warden Samuel Norton assigns Andy to the prison's decrepit
+     library, ostensibly to assist elderly inmate Brooks Hatlen (James Whitmore), bu
+    t in reality, to leverage Andy's financial expertise for managing the finances o
+    f the warden and other prison staff. Andy also starts writing weekly letters to 
+    the state legislature, requesting funding to improve the library. His financial 
+    support practice is so appreciated that even guards from other prisons, when the
+    y visit for inter-prison baseball matches, seek Andy's financial expertise. Andy
+    's client expands greatly and eventually includes Warden Norton himself.
+
+Not lo
+    ng after, Brooks suddenly snaps and threatens to kill Heywood in order to avoid 
+    being paroled. Andy is able to talk him down. Brooks is paroled in 1954 after se
+    rving 50 years, but cannot adjust to the outside world. Brooks goes to live in a
+     halfway house. He is also given a job at a supermarket which he hates. Finding 
+    it impossible to adjust to life outside the prison, he eventually commits suicid
+    e, leaving the message "Brooks was here" carved on a wooden beam .
+
+After years 
+    of Andy's ceaseless letters, Andy receives $200 from the state for the library, 
+    along with a collection of old books and phonograph records. The legislature sen
+    ds a library donation that includes a recording of The Marriage of Figaro; Andy 
+    plays an excerpt over the public address system, experiencing a moment of person
+    al freedom before he is punished with solitary confinement. After his release fr
+    om solitary, Andy explains to a dismissive Red that hope is what gets him throug
+    h his sentence. Though the state Senate thinks this will be enough to get Andy t
+    o halt his letter-writing campaign, he is undaunted and redoubles his efforts.
+
+
+    Not long after, Red has a new parole hearing and realizes he's been in prison fo
+    r 30 years now. He uses the exact same words he used ten years earlier only with
+     no enthusiasm at all. His parole is rejected again. Andy gives him an harmonica
+     to commemorate his 30 years which Red replies by offering Andy a giant poster o
+    f Marilyn Monroe to commemorate his 10 years.
+
+About four years after the Mozart
+     incident, the state senate finally comes to the conclusion that they won't get 
+    rid of Andy with just another check. So they allow him a budget of $500 a year t
+    o expand the library, knocking down a few walls to unused rooms and renovating t
+    he space as he'd planned with his incessant letter campaign. Andy uses the funds
+     wisely and makes deals with book clubs and charities to create the best prison 
+    library in the state and names it after Brooks. With the enlarged library and mo
+    re materials, Andy begins to mentor inmates who want to receive their high schoo
+    l diplomas so they can get decent jobs once they're out.
+
+Warden Norton profits 
+    on Andy's knowledge of bookkeeping and devises a scheme whereby he put prison in
+    mates to work in public projects which he won by outbidding other contractors (c
+    heap labor from the prisoners). Andy launders money for the warden, using a fake
+     identity: "Randall Stephens". Randall Stephens officially has a birth certifica
+    te, social security number and driver's license. Should anyone ever investigate 
+    about the scheme; they will chase a man who only exists on paper. Andy shares th
+    e details with Red, noting that he had to "go to prison to learn how to be a cro
+    ok."
+
+In 1965, Tommy (Gil Bellows) comes to Shawshank, a young inmate convicted 
+    of burglary. When Tommy explains that he's been going in and out of prison ever 
+    since he was 13 years old, Andy suggests that Tommy should consider another line
+     of work besides theft because he seems to be not so good at it. The suggestion 
+    really gets to Tommy, who is also a father to a young child, and he asks Andy to
+     help him work on earning his high school equivalency diploma. Though Tommy is a
+     good student, he is still frustrated when he takes the exam itself, crumpling i
+    t up and tossing it in the trash. Andy retrieves it and sends it in anyway
+
+Red 
+    tells Tommy about Andy's case. Tommy is visibly upset at hearing Andy's story an
+    d tells Andy and Red that he had a cellmate in another prison who boasted about 
+    killing a man who was a professional golfer at the country club he worked at, al
+    ong with his lover. The woman's husband, a banker, had gone to prison for those 
+    murders.
+
+When Andy informs Norton, the warden refuses to act. Although Andy pro
+    mises to keep the money laundering a secret, the warden becomes furious and orde
+    rs him to solitary for a month. The inmates discuss the sentence mentioning it i
+    s the longest time in solitary that they've ever heard of. They also realize tha
+    t Andy may truly be innocent after all and has spent almost 20 years in prison f
+    or a crime he didn't commit.
+
+Tommy receives a letter from the board of educatio
+    n announcing that he has passed the exam and now owns a high school diploma. A g
+    uard pass the news to Andy in his solitary cell which makes him smile a little.
+
+    
+One night, Tommy is escorted outside at night to have a private meeting with th
+    e warden. Warden Norton asks him if the story he told Andy is true and if he wou
+    ld be willing to testify on Andy's behalf. Tommy enthusiastically agrees. The wa
+    rden smiles at him before nodding to Hadley to shoot him dead.
+
+When the warden 
+    visits Andy in solitary, he tells him that Tommy tried to escape and that Hadley
+     had no choice but to shoot him. Andy doesn't buy that story and tells Norton th
+    at ''everything'' stops and that he's not going to work for him anymore. The war
+    den threatens Andy to shut down the library, burn all the books, and move Andy t
+    o a much different cell in a much different part of the prison with the most har
+    dened criminals should he stop working for him. He then leaves and orders Andy t
+    o another month in solitary to think about things.
+
+A disheveled Andy is release
+    d from solitary confinement after two months. Andy tells Red if he's ever freed 
+    or escapes, he'd like to go to Zihuatanejo, a beach town on the Pacific coast of
+     Mexico. He also tells Red how he got engaged. He and his future wife went up to
+     a farm in Buxton, Maine, to a large oak tree at the end of a stone wall. He tel
+    ls Red that, if he should ever be paroled, he should look for that field, and th
+    at oak tree. Red worries that Andy is suicidal, especially after learning that h
+    e asked a fellow inmate for a rope.
+
+The next day Andy escapes. At the next day'
+    s roll call, the guards find Andy's cell empty. An irate Norton throws a rock at
+     the poster hanging on the cell wall, revealing a tunnel. Andy has used the pick
+     to dig tiny amounts of dirt each to create the tunnel over 20 years.
+
+The previ
+    ous night, Andy escaped through the tunnel and prison sewage pipe, taking with h
+    im Norton's suit, shoes, and the ledger containing evidence of the money launder
+    ing and corruption at Shawshank. Andy walks into the Maine National Bank in Port
+    land, where he had put Warden Norton's money. Using his assumed identity as Rand
+    all Stephens, and with all the necessary documentation, he walked out with a cas
+    hier's check. He continues his visitations to nearly a dozen other local banks, 
+    ending up with some $370,000. He also exposes Norton before disappearing. Hadley
+     is arrested & Norton commits suicide.
+
+At Red's next parole hearing in 1967, he
+     talks to the parole board about how "rehabilitated" was a made-up word, and how
+     he regretted his actions of the past. His parole is granted this time, but stru
+    ggles to adapt to life outside prison and fears that he never will. Remembering 
+    his promise to Andy he follows Andy's instructions, hitchhiking to Buxton and ar
+    riving at the stone wall Andy described. Just like Andy said, there was a large 
+    black stone. Under it was a small box containing a large sum of cash and instruc
+    tions to find him. He said he needed somebody "who could get things" for a "proj
+    ect" of his.
+
+Red violates parole and leaves the halfway house, unconcerned sinc
+    e no one would really do an extensive manhunt for "an old crook like [him]." He 
+    takes a bus to Fort Hancock, where he crosses into Mexico. The two friends are f
+    inally reunited on the beach of Zihuatanejo on the Pacific coast, and share a ha
+    ppy embrace.
 outline:
     A banker convicted of uxoricide forms a friendship over a quarter century with a
      hardened convict, while maintaining his innocence and trying to remain hopeful 
@@ -123,7 +327,7 @@ countries: (N=1)
   - US
 studios: (N=1)
   - Castle Rock Entertainment
-trailer: https://imdb-video.media-imdb.com/vi3877612057/1434659454657-dx9ykf-1616202333253.mp4?Expires=1764701331&Signature=S9Llf0-OYhDuUk6QVqrTo9FfFGCl3SM4zF6M7l6oRrFFYGr9vjm8xtoio8ubkhQoMC~51VeMGH-Rvyr~dzV8CY6IZH1~pBVd3QHKWFAn0QsEm4GmnYAC-p1ETK28ZQ21bhNLuPWFWZ0iltqmv9dlHJLFef9Axj1NxIUotAP84aMevjqzDQYBzfVcaq5FIrd3wQlT4RatNq834M31oclxL50eRafy-KuorvQZ1eQ4cY1E99azVF7DMzBP0zWELvCdfTEYf76MBYQw7~l3WsY3veAlmeU-80n7byCUiCjkt9qUhqZKCxPWVprh2GKHWEHHdcRYD8OfOOKpcTRTpVmA-w__&Key-Pair-Id=APKAIFLZBVQZ24NQH3KA
+trailer: https://imdb-video.media-imdb.com/vi3877612057/1434659454657-dx9ykf-1616202333253.mp4?Expires=1767275629&Signature=cGf32v9gJJnEq3wLzrUSIGYdSXBhpW54y6TcJUIwPyXQ9cn7UO6vSZ~P3YrXidhF4nzizG5m2L~wAGWaQ9zi4QUext855d1BgJsnTfzNwB9LDjjcGBUA8zR~gJVdm9tsy02keyJTa8jbL-oZjEslAmQAB2q1pDe5PHppo9kXPfNOs9bEW88E~4oQfMmOYsNqLQf3XsOlldc4KrYfYS6O8VLQY~M8dKbg~yjU9pO8E5YCG7xXaS4BVOvUhFT8zxukcc38Mm~iNmVdyZZbQA~bZ-PvFMlI8h1Ah5gyq-VQvWqawTCxxaK7BOC3t8P6vOSpC6zC1cd-I16KJlZSk-I8VQ__&Key-Pair-Id=APKAIFLZBVQZ24NQH3KA
 showlink: (N=0)
 playcount: 0
 lastPlayed: <not set or invalid>

--- a/test/resources/scrapers/imdb/Welcome_Back_tt3159708.ref.txt
+++ b/test/resources/scrapers/imdb/Welcome_Back_tt3159708.ref.txt
@@ -9,14 +9,101 @@ title: Welcome Back
 sortTitle: 
 originalTitle: Welcome Back
 overview:
-    Uday Shetty and Majnu Bhai have left the underworld, and are now big businessmen
-    . Two women, Chandni and Maharani, enter their life. Chandni is the new love in 
-    Uday Shetty and Majnu's life and both friends dream of tying the knot with her. 
-    However, Appa - Uday's father, plays spoilsport by bringing in his other daughte
-    r, Ranjana. He tells Uday Shetty to get her married to someone from a good famil
-    y. Maharani puts a condition that only after her sister is married, will Chandni
-     will marry one of them. Now, a search to find a suitable husband for Ranjana st
-    arts.
+    The Bhais (Term used in India for Underworld Don's) and their goons are back aft
+    er their mad performances in Welcome (2007 movie). Uday Shetty (Nana Patekar) an
+    d Sagar Pandey "Majnu Bhai" (Anil Kapoor) have left the underworld, and are now 
+    big businessmen settling in Dubai after being duped by Uday's brother-in-law Raj
+    iv, but the two still remain unmarried. Things have changed to an extent that no
+    w small-time dons like Badshah Khan (Neeraj Vora) are chasing the duo for protec
+    tion money. Majnu wants to thrash them, but Uday says that one has to endure suc
+    h things as honest businessmen and asks Majnu to pay Badshah.
+
+Two women, Babita
+     / Rajkumari Chandini (Ankita Shrivastava) and Poonam / Maharani Padmavati (Dimp
+    le Kapadia), enter their life. Chandini is supposed to be a princess & Maharani 
+    a queen, but in reality, both are con women and have served jail time in the pas
+    t. They have been attracted by Uday and Majnu's wealth in Dubai. Chandini gains 
+    the attention of the two men, thus getting them to finance her and Poonam's luxu
+    rious lifestyle. Chandini is the new love in Uday Shetty and Majnu's life and bo
+    th friends dream of tying the knot with her. Both Uday and Majnu shower Maharani
+     and Chandini with expensive gifts which they use to maintain their lavish life 
+    in Dubai.
+
+When they realize that they both love the same girl, they decide that
+     whoever has a better Kundli match with Chandini, will get to marry her.
+
+Later,
+     it is revealed that Uday has another sister Ranjana from his father, Shankar Sh
+    etty's third marriage and Majnu and Uday are emotionally blackmailed by Shankar 
+    into arranging the marriage of Ranjana (Shruti Haasan). He tells Uday Shetty to 
+    get her married to someone from a good family. Maharani also puts on a condition
+     that only after their sister is married will Chandini marry one of them. Now, a
+     search to find a suitable husband for Ranjana starts.
+
+Majnu & Uday reach out t
+    o Dr Ghungroo (Paresh Rawal) again to help in the search of a boy from a good fa
+    mily. Dr Ghungroo has just been made aware that his wife had an affair before he
+    r marriage to him & has an illicit son from the affair. Unlike Rajiv who was dec
+    ent, Ajju is brash and is a local goon of Mumbai, where Ranjana studies. Through
+     a chain of hilarious events, they both fall in love with each other.
+
+Dr Ghungr
+    oo is on his way to meet him, when he is stopped by Majnu & Uday, who also learn
+     that Ghungroo has a son & decide to marry Ranjana to him. Ghungroo tries to tel
+    l them that he has never met his own son, but they don't listen. Ghungroo's son 
+    turns out to be the Mumbai don Ajju Barsi (John Abraham). Ghungroo is afraid tha
+    t Majnu & Uday will kill him if they realize that his son is a don.
+
+But the tro
+    ubles starts when Ranjana already has a boyfriend who is the same Ajay "Ajju" Ba
+    rsi. Ajay turns himself into a nice boy to meet Uday & Majnu, who now go to Ghun
+    groo to call off the marriage with his son. There they realize that Ajay is in f
+    act Ghungroo's son. The wedding is back on, but Majnu suspects that Ajay is not 
+    the nice boy he pretends to be. At the engagement party Ajay meets Maharani & Ch
+    andini & recognizes then as the con-women from their previous job. At the same p
+    arty, Majnu gets confirmation from his sources about the truth regarding Ajay. H
+    e insults Ajay, but Ajay beats up Majnu's goons & declares that he will marry Ra
+    njana, come what may.
+
+Now Bhais have to get Ranjana married to a boy with non-c
+    riminal background by avoiding Ajju and his temper so that they can get married 
+    with the Chandini and while Dr. Ghunghroo has his own agenda.
+
+To downplay Ajju'
+    s threat to the wedding Uday & Majnu invite Wanted Bhai (Naseeruddin Shah) a bli
+    nd don, to the function. It turns out that Wanted Bhai's son Honey (Shiney Ahuja
+    ), is a drug addict & is in love with Ranjana, after seeing her once. He wants t
+    o marry her at any cost but doesn't know who she is. Majnu & Uday escape but fin
+    d that Wanted & Honey are attending the wedding at Ajju's invite, who has told t
+    hem that Honey will meet the girl of his dreams at the wedding. At the wedding, 
+    Ajju reveals Ranjana to Honey & Wanted Bhai takes the entire party to his privat
+    e island.
+
+Uday is angry and to counter Ajju, he announces his acceptance of Hon
+    ey's wedding to Ranjana. Ajju instigates Chandini to have an affair with Honey. 
+    Maharani agrees as she feels Wanted Bhai is a bigger party than Majnu & Uday. At
+     the island, Ajju and Dr. Ghunguroo try to convince Honey that Honey no longer l
+    oves Ranjana and that Babita is his true love. Meanwhile, Uday and Majnu try to 
+    kill Ajju, but are frightened at the graveyard in a ghost act planned by Dr. Ghu
+    nguroo, Ajju and Ranjana.
+
+Uday & Majnu are depressed & drive away. Ranjana beli
+    eves that they are driving away to suicide. She surrenders & says that she will 
+    not wed against their wishes. Ajju also backs away from Ranjana for her happines
+    s. Majnu & Uday realize that they truly love each other & give them their blessi
+    ngs.
+
+Unknown to all of them, their activities have been recorded by a CCTV came
+    ra, causing Wanted Bhai and Honey to plan to finish them off. However, Honey is 
+    kidnapped by all of them, and they escape towards the desert where they are chas
+    ed by Wanted Bhai.
+
+In the middle of saving himself, Dr. Ghunguroo pushes Wanted
+     Bhai, causing him to faint. Meanwhile, a group of camels' marches heavily there
+    . Ajju is successful in saving Wanted Bhai from the stampede of camels, and rest
+    oring his sight. Wanted Bhai himself, as a form of gratitude, decides to arrange
+     the marriage of Ajju with Ranjana, calling Ajju his 'second son'. However, they
+     notice another sandstorm conjuring up, making everyone run for their lives.
 outline:
     A pair of reformed gangsters try to find a husband for their newly discovered si
     ster, but complications arise due to mistaken identities.
@@ -122,7 +209,7 @@ countries: (N=1)
   - IN
 studios: (N=1)
   - Base Industries Group
-trailer: https://imdb-video.media-imdb.com/vi956348441/1434659529640-260ouz-1563738237646.mp4?Expires=1764701340&Signature=YgtVBH3sqP9dDz9WWfLvRv-vIOYF6Tgx3gFzrZyZxNbCK9trUAkUVsn7VbRntQkCJ~W7Qnon26j~iBvsgOKpZmGZSinEgX8wq1WZYJBeivsrMRznurl7aKwaLNDVGgRr6ElCTnCEn5MvN-Bg-PHH6qxUhUloXi3CVlzmG3tj2ReWCk8O8mrwao7IVjqNyd292qAU2dJBADZrtxUJKcqZrUDhOlTYmVzW48QoUSnOS4bFJOTjWW9T2jm6nj6CRka7I72rAC1ITTAqOzfBU7XsJnOMLF2dUnTfMDE8Ms7xs7AUPpcGH0758hRgJT7EeAxu2h9eoTL5GL08fURWGVz2pg__&Key-Pair-Id=APKAIFLZBVQZ24NQH3KA
+trailer: https://imdb-video.media-imdb.com/vi956348441/1434659529640-260ouz-1563738237646.mp4?Expires=1767274995&Signature=BslbKoIw12BeTMaqP3m6n6DT0t-e0WU1He~7ZIzRqAw0GH-Jt3E2LcCNvexIoZUzHWPoAVXTrJz3wNDjP3IEB7wa90NlgeshkO14rqbOafnmXHk1qD-apXLBhuzPdLXsT6R4CnZo4Q5hkhO3DuW7rxizVOJgEiXFycvbEb5HsdZSXV5-uPo9DTZlDU3B16cVUuAeJ9AwyCzOTjkJ3LEVyn88Vld4QeStKLsrFoANf4j5vsm8st3yYfuFkDcxAeAQzlnWipTh8flC6VBOENEW3dITmCS3ccLIxmbIotTAKQ3Ie55Bv5pSRqJua3PImgCePn5hz0bp8g5FPp6DVYqr5Q__&Key-Pair-Id=APKAIFLZBVQZ24NQH3KA
 showlink: (N=0)
 playcount: 0
 lastPlayed: <not set or invalid>

--- a/test/resources/scrapers/imdbtv/Maters-Tall-Tales-tt1384816.ref.txt
+++ b/test/resources/scrapers/imdbtv/Maters-Tall-Tales-tt1384816.ref.txt
@@ -104,16 +104,6 @@ actors: (N>30)
    order: 7
    imageHasChanged: false
  - id: 
-   name: Lori Alan
-   role:
-    Additional Voice Talent / Blue Hawk / Red Car / Area 51 PA Announcer / Ford Mode
-    l T at Wedding
-   thumb:
-    https://m.media-amazon.com/images/M/MV5BMjk4ODUwZmQtNTJkOS00YzIzLWJlYzItMDhjNjJi
-    ODFmNDRlXkEyXkFqcGc@.jpg
-   order: 8
-   imageHasChanged: false
- - id: 
    name: Jess Harnell
    role:
     Additional Voice Talent / Announcer / Announcer #2 / Mission Control Pitty / Boo
@@ -121,6 +111,16 @@ actors: (N>30)
    thumb:
     https://m.media-amazon.com/images/M/MV5BMTU3YTIzYmYtMGYwZi00ZDEyLTg2Y2EtYjk3ZWQx
     MzBlN2RhXkEyXkFqcGc@.jpg
+   order: 8
+   imageHasChanged: false
+ - id: 
+   name: Lori Alan
+   role:
+    Additional Voice Talent / Blue Hawk / Red Car / Area 51 PA Announcer / Ford Mode
+    l T at Wedding
+   thumb:
+    https://m.media-amazon.com/images/M/MV5BMjk4ODUwZmQtNTJkOS00YzIzLWJlYzItMDhjNjJi
+    ODFmNDRlXkEyXkFqcGc@.jpg
    order: 9
    imageHasChanged: false
  - id: 

--- a/test/resources/scrapers/imdbtv/The-Simpsons-tt0096697-minimal-details.ref.txt
+++ b/test/resources/scrapers/imdbtv/The-Simpsons-tt0096697-minimal-details.ref.txt
@@ -15,7 +15,7 @@ overview:
 ratings (N=1)
   source=imdb | rating=8.6 | votes=400000 | min=0 | max=10
 userRating: 0
-imdbTop250: 111
+imdbTop250: 112
 firstAired: 1989-12-17
 runtime: 22min
 genres: (N<6)
@@ -106,7 +106,7 @@ actors: (N>50)
     Ned Flanders / Principal Skinner / Kent Brockman / Lenny / Mr. Burns / Dr. Hibbe
     rt / Lenny Leonard / Waylon Smithers / Reverend Lovejoy / Otto / Montgomery Burn
     s / Scratchy / Jasper / Smithers / Rainier Wolfcastle / Eddie / Kang / Otto Mann
-     / Rev. Lovejoy / Judge Snyder / Mr. Largo / Announcer / Dewey Largo / TV Announ
+     / Rev. Lovejoy / Mr. Largo / Judge Snyder / Announcer / Dewey Largo / TV Announ
     cer / God / Principal Seymour Skinner / Skinner / Seymour Skinner / Jasper Beard
     ly / Dr. Julius Hibbert / Hibbert / Herman / Marty / Dr. Marvin Monroe / Legs / 
     Radio Announcer / Bill / Reverand Lovejoy / Judge / Tom Brokaw / Additional Voic
@@ -205,7 +205,7 @@ actors: (N>50)
  - id: 
    name: Tress MacNeille
    role:
-    Agnes Skinner / Dolph / Various / Lindsey Naegle / Crazy Cat Lady / Mrs. Muntz /
+    Agnes Skinner / Dolph / Lindsey Naegle / Various / Crazy Cat Lady / Mrs. Muntz /
      Brandine / Brandine Spuckler / Shauna Chalmers / Dolph Starbeam / Cookie Kwan /
      Bernice Hibbert / Lunchlady Doris / Nurse / Various Kids / Lindsay Naegle / Man
     jula / Dubya Spuckler / Shauna / Lunchlady Dora / Dolph Shapiro / Mrs. Glick / L
@@ -261,26 +261,26 @@ actors: (N>50)
    role:
     Helen Lovejoy / Luann Van Houten / Maude Flanders / Miss Hoover / Elizabeth Hoov
     er / Nurse / Others / Various / Librarian / Martha Quimby / Mother / Judge / Fan
-     #1 / Reporter / Gavin's Mom / Mrs. Winfield / Shary Bobbins / Ruth Powers / Gov
-    . Mary Bailey / Emma / Auditioning Woman #1 / Dancing Girl #2 / Bowler #3 / Star
-    let / Bernice Hibbert / Chorus Girl #2 / Quimby's Wife / Farrah Fawcett-Majors-O
-    'Neal-Varney / Kitty Carlisle / KBBL Boss / Child #3 / Tar Pit Information Speak
-    er / Child #4 / Richard / Janey Powell / Mrs. Spencer / Woman at Observatory / O
-    perator / Singing Nun / Female Tour Guide / Jimmy Stewart's Granddaughter / Mail
-     Lady / Warren / Maude Flanders #1 / Showgirl / Kristin Shepard / Woman at Park 
-    / Newsreader / Fergie / Mrs. Norton / NASA Scientist #2 / Peggy Bundy / Mrs. Phi
-    llips / Screaming Woman / Woman at Science Fair / Lady / Telemarketer #2 / All i
-    s well / Police Photographer / Thelma / Ashley Grant / Protesting Woman / Woman 
-    on Chat Show / Woman in Gentle Ben Audience #1 / Computer Voice / Marguerita / F
-    emale Worker / Power Plant Voice / Inspector #1 / Application Reviewer #2 / Answ
-    ering Machine / Ticket Booth Lady / Distressed Woman / Dorothy / Building Owner 
-    / Three Stooges Actress / Employee / Guest / Princess Kashmir / Fe-Mail-Man / Ph
-    otography Club Member #1 / Churchgoer / Sunday School Teacher / Strawberry / Old
-     Lady / Ticket Lady / Child Care Woman #1 / Bort #1's Mother / Child Care Woman 
-    #2 / 'I'd be terribly embarrased if I were that boy's mother' / Animator #3 / Sc
-    hool Nurse / Queen Elizabeth / Allison Taylor / Future Tour Guide / Shelbyville 
-    Lemonade Kid / Singing Waiters / Architect Simpson / Sales Coordinator Simpson /
-     Girl #2
+     #1 / Reporter / Gavin's Mom / Mrs. Winfield / Shary Bobbins / Additional Voices
+     / Ruth Powers / Gov. Mary Bailey / Emma / Auditioning Woman #1 / Dancing Girl #
+    2 / Bowler #3 / Starlet / Bernice Hibbert / Chorus Girl #2 / Quimby's Wife / Far
+    rah Fawcett-Majors-O'Neal-Varney / Kitty Carlisle / KBBL Boss / Child #3 / Tar P
+    it Information Speaker / Child #4 / Richard / Janey Powell / Mrs. Spencer / Woma
+    n at Observatory / Operator / Singing Nun / Female Tour Guide / Jimmy Stewart's 
+    Granddaughter / Mail Lady / Warren / Maude Flanders #1 / Showgirl / Kristin Shep
+    ard / Woman at Park / Newsreader / Fergie / Mrs. Norton / NASA Scientist #2 / Pe
+    ggy Bundy / Mrs. Phillips / Screaming Woman / Woman at Science Fair / Lady / Tel
+    emarketer #2 / All is well / Police Photographer / Thelma / Ashley Grant / Prote
+    sting Woman / Woman on Chat Show / Woman in Gentle Ben Audience #1 / Computer Vo
+    ice / Marguerita / Female Worker / Power Plant Voice / Inspector #1 / Applicatio
+    n Reviewer #2 / Answering Machine / Ticket Booth Lady / Distressed Woman / Dorot
+    hy / Building Owner / Three Stooges Actress / Employee / Guest / Princess Kashmi
+    r / Fe-Mail-Man / Photography Club Member #1 / Churchgoer / Sunday School Teache
+    r / Strawberry / Old Lady / Ticket Lady / Child Care Woman #1 / Bort #1's Mother
+     / Child Care Woman #2 / 'I'd be terribly embarrased if I were that boy's mother
+    ' / Animator #3 / School Nurse / Queen Elizabeth / Allison Taylor / Future Tour 
+    Guide / Shelbyville Lemonade Kid / Singing Waiters / Architect Simpson / Sales C
+    oordinator Simpson
    thumb:
     https://m.media-amazon.com/images/M/MV5BOGE4ZmUyOTQtY2MyOS00ZTgwLThkMGEtNDlhMWMy
     MTY1ZDY4XkEyXkFqcGc@.jpg
@@ -369,7 +369,7 @@ actors: (N>50)
    role:
     Carl Carlson / Lou / Security Guard / Fausto / Audrey II / FBI Officer #1 / Empl
     oyee Praising Dance Moves / Partygoer #2 / Gamer / Hockey Player / Wyatt / Fathe
-    r / New York Yankees Player / Male Scientist / Judge
+    r / Chunk Mafia / New York Yankees Player / Male Scientist / Judge
    thumb:
     https://m.media-amazon.com/images/M/MV5BMTY1ODM2NDMzNF5BMl5BanBnXkFtZTcwNzkzMTgy
     Mg@@.jpg
@@ -378,12 +378,13 @@ actors: (N>50)
  - id: 
    name: Grey DeLisle
    role:
-    Martin Prince / Terri / Sherri / Terri Mackleberry / Leland Huebner III / Young 
-    Woman / Martin Prince's Brother / Martin's Child #2 / Women's Bar Customer / Air
-    port Passerby #2 / Airport Passerby #4 / Angry Crowd / Taxidermy Teacher / Frenc
-    h Fry / Francine / Little Girl in Commercial / Parking Enforcement Leader / Rile
-    y / Gloria Prince / Crowd Members / Iris Dalrymple / Malibu Stacy / Mr. Tumnus /
-     Derren Brown Emplyoee / Üter Zörker / Golf Commentator / Sherri Mackleberry
+    Martin Prince / Terri / Sherri / Terri Mackleberry / Sherri Mackleberry / Leland
+     Huebner III / Young Woman / Martin Prince's Brother / Martin's Child #2 / Women
+    's Bar Customer / Airport Passerby #2 / Airport Passerby #4 / Angry Crowd / Taxi
+    dermy Teacher / French Fry / Francine / Little Girl in Commercial / Parking Enfo
+    rcement Leader / Riley / Gloria Prince / Crowd Members / Iris Dalrymple / Malibu
+     Stacy / Mr. Tumnus / Derren Brown Emplyoee / Üter Zörker / Sherri and Terri Mac
+    kleberry / Hub's Mother / Golf Commentator / She-E-O Journalist / Amber
    thumb:
     https://m.media-amazon.com/images/M/MV5BMjg2MTQxOTUyMl5BMl5BanBnXkFtZTcwMTgxNTEx
     OA@@.jpg
@@ -420,7 +421,8 @@ actors: (N>50)
     wyer / Cannabis Influencer / Flight Attendant / Texxon Customer / Female Firefig
     hter / Daly Night / Etta Pryor / Mrs. McBride / Allergy Doctor / Court Bailiff /
      Female Criticizing Workforce / Naima / Grocery Store Clerk / Flight Attendance 
-    #2 / Morher / Karate Kids / Ursula / Party guest
+    #2 / Morher / Karate Kids / Ursula / Party guest / Pam / Perimenopause: The Musi
+    cal Singer
    thumb:
     https://m.media-amazon.com/images/M/MV5BMTYwNTk1NTA3Nl5BMl5BanBnXkFtZTYwNTAyMTM1
     .jpg

--- a/test/scrapers/testImdbMovie.cpp
+++ b/test/scrapers/testImdbMovie.cpp
@@ -89,7 +89,7 @@ TEST_CASE("IMDb scrapes correct movie details", "[movie][IMDb][load_data]")
         CHECK(m.images().posters().size() == 1);
         CHECK(m.runtime() == 97min);
 
-        CHECK_THAT(m.overview(), StartsWith("Dory is a wide-eyed, blue tang fish"));
+        CHECK_THAT(m.overview(), StartsWith("Dory, the regal blue tang"));
         CHECK_THAT(m.outline(), StartsWith("Friendly but forgetful blue tang Dory"));
         CHECK_THAT(m.director(), Contains("Andrew Stanton"));
         CHECK_THAT(m.director(), Contains("Angus MacLane"));


### PR DESCRIPTION
We didn't load the movie's overview/summary/plot from IMDb. We do so now, which means we need to load an additional page.

Furthermore, fixes a bug in the scraper preview: if an error occurred, it loaded forever.

Fix #1929
