### PR TITLE
feat(custom-scraper): add Skip button for sub-scrapers with no results

### DIFF
--- a/data/i18n/MediaElch_de.ts
+++ b/data/i18n/MediaElch_de.ts
@@ -4854,6 +4854,10 @@ Operation abgebrochen.</translation>
         <translation>Schließen</translation>
     </message>
     <message>
+        <source>Skip</source>
+        <translation>Überspringen</translation>
+    </message>
+    <message>
         <location line="+13"/>
         <source>Scrape</source>
         <translation>Laden</translation>

--- a/src/ui/movies/MovieSearch.cpp
+++ b/src/ui/movies/MovieSearch.cpp
@@ -16,11 +16,16 @@ MovieSearch::MovieSearch(QWidget* parent) : QDialog(parent), ui(new Ui::MovieSea
 #endif
     connect(ui->buttonClose, &QAbstractButton::clicked, this, &MovieSearch::reject);
     connect(ui->buttonScrape, &QAbstractButton::clicked, this, &MovieSearch::onScrapeClicked);
+    connect(ui->buttonSkip, &QAbstractButton::clicked, ui->movieSearchWidget, &MovieSearchWidget::onSkipCurrentScraper);
     connect(ui->movieSearchWidget, &MovieSearchWidget::sigResultClicked, this, &MovieSearch::accept);
     connect(ui->movieSearchWidget,
         &MovieSearchWidget::sigMovieSelectionChanged,
         this,
         &MovieSearch::onMovieSelectionChanged);
+    connect(ui->movieSearchWidget,
+        &MovieSearchWidget::sigScraperChanged,
+        this,
+        &MovieSearch::onScraperChanged);
 }
 
 MovieSearch::~MovieSearch()
@@ -90,4 +95,10 @@ QHash<mediaelch::scraper::MovieScraper*, mediaelch::scraper::MovieIdentifier> Mo
 void MovieSearch::onMovieSelectionChanged(bool isSelected)
 {
     ui->buttonScrape->setEnabled(isSelected);
+}
+
+void MovieSearch::onScraperChanged(bool isCustomScraper)
+{
+    ui->buttonSkip->setVisible(isCustomScraper);
+    ui->buttonSkip->setEnabled(isCustomScraper);
 }

--- a/src/ui/movies/MovieSearch.h
+++ b/src/ui/movies/MovieSearch.h
@@ -33,6 +33,8 @@ public slots:
     int execWithSearch(QString searchString, ImdbId id, TmdbId tmdbId);
     /// \brief Called when a movie is (de-)selected in the movie search widget.
     void onMovieSelectionChanged(bool isSelected);
+    /// \brief Show/hide the Skip button based on whether the custom scraper is active.
+    void onScraperChanged(bool isCustomScraper);
 
 public:
     /// \brief Returns the selected locale.

--- a/src/ui/movies/MovieSearch.ui
+++ b/src/ui/movies/MovieSearch.ui
@@ -53,6 +53,22 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="buttonSkip">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="visible">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Skip</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="buttonScrape">
        <property name="enabled">
         <bool>false</bool>

--- a/src/ui/movies/MovieSearchWidget.cpp
+++ b/src/ui/movies/MovieSearchWidget.cpp
@@ -332,6 +332,7 @@ void MovieSearchWidget::onResultDoubleClicked(QTableWidgetItem* item)
 
     if (m_customScrapersLeft.isEmpty()) {
         m_currentScraper = &custom;
+        emit sigScraperChanged(false);
         emit sigResultClicked();
 
     } else {
@@ -456,8 +457,10 @@ void MovieSearchWidget::onScraperChanged(int index)
 
     if (m_currentScraper->meta().identifier == mediaelch::scraper::CustomMovieScraper::ID) {
         onCustomMovieScraperSelected();
+        emit sigScraperChanged(true);
     } else if (!isCustomScrapingInProgress()) {
         ui->lblCustomScraperInfo->hide();
+        emit sigScraperChanged(false);
     }
 
     setupLanguageDropdown();
@@ -626,4 +629,48 @@ void MovieSearchWidget::resolveImdbIdFromTmdb(const QString& tmdbId, std::functi
         onResolved();
     });
     scrapeJob->start();
+}
+
+void MovieSearchWidget::onSkipCurrentScraper()
+{
+    using namespace mediaelch::scraper;
+
+    if (isCustomScrapingInProgress()) {
+        // Skip a sub-scraper during multi-step workflow
+        m_customScrapersLeft.removeOne(m_currentScraper->meta().identifier);
+
+        if (m_customScrapersLeft.isEmpty()) {
+            CustomMovieScraper& custom = Manager::instance()->scrapers().customMovieScraper();
+            m_currentScraper = &custom;
+            emit sigScraperChanged(false);
+            emit sigResultClicked();
+        } else {
+            createCustomScraperListLabel();
+            changeScraperTo(m_customScrapersLeft.first());
+        }
+    } else if (m_currentScraper->meta().identifier == CustomMovieScraper::ID) {
+        // Skip the title scraper — start multi-step with remaining scrapers
+        CustomMovieScraper& custom = Manager::instance()->scrapers().customMovieScraper();
+        MovieScraper* titleScraper = custom.titleScraper();
+        const auto scrapers = custom.scrapersNeedSearch(infosToLoad());
+
+        ui->comboScraper->setEnabled(false);
+        ui->comboLanguage->setEnabled(false);
+        ui->detailsGroupBox->setEnabled(false);
+
+        for (const MovieScraper* scraper : scrapers) {
+            if (scraper != titleScraper) {
+                m_customScrapersLeft << scraper->meta().identifier;
+            }
+        }
+
+        if (m_customScrapersLeft.isEmpty()) {
+            m_currentScraper = &custom;
+            emit sigScraperChanged(false);
+            emit sigResultClicked();
+        } else {
+            createCustomScraperListLabel();
+            changeScraperTo(m_customScrapersLeft.first());
+        }
+    }
 }

--- a/src/ui/movies/MovieSearchWidget.h
+++ b/src/ui/movies/MovieSearchWidget.h
@@ -39,6 +39,8 @@ public slots:
     /// \brief Used by the surrounding dialog when "scrape" button is clicked.
     /// \todo Remove; breaks dependency chain; move buttons to widget?
     void onScrapeSelectedMovie();
+    /// \brief Skip the current sub-scraper in the custom movie scraper workflow.
+    void onSkipCurrentScraper();
 
 public:
     QString scraperId();
@@ -50,6 +52,8 @@ signals:
     void sigResultClicked();
     /// \brief Emitted when a different movie is selected. \p isSelected is false if there is no movie selected.
     void sigMovieSelectionChanged(bool isSelected);
+    /// \brief Emitted when the active scraper changes. \p isCustomScraper is true if the custom movie scraper is active.
+    void sigScraperChanged(bool isCustomScraper);
 
 private slots:
     void startSearch();


### PR DESCRIPTION
## Summary

- Add a "Skip" button to the movie search dialog for the Custom Movie Scraper
- When a sub-scraper returns no results (e.g. movie not listed on VideoBuster), users can skip it and continue with the remaining scrapers
- The button appears whenever the Custom Movie Scraper is active, allowing skipping of any scraper including the title scraper
- The backend already handles missing scrapers gracefully (`CustomMovieScraper::loadMovie()` silently skips any scraper not in the `customScraperIds` map) — this change only adds the missing UI capability

Fixes #1978

## Test plan

- [ ] Select "Custom Movie Scraper", verify Skip button appears
- [ ] Search a movie, double-click TMDb result, skip VideoBuster → remaining scrapers work
- [ ] Search something TMDb doesn't find, skip it → sub-scrapers proceed
- [ ] Switch to a non-custom scraper → Skip button disappears
- [ ] Skip all scrapers → dialog closes without crash

Developed with AI assistance (Claude Code / Opus 4.6).