### PR TITLE
refactor: constructor-inject persistence classes + better testing

### DIFF
--- a/src/database/ConcertPersistence.h
+++ b/src/database/ConcertPersistence.h
@@ -14,14 +14,14 @@ class ConcertPersistence
 {
 public:
     explicit ConcertPersistence(Database& db);
+    virtual ~ConcertPersistence() = default;
     QSqlDatabase db();
 
-    void clearAllConcerts();
-    void clearConcertsInDirectory(DirectoryPath path);
-    void add(Concert* concert, DirectoryPath path);
-    void update(Concert* concert);
-    QVector<Concert*> concertsInDirectory(DirectoryPath path);
-
+    virtual void clearAllConcerts();
+    virtual void clearConcertsInDirectory(DirectoryPath path);
+    virtual void add(Concert* concert, DirectoryPath path);
+    virtual void update(Concert* concert);
+    virtual QVector<Concert*> concertsInDirectory(DirectoryPath path);
 
 private:
     Database& m_db;

--- a/src/database/MoviePersistence.h
+++ b/src/database/MoviePersistence.h
@@ -14,13 +14,14 @@ class MoviePersistence
 {
 public:
     explicit MoviePersistence(Database& db);
+    virtual ~MoviePersistence() = default;
     QSqlDatabase db();
 
-    void clearAllMovies();
-    void clearMoviesInDirectory(DirectoryPath path);
-    void addMovie(Movie* movie, DirectoryPath path);
-    void update(Movie* movie);
-    QVector<Movie*> moviesInDirectory(DirectoryPath path, QObject* movieParent);
+    virtual void clearAllMovies();
+    virtual void clearMoviesInDirectory(DirectoryPath path);
+    virtual void addMovie(Movie* movie, DirectoryPath path);
+    virtual void update(Movie* movie);
+    virtual QVector<Movie*> moviesInDirectory(DirectoryPath path, QObject* movieParent);
 
 private:
     Database& m_db;

--- a/src/database/MusicPersistence.h
+++ b/src/database/MusicPersistence.h
@@ -15,19 +15,20 @@ class MusicPersistence
 {
 public:
     explicit MusicPersistence(Database& db);
+    virtual ~MusicPersistence() = default;
     QSqlDatabase db();
 
-    void clearAllArtists();
-    void clearArtistsInDirectory(DirectoryPath path);
-    void add(Artist* artist, DirectoryPath path);
-    void update(Artist* artist);
-    QVector<Artist*> artistsInDirectory(DirectoryPath path);
+    virtual void clearAllArtists();
+    virtual void clearArtistsInDirectory(DirectoryPath path);
+    virtual void add(Artist* artist, DirectoryPath path);
+    virtual void update(Artist* artist);
+    virtual QVector<Artist*> artistsInDirectory(DirectoryPath path);
 
-    void clearAllAlbums();
-    void clearAlbumsInDirectory(DirectoryPath path);
-    void add(Album* album, DirectoryPath path);
-    void update(Album* album);
-    QVector<Album*> albums(Artist* artist);
+    virtual void clearAllAlbums();
+    virtual void clearAlbumsInDirectory(DirectoryPath path);
+    virtual void add(Album* album, DirectoryPath path);
+    virtual void update(Album* album);
+    virtual QVector<Album*> albums(Artist* artist);
 
 private:
     Database& m_db;

--- a/src/database/TvShowPersistence.h
+++ b/src/database/TvShowPersistence.h
@@ -17,29 +17,28 @@ class TvShowPersistence
 {
 public:
     explicit TvShowPersistence(Database& db);
+    virtual ~TvShowPersistence() = default;
     QSqlDatabase db();
 
+    virtual void add(TvShow* show, mediaelch::DirectoryPath path);
+    virtual void add(TvShowEpisode* episode, mediaelch::DirectoryPath path, mediaelch::DatabaseId idShow);
+    virtual void update(TvShow* show);
+    virtual void update(TvShowEpisode* episode);
+    virtual void clearAllTvShows();
+    virtual void clearTvShowsInDirectory(mediaelch::DirectoryPath path);
+    virtual void clearTvShowInDirectory(mediaelch::DirectoryPath path);
+    virtual int showCount(mediaelch::DirectoryPath path);
+    virtual QVector<TvShow*> showsInDirectory(mediaelch::DirectoryPath path);
+    virtual QVector<TvShowEpisode*> episodes(mediaelch::DatabaseId idShow);
+    virtual int episodeCount();
 
-    void add(TvShow* show, mediaelch::DirectoryPath path);
-    void add(TvShowEpisode* episode, mediaelch::DirectoryPath path, mediaelch::DatabaseId idShow);
-    void update(TvShow* show);
-    void update(TvShowEpisode* episode);
-    void clearAllTvShows();
-    void clearTvShowsInDirectory(mediaelch::DirectoryPath path);
-    void clearTvShowInDirectory(mediaelch::DirectoryPath path);
-    int showCount(mediaelch::DirectoryPath path);
-    QVector<TvShow*> showsInDirectory(mediaelch::DirectoryPath path);
-    QVector<TvShowEpisode*> episodes(mediaelch::DatabaseId idShow);
-    int episodeCount();
-
-    void setShowMissingEpisodes(TvShow* show, bool showMissing);
-    void setHideSpecialsInMissingEpisodes(TvShow* show, bool hideSpecials);
-    mediaelch::DatabaseId showsSettingsId(TvShow* show);
-    void clearEpisodeList(mediaelch::DatabaseId showsSettingsId);
-    void cleanUpEpisodeList(mediaelch::DatabaseId showsSettingsId);
-    void addEpisodeToShowList(TvShowEpisode* episode, mediaelch::DatabaseId showsSettingsId, TmdbId tmdbId);
-    QVector<TvShowEpisode*> showsEpisodes(TvShow* show);
-
+    virtual void setShowMissingEpisodes(TvShow* show, bool showMissing);
+    virtual void setHideSpecialsInMissingEpisodes(TvShow* show, bool hideSpecials);
+    virtual mediaelch::DatabaseId showsSettingsId(TvShow* show);
+    virtual void clearEpisodeList(mediaelch::DatabaseId showsSettingsId);
+    virtual void cleanUpEpisodeList(mediaelch::DatabaseId showsSettingsId);
+    virtual void addEpisodeToShowList(TvShowEpisode* episode, mediaelch::DatabaseId showsSettingsId, TmdbId tmdbId);
+    virtual QVector<TvShowEpisode*> showsEpisodes(TvShow* show);
 
 private:
     Database& m_db;

--- a/src/file_search/ConcertFileSearcher.cpp
+++ b/src/file_search/ConcertFileSearcher.cpp
@@ -1,6 +1,5 @@
 #include "ConcertFileSearcher.h"
 
-#include "database/ConcertPersistence.h"
 #include "globals/Helper.h"
 #include "globals/Manager.h"
 #include "globals/MessageIds.h"
@@ -12,8 +11,8 @@
 #include <QSqlQuery>
 #include <QSqlRecord>
 
-ConcertFileSearcher::ConcertFileSearcher(QObject* parent) :
-    QObject(parent), m_progressMessageId{Constants::ConcertFileSearcherProgressMessageId}
+ConcertFileSearcher::ConcertFileSearcher(mediaelch::ConcertPersistence& persistence, QObject* parent) :
+    QObject(parent), m_progressMessageId{Constants::ConcertFileSearcherProgressMessageId}, m_persistence{persistence}
 {
 }
 
@@ -187,9 +186,8 @@ void ConcertFileSearcher::scanDir(QString startPath,
 
 void ConcertFileSearcher::clearOldConcerts(bool forceClear)
 {
-    mediaelch::ConcertPersistence persistence{*Manager::instance()->database()};
     if (forceClear) {
-        persistence.clearAllConcerts();
+        m_persistence.clearAllConcerts();
     }
 
     // clear gui
@@ -197,14 +195,13 @@ void ConcertFileSearcher::clearOldConcerts(bool forceClear)
 
     for (const mediaelch::MediaDirectory& dir : asConst(m_directories)) {
         if (dir.autoReload || forceClear) {
-            persistence.clearConcertsInDirectory(mediaelch::DirectoryPath(dir.path));
+            m_persistence.clearConcertsInDirectory(mediaelch::DirectoryPath(dir.path));
         }
     }
 }
 
 QVector<QStringList> ConcertFileSearcher::loadContentsFromDiskIfRequired(bool forceReload)
 {
-    mediaelch::ConcertPersistence persistence{*Manager::instance()->database()};
     QVector<QStringList> contents;
 
     for (const mediaelch::MediaDirectory& dir : asConst(m_directories)) {
@@ -212,7 +209,7 @@ QVector<QStringList> ConcertFileSearcher::loadContentsFromDiskIfRequired(bool fo
             continue;
         }
         const QString path = dir.path.path();
-        QVector<Concert*> concertsFromDb = persistence.concertsInDirectory(mediaelch::DirectoryPath(dir.path));
+        QVector<Concert*> concertsFromDb = m_persistence.concertsInDirectory(mediaelch::DirectoryPath(dir.path));
         if (dir.autoReload || forceReload || concertsFromDb.isEmpty()) {
             scanDir(path, path, contents, dir.separateFolders, true);
         }
@@ -222,7 +219,6 @@ QVector<QStringList> ConcertFileSearcher::loadContentsFromDiskIfRequired(bool fo
 
 void ConcertFileSearcher::storeContentsInDatabase(const QVector<QStringList>& contents)
 {
-    mediaelch::ConcertPersistence persistence{*Manager::instance()->database()};
     // Setup concerts
     Manager::instance()->database()->db().transaction();
     for (const QStringList& files : contents) {
@@ -257,7 +253,7 @@ void ConcertFileSearcher::storeContentsInDatabase(const QVector<QStringList>& co
         concert.setInSeparateFolder(inSeparateFolder);
         concert.controller()->loadData(Manager::instance()->mediaCenterInterface());
         emit currentDir(concert.title());
-        persistence.add(&concert, mediaelch::DirectoryPath(path));
+        m_persistence.add(&concert, mediaelch::DirectoryPath(path));
     }
     Manager::instance()->database()->db().commit();
 }
@@ -277,13 +273,12 @@ void ConcertFileSearcher::setupDatabaseConcerts(const QVector<Concert*>& dbConce
 
 QVector<Concert*> ConcertFileSearcher::loadConcertsFromDatabase()
 {
-    mediaelch::ConcertPersistence persistence{*Manager::instance()->database()};
     QVector<Concert*> dbConcerts;
     for (const mediaelch::MediaDirectory& dir : asConst(m_directories)) {
         if (m_aborted) {
             break;
         }
-        dbConcerts.append(persistence.concertsInDirectory(mediaelch::DirectoryPath(dir.path)));
+        dbConcerts.append(m_persistence.concertsInDirectory(mediaelch::DirectoryPath(dir.path)));
     }
     setupDatabaseConcerts(dbConcerts);
     return dbConcerts;

--- a/src/file_search/ConcertFileSearcher.h
+++ b/src/file_search/ConcertFileSearcher.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "database/Database.h"
+#include "database/ConcertPersistence.h"
 #include "globals/MediaDirectory.h"
 
 #include <QDir>
@@ -14,7 +14,7 @@ class ConcertFileSearcher : public QObject
 {
     Q_OBJECT
 public:
-    explicit ConcertFileSearcher(QObject* parent = nullptr);
+    explicit ConcertFileSearcher(mediaelch::ConcertPersistence& persistence, QObject* parent = nullptr);
     void setConcertDirectories(QVector<mediaelch::MediaDirectory> directories);
 
 public slots:
@@ -31,6 +31,7 @@ private:
     QVector<mediaelch::MediaDirectory> m_directories;
     int m_progressMessageId;
     bool m_aborted = false;
+    mediaelch::ConcertPersistence& m_persistence;
 
 private:
     void clearOldConcerts(bool forceClear);

--- a/src/file_search/MusicFileSearcher.cpp
+++ b/src/file_search/MusicFileSearcher.cpp
@@ -2,7 +2,6 @@
 
 #include "data/music/Album.h"
 #include "data/music/Artist.h"
-#include "database/MusicPersistence.h"
 #include "globals/Manager.h"
 #include "globals/MessageIds.h"
 #include "log/Log.h"
@@ -11,8 +10,11 @@
 #include <QFileInfo>
 #include <QtConcurrent>
 
-MusicFileSearcher::MusicFileSearcher(QObject* parent) :
-    QObject(parent), m_progressMessageId{Constants::MusicFileSearcherProgressMessageId}, m_aborted{false}
+MusicFileSearcher::MusicFileSearcher(mediaelch::MusicPersistence& persistence, QObject* parent) :
+    QObject(parent),
+    m_progressMessageId{Constants::MusicFileSearcherProgressMessageId},
+    m_aborted{false},
+    m_persistence{persistence}
 {
 }
 
@@ -50,10 +52,8 @@ void MusicFileSearcher::reload(bool force)
     QVector<Album*> albums;
     QVector<Album*> albumsFromDb;
 
-    mediaelch::MusicPersistence persistence{*Manager::instance()->database()};
-
     if (force) {
-        persistence.clearAllArtists();
+        m_persistence.clearAllArtists();
     }
 
     QMap<Artist*, mediaelch::DirectoryPath> artistPaths;
@@ -67,7 +67,7 @@ void MusicFileSearcher::reload(bool force)
         }
 
         if (dir.autoReload) {
-            persistence.clearArtistsInDirectory(mediaelch::DirectoryPath(dir.path));
+            m_persistence.clearArtistsInDirectory(mediaelch::DirectoryPath(dir.path));
         }
 
         if (dir.autoReload || force) {
@@ -113,12 +113,12 @@ void MusicFileSearcher::reload(bool force)
                 }
             }
         } else {
-            QVector<Artist*> artistsInPath = persistence.artistsInDirectory(mediaelch::DirectoryPath(dir.path));
+            QVector<Artist*> artistsInPath = m_persistence.artistsInDirectory(mediaelch::DirectoryPath(dir.path));
             for (Artist* artist : artistsInPath) {
                 if (artistsFromDb.count() % 20 == 0) {
                     emit currentDir(artist->path().toString().mid(dir.path.path().length()));
                 }
-                QVector<Album*> albumsOfArtist = persistence.albums(artist);
+                QVector<Album*> albumsOfArtist = m_persistence.albums(artist);
                 artistsFromDb.append(artist);
                 albumsFromDb.append(albumsOfArtist);
             }
@@ -142,7 +142,7 @@ void MusicFileSearcher::reload(bool force)
             emit currentDir(artist->name());
         }
         emit progress(++current, max, m_progressMessageId);
-        persistence.add(artist, artistPaths.value(artist));
+        m_persistence.add(artist, artistPaths.value(artist));
     }
     for (Album* album : albums) {
         if (m_aborted) {
@@ -154,7 +154,7 @@ void MusicFileSearcher::reload(bool force)
             emit currentDir(album->artist() + "/" + album->title());
         }
         emit progress(++current, max, m_progressMessageId);
-        persistence.add(album, albumPaths.value(album));
+        m_persistence.add(album, albumPaths.value(album));
     }
     Manager::instance()->database()->db().commit();
 

--- a/src/file_search/MusicFileSearcher.h
+++ b/src/file_search/MusicFileSearcher.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "database/MusicPersistence.h"
 #include "globals/MediaDirectory.h"
 
 #include <QObject>
@@ -13,7 +14,7 @@ class MusicFileSearcher : public QObject
 {
     Q_OBJECT
 public:
-    explicit MusicFileSearcher(QObject* parent = nullptr);
+    explicit MusicFileSearcher(mediaelch::MusicPersistence& persistence, QObject* parent = nullptr);
     ~MusicFileSearcher() override = default;
 
     void setMusicDirectories(QVector<mediaelch::MediaDirectory> directories);
@@ -34,4 +35,5 @@ private:
     QVector<mediaelch::MediaDirectory> m_directories;
     int m_progressMessageId;
     bool m_aborted;
+    mediaelch::MusicPersistence& m_persistence;
 };

--- a/src/file_search/TvShowFileSearcher.cpp
+++ b/src/file_search/TvShowFileSearcher.cpp
@@ -2,7 +2,6 @@
 
 #include "data/tv_show/TvShow.h"
 #include "data/tv_show/TvShowEpisode.h"
-#include "database/TvShowPersistence.h"
 #include "globals/Helper.h"
 #include "globals/Manager.h"
 #include "globals/MessageIds.h"
@@ -15,8 +14,11 @@
 #include <QSqlRecord>
 #include <QtConcurrent/QtConcurrentMap>
 
-TvShowFileSearcher::TvShowFileSearcher(QObject* parent) :
-    QObject(parent), m_progressMessageId{Constants::TvShowSearcherProgressMessageId}, m_aborted{false}
+TvShowFileSearcher::TvShowFileSearcher(mediaelch::TvShowPersistence& persistence, QObject* parent) :
+    QObject(parent),
+    m_progressMessageId{Constants::TvShowSearcherProgressMessageId},
+    m_aborted{false},
+    m_persistence{persistence}
 {
 }
 
@@ -57,8 +59,7 @@ void TvShowFileSearcher::reload(bool force)
     emit searchStarted(tr("Loading TV Shows..."));
     int episodeCounter = 0;
 
-    mediaelch::TvShowPersistence persistence{*Manager::instance()->database()};
-    const int episodeSum = persistence.episodeCount();
+    const int episodeSum = m_persistence.episodeCount();
 
     QVector<TvShow*> dbShows = getShowsFromDatabase(force);
     setupShows(files, episodeCounter, episodeSum);
@@ -84,8 +85,7 @@ TvShowEpisode* TvShowFileSearcher::loadEpisodeData(TvShowEpisode* episode)
 
 void TvShowFileSearcher::reloadEpisodes(const mediaelch::DirectoryPath& showDir)
 {
-    mediaelch::TvShowPersistence persistence{*Manager::instance()->database()};
-    persistence.clearTvShowInDirectory(showDir);
+    m_persistence.clearTvShowInDirectory(showDir);
     emit searchStarted(tr("Searching for Episodes..."));
 
     // remove old show object
@@ -123,7 +123,7 @@ void TvShowFileSearcher::reloadEpisodes(const mediaelch::DirectoryPath& showDir)
     scanTvShowDir(path, showDir, contents);
     auto* show = new TvShow(showDir, this);
     show->loadData(Manager::instance()->mediaCenterInterfaceTvShow());
-    persistence.add(show, path);
+    m_persistence.add(show, path);
 
     emit searchStarted(tr("Loading Episodes..."));
     emit currentDir(show->title());
@@ -149,7 +149,7 @@ void TvShowFileSearcher::reloadEpisodes(const mediaelch::DirectoryPath& showDir)
     QtConcurrent::blockingMapped(episodes, TvShowFileSearcher::reloadEpisodeData);
 
     for (TvShowEpisode* episode : episodes) {
-        persistence.add(episode, path, show->databaseId());
+        m_persistence.add(episode, path, show->databaseId());
         show->addEpisode(episode);
         emit progress(++episodeCounter, episodeSum, m_progressMessageId);
         QApplication::processEvents();
@@ -457,16 +457,15 @@ void TvShowFileSearcher::clearOldTvShows(bool forceClear)
     // clear gui
     Manager::instance()->tvShowModel()->clear();
 
-    mediaelch::TvShowPersistence persistence{*Manager::instance()->database()};
     if (forceClear) {
         // Simply delete all shows
-        persistence.clearAllTvShows();
+        m_persistence.clearAllTvShows();
 
     } else {
         // Otherwise, only clear disabled directories and those with autoReload.
         for (const mediaelch::MediaDirectory& dir : asConst(m_directories)) {
             if (dir.autoReload || dir.disabled) {
-                persistence.clearTvShowsInDirectory(mediaelch::DirectoryPath(dir.path));
+                m_persistence.clearTvShowsInDirectory(mediaelch::DirectoryPath(dir.path));
             }
         }
     }
@@ -474,7 +473,6 @@ void TvShowFileSearcher::clearOldTvShows(bool forceClear)
 
 void TvShowFileSearcher::setupShowsFromDatabase(QVector<TvShow*>& dbShows, int episodeCounter, int episodeSum)
 {
-    mediaelch::TvShowPersistence persistence{*Manager::instance()->database()};
     for (TvShow* show : dbShows) {
         if (m_aborted) {
             return;
@@ -482,7 +480,7 @@ void TvShowFileSearcher::setupShowsFromDatabase(QVector<TvShow*>& dbShows, int e
 
         show->loadData(Manager::instance()->mediaCenterInterfaceTvShow(), false);
 
-        QVector<TvShowEpisode*> episodes = persistence.episodes(show->databaseId());
+        QVector<TvShowEpisode*> episodes = m_persistence.episodes(show->databaseId());
         QtConcurrent::blockingMapped(episodes, TvShowFileSearcher::loadEpisodeData);
         for (TvShowEpisode* episode : episodes) {
             if (episode == nullptr) {
@@ -502,8 +500,6 @@ void TvShowFileSearcher::setupShowsFromDatabase(QVector<TvShow*>& dbShows, int e
 
 void TvShowFileSearcher::setupShows(QMap<QString, QVector<QStringList>>& contents, int& episodeCounter, int episodeSum)
 {
-    mediaelch::TvShowPersistence persistence{*Manager::instance()->database()};
-
     QMapIterator<QString, QVector<QStringList>> it(contents);
     while (it.hasNext()) {
         it.next();
@@ -538,7 +534,7 @@ void TvShowFileSearcher::setupShows(QMap<QString, QVector<QStringList>>& content
         auto* show = new TvShow(mediaelch::DirectoryPath(it.key()), this);
         show->loadData(Manager::instance()->mediaCenterInterfaceTvShow());
         emit currentDir(show->title());
-        persistence.add(show, path);
+        m_persistence.add(show, path);
 
         Manager::instance()->database()->db().transaction();
         QVector<TvShowEpisode*> episodes;
@@ -559,7 +555,7 @@ void TvShowFileSearcher::setupShows(QMap<QString, QVector<QStringList>>& content
 
         // Add episodes to model
         for (TvShowEpisode* episode : asConst(episodes)) {
-            persistence.add(episode, path, show->databaseId());
+            m_persistence.add(episode, path, show->databaseId());
             show->addEpisode(episode);
             emit progress(++episodeCounter, episodeSum, m_progressMessageId);
         }
@@ -573,7 +569,6 @@ void TvShowFileSearcher::setupShows(QMap<QString, QVector<QStringList>>& content
 
 QMap<QString, QVector<QStringList>> TvShowFileSearcher::readTvShowContent(bool forceReload)
 {
-    mediaelch::TvShowPersistence persistence{*Manager::instance()->database()};
     QMap<QString, QVector<QStringList>> contents;
     for (const mediaelch::MediaDirectory& dir : asConst(m_directories)) {
         if (m_aborted) {
@@ -590,7 +585,7 @@ QMap<QString, QVector<QStringList>> TvShowFileSearcher::readTvShowContent(bool f
         // TODO: Check if necessary?
         // If there are no shows in the database for the directory, reload
         // all shows regardless of forceReload.
-        const int showsFromDatabase = persistence.showCount(mediaelch::DirectoryPath(dir.path));
+        const int showsFromDatabase = m_persistence.showCount(mediaelch::DirectoryPath(dir.path));
         if (showsFromDatabase == 0) {
             getTvShows(mediaelch::DirectoryPath(dir.path), contents);
             continue;
@@ -606,7 +601,6 @@ QVector<TvShow*> TvShowFileSearcher::getShowsFromDatabase(bool forceReload)
         return {};
     }
 
-    mediaelch::TvShowPersistence persistence{*Manager::instance()->database()};
     QVector<TvShow*> dbShows;
     for (const mediaelch::MediaDirectory& dir : asConst(m_directories)) {
         if (dir.autoReload) { // Those directories are not read from database.
@@ -615,7 +609,7 @@ QVector<TvShow*> TvShowFileSearcher::getShowsFromDatabase(bool forceReload)
         if (dir.disabled) {
             continue;
         }
-        QVector<TvShow*> showsFromDatabase = persistence.showsInDirectory(mediaelch::DirectoryPath(dir.path));
+        QVector<TvShow*> showsFromDatabase = m_persistence.showsInDirectory(mediaelch::DirectoryPath(dir.path));
         if (!showsFromDatabase.isEmpty()) {
             dbShows.append(showsFromDatabase);
         }

--- a/src/file_search/TvShowFileSearcher.h
+++ b/src/file_search/TvShowFileSearcher.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "data/tv_show/TvShowEpisode.h"
+#include "database/TvShowPersistence.h"
 #include "globals/MediaDirectory.h"
 #include "media/Path.h"
 
@@ -11,7 +12,7 @@ class TvShowFileSearcher : public QObject
 {
     Q_OBJECT
 public:
-    explicit TvShowFileSearcher(QObject* parent = nullptr);
+    explicit TvShowFileSearcher(mediaelch::TvShowPersistence& persistence, QObject* parent = nullptr);
     void setTvShowDirectories(QVector<mediaelch::MediaDirectory> directories);
     static SeasonNumber getSeasonNumber(QStringList files);
     static QVector<EpisodeNumber> getEpisodeNumbers(QStringList files);
@@ -46,4 +47,6 @@ private:
     QVector<TvShow*> getShowsFromDatabase(bool forceReload);
     void setupShows(QMap<QString, QVector<QStringList>>& contents, int& episodeCounter, int episodeSum);
     void setupShowsFromDatabase(QVector<TvShow*>& dbShows, int episodeCounter, int episodeSum);
+
+    mediaelch::TvShowPersistence& m_persistence;
 };

--- a/src/file_search/movie/MovieFileSearcher.cpp
+++ b/src/file_search/movie/MovieFileSearcher.cpp
@@ -1,6 +1,5 @@
 #include "MovieFileSearcher.h"
 
-#include "database/MoviePersistence.h"
 #include "globals/Manager.h"
 #include "globals/MessageIds.h"
 #include "log/Log.h"
@@ -14,7 +13,8 @@
 
 namespace mediaelch {
 
-MovieFileSearcher::MovieFileSearcher(QObject* parent) : QObject(parent), m_store{new MovieLoaderStore(this)}
+MovieFileSearcher::MovieFileSearcher(mediaelch::MoviePersistence& persistence, QObject* parent) :
+    QObject(parent), m_store{new MovieLoaderStore(this)}, m_persistence{persistence}
 {
     connect(this, &MovieFileSearcher::started, this, [this]() { m_reloadTimer.start(); });
     connect(this, &MovieFileSearcher::finished, this, [this]() {
@@ -69,9 +69,8 @@ void MovieFileSearcher::reload(bool reloadFromDisk)
         return;
     }
 
-    MoviePersistence persistence{*Manager::instance()->database()};
     if (reloadFromDisk) {
-        persistence.clearAllMovies();
+        m_persistence.clearAllMovies();
     }
 
     Manager::instance()->movieModel()->clear();
@@ -89,7 +88,7 @@ void MovieFileSearcher::reload(bool reloadFromDisk)
         // was cleared above.  If the directory is disabled, we also clear the cache if
         // autoReload is on.
         if (movieDir.autoReload && !reloadFromDisk) {
-            persistence.clearMoviesInDirectory(movieDir.path);
+            m_persistence.clearMoviesInDirectory(movieDir.path);
         }
         if (!movieDir.disabled) {
             movieDir.autoReload = movieDir.autoReload || reloadFromDisk;

--- a/src/file_search/movie/MovieFileSearcher.h
+++ b/src/file_search/movie/MovieFileSearcher.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "database/MoviePersistence.h"
 #include "globals/MediaDirectory.h"
 
 #include <QDir>
@@ -19,7 +20,6 @@ class Job;
 
 class MovieLoader;
 class MovieLoaderStore;
-class MoviePersistence;
 
 /// \brief Class responsible for (re-)loading all movies inside given directories.
 ///
@@ -33,7 +33,7 @@ class MovieFileSearcher : public QObject
 {
     Q_OBJECT
 public:
-    explicit MovieFileSearcher(QObject* parent = nullptr);
+    explicit MovieFileSearcher(mediaelch::MoviePersistence& persistence, QObject* parent = nullptr);
     ~MovieFileSearcher() override;
 
     /// \brief Sets the directories to scan for movies. Not readable directories are skipped.
@@ -72,6 +72,7 @@ private:
 
     bool m_running = false;
     bool m_aborted = false;
+    mediaelch::MoviePersistence& m_persistence;
 };
 
 } // namespace mediaelch

--- a/src/globals/Manager.cpp
+++ b/src/globals/Manager.cpp
@@ -21,22 +21,28 @@ Manager::Manager(QObject* parent) : QObject(parent)
 
     m_settings = Settings::instance();
     m_scraperManager = new mediaelch::ScraperManager(*m_settings, this);
+    m_database = new Database(this);
 
-    m_movieFileSearcher = new mediaelch::MovieFileSearcher(this);
-    m_tvShowFileSearcher = new TvShowFileSearcher(this);
-    m_concertFileSearcher = new ConcertFileSearcher(this);
-    m_musicFileSearcher = new MusicFileSearcher(this);
+    m_moviePersistence = std::make_unique<mediaelch::MoviePersistence>(*m_database);
+    m_tvShowPersistence = std::make_unique<mediaelch::TvShowPersistence>(*m_database);
+    m_concertPersistence = std::make_unique<mediaelch::ConcertPersistence>(*m_database);
+    m_musicPersistence = std::make_unique<mediaelch::MusicPersistence>(*m_database);
+    m_movieFileSearcher = new mediaelch::MovieFileSearcher(*m_moviePersistence, this);
+    m_tvShowFileSearcher = new TvShowFileSearcher(*m_tvShowPersistence, this);
+    m_concertFileSearcher = new ConcertFileSearcher(*m_concertPersistence, this);
+    m_musicFileSearcher = new MusicFileSearcher(*m_musicPersistence, this);
     m_movieModel = new MovieModel(this);
     m_tvShowModel = new TvShowModel(this);
     m_concertModel = new ConcertModel(this);
     m_musicModel = new MusicModel(this);
-    m_database = new Database(this);
 
     m_kodiSettings = new mediaelch::KodiSettings(*m_settings, this);
     m_kodiSettings->init();
-    m_mediaCenters.append(new KodiXml(*m_kodiSettings, this));
-    m_mediaCentersTvShow.append(new KodiXml(*m_kodiSettings, this));
-    m_mediaCentersConcert.append(new KodiXml(*m_kodiSettings, this));
+    KodiXml::MediaPersistence persistence{
+        *m_moviePersistence, *m_tvShowPersistence, *m_concertPersistence, *m_musicPersistence};
+    m_mediaCenters.append(new KodiXml(*m_kodiSettings, persistence, this));
+    m_mediaCentersTvShow.append(new KodiXml(*m_kodiSettings, persistence, this));
+    m_mediaCentersConcert.append(new KodiXml(*m_kodiSettings, persistence, this));
 
     m_trailerProviders.append(new HdTrailers(this));
 

--- a/src/globals/Manager.h
+++ b/src/globals/Manager.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include "database/ConcertPersistence.h"
 #include "database/Database.h"
+#include "database/MoviePersistence.h"
+#include "database/MusicPersistence.h"
+#include "database/TvShowPersistence.h"
+
 #include "file_search/ConcertFileSearcher.h"
 #include "file_search/MusicFileSearcher.h"
 #include "file_search/TvShowFileSearcher.h"
@@ -21,6 +26,7 @@
 #include "ui/music/MusicFilesWidget.h"
 #include "ui/scrapers/ScraperManager.h"
 #include "ui/tv_show/TvShowFilesWidget.h"
+#include <memory>
 
 #include <QString>
 #include <QVector>
@@ -87,6 +93,10 @@ private:
     ConcertModel* m_concertModel = nullptr;
     MusicModel* m_musicModel = nullptr;
     Database* m_database = nullptr;
+    std::unique_ptr<mediaelch::MoviePersistence> m_moviePersistence;
+    std::unique_ptr<mediaelch::TvShowPersistence> m_tvShowPersistence;
+    std::unique_ptr<mediaelch::ConcertPersistence> m_concertPersistence;
+    std::unique_ptr<mediaelch::MusicPersistence> m_musicPersistence;
     TvShowFilesWidget* m_tvShowFilesWidget = nullptr;
     MusicFilesWidget* m_musicFilesWidget = nullptr;
     FileScannerDialog* m_fileScannerDialog = nullptr;

--- a/src/media_center/KodiXml.cpp
+++ b/src/media_center/KodiXml.cpp
@@ -1,13 +1,6 @@
 #include "KodiXml.h"
 
 #include "data/Image.h"
-#include "data/movie/Movie.h"
-#include "data/tv_show/TvShow.h"
-#include "data/tv_show/TvShowEpisode.h"
-#include "database/ConcertPersistence.h"
-#include "database/MoviePersistence.h"
-#include "database/MusicPersistence.h"
-#include "database/TvShowPersistence.h"
 #include "globals/Globals.h"
 #include "globals/Helper.h"
 #include "globals/Manager.h"
@@ -34,8 +27,8 @@
 #include <array>
 #include <memory>
 
-KodiXml::KodiXml(mediaelch::KodiSettings& settings, QObject* parent) :
-    MediaCenterInterface(parent), m_settings{settings}
+KodiXml::KodiXml(mediaelch::KodiSettings& settings, MediaPersistence persistence, QObject* parent) :
+    MediaCenterInterface(parent), m_settings{settings}, m_persistence{persistence}
 {
 }
 
@@ -183,8 +176,7 @@ bool KodiXml::saveMovie(Movie* movie)
     }
 
     // TODO: Multithreaded?
-    mediaelch::MoviePersistence persistence{*Manager::instance()->database()};
-    persistence.update(movie);
+    m_persistence.movies.update(movie);
 
     return true;
 }
@@ -627,8 +619,7 @@ bool KodiXml::saveConcert(Concert* concert)
     }
 
     concert->setNfoContent(xmlContent);
-    mediaelch::ConcertPersistence persistence{*Manager::instance()->database()};
-    persistence.update(concert);
+    m_persistence.concerts.update(concert);
 
     bool saved = false;
     QFileInfo fi(concert->files().first().toString());
@@ -933,8 +924,7 @@ bool KodiXml::saveTvShow(TvShow* show)
     }
 
     show->setNfoContent(xmlContent);
-    mediaelch::TvShowPersistence persistence{*Manager::instance()->database()};
-    persistence.update(show);
+    m_persistence.tvShows.update(show);
 
     for (DataFile dataFile : Settings::instance()->dataFiles(DataFileType::TvShowNfo)) {
         QString saveFilePath = show->dir().filePath(dataFile.saveFileName(""));
@@ -1042,12 +1032,11 @@ bool KodiXml::saveTvShowEpisode(TvShowEpisode* episode)
     }
 
     const QByteArray xmlContent = getEpisodeXml(episodes);
-    mediaelch::TvShowPersistence persistence{*Manager::instance()->database()};
     for (TvShowEpisode* subEpisode : episodes) {
         subEpisode->setNfoContent(xmlContent);
         subEpisode->setSyncNeeded(true);
         subEpisode->setChanged(false);
-        persistence.update(subEpisode);
+        m_persistence.tvShows.update(subEpisode);
     }
 
     QFileInfo fi(episode->files().first().toString());
@@ -1665,8 +1654,7 @@ bool KodiXml::saveArtist(Artist* artist)
     }
 
     artist->setNfoContent(xmlContent);
-    mediaelch::MusicPersistence persistence{*Manager::instance()->database()};
-    persistence.update(artist);
+    m_persistence.music.update(artist);
 
     QString fileName = nfoFilePath(artist);
     if (fileName.isEmpty()) {
@@ -1733,8 +1721,7 @@ bool KodiXml::saveAlbum(Album* album)
     }
 
     album->setNfoContent(xmlContent);
-    mediaelch::MusicPersistence persistence{*Manager::instance()->database()};
-    persistence.update(album);
+    m_persistence.music.update(album);
 
     QString nfoFileName = nfoFilePath(album);
     if (nfoFileName.isEmpty()) {

--- a/src/media_center/KodiXml.h
+++ b/src/media_center/KodiXml.h
@@ -3,6 +3,10 @@
 #include "data/concert/Concert.h"
 #include "data/music/Album.h"
 #include "data/music/Artist.h"
+#include "database/ConcertPersistence.h"
+#include "database/MoviePersistence.h"
+#include "database/MusicPersistence.h"
+#include "database/TvShowPersistence.h"
 #include "media_center/MediaCenterInterface.h"
 #include "settings/KodiSettings.h"
 
@@ -22,7 +26,15 @@ class KodiXml : public MediaCenterInterface
 {
     Q_OBJECT
 public:
-    explicit KodiXml(mediaelch::KodiSettings& settings, QObject* parent = nullptr);
+    struct MediaPersistence
+    {
+        mediaelch::MoviePersistence& movies;
+        mediaelch::TvShowPersistence& tvShows;
+        mediaelch::ConcertPersistence& concerts;
+        mediaelch::MusicPersistence& music;
+    };
+
+    explicit KodiXml(mediaelch::KodiSettings& settings, MediaPersistence persistence, QObject* parent = nullptr);
     ~KodiXml() override;
 
     // movies
@@ -123,4 +135,5 @@ private:
 
 private:
     mediaelch::KodiSettings& m_settings;
+    MediaPersistence m_persistence;
 };

--- a/test/helpers/diff.cpp
+++ b/test/helpers/diff.cpp
@@ -36,12 +36,14 @@ QDomDocument parseXml(const QString& content)
 
 #else
     QDomDocument::ParseResult result = doc.setContent(content, QDomDocument::ParseOption::Default);
-    CAPTURE(result.errorMessage);
-    CAPTURE(result.errorLine);
-    CAPTURE(result.errorColumn);
+    if (!result) {
+        CAPTURE(result.errorMessage);
+        CAPTURE(result.errorLine);
+        CAPTURE(result.errorColumn);
 
-    REQUIRE(result.errorLine == -1);
-    REQUIRE(result.errorColumn == -1);
+        REQUIRE(result.errorLine == -1);
+        REQUIRE(result.errorColumn == -1);
+    }
 #endif
 
     return doc;


### PR DESCRIPTION


This commit makes the persistence classes virtual, so that we can
better test them in the future.

Furthermore, it constructor-injects the persistence classes where
needed.