### PR TITLE
feat(TMDB): TMDB image provider supports Movie Logos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
   - TvMaze can now load episodes' guest cast (actors) for single-episode scraping (#1801)
   - TVMaze can now load episodes' guest crew (directors, writers) for single-episode scraping (#1877)
 - NFO: `<hdrtype>` is now supported (#1810)
+- TMDB: Movie logos can now be scraped (#1950)
 - Renamer:
   - Placeholder `<tmdbId>` is now also available for TV shows and episodes (#1814)
   - Spaces in file names can be replaced by `_` or `-` (#1827)

--- a/src/scrapers/image/TmdbImages.cpp
+++ b/src/scrapers/image/TmdbImages.cpp
@@ -23,6 +23,7 @@ TmdbImages::TmdbImages(QObject* parent) : ImageProvider(parent)
     m_meta.privacyPolicy = "https://www.themoviedb.org/privacy-policy";
     m_meta.help = "https://www.themoviedb.org/talk";
     m_meta.supportedImageTypes = {  //
+        ImageType::MovieLogo,       //
         ImageType::MovieBackdrop,   //
         ImageType::MoviePoster,     //
         ImageType::ConcertBackdrop, //
@@ -138,6 +139,9 @@ void TmdbImages::onMovieLoadImagesFinished(mediaelch::scraper::MovieScrapeJob* j
 
     } else if (details.contains(MovieScraperInfo::Poster)) {
         posters = job->movie().images().posters();
+
+    } else if (details.contains(MovieScraperInfo::Logo)) {
+        posters = job->movie().images().logos();
     }
 
     emit sigImagesLoaded(posters, {});
@@ -156,7 +160,16 @@ void TmdbImages::movieImages(Movie* movie, TmdbId tmdbId, QSet<ImageType> types)
  */
 void TmdbImages::movieLogos(TmdbId tmdbId)
 {
-    Q_UNUSED(tmdbId);
+    using namespace mediaelch::scraper;
+
+    MovieScrapeJob::Config config;
+    config.identifier = MovieIdentifier(tmdbId);
+    config.details = {MovieScraperInfo::Logo};
+    config.locale = m_tmdb->meta().defaultLocale;
+
+    auto* scrapeJob = m_tmdb->loadMovie(config);
+    connect(scrapeJob, &MovieScrapeJob::loadFinished, this, &TmdbImages::onMovieLoadImagesFinished);
+    scrapeJob->start();
 }
 
 void TmdbImages::movieBanners(TmdbId tmdbId)


### PR DESCRIPTION
Follow up to #1961, which forgot to adapt the UI.