### PR TITLE
Make path and file fields copyable (read-only)

### DIFF
--- a/src/ui/concerts/ConcertInfoWidget.ui
+++ b/src/ui/concerts/ConcertInfoWidget.ui
@@ -41,8 +41,8 @@
    </item>
    <item row="0" column="1">
     <widget class="QLineEdit" name="files">
-     <property name="enabled">
-      <bool>false</bool>
+     <property name="readOnly">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/src/ui/movies/MovieWidget.ui
+++ b/src/ui/movies/MovieWidget.ui
@@ -177,8 +177,8 @@
               </item>
               <item row="0" column="1">
                <widget class="QLineEdit" name="files">
-                <property name="enabled">
-                 <bool>false</bool>
+                <property name="readOnly">
+                 <bool>true</bool>
                 </property>
                </widget>
               </item>

--- a/src/ui/music/MusicWidgetAlbum.ui
+++ b/src/ui/music/MusicWidgetAlbum.ui
@@ -140,8 +140,8 @@
             </item>
             <item row="0" column="1">
              <widget class="QLineEdit" name="path">
-              <property name="enabled">
-               <bool>false</bool>
+              <property name="readOnly">
+               <bool>true</bool>
               </property>
              </widget>
             </item>

--- a/src/ui/music/MusicWidgetArtist.ui
+++ b/src/ui/music/MusicWidgetArtist.ui
@@ -140,8 +140,8 @@
             </item>
             <item row="0" column="1">
              <widget class="QLineEdit" name="path">
-              <property name="enabled">
-               <bool>false</bool>
+              <property name="readOnly">
+               <bool>true</bool>
               </property>
              </widget>
             </item>

--- a/src/ui/tv_show/TvShowWidgetEpisode.ui
+++ b/src/ui/tv_show/TvShowWidgetEpisode.ui
@@ -192,8 +192,8 @@
             </item>
             <item row="0" column="1">
              <widget class="QLineEdit" name="files">
-              <property name="enabled">
-               <bool>false</bool>
+              <property name="readOnly">
+               <bool>true</bool>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
## Summary
- Change informational path/file `QLineEdit`s from `enabled=false` to `readOnly=true` so users can select and copy paths (mouse, Ctrl+C, context menu) without being able to edit them.
- Covers movie/concert/episode **Files** fields and music album/artist **Path** fields.

## Notes / follow-ups
- **Visual:** `readOnly` fields look like normal inputs (not grayed out like disabled widgets). If that feels confusing, we can later tweak the style (e.g. palette/stylesheet closer to a label/disabled look) while keeping selection/copy.
- **Tab focus:** previously disabled fields were usually skipped by Tab; they can now receive focus, which also helps keyboard selection/copy.

## Test plan
- [ ] Open a movie / concert / episode → Files field: cannot edit, can select/copy part of the path
- [ ] Open a music artist/album → Path field: same behavior
- [ ] Confirm Save / scrape still work (path is not persisted from this widget)