### PR TITLE
refactor(imdb): parse search results from JSON instead of HTML regex

### DIFF
--- a/src/scrapers/imdb/ImdbSearchPage.cpp
+++ b/src/scrapers/imdb/ImdbSearchPage.cpp
@@ -1,38 +1,71 @@
 #include "ImdbSearchPage.h"
 
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QRegularExpression>
 
-#include "scrapers/ScraperUtils.h"
+#include "log/Log.h"
 
 namespace mediaelch {
 namespace scraper {
 
 QVector<ImdbSearchPage::SearchResult> ImdbSearchPage::parseSearch(const QString& html)
 {
-    // Search result table from "https://www.imdb.com/search/title/?title=..."
-    // The results may contain the user's locale, e.g. `/de/title/…`.
-    static const QRegularExpression rx(R"(<a href="/(?:\w{2,4}/)?title/(tt[\d]+)/[^>]+>(.+)</a>.*(\d{4})[–<])",
-        QRegularExpression::DotMatchesEverythingOption | QRegularExpression::InvertedGreedinessOption);
-    // Entries are numbered: Remove Number.
-    static const QRegularExpression listNo(
-        R"(^\d+\.\s+)", QRegularExpression::DotMatchesEverythingOption | QRegularExpression::InvertedGreedinessOption);
-
     QVector<SearchResult> results;
-    QRegularExpressionMatchIterator matches = rx.globalMatch(html);
-    QRegularExpressionMatch match;
-    while (matches.hasNext()) {
-        match = matches.next();
-        if (match.hasMatch()) {
-            QString title = normalizeFromHtml(match.captured(2));
-            title.remove(listNo);
-            SearchResult result;
-            result.title = title;
-            result.identifier = match.captured(1);
-            result.released = QDate::fromString(match.captured(3), "yyyy");
-            results.push_back(std::move(result));
-        }
+
+    // IMDb embeds search results as JSON in a <script id="__NEXT_DATA__"> tag.
+    // Extract and parse the JSON rather than scraping the HTML with regex.
+    static const QRegularExpression rx(
+        R"re(<script id="__NEXT_DATA__" type="application/json">(.*)</script>)re",
+        QRegularExpression::DotMatchesEverythingOption | QRegularExpression::InvertedGreedinessOption);
+
+    QRegularExpressionMatch match = rx.match(html);
+    if (!match.hasMatch()) {
+        qCWarning(generic) << "[ImdbSearch] Could not find __NEXT_DATA__ JSON in search page";
+        return results;
     }
 
+    QJsonParseError parseError{};
+    const QJsonDocument doc = QJsonDocument::fromJson(match.captured(1).toUtf8(), &parseError);
+    if (parseError.error != QJsonParseError::NoError) {
+        qCWarning(generic) << "[ImdbSearch] Failed to parse __NEXT_DATA__ JSON:" << parseError.errorString();
+        return results;
+    }
+
+    // Path: props.pageProps.searchResults.titleResults.titleListItems
+    const QJsonArray items = doc.object()
+                                 .value("props")
+                                 .toObject()
+                                 .value("pageProps")
+                                 .toObject()
+                                 .value("searchResults")
+                                 .toObject()
+                                 .value("titleResults")
+                                 .toObject()
+                                 .value("titleListItems")
+                                 .toArray();
+
+    for (const QJsonValue& item : items) {
+        const QJsonObject obj = item.toObject();
+        const QString titleId = obj.value("titleId").toString();
+        const QString titleText = obj.value("titleText").toString();
+        const int releaseYear = obj.value("releaseYear").toInt(0);
+
+        if (titleId.isEmpty() || titleText.isEmpty()) {
+            continue;
+        }
+
+        SearchResult result;
+        result.identifier = titleId;
+        result.title = titleText;
+        if (releaseYear > 0) {
+            result.released = QDate(releaseYear, 1, 1);
+        }
+        results.push_back(std::move(result));
+    }
+
+    qCDebug(generic) << "[ImdbSearch] Parsed" << results.size() << "results from __NEXT_DATA__ JSON";
     return results;
 }
 


### PR DESCRIPTION
## Summary

Replace the regex-based HTML parser in `ImdbSearchPage::parseSearch()` with a JSON parser that reads from IMDB's embedded `__NEXT_DATA__` script tag.

The current regex parser still works, but it is fragile — it depends on IMDB's HTML markup staying compatible. IMDB has already migrated their frontend to Next.js/React, and the HTML structure has changed before (breaking the parser in earlier versions). The `__NEXT_DATA__` JSON is the structured data source that IMDB's own frontend renders from, making it a more stable parsing target.

This is the same approach already used by `ImdbJsonParser` for title detail pages (introduced in PR #1912).

Relates to #1920

## Changes

**`src/scrapers/imdb/ImdbSearchPage.cpp`**

Replace the regex-based HTML extraction with JSON parsing of the `__NEXT_DATA__` script tag.

JSON path: `props.pageProps.searchResults.titleResults.titleListItems[]`

Each item provides `titleId`, `titleText`, and `releaseYear` — exactly the fields needed for search results.

## Testing

Tested manually:
- **Search by IMDB ID** (e.g. `tt1254207`): finds the movie, shows preview with poster and description
- **Search by title** (e.g. `Inception`): returns results with correct titles and years
- **TV show search**: uses the same parser, also works
- **Empty/invalid queries**: returns 0 results gracefully

---
*Developed with AI assistance (Claude Code / Opus 4.6).*