### PR TITLE
fix(videobuster): broaden search to include full rental catalog

### DIFF
--- a/src/scrapers/movie/videobuster/VideoBusterApi.cpp
+++ b/src/scrapers/movie/videobuster/VideoBusterApi.cpp
@@ -69,6 +69,7 @@ QUrl VideoBusterApi::makeMovieSearchUrl(const QString& searchStr) const
     QUrlQuery queries;
     queries.addQueryItem("tab_search_content", "movies");
     queries.addQueryItem("view", "title_list_view_option_list");
+    queries.addQueryItem("search_business_cases", "1");
     queries.addQueryItem("search_title", encodedSearch);
     return makeApiUrl("/titlesearch.php", queries);
 }


### PR DESCRIPTION
Fix VideoBuster movie search missing titles not available in the "aLaCarte" rental category.

The search URL did not set `search_business_cases`, so VideoBuster defaulted to aLaCarte-only (`11`). Adding `search_business_cases=1` broadens the search to the full rental catalog.

Fixes #1971

Developed with AI assistance (Claude Code / Opus 4.6).