### PR TITLE
[TMDb] Fix duplicate include_adult parameter in movie search

### DIFF
--- a/src/scrapers/movie/tmdb/TmdbMovieSearchJob.cpp
+++ b/src/scrapers/movie/tmdb/TmdbMovieSearchJob.cpp
@@ -46,10 +46,7 @@ void TmdbMovieSearchJob::doStart()
         url.swap(newUrl);
 
     } else {
-        QUrl newUrl(m_api.getMovieSearchUrl(searchStr,
-            config().locale,
-            config().includeAdult,
-            TmdbApi::UrlParameterMap{{TmdbApi::ApiUrlParameter::INCLUDE_ADULT, includeAdult}}));
+        QUrl newUrl(m_api.getMovieSearchUrl(searchStr, config().locale, config().includeAdult, {}));
         url.swap(newUrl);
         QVector<QRegularExpression> rxYears;
         rxYears << QRegularExpression(R"(^(.*) \((\d{4})\)$)") << QRegularExpression("^(.*) (\\d{4})$")
@@ -65,8 +62,7 @@ void TmdbMovieSearchJob::doStart()
                 QUrl newSearchUrl = m_api.getMovieSearchUrl(searchTitle,
                     config().locale,
                     config().includeAdult,
-                    TmdbApi::UrlParameterMap{{TmdbApi::ApiUrlParameter::INCLUDE_ADULT, includeAdult},
-                        {TmdbApi::ApiUrlParameter::YEAR, searchYear}});
+                    TmdbApi::UrlParameterMap{{TmdbApi::ApiUrlParameter::YEAR, searchYear}});
                 url.swap(newSearchUrl);
                 break;
             }


### PR DESCRIPTION
Fixes Issue #1992.

The `include_adult` query parameter was being appended twice to TMDb
movie search URLs, causing TMDb to reject the requests with HTTP 400.

In `TmdbMovieSearchJob::doStart()`, `includeAdult` was passed both as
a direct argument to `getMovieSearchUrl()` (which adds it to the
query) and again via the `UrlParameterMap` using
`ApiUrlParameter::INCLUDE_ADULT`. Removed the redundant map entry in
both code paths so the parameter is now sent exactly once.

Testing: Verified the final request URL contains `include_adult`
exactly once and that movie search returns results again instead of
HTTP 400.