### PR TITLE
fix(ui): keep scraper combobox enabled during movie search

### DIFF
--- a/src/ui/movies/MovieSearchWidget.cpp
+++ b/src/ui/movies/MovieSearchWidget.cpp
@@ -227,7 +227,6 @@ void MovieSearchWidget::onShowResults(mediaelch::scraper::MovieSearchJob* search
         // A newer search has been started; discard these stale results.
         return;
     }
-    m_currentSearchJob = nullptr;
 
     if (searchJob->wasKilled()) {
         // If it was killed, don't report anything, but reset the search bar.

--- a/src/ui/movies/MovieSearchWidget.cpp
+++ b/src/ui/movies/MovieSearchWidget.cpp
@@ -96,7 +96,10 @@ void MovieSearchWidget::startSearch()
     emit sigMovieSelectionChanged(false);
 
     abortAndClearResults();
-    ui->comboScraper->setEnabled(false);
+    // Only disable the scraper combobox during custom scraper workflows.
+    // For normal searches, keep it enabled so users can switch scrapers
+    // even while a search is in progress (e.g. if the current scraper is broken).
+    ui->comboScraper->setEnabled(!isCustomScrapingInProgress());
     ui->comboLanguage->setEnabled(false);
     ui->searchString->setLoading(true);
 
@@ -219,6 +222,12 @@ void MovieSearchWidget::onShowResults(mediaelch::scraper::MovieSearchJob* search
 {
     using namespace mediaelch::scraper;
     auto dls = makeDeleteLaterScope(searchJob);
+
+    if (searchJob != m_currentSearchJob) {
+        // A newer search has been started; discard these stale results.
+        return;
+    }
+    m_currentSearchJob = nullptr;
 
     if (searchJob->wasKilled()) {
         // If it was killed, don't report anything, but reset the search bar.


### PR DESCRIPTION
## Problem

When a movie search is in progress, the scraper combobox is disabled. If the active scraper fails (e.g. IMDB returning no data due to changed markup), users cannot switch to a working scraper (e.g. TMDb) until the network request times out (~10 seconds). This makes the search dialog appear frozen and unresponsive.

Additionally, since `doKill()` is not overridden in scraper search jobs, calling `kill()` on a running search job silently fails — the old job continues running in the background. When it eventually completes, its results (or error message) can overwrite the results of a newer search.

Fixes #1945
Relates to #1920

## Changes

**`src/ui/movies/MovieSearchWidget.cpp`**

1. **Keep scraper combobox enabled during search** — Only disable it during custom scraper multi-step workflows (where `isCustomScrapingInProgress()` is true). For normal searches, the combobox stays enabled so users can switch scrapers at any time. Switching mid-search is safe because `startSearch()` already calls `abortAndClearResults()` before starting a new search.

2. **Discard stale search results** — Before processing results in `onShowResults()`, check whether the search job is still the current one. If a newer search has been started, discard the stale results silently. This prevents old error messages from overwriting current search results.

## Testing

Tested manually against v2.12.0 behavior:
- IMDB scraper selected → search returns "0 results" (scraper is broken)
- **Before fix:** Scraper dropdown disabled during search, UI appears frozen
- **After fix:** Dropdown stays clickable, user can immediately switch to TMDb

---
*Developed with AI assistance (Claude Code).*