### PR TITLE
add resolute build logic

### DIFF
--- a/.ci/docker/Dockerfile.build-ubuntu-26.04
+++ b/.ci/docker/Dockerfile.build-ubuntu-26.04
@@ -1,0 +1,37 @@
+FROM ubuntu:26.04
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+        ca-certificates \
+        g++ gcc \
+        build-essential \
+        git \
+        cmake \
+        wget \
+        libmediainfo-dev \
+        ffmpeg \
+        qt6-base-dev \
+        qt6-base-dev-tools \
+        qmake6 \
+        qt6-tools-dev \
+        qt6-tools-dev-tools \
+        qt6-multimedia-dev \
+        qt6-image-formats-plugins \
+        libqt6opengl6 \
+        libqt6opengl6-dev \
+        qt6-svg-dev \
+        libqt5svg5 \
+        libqt6svg6 \
+        libqt6svg6-dev \
+        qt6-l10n-tools \
+        libqt6core5compat6 \
+        libqt6core5compat6-dev \
+        libqt6sql6-sqlite \
+        libqt6concurrent6 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/qmake qmake /usr/bin/qmake6 90
+RUN git config --system --add safe.directory '*'
+
+WORKDIR /opt/src

--- a/.ci/docker/docker-build-all.sh
+++ b/.ci/docker/docker-build-all.sh
@@ -13,5 +13,6 @@ cd "$(dirname "$0")"
 ./docker-build-dist.sh ubuntu-20.04        | tee -a docker-build.log
 ./docker-build-dist.sh ubuntu-22.04        | tee -a docker-build.log
 ./docker-build-dist.sh ubuntu-24.04        | tee -a docker-build.log
+./docker-build-dist.sh ubuntu-26.04        | tee -a docker-build.log
 ./docker-build-dist.sh opensuse-leap-15    | tee -a docker-build.log
 ./docker-build-dist.sh opensuse-tumbleweed | tee -a docker-build.log

--- a/.ci/docker/docker-build-dist.sh
+++ b/.ci/docker/docker-build-dist.sh
@@ -21,6 +21,7 @@ DISTROS=(
 	"ubuntu-20.04"
 	"ubuntu-22.04"
 	"ubuntu-24.04"
+	"ubuntu-26.04"
 	"opensuse-leap-15"
 	"opensuse-tumbleweed"
 )

--- a/.ci/linux/package_linux_launchpad.sh
+++ b/.ci/linux/package_linux_launchpad.sh
@@ -160,7 +160,7 @@ package_and_upload_to_launchpad() {
 
 	# Create builds for other Ubuntu releases that Launchpad supports
 	distr=focal                   # Ubuntu 20.04
-	others=(jammy noble oracular) # Ubuntu 22.04, 24.04, 24.10
+	others=(jammy noble oracular resolute) # Ubuntu 22.04, 24.04, 24.10, 26.04
 	for next in "${others[@]}"; do
 		echo "Now processing ${next}"
 		sed -i "s/${distr}/${next}/g" debian/changelog


### PR DESCRIPTION
I am not 100% on how to get stuff into the PPA, but I just noticed resolute has not been added yet. 

Local docker build works with some warnings. 

Let me know if this need any changes. 