### PR TITLE
fix: use basename without video extension for multi-file sidecars

### DIFF
--- a/src/media_center/KodiXml.cpp
+++ b/src/media_center/KodiXml.cpp
@@ -27,6 +27,21 @@
 #include <array>
 #include <memory>
 
+namespace {
+
+QString firstExistingFileInDir(const QString& dirPath, const QStringList& candidates)
+{
+    for (const QString& file : candidates) {
+        const QString path = dirPath + "/" + file;
+        if (QFileInfo::exists(path)) {
+            return path;
+        }
+    }
+    return {};
+}
+
+} // namespace
+
 KodiXml::KodiXml(mediaelch::KodiSettings& settings, MediaPersistence persistence, QObject* parent) :
     MediaCenterInterface(parent), m_settings{settings}, m_persistence{persistence}
 {
@@ -186,54 +201,54 @@ bool KodiXml::saveMovie(Movie* movie)
  * \param movie Movie
  * \return Path to nfo file, if none found returns an empty string
  */
-QString KodiXml::nfoFilePath(Movie* movie)
+QString KodiXml::nfoFilePath(Movie* movie, bool allowLooseFallbacks)
 {
-    QString nfoFile;
     if (movie->files().isEmpty()) {
         qCWarning(generic) << "Movie has no files";
-        return nfoFile;
+        return {};
     }
     QFileInfo fi(movie->files().first().toString());
     if (!fi.isFile()) {
         qCWarning(generic) << "First file of the movie is not readable" << movie->files().at(0);
-        return nfoFile;
+        return {};
     }
 
-    for (DataFile dataFile : Settings::instance()->dataFiles(DataFileType::MovieNfo)) {
-        QString file = dataFile.saveFileName(fi.fileName(), SeasonNumber::NoSeason, movie->files().count() > 1);
-        QFileInfo nfoFi(fi.absolutePath() + "/" + file);
-        if (nfoFi.exists()) {
-            nfoFile = fi.absolutePath() + "/" + file;
-            break;
-        }
-    }
-
-    return nfoFile;
+    const bool stacked = movie->files().count() > 1;
+    const QString folderName = QFileInfo(fi.absolutePath()).fileName();
+    const SidecarLookupOptions options =
+        allowLooseFallbacks ? SidecarLookupOptions::forMovieLoad() : SidecarLookupOptions::strict();
+    const QStringList candidates = DataFile::sidecarFileNameCandidates( //
+        Settings::instance()->dataFiles(DataFileType::MovieNfo),
+        fi.fileName(),
+        stacked,
+        folderName,
+        options);
+    return firstExistingFileInDir(fi.absolutePath(), candidates);
 }
 
-QString KodiXml::nfoFilePath(TvShowEpisode* episode)
+QString KodiXml::nfoFilePath(TvShowEpisode* episode, bool allowLooseFallbacks)
 {
-    QString nfoFile;
     if (episode->files().isEmpty()) {
         qCWarning(generic) << "[KodiXml] Episode has no files";
-        return nfoFile;
+        return {};
     }
     QFileInfo fi(episode->files().first().toString());
     if (!fi.isFile()) {
         qCWarning(generic) << "[KodiXml] First file of the episode is not readable" << episode->files().first();
-        return nfoFile;
+        return {};
     }
 
-    for (DataFile dataFile : Settings::instance()->dataFiles(DataFileType::TvShowEpisodeNfo)) {
-        QString file = dataFile.saveFileName(fi.fileName(), SeasonNumber::NoSeason, episode->files().size() > 1);
-        QFileInfo nfoFi(fi.absolutePath() + "/" + file);
-        if (nfoFi.exists()) {
-            nfoFile = fi.absolutePath() + "/" + file;
-            break;
-        }
-    }
-
-    return nfoFile;
+    const bool stacked = episode->files().size() > 1;
+    // Season/show folders: never use folder/movie.nfo fallbacks.
+    const SidecarLookupOptions options =
+        allowLooseFallbacks ? SidecarLookupOptions::forEpisodeLoad() : SidecarLookupOptions::strict();
+    const QStringList candidates = DataFile::sidecarFileNameCandidates( //
+        Settings::instance()->dataFiles(DataFileType::TvShowEpisodeNfo),
+        fi.fileName(),
+        stacked,
+        {},
+        options);
+    return firstExistingFileInDir(fi.absolutePath(), candidates);
 }
 
 QString KodiXml::nfoFilePath(TvShow* show)
@@ -260,29 +275,29 @@ QString KodiXml::nfoFilePath(TvShow* show)
  * \param concert Concert
  * \return Path to nfo file, if none found returns an empty string
  */
-QString KodiXml::nfoFilePath(Concert* concert)
+QString KodiXml::nfoFilePath(Concert* concert, bool allowLooseFallbacks)
 {
-    QString nfoFile;
     if (concert->files().isEmpty()) {
         qCWarning(generic) << "[KodiXml] Concert has no files";
-        return nfoFile;
+        return {};
     }
     QFileInfo fi(concert->files().first().toString());
     if (!fi.isFile()) {
         qCWarning(generic) << "[KodiXml] First file of the concert is not readable" << concert->files().at(0);
-        return nfoFile;
+        return {};
     }
 
-    for (DataFile dataFile : Settings::instance()->dataFiles(DataFileType::ConcertNfo)) {
-        QString file = dataFile.saveFileName(fi.fileName(), SeasonNumber::NoSeason, concert->files().size() > 1);
-        QFileInfo nfoFi(fi.absolutePath() + "/" + file);
-        if (nfoFi.exists()) {
-            nfoFile = fi.absolutePath() + "/" + file;
-            break;
-        }
-    }
-
-    return nfoFile;
+    const bool stacked = concert->files().size() > 1;
+    const QString folderName = QFileInfo(fi.absolutePath()).fileName();
+    const SidecarLookupOptions options =
+        allowLooseFallbacks ? SidecarLookupOptions::forConcertLoad() : SidecarLookupOptions::strict();
+    const QStringList candidates = DataFile::sidecarFileNameCandidates( //
+        Settings::instance()->dataFiles(DataFileType::ConcertNfo),
+        fi.fileName(),
+        stacked,
+        folderName,
+        options);
+    return firstExistingFileInDir(fi.absolutePath(), candidates);
 }
 
 /**
@@ -1332,7 +1347,11 @@ QString KodiXml::movieSetFileName(QString setName, DataFile* dataFile)
     return QString();
 }
 
-QString KodiXml::imageFileName(const Movie* movie, ImageType type, QVector<DataFile> dataFiles, bool constructName)
+QString KodiXml::imageFileName(const Movie* movie,
+    ImageType type,
+    QVector<DataFile> dataFiles,
+    bool constructName,
+    bool allowLooseFallbacks)
 {
     DataFileType fileType = [type]() {
         switch (type) {
@@ -1360,29 +1379,52 @@ QString KodiXml::imageFileName(const Movie* movie, ImageType type, QVector<DataF
         dataFiles = Settings::instance()->dataFiles(fileType);
     }
 
-    QString fileName;
     QFileInfo fi(movie->files().first().toString());
-    for (DataFile dataFile : dataFiles) {
-        QString file = dataFile.saveFileName(fi.fileName(), SeasonNumber::NoSeason, movie->files().count() > 1);
-        if (movie->discType() == DiscType::BluRay || movie->discType() == DiscType::Dvd) {
-            if (type == ImageType::MoviePoster) {
-                file = "poster.jpg";
-            } else if (type == ImageType::MovieBackdrop) {
-                file = "fanart.jpg";
+    mediaelch::DirectoryPath path = getPath(movie);
+    const bool stacked = movie->files().count() > 1;
+
+    if (constructName) {
+        for (DataFile dataFile : dataFiles) {
+            QString file = dataFile.saveFileName(fi.fileName(), SeasonNumber::NoSeason, stacked);
+            if (movie->discType() == DiscType::BluRay || movie->discType() == DiscType::Dvd) {
+                if (type == ImageType::MoviePoster) {
+                    file = "poster.jpg";
+                } else if (type == ImageType::MovieBackdrop) {
+                    file = "fanart.jpg";
+                }
             }
+            return path.filePath(file);
         }
-        mediaelch::DirectoryPath path = getPath(movie);
-        QFileInfo pFi(path.filePath(file));
-        if (pFi.isFile() || constructName) {
-            fileName = path.filePath(file);
-            break;
+        return {};
+    }
+
+    // Disc generics first (existing Kodi layout).
+    if (movie->discType() == DiscType::BluRay || movie->discType() == DiscType::Dvd) {
+        if (type == ImageType::MoviePoster && QFileInfo::exists(path.filePath(QStringLiteral("poster.jpg")))) {
+            return path.filePath(QStringLiteral("poster.jpg"));
+        }
+        if (type == ImageType::MovieBackdrop && QFileInfo::exists(path.filePath(QStringLiteral("fanart.jpg")))) {
+            return path.filePath(QStringLiteral("fanart.jpg"));
         }
     }
 
-    return fileName;
+    const QString folderName = QFileInfo(fi.absolutePath()).fileName();
+    const SidecarLookupOptions options =
+        allowLooseFallbacks ? SidecarLookupOptions::forImageLoad() : SidecarLookupOptions::strict();
+    const QStringList candidates = DataFile::sidecarFileNameCandidates( //
+        dataFiles,
+        fi.fileName(),
+        stacked,
+        folderName,
+        options);
+    return firstExistingFileInDir(path.toString(), candidates);
 }
 
-QString KodiXml::imageFileName(const Concert* concert, ImageType type, QVector<DataFile> dataFiles, bool constructName)
+QString KodiXml::imageFileName(const Concert* concert,
+    ImageType type,
+    QVector<DataFile> dataFiles,
+    bool constructName,
+    bool allowLooseFallbacks)
 {
     DataFileType fileType;
     switch (type) {
@@ -1403,27 +1445,45 @@ QString KodiXml::imageFileName(const Concert* concert, ImageType type, QVector<D
         dataFiles = Settings::instance()->dataFiles(fileType);
     }
 
-    QString fileName;
     QFileInfo fi(concert->files().first().toString());
-    for (DataFile dataFile : dataFiles) {
-        QString file = dataFile.saveFileName(fi.fileName(), SeasonNumber::NoSeason, concert->files().count() > 1);
-        if (concert->discType() == DiscType::BluRay || concert->discType() == DiscType::Dvd) {
-            if (type == ImageType::ConcertPoster) {
-                file = "poster.jpg";
+    mediaelch::DirectoryPath path = getPath(concert);
+    const bool stacked = concert->files().count() > 1;
+
+    if (constructName) {
+        for (DataFile dataFile : dataFiles) {
+            QString file = dataFile.saveFileName(fi.fileName(), SeasonNumber::NoSeason, stacked);
+            if (concert->discType() == DiscType::BluRay || concert->discType() == DiscType::Dvd) {
+                if (type == ImageType::ConcertPoster) {
+                    file = "poster.jpg";
+                }
+                if (type == ImageType::ConcertBackdrop) {
+                    file = "fanart.jpg";
+                }
             }
-            if (type == ImageType::ConcertBackdrop) {
-                file = "fanart.jpg";
-            }
+            return path.filePath(file);
         }
-        mediaelch::DirectoryPath path = getPath(concert);
-        QFileInfo pFi(path.filePath(file));
-        if (pFi.isFile() || constructName) {
-            fileName = path.filePath(file);
-            break;
+        return {};
+    }
+
+    if (concert->discType() == DiscType::BluRay || concert->discType() == DiscType::Dvd) {
+        if (type == ImageType::ConcertPoster && QFileInfo::exists(path.filePath(QStringLiteral("poster.jpg")))) {
+            return path.filePath(QStringLiteral("poster.jpg"));
+        }
+        if (type == ImageType::ConcertBackdrop && QFileInfo::exists(path.filePath(QStringLiteral("fanart.jpg")))) {
+            return path.filePath(QStringLiteral("fanart.jpg"));
         }
     }
 
-    return fileName;
+    const QString folderName = QFileInfo(fi.absolutePath()).fileName();
+    const SidecarLookupOptions options =
+        allowLooseFallbacks ? SidecarLookupOptions::forImageLoad() : SidecarLookupOptions::strict();
+    const QStringList candidates = DataFile::sidecarFileNameCandidates( //
+        dataFiles,
+        fi.fileName(),
+        stacked,
+        folderName,
+        options);
+    return firstExistingFileInDir(path.toString(), candidates);
 }
 
 QString KodiXml::imageFileName(const TvShow* show,

--- a/src/media_center/KodiXml.h
+++ b/src/media_center/KodiXml.h
@@ -76,11 +76,13 @@ public:
     QString imageFileName(const Movie* movie,
         ImageType type,
         QVector<DataFile> dataFiles = QVector<DataFile>(),
-        bool constructName = false) override;
+        bool constructName = false,
+        bool allowLooseFallbacks = true) override;
     QString imageFileName(const Concert* concert,
         ImageType type,
         QVector<DataFile> dataFiles = QVector<DataFile>(),
-        bool constructName = false) override;
+        bool constructName = false,
+        bool allowLooseFallbacks = true) override;
     QString imageFileName(const TvShowEpisode* episode,
         ImageType type,
         QVector<DataFile> dataFiles = QVector<DataFile>(),
@@ -99,9 +101,9 @@ public:
         QVector<DataFile> dataFiles = QVector<DataFile>(),
         bool constructName = false) override;
 
-    QString nfoFilePath(Movie* movie) override;
-    QString nfoFilePath(Concert* concert) override;
-    QString nfoFilePath(TvShowEpisode* episode) override;
+    QString nfoFilePath(Movie* movie, bool allowLooseFallbacks = true) override;
+    QString nfoFilePath(Concert* concert, bool allowLooseFallbacks = true) override;
+    QString nfoFilePath(TvShowEpisode* episode, bool allowLooseFallbacks = true) override;
     QString nfoFilePath(TvShow* show) override;
     QString nfoFilePath(Artist* artist) override;
     QString nfoFilePath(Album* album) override;

--- a/src/media_center/MediaCenterInterface.h
+++ b/src/media_center/MediaCenterInterface.h
@@ -62,16 +62,19 @@ public:
     virtual QString actorImageName(TvShowEpisode* episode, Actor actor) = 0;
 
     // nfo file paths
-    virtual QString nfoFilePath(Movie* movie) = 0;
-    virtual QString nfoFilePath(Concert* concert) = 0;
-    virtual QString nfoFilePath(TvShowEpisode* episode) = 0;
+    /// \param allowLooseFallbacks When true (default), also try folder-level / movie.nfo.
+    ///        Renamer should pass false to avoid renaming shared folder sidecars unexpectedly.
+    virtual QString nfoFilePath(Movie* movie, bool allowLooseFallbacks = true) = 0;
+    virtual QString nfoFilePath(Concert* concert, bool allowLooseFallbacks = true) = 0;
+    virtual QString nfoFilePath(TvShowEpisode* episode, bool allowLooseFallbacks = true) = 0;
     virtual QString nfoFilePath(TvShow* show) = 0;
     virtual QString nfoFilePath(Artist* artist) = 0;
     virtual QString nfoFilePath(Album* album) = 0;
 
     // clang-format off
-    virtual QString imageFileName(const Movie *movie,           ImageType type, QVector<DataFile> dataFiles = QVector<DataFile>(), bool constructName = false) = 0;
-    virtual QString imageFileName(const Concert *concert,       ImageType type, QVector<DataFile> dataFiles = QVector<DataFile>(), bool constructName = false) = 0;
+    /// \param allowLooseFallbacks When true (default), also try folder-level art. Renamer should pass false.
+    virtual QString imageFileName(const Movie *movie,           ImageType type, QVector<DataFile> dataFiles = QVector<DataFile>(), bool constructName = false, bool allowLooseFallbacks = true) = 0;
+    virtual QString imageFileName(const Concert *concert,       ImageType type, QVector<DataFile> dataFiles = QVector<DataFile>(), bool constructName = false, bool allowLooseFallbacks = true) = 0;
     virtual QString imageFileName(const TvShowEpisode *episode, ImageType type, QVector<DataFile> dataFiles = QVector<DataFile>(), bool constructName = false) = 0;
     virtual QString imageFileName(const Artist *artist,         ImageType type, QVector<DataFile> dataFiles = QVector<DataFile>(), bool constructName = false) = 0;
     virtual QString imageFileName(const Album *album,           ImageType type, QVector<DataFile> dataFiles = QVector<DataFile>(), bool constructName = false) = 0;

--- a/src/renamer/ConcertRenamer.cpp
+++ b/src/renamer/ConcertRenamer.cpp
@@ -115,7 +115,8 @@ ConcertRenamer::RenameError ConcertRenamer::renameConcert(Concert& concert)
     QString parentDirName;
 
     MediaCenterInterface* mediaCenter = Manager::instance()->mediaCenterInterface();
-    QString nfo = mediaCenter->nfoFilePath(&concert);
+    // Strict lookup: do not pick up folder-level NFO fallbacks for rename.
+    QString nfo = mediaCenter->nfoFilePath(&concert, false);
 
     bool errorOccured = false;
 
@@ -223,7 +224,9 @@ ConcertRenamer::RenameError ConcertRenamer::renameConcert(Concert& concert)
 
         const auto renameImageType = [&](ImageType imageType) {
             DataFileType fileType = DataFile::dataFileTypeForImageType(imageType);
-            renameFileType(mediaCenter->imageFileName(&concert, imageType), fileType);
+            // Strict lookup: do not rename shared folder-level art via fallbacks.
+            renameFileType(
+                mediaCenter->imageFileName(&concert, imageType, QVector<DataFile>(), false, false), fileType);
         };
 
         renameFileType(nfo, DataFileType::ConcertNfo);

--- a/src/renamer/EpisodeRenamer.cpp
+++ b/src/renamer/EpisodeRenamer.cpp
@@ -207,7 +207,8 @@ EpisodeRenamer::RenameError EpisodeRenamer::renameEpisode(TvShowEpisode& episode
     QString fiCanonicalPath = episodeFileinfo.canonicalPath();
     mediaelch::FileList episodeFiles = episode.files();
     MediaCenterInterface* mediaCenter = Manager::instance()->mediaCenterInterface();
-    QString nfo = mediaCenter->nfoFilePath(&episode);
+    // Strict lookup: keep rename targets aligned with primary sidecar patterns only.
+    QString nfo = mediaCenter->nfoFilePath(&episode, false);
     QString newNfoFileName = nfo;
     QString thumbnail = mediaCenter->imageFileName(&episode, ImageType::TvShowEpisodeThumb);
     QString newThumbnailFileName = thumbnail;

--- a/src/renamer/MovieRenamer.cpp
+++ b/src/renamer/MovieRenamer.cpp
@@ -124,7 +124,8 @@ MovieRenamer::RenameError MovieRenamer::renameMovie(Movie& movie)
     QString newDelimiter = (replaceDelimiter) ? m_config.delimiter : oldDelimiter;
 
     MediaCenterInterface* mediaCenter = Manager::instance()->mediaCenterInterface();
-    QString nfo = mediaCenter->nfoFilePath(&movie);
+    // Strict lookup: do not pick up folder-level / movie.nfo fallbacks for rename.
+    QString nfo = mediaCenter->nfoFilePath(&movie, false);
 
     QString newFileName;
     QStringList FilmFiles;
@@ -396,7 +397,9 @@ MovieRenamer::RenameError MovieRenamer::renameMovie(Movie& movie)
 
         const auto renameImageType = [&](ImageType imageType) {
             DataFileType fileType = DataFile::dataFileTypeForImageType(imageType);
-            renameFileType(mediaCenter->imageFileName(&movie, imageType), fileType);
+            // Strict lookup: do not rename shared folder-level art via fallbacks.
+            renameFileType(
+                mediaCenter->imageFileName(&movie, imageType, QVector<DataFile>(), false, false), fileType);
         };
 
         renameFileType(nfo, DataFileType::MovieNfo);

--- a/src/settings/DataFile.cpp
+++ b/src/settings/DataFile.cpp
@@ -47,7 +47,7 @@ int DataFile::pos() const
  * \param fileName File name
  * \param season Season number
  */
-QString DataFile::saveFileName(const QString& fileName, SeasonNumber season, bool stacked)
+QString DataFile::saveFileName(const QString& fileName, SeasonNumber season, bool stacked) const
 {
     if (type() == DataFileType::MovieSetBackdrop || type() == DataFileType::MovieSetPoster) {
         QString newFileName = m_fileName;

--- a/src/settings/DataFile.cpp
+++ b/src/settings/DataFile.cpp
@@ -61,7 +61,10 @@ QString DataFile::saveFileName(const QString& fileName, SeasonNumber season, boo
 
     QString baseName = fi.completeBaseName();
     if (stacked) {
-        baseName = mediaelch::file::stackedBaseName(fileName);
+        // stackedBaseName keeps the video extension when there is no cd/part/disk
+        // marker (see #1175 / FilenameUtils). Sidecar patterns like
+        // "<baseFileName>.nfo" must not become "Title.mkv.nfo".
+        baseName = QFileInfo(mediaelch::file::stackedBaseName(fileName)).completeBaseName();
     }
     newFileName.replace("<baseFileName>", baseName);
 
@@ -74,6 +77,47 @@ QString DataFile::saveFileName(const QString& fileName, SeasonNumber season, boo
     }
 
     return newFileName;
+}
+
+QStringList DataFile::sidecarFileNameCandidates(const QVector<DataFile>& dataFiles,
+    const QString& videoFileName,
+    bool stacked,
+    const QString& folderName,
+    SidecarLookupOptions options)
+{
+    QStringList candidates;
+    const auto add = [&candidates](const QString& name) {
+        if (!name.isEmpty() && !candidates.contains(name)) {
+            candidates.append(name);
+        }
+    };
+
+    for (const DataFile& dataFile : dataFiles) {
+        add(dataFile.saveFileName(videoFileName, SeasonNumber::NoSeason, stacked));
+    }
+
+    // e.g. movie-cd1.avi → also try movie-cd1.nfo if stacked basename missed
+    if (options.tryNonStacked && stacked) {
+        for (const DataFile& dataFile : dataFiles) {
+            add(dataFile.saveFileName(videoFileName, SeasonNumber::NoSeason, false));
+        }
+    }
+
+    // Folder-level sidecars (TMM / multi-edition): Folder.nfo, Folder-poster.jpg, …
+    // Fake extension so completeBaseName()/saveFileName strip it cleanly.
+    if (options.tryFolderBasename && !folderName.isEmpty()) {
+        const QString folderAsVideo = folderName + QStringLiteral(".mkv");
+        for (const DataFile& dataFile : dataFiles) {
+            add(dataFile.saveFileName(folderAsVideo, SeasonNumber::NoSeason, false));
+        }
+    }
+
+    // Last resort only — after folder basename, to prefer TMM-style Folder.nfo over a stale movie.nfo.
+    if (options.tryGenericMovieNfo) {
+        add(QStringLiteral("movie.nfo"));
+    }
+
+    return candidates;
 }
 
 /**

--- a/src/settings/DataFile.h
+++ b/src/settings/DataFile.h
@@ -60,7 +60,9 @@ public:
     DataFileType type() const;
     QString fileName() const;
     int pos() const;
-    QString saveFileName(const QString& fileName, SeasonNumber season = SeasonNumber::NoSeason, bool stacked = false);
+    QString saveFileName(const QString& fileName,
+        SeasonNumber season = SeasonNumber::NoSeason,
+        bool stacked = false) const;
     static bool lessThan(DataFile a, DataFile b);
     void setFileName(QString fileName);
 

--- a/src/settings/DataFile.h
+++ b/src/settings/DataFile.h
@@ -4,6 +4,53 @@
 #include "globals/Globals.h"
 
 #include <QString>
+#include <QStringList>
+#include <QVector>
+
+/// Options for looking up existing sidecars (NFO/art) next to a video file.
+struct SidecarLookupOptions
+{
+    /// Also try saveFileName(..., stacked=false) when stacked was true.
+    bool tryNonStacked = false;
+    /// Apply patterns using the parent folder name as basename (Folder.nfo / Folder-poster.jpg).
+    bool tryFolderBasename = false;
+    /// Also try literal "movie.nfo" (Kodi folder convention). Prefer after folder basename.
+    bool tryGenericMovieNfo = false;
+
+    static SidecarLookupOptions strict() { return {}; }
+
+    static SidecarLookupOptions forMovieLoad()
+    {
+        SidecarLookupOptions o;
+        o.tryNonStacked = true;
+        o.tryFolderBasename = true;
+        o.tryGenericMovieNfo = true;
+        return o;
+    }
+
+    static SidecarLookupOptions forConcertLoad()
+    {
+        SidecarLookupOptions o;
+        o.tryNonStacked = true;
+        o.tryFolderBasename = true;
+        return o;
+    }
+
+    static SidecarLookupOptions forEpisodeLoad()
+    {
+        SidecarLookupOptions o;
+        o.tryNonStacked = true;
+        return o;
+    }
+
+    static SidecarLookupOptions forImageLoad()
+    {
+        SidecarLookupOptions o;
+        o.tryNonStacked = true;
+        o.tryFolderBasename = true;
+        return o;
+    }
+};
 
 class DataFile
 {
@@ -18,6 +65,14 @@ public:
     void setFileName(QString fileName);
 
     static DataFileType dataFileTypeForImageType(ImageType imageType);
+
+    /// Ordered sidecar file-name candidates (not full paths) for lookup next to a video.
+    /// Order: primary (stacked) → optional non-stacked → folder basename patterns → movie.nfo.
+    static QStringList sidecarFileNameCandidates(const QVector<DataFile>& dataFiles,
+        const QString& videoFileName,
+        bool stacked,
+        const QString& folderName,
+        SidecarLookupOptions options);
 
 private:
     QString m_fileName;

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -35,6 +35,7 @@ target_sources(
     scrapers/custom_movie_scraper/testCustomMovieScraper.cpp
     scrapers/testMovieMerger.cpp
     settings/testAdvancedSettings.cpp
+    settings/testDataFile.cpp
     tv_shows/testEpisodeNumberExtraction.cpp
     tv_shows/testSeasonNumberExtraction.cpp
     tv_shows/testTvDbId.cpp

--- a/test/unit/settings/testDataFile.cpp
+++ b/test/unit/settings/testDataFile.cpp
@@ -1,0 +1,146 @@
+#include "test/test_helpers.h"
+
+#include "data/tv_show/SeasonNumber.h"
+#include "globals/Globals.h"
+#include "settings/DataFile.h"
+
+TEST_CASE("DataFile::saveFileName", "[settings]")
+{
+    DataFile nfo(DataFileType::MovieNfo, "<baseFileName>.nfo", 0);
+    DataFile poster(DataFileType::MoviePoster, "<baseFileName>-poster.jpg", 0);
+
+    SECTION("single file: strips video extension")
+    {
+        CHECK(nfo.saveFileName("movie.mkv") == "movie.nfo");
+        CHECK(poster.saveFileName("movie.mkv") == "movie-poster.jpg");
+    }
+
+    SECTION("stacked multi-edition: strips video extension (not movie.mkv.nfo)")
+    {
+        CHECK(nfo.saveFileName("movie.mkv", SeasonNumber::NoSeason, true) == "movie.nfo");
+        CHECK(poster.saveFileName("movie.mkv", SeasonNumber::NoSeason, true) == "movie-poster.jpg");
+
+        CHECK(nfo.saveFileName("The.Dark.Knight.mkv", SeasonNumber::NoSeason, true) == "The.Dark.Knight.nfo");
+    }
+
+    SECTION("stacked cd1/cd2: uses stacked basename without extension")
+    {
+        CHECK(nfo.saveFileName("movie-cd1.avi", SeasonNumber::NoSeason, true) == "movie.nfo");
+        CHECK(nfo.saveFileName("movie-cd2.avi", SeasonNumber::NoSeason, true) == "movie.nfo");
+        CHECK(poster.saveFileName("movie-part1.mkv", SeasonNumber::NoSeason, true) == "movie-poster.jpg");
+    }
+
+    SECTION("stacked edition suffix: strips only the video extension")
+    {
+        CHECK(nfo.saveFileName("Title - US.mp4", SeasonNumber::NoSeason, true) == "Title - US.nfo");
+        CHECK(poster.saveFileName("Clerks (1994) [tmdbid-2292] - First Cut.mkv", SeasonNumber::NoSeason, true)
+            == "Clerks (1994) [tmdbid-2292] - First Cut-poster.jpg");
+    }
+
+    SECTION("stacked Part I (roman): stacking strips part → folder-level nfo basename")
+    {
+        // stackedBaseName treats "Part I" as a disc marker (I in [0-9a-f]).
+        const QString video =
+            "Jay and Silent Bob Get Irish - The Swearing o' the Green! (2012) [tmdbid-177361] - Part I.mkv";
+        const QString expected =
+            "Jay and Silent Bob Get Irish - The Swearing o' the Green! (2012) [tmdbid-177361].nfo";
+        CHECK(nfo.saveFileName(video, SeasonNumber::NoSeason, true) == expected);
+        CHECK_FALSE(nfo.saveFileName(video, SeasonNumber::NoSeason, true).endsWith(".mkv.nfo"));
+    }
+
+    SECTION("nfoFilePath-style: multi-file movie finds Title.nfo from Title.mkv")
+    {
+        const QString candidate = nfo.saveFileName("Title.mkv", SeasonNumber::NoSeason, true);
+        CHECK(candidate == "Title.nfo");
+        CHECK(candidate != "Title.mkv.nfo");
+    }
+}
+
+TEST_CASE("DataFile::sidecarFileNameCandidates", "[settings]")
+{
+    const QVector<DataFile> nfoPatterns{DataFile(DataFileType::MovieNfo, "<baseFileName>.nfo", 0)};
+    const QVector<DataFile> posterPatterns{DataFile(DataFileType::MoviePoster, "<baseFileName>-poster.jpg", 0)};
+
+    SECTION("strict: only primary stacked candidate")
+    {
+        const QString folder = "Faust (1926) [tmdbid-10728]";
+        const QStringList c = DataFile::sidecarFileNameCandidates(
+            nfoPatterns, folder + " - Sub.avi", true, folder, SidecarLookupOptions::strict());
+
+        REQUIRE(c.size() == 1);
+        CHECK(c.first() == folder + " - Sub.nfo");
+        CHECK_FALSE(c.contains(folder + ".nfo"));
+        CHECK_FALSE(c.contains("movie.nfo"));
+    }
+
+    SECTION("movie load: folder.nfo before movie.nfo (prefer TMM over stale movie.nfo)")
+    {
+        const QString folder = "Faust (1926) [tmdbid-10728]";
+        const QStringList c = DataFile::sidecarFileNameCandidates(
+            nfoPatterns, folder + " - Sub.avi", true, folder, SidecarLookupOptions::forMovieLoad());
+
+        REQUIRE(c.contains(folder + " - Sub.nfo"));
+        REQUIRE(c.contains(folder + ".nfo"));
+        REQUIRE(c.contains("movie.nfo"));
+        CHECK(c.indexOf(folder + " - Sub.nfo") < c.indexOf(folder + ".nfo"));
+        CHECK(c.indexOf(folder + ".nfo") < c.indexOf("movie.nfo"));
+    }
+
+    SECTION("primary stacked candidate without video extension")
+    {
+        const QStringList c = DataFile::sidecarFileNameCandidates(
+            nfoPatterns, "Title.mkv", true, "Title", SidecarLookupOptions::forMovieLoad());
+        REQUIRE_FALSE(c.isEmpty());
+        CHECK(c.first() == "Title.nfo");
+        CHECK_FALSE(c.contains("Title.mkv.nfo"));
+    }
+
+    SECTION("cd1: non-stacked retry and folder basename")
+    {
+        const QStringList c = DataFile::sidecarFileNameCandidates(
+            nfoPatterns, "movie-cd1.avi", true, "Movie Folder", SidecarLookupOptions::forConcertLoad());
+        CHECK(c.contains("movie.nfo"));     // stacked base
+        CHECK(c.contains("movie-cd1.nfo")); // non-stacked
+        CHECK(c.contains("Movie Folder.nfo"));
+        CHECK(c.count("movie.nfo") == 1);
+    }
+
+    SECTION("deduplicates identical candidates")
+    {
+        const QStringList c = DataFile::sidecarFileNameCandidates(
+            nfoPatterns, "Title.mkv", true, "Title", SidecarLookupOptions::forMovieLoad());
+        CHECK(c.count("Title.nfo") == 1);
+    }
+
+    SECTION("Part I video: primary already folder-level; folder fallback still listed once")
+    {
+        const QString folder = "Jay and Silent Bob Get Irish - The Swearing o' the Green! (2012) [tmdbid-177361]";
+        const QString video = folder + " - Part I.mkv";
+        const QStringList c = DataFile::sidecarFileNameCandidates(
+            nfoPatterns, video, true, folder, SidecarLookupOptions::forMovieLoad());
+        CHECK(c.first() == folder + ".nfo");
+        CHECK(c.count(folder + ".nfo") == 1);
+    }
+
+    SECTION("image load: folder-level poster candidate for edition-first file")
+    {
+        const QString folder = "Faust (1926) [tmdbid-10728]";
+        const QStringList c = DataFile::sidecarFileNameCandidates(
+            posterPatterns, folder + " - Sub.avi", true, folder, SidecarLookupOptions::forImageLoad());
+
+        CHECK(c.contains(folder + " - Sub-poster.jpg"));
+        CHECK(c.contains(folder + "-poster.jpg"));
+        CHECK_FALSE(c.contains("movie.nfo"));
+        CHECK(c.indexOf(folder + " - Sub-poster.jpg") < c.indexOf(folder + "-poster.jpg"));
+    }
+
+    SECTION("episode load: non-stacked only, no folder/movie.nfo")
+    {
+        const QStringList c = DataFile::sidecarFileNameCandidates(
+            nfoPatterns, "Show.S01E01-cd1.mkv", true, "Season 01", SidecarLookupOptions::forEpisodeLoad());
+        CHECK(c.contains("Show.S01E01.nfo"));     // stacked
+        CHECK(c.contains("Show.S01E01-cd1.nfo")); // non-stacked
+        CHECK_FALSE(c.contains("Season 01.nfo"));
+        CHECK_FALSE(c.contains("movie.nfo"));
+    }
+}


### PR DESCRIPTION
## Summary
- When a movie/concert/episode has multiple files, `DataFile::saveFileName(..., stacked=true)` used `stackedBaseName()`, which keeps the video extension on purpose for file grouping (#1175). Sidecar patterns then became `Title.mkv.nfo` / `Title.mkv-poster.jpg`, so a normal `Title.nfo` was ignored on reload and scrape/save wrote junk names.
- Strip the extension after `stackedBaseName` for sidecar naming only (grouping behavior unchanged).
- Add ordered NFO/art lookup fallbacks for load: primary → non-stacked → folder basename → `movie.nfo` (last). Renamer uses strict primary lookup so shared folder-level sidecars are not renamed unexpectedly.
- Unit tests for `saveFileName` and `sidecarFileNameCandidates`.

## Test plan
- [ ] Multi-file folder with only `Title.nfo` (no `Title.mkv.nfo`): Reload fills title/plot from NFO
- [ ] Multi-edition folder where first file is an edition (`Title - US.mkv`) but only `Title.nfo` / `Title-poster.jpg` exist: Reload finds folder-level NFO/art
- [ ] Scrape+save on multi-file movie does **not** create `*.mkv.nfo` / `*.mkv-poster.jpg`
- [ ] `movie-cd1` / `movie-cd2` still resolve `movie.nfo` / `movie-poster.jpg`
- [ ] Renamer does not rename a folder-level NFO that is only found via loose fallbacks
- [ ] `test/unit/settings/testDataFile.cpp` passes
