### PR TITLE
fix(videobuster): strip year from search query

### DIFF
--- a/src/scrapers/movie/MovieSearchJob.cpp
+++ b/src/scrapers/movie/MovieSearchJob.cpp
@@ -18,9 +18,9 @@ QPair<QString, QString> MovieSearchJob::extractTitleAndYear(const QString& query
         rxYear.setPatternOptions(QRegularExpression::InvertedGreedinessOption);
         auto match = rxYear.match(query);
         if (match.hasMatch()) {
-            QString searchTitle = match.captured(0);
-            QString searchYear = match.captured(1);
-            return {searchTitle, searchTitle};
+            QString searchTitle = match.captured(1);
+            QString searchYear = match.captured(2);
+            return {searchTitle, searchYear};
         }
     }
     return {};

--- a/src/scrapers/movie/videobuster/VideoBusterSearchJob.cpp
+++ b/src/scrapers/movie/videobuster/VideoBusterSearchJob.cpp
@@ -14,7 +14,11 @@ VideoBusterSearchJob::VideoBusterSearchJob(VideoBusterApi& api, MovieSearchJob::
 
 void VideoBusterSearchJob::doStart()
 {
-    m_api.searchForMovie(config().query, [this](QString data, ScraperError error) {
+    QString query = MovieSearchJob::extractTitleAndYear(config().query).first;
+    if (query.isEmpty()) {
+        query = config().query;
+    }
+    m_api.searchForMovie(query, [this](QString data, ScraperError error) {
         if (error.hasError()) {
             setScraperError(error);
 


### PR DESCRIPTION
Fix VideoBuster search returning 0 results when the query contains a year (e.g. "Inception 2010"). VideoBuster does not support year in the search string.

Also fixes a bug in `MovieSearchJob::extractTitleAndYear()` where `captured(0)` (full match) was returned instead of `captured(1)` (title) and `captured(2)` (year).

Fixes #1973

Developed with AI assistance (Claude Code / Opus 4.6).