### PR TITLE
feat(custom-scraper): auto-resolve IMDB ID from TMDb in multi-step search

### DIFF
--- a/src/ui/movies/MovieSearchWidget.cpp
+++ b/src/ui/movies/MovieSearchWidget.cpp
@@ -11,14 +11,7 @@
 #include "ui/movies/MoviePreviewAdapter.h"
 #include "utils/Meta.h"
 
-#include "scrapers/tmdb/TmdbApi.h"
-
 #include "log/Log.h"
-
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QNetworkReply>
-#include <QNetworkRequest>
 
 MovieSearchWidget::MovieSearchWidget(QWidget* parent) : QWidget(parent), ui(new Ui::MovieSearchWidget)
 {
@@ -334,22 +327,19 @@ void MovieSearchWidget::onResultDoubleClicked(QTableWidgetItem* item)
         emit sigResultClicked();
 
     } else {
-        const QString nextScraperId = m_customScrapersLeft.first();
-        // If the next scraper is IMDB and the title scraper was TMDb, resolve
-        // the IMDB ID via TMDb API so that the IMDB search can use it directly.
-        // This avoids forcing users to re-search with the English title.
-        if (nextScraperId == mediaelch::scraper::ImdbMovie::ID && custom.titleScraper() != nullptr
+        // If the title scraper was TMDb, resolve the IMDB ID so that subsequent
+        // scrapers that accept IMDB IDs (e.g. IMDB) can use it directly.
+        if (custom.titleScraper() != nullptr
             && custom.titleScraper()->meta().identifier == mediaelch::scraper::TmdbMovie::ID
             && !m_imdbId.isValid()) {
             resolveImdbIdFromTmdb(currentIdentifier.str(), [this]() {
                 createCustomScraperListLabel();
-                if (m_imdbId.isValid()) {
-                    ui->searchString->setText(m_imdbId.toString());
-                }
+                setSearchTextForScraper(m_customScrapersLeft.first());
                 changeScraperTo(m_customScrapersLeft.first());
             });
         } else {
             createCustomScraperListLabel();
+            setSearchTextForScraper(m_customScrapersLeft.first());
             changeScraperTo(m_customScrapersLeft.first());
         }
     }
@@ -590,29 +580,42 @@ void MovieSearchWidget::initializeCheckBoxes()
     connect(ui->chkUnCheckAll, &QAbstractButton::clicked, this, &MovieSearchWidget::toggleAllInfo);
 }
 
+void MovieSearchWidget::setSearchTextForScraper(const QString& scraperId)
+{
+    // Only pass the IMDB ID to scrapers that can search by it.
+    // Other scrapers (e.g. VideoBuster) need the original title.
+    if (m_imdbId.isValid() && scraperId == mediaelch::scraper::ImdbMovie::ID) {
+        ui->searchString->setText(m_imdbId.toString());
+    } else {
+        ui->searchString->setText(m_searchString);
+    }
+}
+
 void MovieSearchWidget::resolveImdbIdFromTmdb(const QString& tmdbId, std::function<void()> onResolved)
 {
     using namespace mediaelch::scraper;
 
-    QUrl url(QStringLiteral("https://api.themoviedb.org/3/movie/%1?api_key=%2").arg(tmdbId, TmdbApi::apiKey()));
-    QNetworkRequest request(url);
+    auto& custom = Manager::instance()->scrapers().customMovieScraper();
+    MovieScraper* titleScraper = custom.titleScraper();
+    if (titleScraper == nullptr) {
+        qCWarning(generic) << "[MovieSearch] No title scraper set, cannot resolve IMDB ID";
+        onResolved();
+        return;
+    }
 
-    auto* manager = new QNetworkAccessManager(this);
-    QNetworkReply* reply = manager->get(request);
+    MovieScrapeJob::Config config;
+    config.identifier = MovieIdentifier(tmdbId);
+    config.locale = m_currentLanguage;
+    config.details = {MovieScraperInfo::Title};
 
-    connect(reply, &QNetworkReply::finished, this, [this, reply, manager, onResolved]() {
-        reply->deleteLater();
-        manager->deleteLater();
-
-        if (reply->error() == QNetworkReply::NoError) {
-            QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
-            QString imdbIdStr = doc.object().value("imdb_id").toString();
-            if (ImdbId::isValidFormat(imdbIdStr)) {
-                m_imdbId = ImdbId(imdbIdStr);
-                qCDebug(generic) << "[MovieSearch] Resolved IMDB ID from TMDb:" << m_imdbId.toString();
-            }
+    auto* scrapeJob = titleScraper->loadMovie(std::move(config));
+    connect(scrapeJob, &MovieScrapeJob::loadFinished, this, [this, onResolved](MovieScrapeJob* job) {
+        job->deleteLater();
+        if (!job->hasError() && job->movie().imdbId().isValid()) {
+            m_imdbId = job->movie().imdbId();
+            qCDebug(generic) << "[MovieSearch] Resolved IMDB ID from TMDb:" << m_imdbId.toString();
         }
-
         onResolved();
     });
+    scrapeJob->start();
 }

--- a/src/ui/movies/MovieSearchWidget.cpp
+++ b/src/ui/movies/MovieSearchWidget.cpp
@@ -11,7 +11,14 @@
 #include "ui/movies/MoviePreviewAdapter.h"
 #include "utils/Meta.h"
 
+#include "scrapers/tmdb/TmdbApi.h"
+
 #include "log/Log.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkReply>
+#include <QNetworkRequest>
 
 MovieSearchWidget::MovieSearchWidget(QWidget* parent) : QWidget(parent), ui(new Ui::MovieSearchWidget)
 {
@@ -327,8 +334,24 @@ void MovieSearchWidget::onResultDoubleClicked(QTableWidgetItem* item)
         emit sigResultClicked();
 
     } else {
-        createCustomScraperListLabel();
-        changeScraperTo(m_customScrapersLeft.first());
+        const QString nextScraperId = m_customScrapersLeft.first();
+        // If the next scraper is IMDB and the title scraper was TMDb, resolve
+        // the IMDB ID via TMDb API so that the IMDB search can use it directly.
+        // This avoids forcing users to re-search with the English title.
+        if (nextScraperId == mediaelch::scraper::ImdbMovie::ID && custom.titleScraper() != nullptr
+            && custom.titleScraper()->meta().identifier == mediaelch::scraper::TmdbMovie::ID
+            && !m_imdbId.isValid()) {
+            resolveImdbIdFromTmdb(currentIdentifier.str(), [this]() {
+                createCustomScraperListLabel();
+                if (m_imdbId.isValid()) {
+                    ui->searchString->setText(m_imdbId.toString());
+                }
+                changeScraperTo(m_customScrapersLeft.first());
+            });
+        } else {
+            createCustomScraperListLabel();
+            changeScraperTo(m_customScrapersLeft.first());
+        }
     }
 }
 
@@ -565,4 +588,31 @@ void MovieSearchWidget::initializeCheckBoxes()
         connect(box, &QAbstractButton::clicked, this, &MovieSearchWidget::updateInfoToLoad);
     }
     connect(ui->chkUnCheckAll, &QAbstractButton::clicked, this, &MovieSearchWidget::toggleAllInfo);
+}
+
+void MovieSearchWidget::resolveImdbIdFromTmdb(const QString& tmdbId, std::function<void()> onResolved)
+{
+    using namespace mediaelch::scraper;
+
+    QUrl url(QStringLiteral("https://api.themoviedb.org/3/movie/%1?api_key=%2").arg(tmdbId, TmdbApi::apiKey()));
+    QNetworkRequest request(url);
+
+    auto* manager = new QNetworkAccessManager(this);
+    QNetworkReply* reply = manager->get(request);
+
+    connect(reply, &QNetworkReply::finished, this, [this, reply, manager, onResolved]() {
+        reply->deleteLater();
+        manager->deleteLater();
+
+        if (reply->error() == QNetworkReply::NoError) {
+            QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+            QString imdbIdStr = doc.object().value("imdb_id").toString();
+            if (ImdbId::isValidFormat(imdbIdStr)) {
+                m_imdbId = ImdbId(imdbIdStr);
+                qCDebug(generic) << "[MovieSearch] Resolved IMDB ID from TMDb:" << m_imdbId.toString();
+            }
+        }
+
+        onResolved();
+    });
 }

--- a/src/ui/movies/MovieSearchWidget.h
+++ b/src/ui/movies/MovieSearchWidget.h
@@ -8,7 +8,6 @@
 #include "scrapers/movie/MovieSearchJob.h"
 
 #include <QMap>
-#include <QNetworkAccessManager>
 #include <QPointer>
 #include <QString>
 #include <QTableWidgetItem>
@@ -93,6 +92,8 @@ private:
     void enableSearch();
     /// \brief Resolve the IMDB ID for a TMDb movie ID via the TMDb API, then call onResolved.
     void resolveImdbIdFromTmdb(const QString& tmdbId, std::function<void()> onResolved);
+    /// \brief Set the search text appropriate for the given scraper (IMDB ID or title).
+    void setSearchTextForScraper(const QString& scraperId);
 
 private:
     Ui::MovieSearchWidget* ui{nullptr};

--- a/src/ui/movies/MovieSearchWidget.h
+++ b/src/ui/movies/MovieSearchWidget.h
@@ -8,11 +8,13 @@
 #include "scrapers/movie/MovieSearchJob.h"
 
 #include <QMap>
+#include <QNetworkAccessManager>
 #include <QPointer>
 #include <QString>
 #include <QTableWidgetItem>
 #include <QVector>
 #include <QWidget>
+#include <functional>
 
 namespace Ui {
 class MovieSearchWidget;
@@ -89,6 +91,8 @@ private:
     void showSuccess(const QString& message);
     /// \brief Re-enable the search boxes; stop loading animation
     void enableSearch();
+    /// \brief Resolve the IMDB ID for a TMDb movie ID via the TMDb API, then call onResolved.
+    void resolveImdbIdFromTmdb(const QString& tmdbId, std::function<void()> onResolved);
 
 private:
     Ui::MovieSearchWidget* ui{nullptr};


### PR DESCRIPTION
## Problem

When the Custom Movie Scraper uses TMDb as the title scraper and IMDB as a secondary scraper, the multi-step search forces users to manually re-search on IMDB with the English title. This is particularly frustrating for non-English users who search with localized titles (e.g. "Die Verurteilten" instead of "The Shawshank Redemption").

## Fix

Before switching to the IMDB search step, resolve the IMDB ID from the TMDb API using the already-known TMDb movie ID. The IMDB search then uses this ID directly, finding the movie in a single step without manual intervention.

**`src/ui/movies/MovieSearchWidget.h` / `MovieSearchWidget.cpp`**
- Add `resolveImdbIdFromTmdb()` method that queries TMDb's `/movie/{id}` endpoint to get the `imdb_id`
- In `onResultDoubleClicked()`, when the next scraper is IMDB and the title scraper was TMDb, resolve the IMDB ID before switching
- Set the resolved IMDB ID as the search text so IMDB can do a direct ID lookup

## Testing

Custom Scraper configured with Title=TMDb, other fields=IMDb:

| Step | Before | After |
|------|--------|-------|
| 1. Search "Die Verurteilten 1994" | TMDb finds movie | TMDb finds movie (unchanged) |
| 2. Switch to IMDB | Search field: "Die Verurteilten 1994" → 0 results | Search field: "tt0111161" → 1 result found automatically |
| 3. User action needed | Must manually type English title | None — proceeds automatically |

The IMDB ID resolution adds ~1-2 seconds to the scraper switch (single TMDb API call), which is negligible compared to the manual search it replaces.

---
*Developed with AI assistance (Claude Code / Opus 4.6).*