### PR TITLE
i18n: Add Russian translation for desktop entry and AppStream data

### DIFF
--- a/data/desktop/MediaElch.desktop
+++ b/data/desktop/MediaElch.desktop
@@ -6,3 +6,4 @@ Terminal=false
 Exec=MediaElch
 Categories=AudioVideo;AudioVideoEditing;Database;Qt;
 GenericName=Media Manager
+GenericName[ru]=Менеджер медиатеки

--- a/data/desktop/com.kvibes.MediaElch.metainfo.xml
+++ b/data/desktop/com.kvibes.MediaElch.metainfo.xml
@@ -3,6 +3,7 @@
   <id>com.kvibes.MediaElch</id>
   <name>MediaElch</name>
   <summary>MediaElch is a MediaManager for Kodi</summary>
+  <summary xml:lang="ru">Менеджер медиатеки для Kodi</summary>
   <developer_name>MediaElch Team</developer_name>
   <metadata_license>CC-BY-4.0</metadata_license>
   <project_license>LGPL-3.0-only</project_license>
@@ -10,6 +11,9 @@
   <description>
     <p>
       MediaElch is a MediaManager for Kodi. Information about Movies, TV Shows, Concerts and Music are stored as nfo files. Fanarts are downloaded automatically from fanart.tv. Using the nfo generator, MediaElch can be used with other MediaCenters as well.
+    </p>
+    <p xml:lang="ru">
+      MediaElch — менеджер медиатеки для Kodi. Сведения о фильмах, сериалах, концертах и музыке он хранит в файлах NFO, а фан-арт скачивает с fanart.tv сам. Генератор NFO позволяет работать и с другими медиацентрами, не только с Kodi.
     </p>
   </description>
 
@@ -25,6 +29,7 @@
     <screenshot type="default">
       <image>https://mediaelch.github.io/mediaelch-doc/_images/movie-main.png</image>
       <caption>Manage your movies</caption>
+      <caption xml:lang="ru">Управление фильмами</caption>
     </screenshot>
   </screenshots>
 </component>


### PR DESCRIPTION
The launcher entry and the AppStream data are about the only user-visible strings MediaElch ships that are not translated into anything — they are not part of the Transifex resource, so they can only arrive as a patch. On a Russian desktop that shows: the application itself speaks Russian, while the menu and the software centre still say "Media Manager".

I translated `GenericName` instead of adding a `Comment`. Plasma's launcher and KRunner take the generic name first and only fall back to `Comment` when it is empty, so a `Comment[ru]` on its own would have changed nothing — I tried it locally and the menu still read "Media Manager"; with `GenericName[ru]` it reads "Менеджер медиатеки". That also keeps the entry free of a second field saying the same thing twice.

The wording follows the Russian UI translation that is already on Transifex (фильмы, сериалы, концерты, музыка, файлы NFO), so the menu and the application use the same terms. `desktop-file-validate` stays clean and `appstreamcli validate` reports exactly the same notes as before the change; `appstreamcli compose` picks up all three translated strings into the catalogue.
