### PR TITLE
fix(custom-scraper): use configured language for sub-scraper requests

### DIFF
--- a/src/scrapers/movie/custom/CustomMovieScraper.cpp
+++ b/src/scrapers/movie/custom/CustomMovieScraper.cpp
@@ -94,7 +94,13 @@ MovieScrapeJob* CustomMovieScraper::loadMovie(MovieScrapeJob::Config config)
         if (!scraperMap.contains(detailScraper)) {
             MovieScrapeJob::Config scraperConfig;
             scraperConfig.identifier = m_scraperMovieIds[detailScraper];
-            scraperConfig.locale = detailScraper->meta().defaultLocale;
+            // Use the user-configured language for each sub-scraper, not the
+            // hardcoded default locale.  Fall back to the default if no
+            // configuration is found (e.g. for image-only scrapers).
+            mediaelch::ScraperConfiguration* scraperSettings =
+                Manager::instance()->scrapers().movieScraperConfig(detailScraper->meta().identifier);
+            scraperConfig.locale = (scraperSettings != nullptr) ? scraperSettings->language()
+                                                                : detailScraper->meta().defaultLocale;
             scraperConfig.details = {};
             scraperMap.insert(detailScraper, scraperConfig);
         }


### PR DESCRIPTION
## Problem

The Custom Movie Scraper ignores the user-configured language for each sub-scraper. For example, when TMDb is set to "Deutsch (DE)" in the scraper settings, text fields like Plot, Tagline, and Overview still come back in English.

Relates to #1808

## Root Cause

In `CustomMovieScraper::loadMovie()`, the locale for each sub-scraper request was taken from `detailScraper->meta().defaultLocale` — the **hardcoded default** (English for TMDb), not the **user-configured** language.

```cpp
// Before:
scraperConfig.locale = detailScraper->meta().defaultLocale;  // always English
```

Meanwhile, the user's language choice (e.g. "de-DE") is stored in `ScraperConfiguration::language()` and never queried by the Custom Scraper.

## Fix

Retrieve the configured language from each sub-scraper's `ScraperConfiguration` via `Manager::instance()->scrapers().movieScraperConfig()`. Fall back to the default locale only when no configuration is found (e.g. for image-only scrapers like Fanart.tv).

```cpp
// After:
ScraperConfiguration* scraperSettings =
    Manager::instance()->scrapers().movieScraperConfig(detailScraper->meta().identifier);
scraperConfig.locale = (scraperSettings != nullptr) ? scraperSettings->language()
                                                    : detailScraper->meta().defaultLocale;
```

## Testing

Custom Scraper configured with: Title=IMDb, Plot/Tagline/Overview=TMDb (Deutsch), Images=Fanart.tv

| Field | Before | After |
|-------|--------|-------|
| Tagline | "Break the story. Break the silence." | "Die Wahrheit steckt zwischen den Lügen." |
| Plot | English | German |
| Overview | English | German |
| Images | Loaded correctly | Loaded correctly (unchanged) |